### PR TITLE
Adds retry metrics for #72

### DIFF
--- a/resilience4j-metrics/build.gradle
+++ b/resilience4j-metrics/build.gradle
@@ -1,8 +1,12 @@
 dependencies {
     compile (libraries.metrics)
     compileOnly project(':resilience4j-circuitbreaker')
+    compileOnly project(':resilience4j-retry')
     compileOnly project(':resilience4j-ratelimiter')
     testCompile project(':resilience4j-test')
     testCompile project(':resilience4j-circuitbreaker')
     testCompile project(':resilience4j-ratelimiter')
+    testCompile project(':resilience4j-retry')
+    testCompile project(':resilience4j-test')
+    testCompile project(':resilience4j-circuitbreaker')
 }

--- a/resilience4j-metrics/src/main/java/io/github/resilience4j/metrics/RetryMetrics.java
+++ b/resilience4j-metrics/src/main/java/io/github/resilience4j/metrics/RetryMetrics.java
@@ -1,0 +1,82 @@
+package io.github.resilience4j.metrics;
+
+import com.codahale.metrics.*;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryRegistry;
+import javaslang.collection.Array;
+
+import java.util.Map;
+
+import static com.codahale.metrics.MetricRegistry.name;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * An adapter which exports {@link Retry.Metrics} as Dropwizard Metrics Gauges.
+ */
+public class RetryMetrics implements MetricSet {
+
+    private final MetricRegistry metricRegistry = new MetricRegistry();
+    private static final String DEFAULT_PREFIX = "resilience4j.retry";
+
+    private RetryMetrics(Iterable<Retry> retries){
+        this(DEFAULT_PREFIX, retries);
+    }
+
+    private RetryMetrics(String prefix, Iterable<Retry> retries){
+        requireNonNull(prefix);
+        requireNonNull(retries);
+        retries.forEach(retry -> {
+            String name = retry.getName();
+            Retry.Metrics metrics = retry.getMetrics();
+
+            metricRegistry.register(name(prefix, name, "retry_max_ratio"),
+                    new RetryRatio(metrics.getNumAttempts(), metrics.getMaxAttempts()));
+            
+        });
+    }
+
+    public static RetryMetrics ofRateLimiterRegistry(String prefix, RetryRegistry retryRegistry) {
+        return new RetryMetrics(prefix, retryRegistry.getAllRetries());
+    }
+
+    public static RetryMetrics ofRateLimiterRegistry(RetryRegistry retryRegistry) {
+        return new RetryMetrics(retryRegistry.getAllRetries());
+    }
+
+    public static RetryMetrics ofIterable(String prefix, Iterable<Retry> retries) {
+        return new RetryMetrics(prefix, retries);
+    }
+
+    public static RetryMetrics ofIterable(Iterable<Retry> retries) {
+        return new RetryMetrics(retries);
+    }
+
+    public static RetryMetrics ofRateLimiter(Retry retry) {
+        return new RetryMetrics(Array.of(retry));
+    }
+
+    @Override
+    public Map<String, Metric> getMetrics() {
+        return metricRegistry.getMetrics();
+    }
+
+    /**
+     * Implements a {@link RatioGauge} that represents the ratio between attempts made, and the maximum allowed retry attempts.
+     */
+    private final class RetryRatio extends RatioGauge {
+
+        private double numAttempts;
+
+        private double maxAttempts;
+
+        public RetryRatio(int numAttempts, int maxAttempts) {
+            this.numAttempts = (double) numAttempts;
+            this.maxAttempts = (double) maxAttempts;
+        }
+
+        @Override
+        protected Ratio getRatio() {
+            return Ratio.of(numAttempts, maxAttempts);
+        }
+    }
+}

