### PR TITLE
Add rate limiting to the retrofit module

### DIFF
--- a/resilience4j-documentation/src/docs/asciidoc/retrofit.adoc
+++ b/resilience4j-documentation/src/docs/asciidoc/retrofit.adoc
@@ -1,10 +1,10 @@
 = resilience4j-retrofit
 
-https://square.github.io/retrofit/[Retrofit] client circuit breaking.  Short-circuits http client calls based upon the policy
-associated to the CircuitBreaker instance provided.
+https://square.github.io/retrofit/[Retrofit] client circuit breaking & rate limiting.
 
-For circuit breaking triggered by timeout the thresholds can be set
-on a OkHttpClient which can be set on the Retrofit.Builder.
+== Circuit Breaking
+
+Circuit breaking http client calls is based upon the `CircuitBreaker` instance provided to a `CircuitBreakerCallAdaptor`.
 
 [source,java]
 ----
@@ -16,19 +16,61 @@ Retrofit retrofit = new Retrofit.Builder()
                 .addCallAdapterFactory(CircuitBreakerCallAdapter.of(circuitBreaker))
                 .baseUrl("http://localhost:8080/")
                 .build();
-                
+
 // Get an instance of your service with circuit breaking built in.
 RetrofitService service = retrofit.create(RetrofitService.class);
 ----
 
-By default, all exceptions and responses where `!Response.isSuccessful()` will be recorded as an error in the CircuitBreaker.
+=== Timeouts
+To trigger circuit breaking by timeout, the time thresholds should be set on a `OkHttpClient` instance passed into the
+`Retrofit.Builder`.
+
+[source,java]
+----
+// Create a CircuitBreaker
+private final CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
+
+final long TIMEOUT = 300; // ms
+OkHttpClient client = new OkHttpClient.Builder()
+        .connectTimeout(TIMEOUT, TimeUnit.MILLISECONDS)
+        .readTimeout(TIMEOUT, TimeUnit.MILLISECONDS)
+        .writeTimeout(TIMEOUT, TimeUnit.MILLISECONDS)
+        .build();
+
+Retrofit retrofit = new Retrofit.Builder()
+        .addCallAdapterFactory(CircuitBreakerCallAdapter.of(circuitBreaker))
+        .baseUrl("http://localhost:8080/")
+        .client(client)
+        .build();
+----
+
+=== Error responses
+
+By default, all exceptions and responses where `!Response.isSuccessful()` will be recorded as an error in the `CircuitBreaker`.
 
 Customising what is considered a _successful_ response is possible like so:
 
 [source,java]
 ----
 Retrofit retrofit = new Retrofit.Builder()
-                .addCallAdapterFactory(CircuitBreakerCallAdapter.of(circuitBreaker, (r) -> r.code() < 500));
-                .baseUrl("http://localhost:8080/")
-                .build();
+        .addCallAdapterFactory(CircuitBreakerCallAdapter.of(circuitBreaker, (r) -> r.code() < 500));
+        .baseUrl("http://localhost:8080/")
+        .build();
 ----
+
+== Rate Limiting
+
+Rate limiting of http client calls is based upon the configuration passed to the RateLimiterCallAdaptor.
+
+[source, java]
+----
+RateLimiter rateLimiter = RateLimiter.ofDefaults("testName");
+
+Retrofit retrofit = new Retrofit.Builder()
+        .addCallAdapterFactory(RateLimiterCallAdapter.of(rateLimiter))
+        .baseUrl("http://localhost:8080/")
+        .build();
+----
+
+
+If the number of calls are exceeded within the period defined by the RateLimiter, a HTTP 429 response (too many requests) will be returned.

--- a/resilience4j-retrofit/README.adoc
+++ b/resilience4j-retrofit/README.adoc
@@ -1,10 +1,10 @@
 = resilience4j-retrofit
 
-https://square.github.io/retrofit/[Retrofit] client circuit breaking.  Short-circuits http client calls based upon the policy
-associated to the CircuitBreaker instance provided.
+https://square.github.io/retrofit/[Retrofit] client circuit breaking & rate limiting.
 
