### PR TITLE
Remove decorateFuture

### DIFF
--- a/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/TimeLimiter.java
+++ b/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/TimeLimiter.java
@@ -48,28 +48,6 @@ public interface TimeLimiter {
     }
 
     /**
-     * Creates a Callable that is restricted by a TimeLimiter.
-     *
-     * @param timeLimiter   the TimeLimiter
-     * @param future        the original future
-     * @param <T> the type of results supplied by the future
-     * @param <F> the future type supplied
-     * @return a future which is restricted by a {@link TimeLimiter}.
-     */
-    static <T, F extends Future<T>> Callable<T> decorateFuture(final TimeLimiter timeLimiter, final F future) {
-        return () -> {
-            try {
-                return future.get(timeLimiter.getTimeLimiterConfig().getTimeoutDuration().toMillis(), TimeUnit.MILLISECONDS);
-            } catch (TimeoutException e) {
-                if (timeLimiter.getTimeLimiterConfig().shouldCancelRunningFuture()) {
-                    future.cancel(true);
-                }
-                throw e;
-            }
-        };
-    }
-
-    /**
      * Creates a Callback that is restricted by a TimeLimiter.
      *
      * @param timeLimiter        the TimeLimiter
@@ -98,19 +76,6 @@ public interface TimeLimiter {
      * @return the TimeLimiterConfig of this TimeLimiter decorator
      */
     TimeLimiterConfig getTimeLimiterConfig();
-
-    /**
-     * Decorates and executes the Future.
-     *
-     * @param future the original Future
-     * @param <T> the result type of the future
-     * @param <F> the type of Future
-     * @return the result of the decorated Future.
-     * @throws Exception if unable to compute a result
-     */
-    default <T, F extends Future<T>> T executeFuture(F future) throws Exception {
-        return decorateFuture(this, future).call();
-    }
 
     /**
      * Decorates and executes the Future Supplier.

--- a/resilience4j-timelimiter/src/test/java/io/github/resilience4j/timelimiter/TimeLimiterTest.java
+++ b/resilience4j-timelimiter/src/test/java/io/github/resilience4j/timelimiter/TimeLimiterTest.java
@@ -56,61 +56,6 @@ public class TimeLimiterTest {
     }
 
     @Test
-    public void decorateFuture() throws Throwable {
-        when(timeLimiter.getTimeLimiterConfig()).thenReturn(shortConfig);
-
-        Future<Integer> future = EXECUTOR_SERVICE.submit(() -> {
-                    Thread.sleep(SLEEP_DURATION.toMillis());
-                    return 1;
-                }
-            );
-
-        Callable<Integer> decorated = TimeLimiter.decorateFuture(timeLimiter, future);
-
-        Try decoratedResult = Try.success(decorated).mapTry(Callable::call);
-        then(decoratedResult.isFailure()).isTrue();
-        then(decoratedResult.getCause()).isInstanceOf(TimeoutException.class);
-        then(future.isCancelled()).isTrue();
-
-        when(timeLimiter.getTimeLimiterConfig())
-                .thenReturn(longConfig);
-
-        future = EXECUTOR_SERVICE.submit(() -> {
-                    Thread.sleep(SLEEP_DURATION.toMillis());
-                    return 1;
-                }
-        );
-
-        decorated = TimeLimiter.decorateFuture(timeLimiter, future);
-
-        Try secondResult = Try.success(decorated).mapTry(Callable::call);
-        then(secondResult.isSuccess()).isTrue();
-    }
-
-    @Test
-    public void executeFuture() throws Throwable {
-        Future<Integer> future = EXECUTOR_SERVICE.submit(() -> {
-                    Thread.sleep(SLEEP_DURATION.toMillis());
-                    return 1;
-                }
-        );
-
-        Try decoratedResult = Try.of(() -> TimeLimiter.of(shortConfig).executeFuture(future));
-        then(decoratedResult.isFailure()).isTrue();
-        then(decoratedResult.getCause()).isInstanceOf(TimeoutException.class);
-        then(future.isCancelled()).isTrue();
-
-        Future<Integer> secondFuture = EXECUTOR_SERVICE.submit(() -> {
-                    Thread.sleep(SLEEP_DURATION.toMillis());
-                    return 1;
-                }
-        );
-
-        Try secondResult = Try.of(() -> TimeLimiter.of(longConfig).executeFuture(secondFuture));
-        then(secondResult.isSuccess()).isTrue();
-    }
-
-    @Test
     public void decorateFutureSupplier() throws Throwable {
         when(timeLimiter.getTimeLimiterConfig()).thenReturn(shortConfig);
 


### PR DESCRIPTION
decorateFuture could cause confusion on the execution of the future while chaining with other decorators and most likely has little use as compared to the future supplier.