### PR TITLE
Add osgi support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
 - chmod +x gradlew
 
 script:
-- ./gradlew clean check allTests -x test
+- ./gradlew clean check jar allTests -x test
 
 after_success:
 - ./gradlew coberturaReport coveralls

--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 jar {
     manifest {
         instruction 'Export-Package', '!io.github.robwin.*.internal,*'
-        instruction 'Import-Package', '!io.github.robwin.*,io.reactivex.*;resolution:=optional,javax.cache;resolution:=optional,org.reactivestreams;resolution:=optional,*'
+        instruction 'Import-Package', '!io.github.robwin.*,*'
         instruction 'Bundle-Description', 'A lightweight fault tolerance library'
         instruction 'Bundle-DocURL', 'http://robwin.github.io/javaslang-circuitbreaker/'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -100,6 +100,15 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     from javadoc.destinationDir
 }
 
+jar {
+    manifest {
+        instruction 'Export-Package', '!io.github.robwin.*.internal,*'
+        instruction 'Import-Package', '!io.github.robwin.*,*'
+        instruction 'Bundle-Description', 'A lightweight fault tolerance library'
+        instruction 'Bundle-DocURL', 'http://robwin.github.io/javaslang-circuitbreaker/'
+    }
+}
+
 artifacts {
     archives sourcesJar
     archives javadocJar

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ buildscript {
 
 apply plugin: 'idea'
 apply plugin: 'java'
+apply plugin: 'osgi'
 apply plugin: 'maven-publish'
 apply plugin: 'net.saliman.cobertura'
 apply plugin: 'com.github.kt3k.coveralls'

--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 jar {
     manifest {
         instruction 'Export-Package', '!io.github.robwin.*.internal,*'
-        instruction 'Import-Package', '!io.github.robwin.*,*'
+        instruction 'Import-Package', '!io.github.robwin.*,io.reactivex.*;resolution:=optional,javax.cache;resolution:=optional,org.reactivestreams;resolution:=optional,*'
         instruction 'Bundle-Description', 'A lightweight fault tolerance library'
         instruction 'Bundle-DocURL', 'http://robwin.github.io/javaslang-circuitbreaker/'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -61,11 +61,11 @@ jmh {
 }
 
 dependencies {
-    compile "io.javaslang:javaslang:2.0.5"
-    // compile 'org.reactivestreams:reactive-streams:1.0.0'
-    compile "io.reactivex.rxjava2:rxjava:2.0.6"
-    compile "org.slf4j:slf4j-api:1.7.24"
-    compile "javax.cache:cache-api:1.0.0"
+    compile "io.javaslang:javaslang:${javaslangVersion}"
+    // compile "org.reactivestreams:reactive-streams:${reactiveStreamsVersion}"
+    compile "io.reactivex.rxjava2:rxjava:${rxjavaVersion}"
+    compile "org.slf4j:slf4j-api:${slf4jApiVersion}"
+    compile "javax.cache:cache-api:${cacheApiVersion}"
 
     testCompile "io.dropwizard.metrics:metrics-core:3.1.2"
     testCompile "junit:junit:4.11"

--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,14 @@ dependencies {
     testCompile "org.powermock:powermock-module-junit4:1.6.6"
     testCompile "com.jayway.awaitility:awaitility:1.7.0"
     testCompile "org.mapdb:thread-weaver:3.0.mapdb"
+    testCompile "javax.inject:javax.inject:1"
+    testCompile "org.ops4j.pax.exam:pax-exam-junit4:4.10.0"
+    testCompile "org.osgi:org.osgi.core:6.0.0"
+
+    testRuntime "org.ops4j.pax.exam:pax-exam-container-native:4.10.0"
+    testRuntime "org.ops4j.pax.exam:pax-exam-link-mvn:4.10.0"
+    testRuntime "org.ops4j.pax.url:pax-url-aether:2.5.2"
+    testRuntime "org.apache.felix:org.apache.felix.framework:5.6.2"
 
     jmh "ch.qos.logback:logback-classic:0.9.26"
     jmh "org.openjdk.jmh:jmh-generator-annprocess:1.12"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,5 @@
+javaslangVersion = 2.0.5
+rxjavaVersion = 2.0.6
+slf4jApiVersion = 1.7.24
+cacheApiVersion = 1.0.0
+reactiveStreamsVersion = 1.0.0

--- a/src/test/java/io/github/robwin/osgi/OsgiIntegrationTest.java
+++ b/src/test/java/io/github/robwin/osgi/OsgiIntegrationTest.java
@@ -57,7 +57,7 @@ public class OsgiIntegrationTest {
     }
 
     private UrlProvisionOption projectBundle() {
-        final File dir = new File( PathUtils.getBaseDir() + "/build/libs/");
+        final File dir = new File( "./build/libs");
         final File[] files = dir.listFiles();
         return bundle("reference:file:" + files[0].getPath());
     }

--- a/src/test/java/io/github/robwin/osgi/OsgiIntegrationTest.java
+++ b/src/test/java/io/github/robwin/osgi/OsgiIntegrationTest.java
@@ -9,12 +9,14 @@ import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.options.UrlProvisionOption;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
-import org.ops4j.pax.exam.util.PathUtils;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 
 import javax.inject.Inject;
 import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 import static org.ops4j.pax.exam.CoreOptions.bundle;
@@ -30,13 +32,15 @@ public class OsgiIntegrationTest {
     private BundleContext bundleContext;
 
     @Configuration
-    public Option[] config() {
+    public Option[] config() throws IOException {
+        Properties props = new Properties();
+        props.load(new FileReader("gradle.properties"));
         return options(
-                mavenBundle("io.javaslang", "javaslang", "2.0.5"),
-                mavenBundle("io.reactivex.rxjava2", "rxjava", "2.0.6"),
-                mavenBundle("org.slf4j",  "slf4j-api", "1.7.24"),
-                mavenBundle("javax.cache",  "cache-api", "1.0.0"),
-                mavenBundle("org.reactivestreams", "reactive-streams", "1.0.0"),
+                mavenBundle("io.javaslang", "javaslang", props.getProperty("javaslangVersion")),
+                mavenBundle("io.reactivex.rxjava2", "rxjava", props.getProperty("rxjavaVersion")),
+                mavenBundle("org.slf4j",  "slf4j-api", props.getProperty("slf4jApiVersion")),
+                mavenBundle("javax.cache",  "cache-api", props.getProperty("cacheApiVersion")),
+                mavenBundle("org.reactivestreams", "reactive-streams", props.getProperty("reactiveStreamsVersion")),
                 projectBundle(),
                 junitBundles());
     }

--- a/src/test/java/io/github/robwin/osgi/OsgiIntegrationTest.java
+++ b/src/test/java/io/github/robwin/osgi/OsgiIntegrationTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.ops4j.pax.exam.CoreOptions.bundle;
 import static org.ops4j.pax.exam.CoreOptions.junitBundles;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
@@ -52,7 +53,12 @@ public class OsgiIntegrationTest {
 
     @Test
     public void circuitBreakerShouldResolve() {
-        CircuitBreaker.ofDefaults("test");
+        try {
+            Class.forName("io.github.robwin.circuitbreaker.CircuitBreaker");
+            CircuitBreaker.ofDefaults("test");
+        } catch (ClassNotFoundException cnfe) {
+            fail("Should be able load CircuitBreaker from public api");
+        }
     }
 
     @Test(expected = ClassNotFoundException.class)

--- a/src/test/java/io/github/robwin/osgi/OsgiIntegrationTest.java
+++ b/src/test/java/io/github/robwin/osgi/OsgiIntegrationTest.java
@@ -1,0 +1,102 @@
+package io.github.robwin.osgi;
+
+import io.github.robwin.circuitbreaker.CircuitBreaker;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.options.UrlProvisionOption;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.ops4j.pax.exam.util.PathUtils;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+
+import javax.inject.Inject;
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.ops4j.pax.exam.CoreOptions.bundle;
+import static org.ops4j.pax.exam.CoreOptions.junitBundles;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.CoreOptions.options;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class OsgiIntegrationTest {
+
+    @Inject
+    private BundleContext bundleContext;
+
+    @Configuration
+    public Option[] config() {
+        return options(
+                mavenBundle("io.javaslang", "javaslang", "2.0.5"),
+                mavenBundle("io.reactivex.rxjava2", "rxjava", "2.0.6"),
+                mavenBundle("org.slf4j",  "slf4j-api", "1.7.24"),
+                mavenBundle("javax.cache",  "cache-api", "1.0.0"),
+                mavenBundle("org.reactivestreams", "reactive-streams", "1.0.0"),
+                projectBundle(),
+                junitBundles());
+    }
+ 
+    @Test
+    public void bundleShouldBeActive() {
+        assertBundleActive("io.github.robwin.javaslang-circuitbreaker");
+    }
+
+    @Test
+    public void circuitBreakerShouldResolve() {
+        CircuitBreaker.ofDefaults("test");
+    }
+
+    @Test(expected = ClassNotFoundException.class)
+    public void internalClassesShouldNotBeExported() throws ClassNotFoundException {
+        Class.forName("io.github.robwin.circuitbreaker.internal.RingBitSet");
+    }
+
+    private UrlProvisionOption projectBundle() {
+        final File dir = new File( PathUtils.getBaseDir() + "/build/libs/");
+        final File[] files = dir.listFiles();
+        return bundle("reference:file:" + files[0].getPath());
+    }
+
+    private void assertBundleActive(String symbolicName) {
+        assertEquals("Expecting bundle to be active:" + symbolicName, Bundle.ACTIVE, getBundleState(symbolicName));
+    }
+
+    private boolean isFragment(Bundle b) {
+        return b.getHeaders().get("Fragment-Host") != null;
+    }
+
+    private Bundle getBundle(String symbolicName) {
+        return getBundle(bundleContext, symbolicName);
+    }
+
+    static Bundle getBundle(BundleContext bc, String symbolicName) {
+        for(Bundle b : bc.getBundles()) {
+            if(symbolicName.equals(b.getSymbolicName())) {
+                return b;
+            }
+        }
+        return null;
+    }
+
+    /** @return bundle state, UNINSTALLED if absent */
+    private int getBundleState(String symbolicName) {
+        return getBundleState(getBundle(symbolicName));
+    }
+
+    /** @return bundle state, UNINSTALLED if absent, ACTIVE  */
+    private int getBundleState(Bundle b) {
+        if(b == null) {
+            return Bundle.UNINSTALLED;
+        } else if(isFragment(b)) {
+            return Bundle.ACTIVE;
+        } else {
+            return b.getState();
+        }
+    }
+
+}


### PR DESCRIPTION
This PR implements #47 

This generates the OSGi META-INF/MANIFEST.MF file that decribes the jar as an OSGi bundle.

See https://docs.gradle.org/current/userguide/osgi_plugin.html

The library depends upon `javaslang` & `slf4j`, which both seems to be an [OSGi bundle]:(https://github.com/javaslang/javaslang/blob/master/pom.xml#L271-L284)
```
javaslang.collection,version=[2.0,3) from io.javaslang (482)
javaslang.control,version=[2.0,3) from io.javaslang (482)
org.slf4j,version=[1.7,2) from slf4j.api (17)
```

It also has the following dependencies which it expects to import - I wanted to check whether the following dependencies could be considered _optional_ - only required for certain features?
```
io.reactivex,version=[2.0,3) -- Cannot be resolved
io.reactivex.disposables,version=[2.0,3) -- Cannot be resolved
io.reactivex.functions,version=[2.0,3) -- Cannot be resolved
io.reactivex.processors,version=[2.0,3) -- Cannot be resolved
javax.cache,version=[1.0,2) -- Cannot be resolved
org.reactivestreams,version=[1.0,2) -- Cannot be resolved
```
