### PR TITLE
Autoconfig for RateLimiter metrics registration and Health checks registration via properties

### DIFF
--- a/resilience4j-spring-boot/README.adoc
+++ b/resilience4j-spring-boot/README.adoc
@@ -84,7 +84,7 @@ For example:
 ----
 {
   "status": "UP",
-  "backendA": {
+  "backendACircuitBreaker": {
     "status": "DOWN",
     "failureRate": "60.0%",
     "failureRateThreshold": "50.0%",
@@ -93,7 +93,7 @@ For example:
     "failedCalls": 3,
     "notPermittedCalls": 0
   },
-  "backendB": {
+  "backendBCircuitBreaker": {
     "status": "UP",
     "failureRate": "0.0%",
     "failureRateThreshold": "50.0%",
@@ -162,7 +162,7 @@ For example:
 ----
 {
   "status": "UP",
-  "backendA": {
+  "backendARateLimiter": {
     "status": "UP",
     "availablePermissions": 10,
     "numberOfWaitingThreads": 0

--- a/resilience4j-spring-boot/README.adoc
+++ b/resilience4j-spring-boot/README.adoc
@@ -170,12 +170,27 @@ For example:
 }
 ----
 
+You can publish RateLimiter metrics on the Metrics endpoint,
+you can add `resilience4j-metrics` to register metrics in a Dropwizard Metrics Registry.
+For example:
+
+[source,json]
+----
+{
+    "resilience4j.ratelimiter.backendA.available_permissions": 10,
+    "resilience4j.ratelimiter.backendA.number_of_waiting_threads": 0,
+    "resilience4j.ratelimiter.backendB.available_permissions": 6,
+    "resilience4j.ratelimiter.backendB.number_of_waiting_threads": 0
+}
+----
+
 == Configuration
 
 === CircuitBreaker
 You can configure your CircuitBreakers in Spring Boot's `application.yml` config file.
 For example
 
+[source,yaml]
 ----
 resilience4j.circuitbreaker:
     backends:
@@ -185,18 +200,21 @@ resilience4j.circuitbreaker:
             waitInterval: 5000
             failureRateThreshold: 50
             eventConsumerBufferSize: 10
+            registerHealthIndicator: true
         backendB:
             ringBufferSizeInClosedState: 10
             ringBufferSizeInHalfOpenState: 5
             waitInterval: 5000
             failureRateThreshold: 50
             eventConsumerBufferSize: 10
+            registerHealthIndicator: true
 ----
 
 === RateLimiter
 You can configure your CircuitBreakers in Spring Boot's `application.yml` config file.
 For example
 
+[source,yaml]
 ----
 resilience4j.ratelimiter:
     limiters:
@@ -206,6 +224,7 @@ resilience4j.ratelimiter:
             timeoutInMillis: 0
             subscribeForEvents: true
             registerHealthIndicator: true
+            eventConsumerBufferSize: 100
         backendB:
             limitForPeriod: 6
             limitRefreshPeriodInMillis: 500

--- a/resilience4j-spring-boot/src/main/java/io/github/resilience4j/circuitbreaker/autoconfigure/CircuitBreakerAutoConfiguration.java
+++ b/resilience4j-spring-boot/src/main/java/io/github/resilience4j/circuitbreaker/autoconfigure/CircuitBreakerAutoConfiguration.java
@@ -15,17 +15,19 @@
  */
 package io.github.resilience4j.circuitbreaker.autoconfigure;
 
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.circuitbreaker.event.CircuitBreakerEvent;
 import io.github.resilience4j.circuitbreaker.internal.InMemoryCircuitBreakerRegistry;
 import io.github.resilience4j.circuitbreaker.monitoring.endpoint.CircuitBreakerEndpoint;
-import io.github.resilience4j.circuitbreaker.monitoring.endpoint.CircuitBreakerEventsEndpoint;
+import io.github.resilience4j.circuitbreaker.monitoring.health.CircuitBreakerHealthIndicator;
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
 
@@ -39,30 +41,38 @@ import io.github.resilience4j.consumer.EventConsumerRegistry;
 public class CircuitBreakerAutoConfiguration {
 
     @Bean
-    public CircuitBreakerRegistry circuitBreakerRegistry(CircuitBreakerProperties circuitBreakerProperties){
+    public CircuitBreakerRegistry circuitBreakerRegistry(CircuitBreakerProperties circuitBreakerProperties,
+                                                         EventConsumerRegistry<CircuitBreakerEvent> eventConsumerRegistry,
+                                                         ConfigurableBeanFactory beanFactory) {
         CircuitBreakerRegistry circuitBreakerRegistry = new InMemoryCircuitBreakerRegistry();
         circuitBreakerProperties.getBackends().forEach(
-                (name, properties) -> circuitBreakerRegistry.circuitBreaker(name, circuitBreakerProperties
-                        .createCircuitBreakerConfig(name))
+            (name, properties) -> {
+                CircuitBreakerConfig circuitBreakerConfig = circuitBreakerProperties.createCircuitBreakerConfig(name);
+                CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker(name, circuitBreakerConfig);
+                circuitBreaker.getEventStream()
+                    .subscribe(eventConsumerRegistry.createEventConsumer(name, properties.getEventConsumerBufferSize()));
+
+                if (properties.getRegisterHealthIndicator()) {
+                    CircuitBreakerHealthIndicator healthIndicator = new CircuitBreakerHealthIndicator(circuitBreaker);
+                    beanFactory.registerSingleton(
+                        name + "CircuitBreakerHealthIndicator",
+                        healthIndicator
+                    );
+                }
+            }
         );
         return circuitBreakerRegistry;
     }
 
     @Bean
     public CircuitBreakerAspect circuitBreakerAspect(CircuitBreakerProperties circuitBreakerProperties,
-                                                     CircuitBreakerRegistry circuitBreakerRegistry){
+                                                     CircuitBreakerRegistry circuitBreakerRegistry) {
         return new CircuitBreakerAspect(circuitBreakerProperties, circuitBreakerRegistry);
     }
 
     @Bean
     public CircuitBreakerEndpoint circuitBreakerEndpoint(CircuitBreakerRegistry circuitBreakerRegistry) {
         return new CircuitBreakerEndpoint(circuitBreakerRegistry);
-    }
-
-    @Bean
-    public CircuitBreakerEventsEndpoint circuitBreakerEventsEndpoint(EventConsumerRegistry<CircuitBreakerEvent> eventConsumerRegistry,
-                                                                     CircuitBreakerRegistry circuitBreakerRegistry) {
-        return new CircuitBreakerEventsEndpoint(eventConsumerRegistry, circuitBreakerRegistry);
     }
 
     /**

--- a/resilience4j-spring-boot/src/main/java/io/github/resilience4j/circuitbreaker/autoconfigure/CircuitBreakerMetricsAutoConfiguration.java
+++ b/resilience4j-spring-boot/src/main/java/io/github/resilience4j/circuitbreaker/autoconfigure/CircuitBreakerMetricsAutoConfiguration.java
@@ -37,8 +37,7 @@ import io.github.resilience4j.metrics.CircuitBreakerMetrics;
 @ConditionalOnClass(MetricRepository.class)
 @AutoConfigureAfter(value = {CircuitBreakerAutoConfiguration.class, MetricsDropwizardAutoConfiguration.class})
 @AutoConfigureBefore(MetricRepositoryAutoConfiguration.class)
-public class MetricsAutoConfiguration{
-
+public class CircuitBreakerMetricsAutoConfiguration {
     @Bean
     public CircuitBreakerMetrics registerCircuitBreakerMetrics(CircuitBreakerRegistry circuitBreakerRegistry, MetricRegistry metricRegistry){
         CircuitBreakerMetrics circuitBreakerMetrics = CircuitBreakerMetrics.ofCircuitBreakerRegistry(circuitBreakerRegistry);

--- a/resilience4j-spring-boot/src/main/java/io/github/resilience4j/circuitbreaker/autoconfigure/CircuitBreakerPrometheusAutoConfiguration.java
+++ b/resilience4j-spring-boot/src/main/java/io/github/resilience4j/circuitbreaker/autoconfigure/CircuitBreakerPrometheusAutoConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Robert Winkler
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.circuitbreaker.autoconfigure;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.prometheus.CircuitBreakerExports;
+import io.prometheus.client.CollectorRegistry;
+
+/**
+ * {@link org.springframework.boot.autoconfigure.EnableAutoConfiguration
+ * Auto-configuration} for resilience4j-metrics.
+ */
+@Configuration
+@ConditionalOnClass(CollectorRegistry.class)
+public class CircuitBreakerPrometheusAutoConfiguration {
+    @Bean
+    public CircuitBreakerExports circuitBreakerPrometheusCollector(CircuitBreakerRegistry circuitBreakerRegistry){
+        CircuitBreakerExports collector = CircuitBreakerExports.ofCircuitBreakerRegistry(circuitBreakerRegistry);
+        collector.register();
+        return collector;
+    }
+}

--- a/resilience4j-spring-boot/src/main/java/io/github/resilience4j/circuitbreaker/autoconfigure/CircuitBreakerProperties.java
+++ b/resilience4j-spring-boot/src/main/java/io/github/resilience4j/circuitbreaker/autoconfigure/CircuitBreakerProperties.java
@@ -81,6 +81,8 @@ public class CircuitBreakerProperties {
 
         private Integer eventConsumerBufferSize = 100;
 
+        private Boolean registerHealthIndicator = false;
+
 
         /**
          * Returns the wait duration in seconds the CircuitBreaker will stay open, before it switches to half closed.
@@ -160,6 +162,14 @@ public class CircuitBreakerProperties {
 
         public void setEventConsumerBufferSize(Integer eventConsumerBufferSize) {
             this.eventConsumerBufferSize = eventConsumerBufferSize;
+        }
+
+        public Boolean getRegisterHealthIndicator() {
+            return registerHealthIndicator;
+        }
+
+        public void setRegisterHealthIndicator(Boolean registerHealthIndicator) {
+            this.registerHealthIndicator = registerHealthIndicator;
         }
     }
 

--- a/resilience4j-spring-boot/src/main/java/io/github/resilience4j/circuitbreaker/monitoring/health/CircuitBreakerHealthIndicator.java
+++ b/resilience4j-spring-boot/src/main/java/io/github/resilience4j/circuitbreaker/monitoring/health/CircuitBreakerHealthIndicator.java
@@ -19,14 +19,10 @@ package io.github.resilience4j.circuitbreaker.monitoring.health;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
 
-import java.util.Optional;
-
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
-import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
-import io.github.resilience4j.circuitbreaker.autoconfigure.CircuitBreakerProperties;
-import io.github.resilience4j.circuitbreaker.event.CircuitBreakerEvent;
-import io.github.resilience4j.consumer.EventConsumerRegistry;
+
+import java.util.Optional;
 
 /**
  * A Spring Boot health indicators which adds the state of a CircuitBreaker and it's metrics to the health endpoints
@@ -40,17 +36,9 @@ public class CircuitBreakerHealthIndicator implements HealthIndicator {
     private static final String NOT_PERMITTED = "notPermittedCalls";
     private static final String MAX_BUFFERED_CALLS = "maxBufferedCalls";
     private CircuitBreaker circuitBreaker;
-    private static final int DEFAULT_BUFFER_SIZE = 100;
 
-    public CircuitBreakerHealthIndicator(CircuitBreakerRegistry circuitBreakerRegistry,
-                                         EventConsumerRegistry<CircuitBreakerEvent> eventConsumerRegistry,
-                                         CircuitBreakerProperties circuitBreakerProperties,
-                                         String backendName) {
-        this.circuitBreaker = circuitBreakerRegistry.circuitBreaker(backendName, () -> circuitBreakerProperties.createCircuitBreakerConfig(backendName));
-        CircuitBreakerProperties.BackendProperties backendProperties = circuitBreakerProperties.getBackends().get(backendName);
-        int bufferSize = backendProperties != null ? backendProperties.getEventConsumerBufferSize() : DEFAULT_BUFFER_SIZE;
-        circuitBreaker.getEventStream()
-                .subscribe(eventConsumerRegistry.createEventConsumer(backendName, bufferSize));
+    public CircuitBreakerHealthIndicator(CircuitBreaker circuitBreaker) {
+        this.circuitBreaker = circuitBreaker;
     }
 
     @Override

--- a/resilience4j-spring-boot/src/main/java/io/github/resilience4j/ratelimiter/autoconfigure/RateLimiterAutoConfiguration.java
+++ b/resilience4j-spring-boot/src/main/java/io/github/resilience4j/ratelimiter/autoconfigure/RateLimiterAutoConfiguration.java
@@ -77,12 +77,6 @@ public class RateLimiterAutoConfiguration {
         return new RateLimiterEndpoint(rateLimiterRegistry);
     }
 
-    @Bean
-    public RateLimiterEventsEndpoint rateLimiterEventsEndpoint(EventConsumerRegistry<RateLimiterEvent> rateLimiterEventsConsumerRegistry,
-                                                               RateLimiterRegistry rateLimiterRegistry) {
-        return new RateLimiterEventsEndpoint(rateLimiterEventsConsumerRegistry, rateLimiterRegistry);
-    }
-
     /**
      * The EventConsumerRegistry is used to manage EventConsumer instances.
      * The EventConsumerRegistry is used by the RateLimiterHealthIndicator to show the latest RateLimiterEvents events
@@ -95,7 +89,7 @@ public class RateLimiterAutoConfiguration {
 
     private void createHealthIndicatorForLimiter(ConfigurableBeanFactory beanFactory, String name, RateLimiter rateLimiter) {
         beanFactory.registerSingleton(
-            name + "HealthIndicator",
+            name + "RateLimiterHealthIndicator",
             new RateLimiterHealthIndicator(rateLimiter)
         );
     }

--- a/resilience4j-spring-boot/src/main/java/io/github/resilience4j/ratelimiter/autoconfigure/RateLimiterMetricsAutoConfiguration.java
+++ b/resilience4j-spring-boot/src/main/java/io/github/resilience4j/ratelimiter/autoconfigure/RateLimiterMetricsAutoConfiguration.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Bohdan Storozhuk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.ratelimiter.autoconfigure;
+
+import com.codahale.metrics.MetricRegistry;
+
+import org.springframework.boot.actuate.autoconfigure.MetricRepositoryAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.MetricsDropwizardAutoConfiguration;
+import org.springframework.boot.actuate.metrics.repository.MetricRepository;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.github.resilience4j.metrics.RateLimiterMetrics;
+import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
+
+/**
+ * {@link org.springframework.boot.autoconfigure.EnableAutoConfiguration
+ * Auto-configuration} for resilience4j-metrics.
+ */
+@Configuration
+@ConditionalOnClass(MetricRepository.class)
+@AutoConfigureAfter(value = {RateLimiterAutoConfiguration.class, MetricsDropwizardAutoConfiguration.class})
+@AutoConfigureBefore(MetricRepositoryAutoConfiguration.class)
+public class RateLimiterMetricsAutoConfiguration {
+    @Bean
+    public RateLimiterMetrics registerRateLimiterMetrics(RateLimiterRegistry rateLimiterRegistry, MetricRegistry metricRegistry) {
+        RateLimiterMetrics rateLimiterMetrics = RateLimiterMetrics.ofRateLimiterRegistry(rateLimiterRegistry);
+        metricRegistry.registerAll(rateLimiterMetrics);
+        return rateLimiterMetrics;
+    }
+}

--- a/resilience4j-spring-boot/src/main/java/io/github/resilience4j/ratelimiter/autoconfigure/RateLimiterPrometheusAutoConfiguration.java
+++ b/resilience4j-spring-boot/src/main/java/io/github/resilience4j/ratelimiter/autoconfigure/RateLimiterPrometheusAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Robert Winkler
+ * Copyright 2017 Bohdan Storozhuk
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,29 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.github.resilience4j.circuitbreaker.autoconfigure;
+package io.github.resilience4j.ratelimiter.autoconfigure;
 
+import org.springframework.boot.actuate.metrics.repository.MetricRepository;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
-import io.github.resilience4j.prometheus.CircuitBreakerExports;
-import io.prometheus.client.CollectorRegistry;
+import io.github.resilience4j.prometheus.RateLimiterExports;
+import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
 
 /**
  * {@link org.springframework.boot.autoconfigure.EnableAutoConfiguration
  * Auto-configuration} for resilience4j-metrics.
  */
 @Configuration
-@ConditionalOnClass(CollectorRegistry.class)
-public class PrometheusAutoConfiguration {
-
+@ConditionalOnClass(MetricRepository.class)
+public class RateLimiterPrometheusAutoConfiguration {
     @Bean
-    public CircuitBreakerExports circuitBreakerCollector(CircuitBreakerRegistry circuitBreakerRegistry){
-        CircuitBreakerExports collector = CircuitBreakerExports.ofCircuitBreakerRegistry(circuitBreakerRegistry);
+    public RateLimiterExports rateLimiterPrometheusCollector(RateLimiterRegistry rateLimiterRegistry){
+        RateLimiterExports collector = RateLimiterExports.ofRateLimiterRegistry(rateLimiterRegistry);
         collector.register();
         return collector;
     }
-
 }

--- a/resilience4j-spring-boot/src/main/resources/META-INF/spring.factories
+++ b/resilience4j-spring-boot/src/main/resources/META-INF/spring.factories
@@ -1,5 +1,7 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 io.github.resilience4j.circuitbreaker.autoconfigure.CircuitBreakerAutoConfiguration,\
-io.github.resilience4j.circuitbreaker.autoconfigure.MetricsAutoConfiguration,\
-io.github.resilience4j.circuitbreaker.autoconfigure.PrometheusAutoConfiguration,\
-io.github.resilience4j.ratelimiter.autoconfigure.RateLimiterAutoConfiguration
+io.github.resilience4j.circuitbreaker.autoconfigure.CircuitBreakerMetricsAutoConfiguration,\
+io.github.resilience4j.circuitbreaker.autoconfigure.CircuitBreakerPrometheusAutoConfiguration,\
+io.github.resilience4j.ratelimiter.autoconfigure.RateLimiterAutoConfiguration,\
+io.github.resilience4j.ratelimiter.autoconfigure.RateLimiterMetricsAutoConfiguration,\
+io.github.resilience4j.ratelimiter.autoconfigure.RateLimiterPrometheusAutoConfiguration

--- a/resilience4j-spring-boot/src/test/java/io/github/resilience4j/service/test/TestApplication.java
+++ b/resilience4j-spring-boot/src/test/java/io/github/resilience4j/service/test/TestApplication.java
@@ -1,15 +1,8 @@
 package io.github.resilience4j.service.test;
 
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
 
-import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
-import io.github.resilience4j.circuitbreaker.autoconfigure.CircuitBreakerProperties;
-import io.github.resilience4j.circuitbreaker.event.CircuitBreakerEvent;
-import io.github.resilience4j.circuitbreaker.monitoring.health.CircuitBreakerHealthIndicator;
-import io.github.resilience4j.consumer.EventConsumerRegistry;
 import io.prometheus.client.spring.boot.EnablePrometheusEndpoint;
 import io.prometheus.client.spring.boot.EnableSpringBootMetricsCollector;
 
@@ -22,25 +15,5 @@ import io.prometheus.client.spring.boot.EnableSpringBootMetricsCollector;
 public class TestApplication {
     public static void main(String[] args) {
         SpringApplication.run(TestApplication.class, args);
-    }
-
-    @Bean
-    public HealthIndicator backendA(CircuitBreakerRegistry circuitBreakerRegistry,
-                                    EventConsumerRegistry<CircuitBreakerEvent> eventConsumerRegistry,
-                                    CircuitBreakerProperties circuitBreakerProperties) {
-        return new CircuitBreakerHealthIndicator(circuitBreakerRegistry,
-            eventConsumerRegistry,
-            circuitBreakerProperties,
-            "backendA");
-    }
-
-    @Bean
-    public HealthIndicator backendB(CircuitBreakerRegistry circuitBreakerRegistry,
-                                    EventConsumerRegistry<CircuitBreakerEvent> eventConsumerRegistry,
-                                    CircuitBreakerProperties circuitBreakerProperties) {
-        return new CircuitBreakerHealthIndicator(circuitBreakerRegistry,
-            eventConsumerRegistry,
-            circuitBreakerProperties,
-            "backendB");
     }
 }

--- a/resilience4j-spring-boot/src/test/resources/application.yaml
+++ b/resilience4j-spring-boot/src/test/resources/application.yaml
@@ -6,12 +6,14 @@ resilience4j.circuitbreaker:
             waitInterval: 5000
             failureRateThreshold: 70
             eventConsumerBufferSize: 10
+            registerHealthIndicator: true
         backendB:
             ringBufferSizeInClosedState: 10
             ringBufferSizeInHalfOpenState: 5
             waitInterval: 5000
             failureRateThreshold: 50
             eventConsumerBufferSize: 10
+            registerHealthIndicator: true
 
 resilience4j.ratelimiter:
     limiters:


### PR DESCRIPTION
@RobWin 
I've noticed that some of our health check beans can replace each other in AplicationContext due to names clashes, so I've made simplified  health checks registration via property and auto name generation.