### PR TITLE
Server-Sent-Events to publish CircuitBreaker events

### DIFF
--- a/resilience4j-spring-boot/src/main/java/io/github/resilience4j/circuitbreaker/autoconfigure/CircuitBreakerAutoConfiguration.java
+++ b/resilience4j-spring-boot/src/main/java/io/github/resilience4j/circuitbreaker/autoconfigure/CircuitBreakerAutoConfiguration.java
@@ -56,8 +56,9 @@ public class CircuitBreakerAutoConfiguration {
 
     @Bean
     public CircuitBreakerEventsEndpoint circuitBreakerEventsEndpoint(CircuitBreakerEndpoint circuitBreakerEndpoint,
-                                                                     EventConsumerRegistry<CircuitBreakerEvent> eventConsumerRegistry) {
-        return new CircuitBreakerEventsEndpoint(circuitBreakerEndpoint, eventConsumerRegistry);
+                                                                     EventConsumerRegistry<CircuitBreakerEvent> eventConsumerRegistry,
+                                                                     CircuitBreakerRegistry circuitBreakerRegistry) {
+        return new CircuitBreakerEventsEndpoint(circuitBreakerEndpoint, eventConsumerRegistry, circuitBreakerRegistry);
     }
 
     /**

--- a/resilience4j-spring-boot/src/main/java/io/github/resilience4j/circuitbreaker/monitoring/endpoint/CircuitBreakerEventSseEmitter.java
+++ b/resilience4j-spring-boot/src/main/java/io/github/resilience4j/circuitbreaker/monitoring/endpoint/CircuitBreakerEventSseEmitter.java
@@ -1,0 +1,34 @@
+package io.github.resilience4j.circuitbreaker.monitoring.endpoint;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.event.CircuitBreakerEvent;
+import io.reactivex.disposables.Disposable;
+import org.springframework.http.MediaType;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+class CircuitBreakerEventSseEmitter {
+
+    private final SseEmitter sseEmitter;
+    private final Disposable disposable;
+
+    CircuitBreakerEventSseEmitter(CircuitBreaker circuitBreaker) {
+        this.sseEmitter = new SseEmitter();
+        this.sseEmitter.onCompletion(this::unsubscribe);
+        this.disposable = circuitBreaker.getEventStream()
+                .subscribe(this::notify,
+                        this.sseEmitter::completeWithError,
+                        this.sseEmitter::complete);
+    }
+
+    SseEmitter getSseEmitter() {
+        return this.sseEmitter;
+    }
+
+    private void notify(CircuitBreakerEvent circuitBreakerEvent) throws Exception {
+        sseEmitter.send(CircuitBreakerEventDTOFactory.createCircuitBreakerEventDTO(circuitBreakerEvent), MediaType.APPLICATION_JSON);
+    }
+
+    private void unsubscribe() {
+        this.disposable.dispose();
+    }
+}


### PR DESCRIPTION
This PR uses Springs SseEmitter to publish CircuitBreaker events to monitor events in realtime in an external client. It's a basic POC...