-For circuit breaking triggered by timeout the thresholds can be set
-on a OkHttpClient which can be set on the Retrofit.Builder.
+== Circuit Breaking
+
+Circuit breaking http client calls is based upon the `CircuitBreaker` instance provided to a `CircuitBreakerCallAdaptor`.
 
 [source,java]
 ----
@@ -21,17 +21,59 @@ Retrofit retrofit = new Retrofit.Builder()
 RetrofitService service = retrofit.create(RetrofitService.class);
 ----
 
-By default, all exceptions and responses where `!Response.isSuccessful()` will be recorded as an error in the CircuitBreaker.
+=== Timeouts
+To trigger circuit breaking by timeout, the time thresholds should be set on a `OkHttpClient` instance passed into the
+`Retrofit.Builder`.
+
+[source,java]
+----
+// Create a CircuitBreaker
+private final CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
+
+final long TIMEOUT = 300; // ms
+OkHttpClient client = new OkHttpClient.Builder()
+        .connectTimeout(TIMEOUT, TimeUnit.MILLISECONDS)
+        .readTimeout(TIMEOUT, TimeUnit.MILLISECONDS)
+        .writeTimeout(TIMEOUT, TimeUnit.MILLISECONDS)
+        .build();
+
+Retrofit retrofit = new Retrofit.Builder()
+        .addCallAdapterFactory(CircuitBreakerCallAdapter.of(circuitBreaker))
+        .baseUrl("http://localhost:8080/")
+        .client(client)
+        .build();
+----
+
+=== Error responses
+
+By default, all exceptions and responses where `!Response.isSuccessful()` will be recorded as an error in the `CircuitBreaker`.
 
 Customising what is considered a _successful_ response is possible like so:
 
 [source,java]
 ----
 Retrofit retrofit = new Retrofit.Builder()
-                .addCallAdapterFactory(CircuitBreakerCallAdapter.of(circuitBreaker, (r) -> r.code() < 500));
-                .baseUrl("http://localhost:8080/")
-                .build();
+        .addCallAdapterFactory(CircuitBreakerCallAdapter.of(circuitBreaker, (r) -> r.code() < 500));
+        .baseUrl("http://localhost:8080/")
+        .build();
 ----
+
+== Rate Limiting
+
+Rate limiting of http client calls is based upon the configuration passed to the RateLimiterCallAdaptor.
+
+[source, java]
+----
+RateLimiter rateLimiter = RateLimiter.ofDefaults("testName");
+
+Retrofit retrofit = new Retrofit.Builder()
+        .addCallAdapterFactory(RateLimiterCallAdapter.of(rateLimiter))
+        .baseUrl("http://localhost:8080/")
+        .build();
+----
+
+
+If the number of calls are exceeded within the period defined by the RateLimiter, a HTTP 429 response (too many requests) will be returned.
 
 == License
 

--- a/resilience4j-retrofit/build.gradle
+++ b/resilience4j-retrofit/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     compile ( libraries.retrofit )
     compile project(':resilience4j-circuitbreaker')
+    compile project(':resilience4j-ratelimiter')
     testCompile ( libraries.retrofit_test )
     testCompile ( libraries.retrofit_wiremock )
 }

--- a/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/RateLimiterCallAdapter.java
+++ b/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/RateLimiterCallAdapter.java
@@ -18,48 +18,35 @@
  */
 package io.github.resilience4j.retrofit;
 
-import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.ratelimiter.RateLimiter;
 import retrofit2.Call;
 import retrofit2.CallAdapter;
-import retrofit2.Response;
 import retrofit2.Retrofit;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.function.Predicate;
 
 /**
  * Creates a Retrofit {@link CallAdapter.Factory} that decorates a Call to provide integration with a
- * {@link CircuitBreaker}
+ * supplied {@link RateLimiter}
  */
