### PR TITLE
Migrated cpilsworth/retrofit-circuitbreaker to the resilience4j project

### DIFF
--- a/libraries.gradle
+++ b/libraries.gradle
@@ -14,6 +14,7 @@ ext {
     metricsVersion = '3.1.2'
     vertxVersion = '3.4.1'
     springBootVersion = '1.4.3.RELEASE'
+    retrofitVersion = '2.1.0'
 
     libraries = [
             // compile
@@ -40,6 +41,11 @@ ext {
             spring_boot_actuator: "org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}",
             spring_boot_web: "org.springframework.boot:spring-boot-starter-web:${springBootVersion}",
             spring_boot_test:  "org.springframework.boot:spring-boot-starter-test:${springBootVersion}",
+
+            // retrofit addon
+            retrofit: "com.squareup.retrofit2:retrofit:${retrofitVersion}",
+            retrofit_test: "com.squareup.retrofit2:converter-scalars:${retrofitVersion}",
+            retrofit_wiremock: "com.github.tomakehurst:wiremock:1.58",
 
             // circuitbreaker documentation
             metrics: "io.dropwizard.metrics:metrics-core:${metricsVersion}",

--- a/resilience4j-documentation/src/docs/asciidoc/retrofit.adoc
+++ b/resilience4j-documentation/src/docs/asciidoc/retrofit.adoc
@@ -9,7 +9,7 @@ private final CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testNam
 
 // Create a retrofit instance with CircuitBreaker call adapter
 Retrofit retrofit = new Retrofit.Builder()
-                .addCallAdapterFactory(new CircuitBreakerCallAdapterFactory(circuitBreaker))
+                .addCallAdapterFactory(CircuitBreakerCallAdapter.of(circuitBreaker))
                 .baseUrl("http://localhost:8080/")
                 .build();
                 
@@ -18,16 +18,14 @@ RetrofitService service = retrofit.create(RetrofitService.class);
 ----
 
 By default, all exceptions and responses where
-`!Response.isSuccessful()` will be recorded as an error in the
-CircuitBreaker.
+`!Response.isSuccessful()` will be recorded as an error in the CircuitBreaker.
 
-Customising what is considered a _successful_ response is possible like
-so:
+Customising what is considered a _successful_ response is possible like so:
 
 [source,java]
 ----
 Retrofit retrofit = new Retrofit.Builder()
-                .addCallAdapterFactory(new CircuitBreakerCallAdapterFactory(circuitBreaker, (r) -> r.code() < 500));
+                .addCallAdapterFactory(CircuitBreakerCallAdapter.of(circuitBreaker, (r) -> r.code() < 500));
                 .baseUrl("http://localhost:8080/")
                 .build();
 ----

--- a/resilience4j-retrofit/README.adoc
+++ b/resilience4j-retrofit/README.adoc
@@ -1,8 +1,6 @@
-= Retrofit Circuitbreaker
+= resilience4j-retrofit
 
 https://square.github.io/retrofit/[Retrofit] client circuit breaking
-using
-https://github.com/robwin/javaslang-circuitbreaker[Javaslang-circuitbreaker]
 
 [source,java]
 ----
@@ -34,6 +32,5 @@ Retrofit retrofit = new Retrofit.Builder()
                 .build();
 ----
 
-For circuit breaking triggered by timeout the thresholds can be set on
-the OkHttpClient
+For circuit breaking triggered by timeout the thresholds can be set on the OkHttpClient
 

--- a/resilience4j-retrofit/README.adoc
+++ b/resilience4j-retrofit/README.adoc
@@ -1,0 +1,39 @@
+= Retrofit Circuitbreaker
+
+https://square.github.io/retrofit/[Retrofit] client circuit breaking
+using
+https://github.com/robwin/javaslang-circuitbreaker[Javaslang-circuitbreaker]
+
+[source,java]
+----
+// Create a CircuitBreaker
+private final CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
+
+// Create a retrofit instance with CircuitBreaker call adapter
+Retrofit retrofit = new Retrofit.Builder()
+                .addCallAdapterFactory(new CircuitBreakerCallAdapterFactory(circuitBreaker))
+                .baseUrl("http://localhost:8080/")
+                .build();
+                
+// Get an instance of your service with circuit breaking built in.
+RetrofitService service = retrofit.create(RetrofitService.class);
+----
+
+By default, all exceptions and responses where
+`!Response.isSuccessful()` will be recorded as an error in the
+CircuitBreaker.
+
+Customising what is considered a _successful_ response is possible like
+so:
+
+[source,java]
+----
+Retrofit retrofit = new Retrofit.Builder()
+                .addCallAdapterFactory(new CircuitBreakerCallAdapterFactory(circuitBreaker, (r) -> r.code() < 500));
+                .baseUrl("http://localhost:8080/")
+                .build();
+----
+
+For circuit breaking triggered by timeout the thresholds can be set on
+the OkHttpClient
+

--- a/resilience4j-retrofit/README.adoc
+++ b/resilience4j-retrofit/README.adoc
@@ -16,7 +16,7 @@ Retrofit retrofit = new Retrofit.Builder()
                 .addCallAdapterFactory(CircuitBreakerCallAdapter.of(circuitBreaker))
                 .baseUrl("http://localhost:8080/")
                 .build();
-                
+
 // Get an instance of your service with circuit breaking built in.
 RetrofitService service = retrofit.create(RetrofitService.class);
 ----
@@ -32,3 +32,13 @@ Retrofit retrofit = new Retrofit.Builder()
                 .baseUrl("http://localhost:8080/")
                 .build();
 ----
+
+== License
+
+Copyright 2017 Christopher Pilsworth
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/resilience4j-retrofit/build.gradle
+++ b/resilience4j-retrofit/build.gradle
@@ -1,0 +1,6 @@
+dependencies {
+    compile ( libraries.retrofit )
+    compile project(':resilience4j-circuitbreaker')
+    testCompile ( libraries.retrofit_test )
+    testCompile ( libraries.retrofit_wiremock )
+}

--- a/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/CircuitBreakerCallAdapter.java
+++ b/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/CircuitBreakerCallAdapter.java
@@ -12,19 +12,38 @@ import java.lang.reflect.Type;
 import java.util.function.Predicate;
 
 /**
- * Creates {@link CallAdapter} that decorates a {@link Call} to provide integration with a
- * Javaslang {@link CircuitBreaker} using {@link RetrofitCircuitBreaker}
+ * Creates a Retrofit {@link CallAdapter.Factory} that decorates a Call to provide integration with a
+ * {@link CircuitBreaker} using {@link RetrofitCircuitBreaker}
  */
-public final class CircuitBreakerCallAdapterFactory extends CallAdapter.Factory {
+public final class CircuitBreakerCallAdapter extends CallAdapter.Factory {
 
     private final CircuitBreaker circuitBreaker;
     private final Predicate<Response> successResponse;
 
-    public CircuitBreakerCallAdapterFactory(final CircuitBreaker circuitBreaker) {
+    /**
+     * Create a circuit-breaking call adapter that decorates retrofit calls
+     * @param circuitBreaker circuit breaker to use
+     * @return a {@link CallAdapter.Factory} that can be passed into the {@link Retrofit.Builder}
+     */
+    public static CircuitBreakerCallAdapter of(final CircuitBreaker circuitBreaker) {
+        return new CircuitBreakerCallAdapter(circuitBreaker);
+    }
+
+    /**
+     * Create a circuit-breaking call adapter that decorates retrofit calls
+     * @param circuitBreaker circuit breaker to use
+     * @param successResponse {@link Predicate} that determines whether the {@link Call} {@link Response} should be considered successful
+     * @return a {@link CallAdapter.Factory} that can be passed into the {@link Retrofit.Builder}
+     */
+    public static CircuitBreakerCallAdapter of(final CircuitBreaker circuitBreaker, final Predicate<Response> successResponse) {
+        return new CircuitBreakerCallAdapter(circuitBreaker, successResponse);
+    }
+
+    private CircuitBreakerCallAdapter(final CircuitBreaker circuitBreaker) {
         this(circuitBreaker, Response::isSuccessful);
     }
 
-    public CircuitBreakerCallAdapterFactory(final CircuitBreaker circuitBreaker, Predicate<Response> successResponse) {
+    private CircuitBreakerCallAdapter(final CircuitBreaker circuitBreaker, final Predicate<Response> successResponse) {
         this.circuitBreaker = circuitBreaker;
         this.successResponse = successResponse;
     }
@@ -49,7 +68,7 @@ public final class CircuitBreakerCallAdapterFactory extends CallAdapter.Factory 
         };
     }
 
-    static Type getCallResponseType(Type returnType) {
+    private static Type getCallResponseType(Type returnType) {
         if (!(returnType instanceof ParameterizedType)) {
             throw new IllegalArgumentException(
                     "Call return type must be parameterized as Call<Foo> or Call<? extends Foo>");

--- a/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/CircuitBreakerCallAdapter.java
+++ b/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/CircuitBreakerCallAdapter.java
@@ -26,7 +26,7 @@ public final class CircuitBreakerCallAdapter extends CallAdapter.Factory {
      * @return a {@link CallAdapter.Factory} that can be passed into the {@link Retrofit.Builder}
      */
     public static CircuitBreakerCallAdapter of(final CircuitBreaker circuitBreaker) {
-        return new CircuitBreakerCallAdapter(circuitBreaker);
+        return of(circuitBreaker, Response::isSuccessful);
     }
 
     /**
@@ -37,10 +37,6 @@ public final class CircuitBreakerCallAdapter extends CallAdapter.Factory {
      */
     public static CircuitBreakerCallAdapter of(final CircuitBreaker circuitBreaker, final Predicate<Response> successResponse) {
         return new CircuitBreakerCallAdapter(circuitBreaker, successResponse);
-    }
-
-    private CircuitBreakerCallAdapter(final CircuitBreaker circuitBreaker) {
-        this(circuitBreaker, Response::isSuccessful);
     }
 
     private CircuitBreakerCallAdapter(final CircuitBreaker circuitBreaker, final Predicate<Response> successResponse) {

--- a/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/CircuitBreakerCallAdapter.java
+++ b/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/CircuitBreakerCallAdapter.java
@@ -1,3 +1,21 @@
+/*
+ *
+ *  Copyright 2017 Christopher Pilsworth
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
 package io.github.resilience4j.retrofit;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;

--- a/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/CircuitBreakerCallAdapterFactory.java
+++ b/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/CircuitBreakerCallAdapterFactory.java
@@ -1,0 +1,62 @@
+package io.github.resilience4j.retrofit;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import retrofit2.Call;
+import retrofit2.CallAdapter;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.function.Predicate;
+
+/**
+ * Creates {@link CallAdapter} that decorates a {@link Call} to provide integration with a
+ * Javaslang {@link CircuitBreaker} using {@link RetrofitCircuitBreaker}
+ */
+public final class CircuitBreakerCallAdapterFactory extends CallAdapter.Factory {
+
+    private final CircuitBreaker circuitBreaker;
+    private final Predicate<Response> successResponse;
+    private final Predicate<Response> PREDICATE_IS_SUCCESSFUL = Response::isSuccessful;
+
+    public CircuitBreakerCallAdapterFactory(final CircuitBreaker circuitBreaker) {
+        this.circuitBreaker = circuitBreaker;
+        this.successResponse = PREDICATE_IS_SUCCESSFUL;
+    }
+
+    public CircuitBreakerCallAdapterFactory(final CircuitBreaker circuitBreaker, Predicate<Response> successResponse) {
+        this.circuitBreaker = circuitBreaker;
+        this.successResponse = successResponse;
+    }
+
+    @Override
+    public CallAdapter<?> get(Type returnType, Annotation[] annotations, Retrofit retrofit) {
+        if (getRawType(returnType) != Call.class) {
+            return null;
+        }
+
+        final Type responseType = getCallResponseType(returnType);
+        return new CallAdapter<Call<?>>() {
+            @Override
+            public Type responseType() {
+                return responseType;
+            }
+
+            @Override
+            public <R> Call<R> adapt(Call<R> call) {
+                return RetrofitCircuitBreaker.decorateCall(circuitBreaker, call, successResponse);
+            }
+        };
+    }
+
+    static Type getCallResponseType(Type returnType) {
+        if (!(returnType instanceof ParameterizedType)) {
+            throw new IllegalArgumentException(
+                    "Call return type must be parameterized as Call<Foo> or Call<? extends Foo>");
+        }
+        return getParameterUpperBound(0, (ParameterizedType) returnType);
+    }
+
+}

--- a/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/CircuitBreakerCallAdapterFactory.java
+++ b/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/CircuitBreakerCallAdapterFactory.java
@@ -19,11 +19,9 @@ public final class CircuitBreakerCallAdapterFactory extends CallAdapter.Factory 
 
     private final CircuitBreaker circuitBreaker;
     private final Predicate<Response> successResponse;
-    private final Predicate<Response> PREDICATE_IS_SUCCESSFUL = Response::isSuccessful;
 
     public CircuitBreakerCallAdapterFactory(final CircuitBreaker circuitBreaker) {
-        this.circuitBreaker = circuitBreaker;
-        this.successResponse = PREDICATE_IS_SUCCESSFUL;
+        this(circuitBreaker, Response::isSuccessful);
     }
 
     public CircuitBreakerCallAdapterFactory(final CircuitBreaker circuitBreaker, Predicate<Response> successResponse) {

--- a/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/RetrofitCircuitBreaker.java
+++ b/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/RetrofitCircuitBreaker.java
@@ -1,0 +1,88 @@
+package io.github.resilience4j.retrofit;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.utils.CircuitBreakerUtils;
+import io.github.resilience4j.metrics.StopWatch;
+import okhttp3.Request;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+import java.io.IOException;
+import java.util.function.Predicate;
+
+/**
+ * Decorates a Retrofit {@link Call} to inform a Javaslang {@link CircuitBreaker} when an exception is thrown.
+ * All exceptions are marked as errors or responses not matching the supplied predicate.  For example:
+ * <p>
+ * <code>
+ * RetrofitCircuitBreaker.decorateCall(circuitBreaker, call, (r) -> r.isSuccessful());
+ * </code>
+ */
+public interface RetrofitCircuitBreaker {
+
+    /**
+     * Decorate {@link Call}s allow {@link CircuitBreaker} functionality.
+     *
+     * @param circuitBreaker  {@link CircuitBreaker} to apply
+     * @param call            Call to decorate
+     * @param responseSuccess determines whether the response should be considered an expected response
+     * @param <T> Response type of call
+     * @return Original Call decorated with CircuitBreaker
+     */
+    static <T> Call<T> decorateCall(final CircuitBreaker circuitBreaker, final Call<T> call, final Predicate<Response> responseSuccess) {
+        return new Call<T>() {
+            @Override
+            public Response<T> execute() throws IOException {
+                CircuitBreakerUtils.isCallPermitted(circuitBreaker);
+                final StopWatch stopWatch = StopWatch.start(circuitBreaker.getName());
+                try {
+                    final Response<T> response = call.execute();
+
+                    if (responseSuccess.test(response)) {
+                        circuitBreaker.onSuccess(stopWatch.stop().getProcessingDuration());
+                    } else {
+                        final Throwable throwable = new Throwable("Response error: HTTP " + response.code() + " - " + response.message());
+                        circuitBreaker.onError(stopWatch.stop().getProcessingDuration(), throwable);
+                    }
+
+                    return response;
+                } catch (Throwable throwable) {
+                    circuitBreaker.onError(stopWatch.stop().getProcessingDuration(), throwable);
+                    throw throwable;
+                }
+            }
+
+            @Override
+            public void enqueue(Callback<T> callback) {
+                call.enqueue(callback);
+            }
+
+            @Override
+            public boolean isExecuted() {
+                return call.isExecuted();
+            }
+
+            @Override
+            public void cancel() {
+                call.cancel();
+            }
+
+            @Override
+            public boolean isCanceled() {
+                return call.isCanceled();
+            }
+
+            @Override
+            public Call<T> clone() {
+                return decorateCall(circuitBreaker, call.clone(), responseSuccess);
+            }
+
+            @Override
+            public Request request() {
+                return call.request();
+            }
+        };
+    }
+
+}

--- a/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/RetrofitCircuitBreaker.java
+++ b/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/RetrofitCircuitBreaker.java
@@ -16,7 +16,7 @@ import java.util.function.Predicate;
  * All exceptions are marked as errors or responses not matching the supplied predicate.  For example:
  * <p>
  * <code>
- * RetrofitCircuitBreaker.decorateCall(circuitBreaker, call, (r) -> r.isSuccessful());
+ * RetrofitCircuitBreaker.decorateCall(circuitBreaker, call, Response::isSuccessful);
  * </code>
  */
 public interface RetrofitCircuitBreaker {

--- a/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/RetrofitCircuitBreaker.java
+++ b/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/RetrofitCircuitBreaker.java
@@ -1,3 +1,21 @@
+/*
+ *
+ *  Copyright 2017 Christopher Pilsworth
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
 package io.github.resilience4j.retrofit;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;

--- a/resilience4j-retrofit/src/test/java/io/github/resilience4j/retrofit/RetrofitCircuitBreakerTest.java
+++ b/resilience4j-retrofit/src/test/java/io/github/resilience4j/retrofit/RetrofitCircuitBreakerTest.java
@@ -1,0 +1,107 @@
+package io.github.resilience4j.retrofit;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import okhttp3.OkHttpClient;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import retrofit2.Retrofit;
+import retrofit2.converter.scalars.ScalarsConverterFactory;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests the integration of the Retrofit HTTP client and JavaSlang-circuitbreaker.
+ * Validates that connection timeouts will trip circuit breaking
+ */
+public class RetrofitCircuitBreakerTest {
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule();
+
+    private RetrofitService service;
+    private final CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
+            .ringBufferSizeInClosedState(3)
+            .waitDurationInOpenState(Duration.ofMillis(1000))
+            .build();
+    private final CircuitBreaker circuitBreaker = CircuitBreaker.of("test", circuitBreakerConfig);
+
+
+    @Before
+    public void setUp() {
+        final long TIMEOUT = 300; // ms
+        OkHttpClient client = new OkHttpClient.Builder()
+                .connectTimeout(TIMEOUT, TimeUnit.MILLISECONDS)
+                .readTimeout(TIMEOUT, TimeUnit.MILLISECONDS)
+                .writeTimeout(TIMEOUT, TimeUnit.MILLISECONDS)
+                .build();
+
+        this.service = new Retrofit.Builder()
+                .addCallAdapterFactory(new CircuitBreakerCallAdapterFactory(circuitBreaker))
+                .addConverterFactory(ScalarsConverterFactory.create())
+                .baseUrl("http://localhost:8080/")
+                .client(client)
+                .build()
+                .create(RetrofitService.class);
+    }
+
+    @Test
+    public void decorateSuccessfulCall() throws Exception {
+        stubFor(get(urlPathEqualTo("/greeting"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("hello world")));
+
+        service.greeting().execute();
+
+        verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+    }
+
+    @Test
+    public void decorateTimingOutCall() throws Exception {
+        stubFor(get(urlPathEqualTo("/greeting"))
+                .willReturn(aResponse()
+                        .withFixedDelay(500)
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("hello world")));
+
+        try {
+            service.greeting().execute();
+        } catch (Throwable t) {
+        }
+
+        final CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertEquals(1, metrics.getNumberOfFailedCalls());
+
+        // Circuit breaker should still be closed, not hit open threshold
+        assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.getState());
+
+        try {
+            service.greeting().execute();
+        } catch (Throwable t) {
+        }
+
+        try {
+            service.greeting().execute();
+        } catch (Throwable t) {
+        }
+
+        assertEquals(3, metrics.getNumberOfFailedCalls());
+        // Circuit breaker should be OPEN, threshold met
+        assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+    }
+
+}

--- a/resilience4j-retrofit/src/test/java/io/github/resilience4j/retrofit/RetrofitCircuitBreakerTest.java
+++ b/resilience4j-retrofit/src/test/java/io/github/resilience4j/retrofit/RetrofitCircuitBreakerTest.java
@@ -1,3 +1,21 @@
+/*
+ *
+ *  Copyright 2017 Christopher Pilsworth
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
 package io.github.resilience4j.retrofit;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;

--- a/resilience4j-retrofit/src/test/java/io/github/resilience4j/retrofit/RetrofitCircuitBreakerTest.java
+++ b/resilience4j-retrofit/src/test/java/io/github/resilience4j/retrofit/RetrofitCircuitBreakerTest.java
@@ -27,8 +27,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 
 /**
- * Tests the integration of the Retrofit HTTP client and JavaSlang-circuitbreaker.
- * Validates that connection timeouts will trip circuit breaking
+ * Tests the integration of the Retrofit HTTP client and {@link CircuitBreaker}
  */
 public class RetrofitCircuitBreakerTest {
 
@@ -42,7 +41,6 @@ public class RetrofitCircuitBreakerTest {
             .build();
     private final CircuitBreaker circuitBreaker = CircuitBreaker.of("test", circuitBreakerConfig);
 
-
     @Before
     public void setUp() {
         final long TIMEOUT = 300; // ms
@@ -53,7 +51,7 @@ public class RetrofitCircuitBreakerTest {
                 .build();
 
         this.service = new Retrofit.Builder()
-                .addCallAdapterFactory(new CircuitBreakerCallAdapterFactory(circuitBreaker))
+                .addCallAdapterFactory(CircuitBreakerCallAdapter.of(circuitBreaker))
                 .addConverterFactory(ScalarsConverterFactory.create())
                 .baseUrl("http://localhost:8080/")
                 .client(client)
@@ -85,7 +83,7 @@ public class RetrofitCircuitBreakerTest {
 
         try {
             service.greeting().execute();
-        } catch (Throwable t) {
+        } catch (Throwable ignored) {
         }
 
         final CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
@@ -96,12 +94,12 @@ public class RetrofitCircuitBreakerTest {
 
         try {
             service.greeting().execute();
-        } catch (Throwable t) {
+        } catch (Throwable ignored) {
         }
 
         try {
             service.greeting().execute();
-        } catch (Throwable t) {
+        } catch (Throwable ignored) {
         }
 
         assertEquals(3, metrics.getNumberOfFailedCalls());

--- a/resilience4j-retrofit/src/test/java/io/github/resilience4j/retrofit/RetrofitService.java
+++ b/resilience4j-retrofit/src/test/java/io/github/resilience4j/retrofit/RetrofitService.java
@@ -1,0 +1,11 @@
+package io.github.resilience4j.retrofit;
+
+import retrofit2.Call;
+import retrofit2.http.GET;
+
+public interface RetrofitService {
+
+    @GET("greeting")
+    Call<String> greeting();
+
+}

--- a/resilience4j-retrofit/src/test/java/io/github/resilience4j/retrofit/RetrofitService.java
+++ b/resilience4j-retrofit/src/test/java/io/github/resilience4j/retrofit/RetrofitService.java
@@ -1,3 +1,21 @@
+/*
+ *
+ *  Copyright 2017 Christopher Pilsworth
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
 package io.github.resilience4j.retrofit;
 
 import retrofit2.Call;

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,4 +11,5 @@ include 'resilience4j-consumer'
 include 'resilience4j-test'
 include 'resilience4j-vertx'
 include 'resilience4j-spring-boot'
+include 'resilience4j-retrofit'
 


### PR DESCRIPTION
I took the code from [cpilsworth/retrofit-circuitbreaker](https://github.com/cpilsworth/retrofit-circuitbreaker) to be a module within this project.

The code is within the `resilience4j-retrofit` module and within the `io.github.resilience4j.retrofit` package.  CircuitBreaker support is there right now, but rate limiting etc could be added later.

I haven't pulled across the [README](https://github.com/cpilsworth/retrofit-circuitbreaker/blob/master/README.md) from the project - let me know where you want that & I will bring it across.  

I noticed that a few of the other modules still have share a common `io.github.resilience4j.circuitbreaker` package - if you plan to allow modules to be deployed independently, this might be a problem for OSGi bundles or Java 9 modules.  Java 9 modules will expect only a single module to export a package, OSGi will expect only a single bundle to export a _version_ of a package.