--- a/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/RetryMetricsTest.java
+++ b/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/RetryMetricsTest.java
@@ -1,0 +1,89 @@
+package io.github.resilience4j.metrics;
+
+import com.codahale.metrics.MetricRegistry;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryRegistry;
+import io.github.resilience4j.test.HelloWorldService;
+import javaslang.control.Try;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.BDDMockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+public class RetryMetricsTest {
+
+    private MetricRegistry metricRegistry;
+    private HelloWorldService helloWorldService;
+
+    @Before
+    public void setUp(){
+        metricRegistry = new MetricRegistry();
+        helloWorldService = mock(HelloWorldService.class);
+    }
+
+    @Test
+    public void shouldRegisterMetrics() throws Throwable {
+        //Given
+        RetryRegistry retryRegistry = RetryRegistry.ofDefaults();
+        Retry retry = retryRegistry.retry("testName");
+        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
+        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
+        metricRegistry.registerAll(RetryMetrics.ofRateLimiterRegistry(retryRegistry));
+
+        // Given the HelloWorldService returns Hello world
+        BDDMockito.given(helloWorldService.returnHelloWorld()).willReturn("Hello world");
+
+        // Setup circuitbreaker with retry
+        Try.CheckedSupplier<String> decoratedSupplier = CircuitBreaker
+                .decorateCheckedSupplier(circuitBreaker, helloWorldService::returnHelloWorld);
+        decoratedSupplier = Retry
+                .decorateCheckedSupplier(retry, decoratedSupplier);
+
+
+        //When
+        String value = Try.of(decoratedSupplier)
+                .recover(throwable -> "Hello from Recovery").get();
+
+        //Then
+        assertThat(value).isEqualTo("Hello world");
+        // Then the helloWorldService should be invoked 1 time
+        BDDMockito.then(helloWorldService).should(times(1)).returnHelloWorld();
+        assertThat(metricRegistry.getMetrics()).hasSize(1);
+        assertThat(metricRegistry.getGauges().get("resilience4j.retry.testName.retry_max_ratio").getValue()).isEqualTo(0.0);
+    }
+
+    @Test
+    public void shouldUseCustomPrefix() throws Throwable {
+        //Given
+        RetryRegistry retryRegistry = RetryRegistry.ofDefaults();
+        Retry retry = retryRegistry.retry("testName");
+        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
+        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
+        metricRegistry.registerAll(RetryMetrics.ofRateLimiterRegistry("testPrefix",retryRegistry));
+
+        // Given the HelloWorldService returns Hello world
+        BDDMockito.given(helloWorldService.returnHelloWorld()).willReturn("Hello world");
+
+        // Setup circuitbreaker with retry
+        Try.CheckedSupplier<String> decoratedSupplier = CircuitBreaker
+                .decorateCheckedSupplier(circuitBreaker, helloWorldService::returnHelloWorld);
+        decoratedSupplier = Retry
+                .decorateCheckedSupplier(retry, decoratedSupplier);
+
+        //When
+        String value = Try.of(decoratedSupplier)
+                .recover(throwable -> "Hello from Recovery").get();
+
+        //Then
+        assertThat(value).isEqualTo("Hello world");
+        // Then the helloWorldService should be invoked 1 time
+        BDDMockito.then(helloWorldService).should(times(1)).returnHelloWorld();
+        assertThat(metricRegistry.getMetrics()).hasSize(1);
+        assertThat(metricRegistry.getGauges().get("testPrefix.testName.retry_max_ratio").getValue()).isEqualTo(0.0);
+    }
+}

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/AsyncRetry.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/AsyncRetry.java
@@ -17,7 +17,7 @@ public interface AsyncRetry {
      *
      * @return the ID of this Retry
      */
-    String getId();
+    String getName();
 
     /**
      *  Records a successful call.
@@ -94,6 +94,29 @@ public interface AsyncRetry {
 
             return promise;
         };
+    }
+
+    /**
+     * Get the Metrics of this RateLimiter.
+     *
+     * @return the Metrics of this RateLimiter
+     */
+    Metrics getMetrics();
+
+    interface Metrics {
+        /**
+         * Returns how many attempts this have been made by this retry.
+         *
+         * @return how many retries have been attempted, but failed.
+         */
+        int getNumAttempts();
+
+        /**
+         * Returns how many retry attempts are allowed before failure.
+         *
+         * @return how many retries are allowed before failure.
+         */
+        int getMaxAttempts();
     }
 }
 

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/Retry.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/Retry.java
@@ -34,7 +34,7 @@ public interface Retry {
      *
      * @return the ID of this Retry
      */
-    String getId();
+    String getName();
 
     /**
      *  Records a successful call.
@@ -66,35 +66,35 @@ public interface Retry {
     /**
      * Creates a Retry with a custom Retry configuration.
      *
-     * @param id the ID of the Retry
+     * @param name the ID of the Retry
      * @param retryConfig a custom Retry configuration
      *
      * @return a Retry with a custom Retry configuration.
      */
-    static RetryContext of(String id, RetryConfig retryConfig){
-        return new RetryContext(id, retryConfig);
+    static RetryContext of(String name, RetryConfig retryConfig){
+        return new RetryContext(name, retryConfig);
     }
 
     /**
      * Creates a Retry with a custom Retry configuration.
      *
-     * @param id the ID of the Retry
+     * @param name the ID of the Retry
      * @param retryConfigSupplier a supplier of a custom Retry configuration
      *
      * @return a Retry with a custom Retry configuration.
      */
-    static RetryContext of(String id, Supplier<RetryConfig> retryConfigSupplier){
-        return new RetryContext(id, retryConfigSupplier.get());
+    static RetryContext of(String name, Supplier<RetryConfig> retryConfigSupplier){
+        return new RetryContext(name, retryConfigSupplier.get());
     }
 
     /**
      * Creates a Retry with default configuration.
      *
-     * @param id the ID of the Retry
+     * @param name the ID of the Retry
      * @return a Retry with default configuration
      */
-    static Retry ofDefaults(String id){
-        return new RetryContext(id, RetryConfig.ofDefaults());
+    static Retry ofDefaults(String name){
+        return new RetryContext(name, RetryConfig.ofDefaults());
     }
 
     /**
@@ -277,4 +277,26 @@ public interface Retry {
         };
     }
 
+    /**
+     * Get the Metrics of this RateLimiter.
+     *
+     * @return the Metrics of this RateLimiter
+     */
+    Metrics getMetrics();
+
+    interface Metrics {
+        /**
+         * Returns how many attempts this have been made by this retry.
+         *
+         * @return how many retries have been attempted, but failed.
+         */
+        int getNumAttempts();
+
+        /**
+         * Returns how many retry attempts are allowed before failure.
+         *
+         * @return how many retries are allowed before failure.
+         */
+        int getMaxAttempts();
+    }
 }

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/event/AbstractRetryEvent.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/event/AbstractRetryEvent.java
@@ -22,21 +22,21 @@ import java.time.ZonedDateTime;
 
 abstract class AbstractRetryEvent implements RetryEvent {
 
-    private final String id;
+    private final String name;
     private final ZonedDateTime creationTime;
     private final int numberOfAttempts;
     private final Throwable lastThrowable;
 
-    AbstractRetryEvent(String id, int numberOfAttempts, Throwable lastThrowable) {
-        this.id = id;
+    AbstractRetryEvent(String name, int numberOfAttempts, Throwable lastThrowable) {
+        this.name = name;
         this.numberOfAttempts = numberOfAttempts;
         this.creationTime = ZonedDateTime.now();
         this.lastThrowable = lastThrowable;
     }
 
     @Override
-    public String getId() {
-        return id;
+    public String getName() {
+        return name;
     }
 
     @Override

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/event/RetryEvent.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/event/RetryEvent.java
@@ -30,7 +30,7 @@ public interface RetryEvent {
      *
      * @return the ID of the Retry
      */
-    String getId();
+    String getName();
 
     /**
      * Returns the number of attempts.

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/event/RetryOnErrorEvent.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/event/RetryOnErrorEvent.java
@@ -23,8 +23,8 @@ package io.github.resilience4j.retry.event;
  */
 public class RetryOnErrorEvent extends AbstractRetryEvent {
 
-    public RetryOnErrorEvent(String id, int numberOfAttempts, Throwable lastThrowable) {
-        super(id, numberOfAttempts, lastThrowable);
+    public RetryOnErrorEvent(String name, int numberOfAttempts, Throwable lastThrowable) {
+        super(name, numberOfAttempts, lastThrowable);
     }
     @Override
     public Type getEventType() {
@@ -35,7 +35,7 @@ public class RetryOnErrorEvent extends AbstractRetryEvent {
     public String toString() {
         return String.format("%s: Retry '%s' recorded a failed retry attempt. Number of retry attempts: '%d', Last exception was: '%s'.",
                 getCreationTime(),
-                getId(),
+                getName(),
                 getNumberOfAttempts(),
                 getLastThrowable().toString());
     }

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/event/RetryOnSuccessEvent.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/event/RetryOnSuccessEvent.java
@@ -23,8 +23,8 @@ package io.github.resilience4j.retry.event;
  */
 public class RetryOnSuccessEvent extends AbstractRetryEvent {
 
-    public RetryOnSuccessEvent(String id, int currentNumOfAttempts, Throwable lastThrowable) {
-        super(id, currentNumOfAttempts, lastThrowable);
+    public RetryOnSuccessEvent(String name, int currentNumOfAttempts, Throwable lastThrowable) {
+        super(name, currentNumOfAttempts, lastThrowable);
     }
 
     @Override
@@ -36,7 +36,7 @@ public class RetryOnSuccessEvent extends AbstractRetryEvent {
     public String toString() {
         return String.format("%s: Retry '%s' recorded a successful retry attempt. Number of retry attempts: '%d', Last exception was: '%s'.",
                 getCreationTime(),
-                getId(),
+                getName(),
                 getNumberOfAttempts(),
                 getLastThrowable().toString());
     }

--- a/resilience4j-retry/src/test/java/io/github/resilience4j/retry/RetryRegistryTest.java
+++ b/resilience4j-retry/src/test/java/io/github/resilience4j/retry/RetryRegistryTest.java
@@ -35,7 +35,7 @@ public class RetryRegistryTest {
     public void shouldReturnTheCorrectName() {
         Retry retry = retryRegistry.retry("testName");
         Assertions.assertThat(retry).isNotNull();
-        Assertions.assertThat(retry.getId()).isEqualTo("testName");
+        Assertions.assertThat(retry.getName()).isEqualTo("testName");
     }
 
     @Test

--- a/resilience4j-retry/src/test/java/io/github/resilience4j/retry/event/RetryEventTest.java
+++ b/resilience4j-retry/src/test/java/io/github/resilience4j/retry/event/RetryEventTest.java
@@ -31,7 +31,7 @@ public class RetryEventTest {
     public void testRetryOnErrorEvent() {
         RetryOnErrorEvent retryOnErrorEvent = new RetryOnErrorEvent("test", 2,
                 new IOException());
-        Assertions.assertThat(retryOnErrorEvent.getId()).isEqualTo("test");
+        Assertions.assertThat(retryOnErrorEvent.getName()).isEqualTo("test");
         Assertions.assertThat(retryOnErrorEvent.getNumberOfAttempts()).isEqualTo(2);
         Assertions.assertThat(retryOnErrorEvent.getEventType()).isEqualTo(Type.ERROR);
         Assertions.assertThat(retryOnErrorEvent.getLastThrowable()).isInstanceOf(IOException.class);
@@ -42,7 +42,7 @@ public class RetryEventTest {
     public void testRetryOnSuccessEvent() {
         RetryOnSuccessEvent retryOnSuccessEvent = new RetryOnSuccessEvent("test", 2,
                 new IOException());
-        Assertions.assertThat(retryOnSuccessEvent.getId()).isEqualTo("test");
+        Assertions.assertThat(retryOnSuccessEvent.getName()).isEqualTo("test");
         Assertions.assertThat(retryOnSuccessEvent.getNumberOfAttempts()).isEqualTo(2);
         Assertions.assertThat(retryOnSuccessEvent.getEventType()).isEqualTo(Type.SUCCESS);
         Assertions.assertThat(retryOnSuccessEvent.getLastThrowable()).isInstanceOf(IOException.class);


### PR DESCRIPTION
I also refactored `id` to `name` to match the conventions set for the rateLimiter and circuitBreaker classes. 

It looks like there's not a registry for AsyncRetry, and it looks like this feature isn't quite complete? So I didn't bother setting up metrics for it. Let me know if you also want this in a separate PR.