-public final class CircuitBreakerCallAdapter extends CallAdapter.Factory {
+public final class RateLimiterCallAdapter extends CallAdapter.Factory {
 
-    private final CircuitBreaker circuitBreaker;
-    private final Predicate<Response> successResponse;
-
-    /**
-     * Create a circuit-breaking call adapter that decorates retrofit calls
-     * @param circuitBreaker circuit breaker to use
-     * @return a {@link CallAdapter.Factory} that can be passed into the {@link Retrofit.Builder}
-     */
-    public static CircuitBreakerCallAdapter of(final CircuitBreaker circuitBreaker) {
-        return of(circuitBreaker, Response::isSuccessful);
-    }
+    private final RateLimiter rateLimiter;
 
     /**
-     * Create a circuit-breaking call adapter that decorates retrofit calls
-     * @param circuitBreaker circuit breaker to use
-     * @param successResponse {@link Predicate} that determines whether the {@link Call} {@link Response} should be considered successful
+     * Create a rate-limiting call adapter factory that decorates retrofit calls
+     *
+     * @param rateLimiter rate limiter to use
      * @return a {@link CallAdapter.Factory} that can be passed into the {@link Retrofit.Builder}
      */
-    public static CircuitBreakerCallAdapter of(final CircuitBreaker circuitBreaker, final Predicate<Response> successResponse) {
-        return new CircuitBreakerCallAdapter(circuitBreaker, successResponse);
+    public static RateLimiterCallAdapter of(final RateLimiter rateLimiter) {
+        return new RateLimiterCallAdapter(rateLimiter);
     }
 
-    private CircuitBreakerCallAdapter(final CircuitBreaker circuitBreaker, final Predicate<Response> successResponse) {
-        this.circuitBreaker = circuitBreaker;
-        this.successResponse = successResponse;
+    private RateLimiterCallAdapter(final RateLimiter rateLimiter) {
+        this.rateLimiter = rateLimiter;
     }
 
     @Override
@@ -77,7 +64,7 @@ public final class CircuitBreakerCallAdapter extends CallAdapter.Factory {
 
             @Override
             public <R> Call<R> adapt(Call<R> call) {
-                return RetrofitCircuitBreaker.decorateCall(circuitBreaker, call, successResponse);
+                return RetrofitRateLimiter.decorateCall(rateLimiter, call);
             }
         };
     }

--- a/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/RetrofitRateLimiter.java
+++ b/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/RetrofitRateLimiter.java
@@ -1,0 +1,70 @@
+/*
+ *
+ *  Copyright 2017 Christopher Pilsworth
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.retrofit;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import io.github.resilience4j.retrofit.internal.DecoratedCall;
+import javaslang.control.Try;
+import okhttp3.MediaType;
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.Response;
+
+import java.io.IOException;
+
+/**
+ * Decorates a Retrofit {@link Call} to check with a {@link RateLimiter} if a call can be made.
+ * Returns an error response with a HTTP 429 (too many requests) code and a message which indicates that the client
+ * prevented the request.
+ *
+ * <p>
+ * <code>
+ * RetrofitRateLimiter.decorateCall(rateLimiter, call);
+ * </code>
+ */
+public interface RetrofitRateLimiter {
+
+    int ERROR_CODE = 429;
+    String ERROR_MESSAGE = "Too many requests for the client";
+
+    /**
+     * Decorate {@link Call}s allow {@link CircuitBreaker} functionality.
+     *
+     * @param rateLimiter  {@link RateLimiter} to apply
+     * @param call            Call to decorate
+     * @param <T> Response type of call
+     * @return Original Call decorated with CircuitBreaker
+     */
+    static <T> Call<T> decorateCall(final RateLimiter rateLimiter, final Call<T> call) {
+        return new DecoratedCall<T>(call) {
+            @Override
+            public Response<T> execute() throws IOException {
+                Try.CheckedSupplier<Response<T>> restrictedSupplier = RateLimiter.decorateCheckedSupplier(rateLimiter, call::execute);
+                final Try<Response<T>> response = Try.of(restrictedSupplier);
+                return response.isSuccess() ? response.get() : tooManyRequestsError();
+            }
+
+            private Response<T> tooManyRequestsError() {
+                return Response.error(ERROR_CODE, ResponseBody.create(MediaType.parse("text/plain"), ERROR_MESSAGE));
+            }
+        };
+    }
+
+}

--- a/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/internal/DecoratedCall.java
+++ b/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/internal/DecoratedCall.java
@@ -26,7 +26,7 @@ import retrofit2.Response;
 import java.io.IOException;
 
 /**
- * Simple decorator class that implements Call<T> and delegates all calls the the Call instance
+ * Simple decorator class that implements Call&lt;T&gt; and delegates all calls the the Call instance
  * provided in the constructor.  Methods can be overridden as required.
  * @param <T> Call parameter type
  */

--- a/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/internal/DecoratedCall.java
+++ b/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/internal/DecoratedCall.java
@@ -1,0 +1,75 @@
+/*
+ *
+ *  Copyright 2017 Christopher Pilsworth
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.retrofit.internal;
+
+import okhttp3.Request;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+import java.io.IOException;
+
+/**
+ * Simple decorator class that implements Call<T> and delegates all calls the the Call instance
+ * provided in the constructor.  Methods can be overridden as required.
+ * @param <T> Call parameter type
+ */
+public class DecoratedCall<T> implements Call<T> {
+
+    private final Call<T> call;
+
+    public DecoratedCall(Call<T> call) {
+        this.call = call;
+    }
+
+    @Override
+    public Response<T> execute() throws IOException {
+        return this.call.execute();
+    }
+
+    @Override
+    public void enqueue(Callback<T> callback) {
+        call.enqueue(callback);
+    }
+
+    @Override
+    public boolean isExecuted() {
+        return call.isExecuted();
+    }
+
+    @Override
+    public void cancel() {
+        call.cancel();
+    }
+
+    @Override
+    public boolean isCanceled() {
+        return call.isCanceled();
+    }
+
+    @Override
+    public Call<T> clone() {
+        return call.clone();
+    }
+
+    @Override
+    public Request request() {
+        return call.request();
+    }
+}

--- a/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/internal/DecoratedCall.java
+++ b/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/internal/DecoratedCall.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 /**
  * Simple decorator class that implements Call&lt;T&gt; and delegates all calls the the Call instance
  * provided in the constructor.  Methods can be overridden as required.
+ *
  * @param <T> Call parameter type
  */
 public class DecoratedCall<T> implements Call<T> {

--- a/resilience4j-retrofit/src/test/java/io/github/resilience4j/retrofit/BadRetrofitService.java
+++ b/resilience4j-retrofit/src/test/java/io/github/resilience4j/retrofit/BadRetrofitService.java
@@ -1,0 +1,29 @@
+/*
+ *
+ *  Copyright 2017 Christopher Pilsworth
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.retrofit;
+
+import retrofit2.Call;
+import retrofit2.http.GET;
+
+public interface BadRetrofitService {
+
+    @GET("greeting")
+    Call greeting();
+
+}

--- a/resilience4j-retrofit/src/test/java/io/github/resilience4j/retrofit/RetrofitCircuitBreakerTest.java
+++ b/resilience4j-retrofit/src/test/java/io/github/resilience4j/retrofit/RetrofitCircuitBreakerTest.java
@@ -48,17 +48,21 @@ public class RetrofitCircuitBreakerTest {
     @Rule
     public WireMockRule wireMockRule = new WireMockRule();
 
-    private RetrofitService service;
-    private final CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
+    private static final CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
             .ringBufferSizeInClosedState(3)
             .waitDurationInOpenState(Duration.ofMillis(1000))
             .build();
-    private final CircuitBreaker circuitBreaker = CircuitBreaker.of("test", circuitBreakerConfig);
+
+    private CircuitBreaker circuitBreaker = CircuitBreaker.of("test", circuitBreakerConfig);
+
+    private RetrofitService service;
 
     @Before
     public void setUp() {
+        this.circuitBreaker = CircuitBreaker.of("test", circuitBreakerConfig);
+
         final long TIMEOUT = 300; // ms
-        OkHttpClient client = new OkHttpClient.Builder()
+        final OkHttpClient client = new OkHttpClient.Builder()
                 .connectTimeout(TIMEOUT, TimeUnit.MILLISECONDS)
                 .readTimeout(TIMEOUT, TimeUnit.MILLISECONDS)
                 .writeTimeout(TIMEOUT, TimeUnit.MILLISECONDS)
@@ -125,7 +129,6 @@ public class RetrofitCircuitBreakerTest {
         assertThat(circuitBreaker.getState())
                 .isEqualTo(CircuitBreaker.State.OPEN);
     }
-
 
     @Test
     public void decorateUnsuccessfulCall() throws Exception {

--- a/resilience4j-retrofit/src/test/java/io/github/resilience4j/retrofit/RetrofitRateLimiterTest.java
+++ b/resilience4j-retrofit/src/test/java/io/github/resilience4j/retrofit/RetrofitRateLimiterTest.java
@@ -36,9 +36,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 /**
  * Tests the integration of the Retrofit HTTP client and {@link RateLimiter}
@@ -88,11 +86,17 @@ public class RetrofitRateLimiterTest {
                         .withBody("hello world")));
 
         final Response<String> execute = service.greeting().execute();
-        assertTrue(execute.isSuccessful());
+        assertThat(execute.isSuccessful())
+                .describedAs("Response successful")
+                .isTrue();
 
         final Response<String> rateLimitedResponse = service.greeting().execute();
-        assertFalse("Expected unsuccessful, rate limited, response", rateLimitedResponse.isSuccessful());
-        assertEquals("Expected too many requests error code", 429, rateLimitedResponse.code());
+        assertThat(rateLimitedResponse.isSuccessful())
+                .describedAs("Response successful")
+                .isFalse();
+        assertThat(rateLimitedResponse.code())
+                .describedAs("HTTP Error Code")
+                .isEqualTo(429);
 
     }
 

--- a/resilience4j-retrofit/src/test/java/io/github/resilience4j/retrofit/RetrofitRateLimiterTest.java
+++ b/resilience4j-retrofit/src/test/java/io/github/resilience4j/retrofit/RetrofitRateLimiterTest.java
@@ -47,15 +47,18 @@ public class RetrofitRateLimiterTest {
     public WireMockRule wireMockRule = new WireMockRule();
 
     private RetrofitService service;
+
     private final RateLimiterConfig config = RateLimiterConfig.custom()
             .timeoutDuration(Duration.ofMillis(100))
             .limitRefreshPeriod(Duration.ofSeconds(1))
             .limitForPeriod(1)
             .build();
-    private final RateLimiter rateLimiter = RateLimiter.of("backendName", config);
+
+    private RateLimiter rateLimiter;
 
     @Before
     public void setUp() {
+        this.rateLimiter = RateLimiter.of("backendName", config);
         this.service = new Retrofit.Builder()
                 .addCallAdapterFactory(RateLimiterCallAdapter.of(rateLimiter))
                 .addConverterFactory(ScalarsConverterFactory.create())

--- a/resilience4j-retrofit/src/test/java/io/github/resilience4j/retrofit/internal/DecoratedCallTest.java
+++ b/resilience4j-retrofit/src/test/java/io/github/resilience4j/retrofit/internal/DecoratedCallTest.java
@@ -1,0 +1,46 @@
+package io.github.resilience4j.retrofit.internal;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+import retrofit2.Call;
+
+import java.io.IOException;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+
+@RunWith(JUnit4.class)
+public class DecoratedCallTest {
+
+    @Test
+    public void passThroughCallsToDecoratedObject() throws IOException {
+        final Call<String> call = mock(StringCall.class);
+        final Call<String> decorated = new DecoratedCall<>(call);
+
+        decorated.cancel();
+        Mockito.verify(call).cancel();
+
+        decorated.enqueue(null);
+        Mockito.verify(call).enqueue(any());
+
+        decorated.isExecuted();
+        Mockito.verify(call).isExecuted();
+
+        decorated.isCanceled();
+        Mockito.verify(call).isCanceled();
+
+        decorated.clone();
+        Mockito.verify(call).clone();
+
+        decorated.request();
+        Mockito.verify(call).request();
+
+        decorated.execute();
+        Mockito.verify(call).execute();
+    }
+
+    private interface StringCall extends Call<String> {
+    }
+}


### PR DESCRIPTION
Adds support for rate limiting http client calls as described in #97 

* Added RateLimiterCallAdapter
* Created internal DecoratedCall to minimise duplication
* Added tests for Retrofit Call without type parameters for better coverage
* Updated docs and included rate limiting examples
