### PR TITLE
Adding Bulkhead integration with Ratpack and Bulkhead call finished metric

### DIFF
--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/Bulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/Bulkhead.java
@@ -19,6 +19,7 @@
 package io.github.resilience4j.bulkhead;
 
 import io.github.resilience4j.bulkhead.event.BulkheadEvent;
+import io.github.resilience4j.bulkhead.event.BulkheadOnCallFinishedEvent;
 import io.github.resilience4j.bulkhead.event.BulkheadOnCallPermittedEvent;
 import io.github.resilience4j.bulkhead.event.BulkheadOnCallRejectedEvent;
 import io.github.resilience4j.bulkhead.internal.SemaphoreBulkhead;
@@ -417,5 +418,6 @@ public interface Bulkhead {
 
         EventPublisher onCallPermitted(EventConsumer<BulkheadOnCallPermittedEvent> eventConsumer);
 
+        EventPublisher onCallFinished(EventConsumer<BulkheadOnCallFinishedEvent> eventConsumer);
     }
 }

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/event/BulkheadEvent.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/event/BulkheadEvent.java
@@ -54,5 +54,7 @@ public interface BulkheadEvent {
         CALL_PERMITTED,
         /** A BulkheadEvent which informs that a call was rejected due to bulkhead being full */
         CALL_REJECTED,
+        /** A BulkheadEvent which informs that a call was finished(success and failure is indistinguishable) */
+        CALL_FINISHED
     }
 }

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/event/BulkheadFinishedCallEvent.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/event/BulkheadFinishedCallEvent.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 Jan Sykora
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.bulkhead.event;
+
+/**
+ * A BulkheadEvent which informs that a call has been finished. The event doesn't
+ * provide any information on whether the call's execution was successful or not.
+ */
+public class BulkheadFinishedCallEvent extends AbstractBulkheadEvent {
+
+    public BulkheadFinishedCallEvent(String bulkheadName) {
+        super(bulkheadName);
+    }
+
+    @Override
+    public Type getEventType() {
+        return Type.CALL_FINISHED;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "%s: Bulkhead '%s' has finished a call.",
+                getCreationTime(),
+                getBulkheadName()
+        );
+    }
+}

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/event/BulkheadOnCallFinishedEvent.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/event/BulkheadOnCallFinishedEvent.java
@@ -19,9 +19,9 @@ package io.github.resilience4j.bulkhead.event;
  * A BulkheadEvent which informs that a call has been finished. The event doesn't
  * provide any information on whether the call's execution was successful or not.
  */
-public class BulkheadFinishedCallEvent extends AbstractBulkheadEvent {
+public class BulkheadOnCallFinishedEvent extends AbstractBulkheadEvent {
 
-    public BulkheadFinishedCallEvent(String bulkheadName) {
+    public BulkheadOnCallFinishedEvent(String bulkheadName) {
         super(bulkheadName);
     }
 

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/event/BulkheadOnCallPermittedEvent.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/event/BulkheadOnCallPermittedEvent.java
@@ -40,6 +40,4 @@ public class BulkheadOnCallPermittedEvent extends AbstractBulkheadEvent {
                    getBulkheadName()
                );
     }
-
-
 }

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkhead.java
@@ -95,11 +95,8 @@ public class SemaphoreBulkhead implements Bulkhead {
 
     @Override
     public void onComplete() {
-        try {
-            publishBulkheadEvent(() -> new BulkheadOnCallFinishedEvent(name));
-        } finally {
-            semaphore.release();
-        }
+        semaphore.release();
+        publishBulkheadEvent(() -> new BulkheadOnCallFinishedEvent(name));
     }
 
     @Override

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkhead.java
@@ -22,7 +22,7 @@ package io.github.resilience4j.bulkhead.internal;
 import io.github.resilience4j.bulkhead.Bulkhead;
 import io.github.resilience4j.bulkhead.BulkheadConfig;
 import io.github.resilience4j.bulkhead.event.BulkheadEvent;
-import io.github.resilience4j.bulkhead.event.BulkheadFinishedCallEvent;
+import io.github.resilience4j.bulkhead.event.BulkheadOnCallFinishedEvent;
 import io.github.resilience4j.bulkhead.event.BulkheadOnCallPermittedEvent;
 import io.github.resilience4j.bulkhead.event.BulkheadOnCallRejectedEvent;
 import io.github.resilience4j.core.EventConsumer;
@@ -96,7 +96,7 @@ public class SemaphoreBulkhead implements Bulkhead {
     @Override
     public void onComplete() {
         try {
-            publishBulkheadEvent(() -> new BulkheadFinishedCallEvent(name));
+            publishBulkheadEvent(() -> new BulkheadOnCallFinishedEvent(name));
         } finally {
             semaphore.release();
         }
@@ -134,6 +134,12 @@ public class SemaphoreBulkhead implements Bulkhead {
         @Override
         public EventPublisher onCallRejected(EventConsumer<BulkheadOnCallRejectedEvent> onCallRejectedEventConsumer) {
             registerConsumer(BulkheadOnCallRejectedEvent.class, onCallRejectedEventConsumer);
+            return this;
+        }
+
+        @Override
+        public EventPublisher onCallFinished(EventConsumer<BulkheadOnCallFinishedEvent> onCallFinishedEventConsumer) {
+            registerConsumer(BulkheadOnCallFinishedEvent.class, onCallFinishedEventConsumer);
             return this;
         }
 

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkhead.java
@@ -22,6 +22,7 @@ package io.github.resilience4j.bulkhead.internal;
 import io.github.resilience4j.bulkhead.Bulkhead;
 import io.github.resilience4j.bulkhead.BulkheadConfig;
 import io.github.resilience4j.bulkhead.event.BulkheadEvent;
+import io.github.resilience4j.bulkhead.event.BulkheadFinishedCallEvent;
 import io.github.resilience4j.bulkhead.event.BulkheadOnCallPermittedEvent;
 import io.github.resilience4j.bulkhead.event.BulkheadOnCallRejectedEvent;
 import io.github.resilience4j.core.EventConsumer;
@@ -34,7 +35,7 @@ import java.util.function.Supplier;
 /**
  * A Bulkhead implementation based on a semaphore.
  */
-public class SemaphoreBulkhead implements Bulkhead{
+public class SemaphoreBulkhead implements Bulkhead {
 
     private final String name;
     private final Semaphore semaphore;
@@ -71,7 +72,7 @@ public class SemaphoreBulkhead implements Bulkhead{
     /**
      * Create a bulkhead using a configuration supplier
      *
-     * @param name the name of this bulkhead
+     * @param name           the name of this bulkhead
      * @param configSupplier BulkheadConfig supplier
      */
     public SemaphoreBulkhead(String name, Supplier<BulkheadConfig> configSupplier) {
@@ -94,7 +95,11 @@ public class SemaphoreBulkhead implements Bulkhead{
 
     @Override
     public void onComplete() {
-        semaphore.release();
+        try {
+            publishBulkheadEvent(() -> new BulkheadFinishedCallEvent(name));
+        } finally {
+            semaphore.release();
+        }
     }
 
     @Override
@@ -150,12 +155,10 @@ public class SemaphoreBulkhead implements Bulkhead{
 
         if (timeout == 0) {
             callPermitted = semaphore.tryAcquire();
-        }
-        else {
+        } else {
             try {
                 callPermitted = semaphore.tryAcquire(timeout, TimeUnit.MILLISECONDS);
-            }
-            catch (InterruptedException ex) {
+            } catch (InterruptedException ex) {
                 callPermitted = false;
             }
         }
@@ -164,7 +167,7 @@ public class SemaphoreBulkhead implements Bulkhead{
     }
 
     private void publishBulkheadEvent(Supplier<BulkheadEvent> eventSupplier) {
-        if(eventProcessor.hasConsumers()) {
+        if (eventProcessor.hasConsumers()) {
             eventProcessor.consumeEvent(eventSupplier.get());
         }
     }
@@ -178,5 +181,4 @@ public class SemaphoreBulkhead implements Bulkhead{
             return semaphore.availablePermits();
         }
     }
-
 }

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/BulkheadEventPublisherTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/BulkheadEventPublisherTest.java
@@ -59,7 +59,6 @@ public class BulkheadEventPublisherTest {
 
     @Test
     public void shouldConsumeOnCallPermittedEvent() {
-
         // Given
         Bulkhead bulkhead = Bulkhead.of("test", config);
         BDDMockito.given(helloWorldService.returnHelloWorld()).willReturn("Hello world");
@@ -79,7 +78,6 @@ public class BulkheadEventPublisherTest {
 
     @Test
     public void shouldConsumeOnCallRejectedEvent() {
-
         // Given
         Bulkhead bulkhead = Bulkhead.of("test", config);
 
@@ -96,5 +94,35 @@ public class BulkheadEventPublisherTest {
         then(logger).should(times(1)).info("CALL_REJECTED");
     }
 
+    @Test
+    public void shouldConsumeOnCallFinishedEventWhenExecutionIsFinished() throws Exception {
+        // Given
+        Bulkhead bulkhead = Bulkhead.of("test", config);
 
+        // When
+        bulkhead.getEventPublisher()
+                .onCallFinished(event ->
+                        logger.info(event.getEventType().toString()));
+
+        Try.ofSupplier(Bulkhead.decorateSupplier(bulkhead,helloWorldService::returnHelloWorld));
+
+        // Then
+        then(logger).should(times(1)).info("CALL_FINISHED");
+    }
+
+    @Test
+    public void shouldConsumeOnCallFinishedEventOnComplete() throws Exception {
+        // Given
+        Bulkhead bulkhead = Bulkhead.of("test", config);
+
+        // When
+        bulkhead.getEventPublisher()
+                .onCallFinished(event ->
+                        logger.info(event.getEventType().toString()));
+
+        bulkhead.onComplete();
+
+        // Then
+        then(logger).should(times(1)).info("CALL_FINISHED");
+    }
 }

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkheadTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkheadTest.java
@@ -76,8 +76,8 @@ public class SemaphoreBulkheadTest {
 
         bulkhead.isCallPermitted();
 
-        testSubscriber.assertValueCount(4)
-                      .assertValues(CALL_PERMITTED, CALL_PERMITTED, CALL_REJECTED, CALL_PERMITTED);
+        testSubscriber.assertValueCount(6)
+                      .assertValues(CALL_PERMITTED, CALL_PERMITTED, CALL_REJECTED, CALL_FINISHED, CALL_FINISHED, CALL_PERMITTED);
     }
 
     @Test

--- a/resilience4j-documentation/src/docs/asciidoc/addon_guides/ratpack.adoc
+++ b/resilience4j-documentation/src/docs/asciidoc/addon_guides/ratpack.adoc
@@ -20,10 +20,10 @@ dependencies {
 
 ==== Basic Usage
 
-Installing the `Resilience4jModule` module provides a `CircuitBreakerRegistry`, `RateLimiterRegistry`,
+Installing the `Resilience4jModule` module provides a `BulkheadRegistry` `CircuitBreakerRegistry`, `RateLimiterRegistry`,
 and `RetryRegistry` with the default configurations. It also install the Guice method interceptors
-for CircuitBreakers, RateLimiters, and Retries. Finally, it allows configuration of metrics
-and even the building of CircuitBreakers, RateLimiters, and Retries. See below for configuration details.
+for Bulkheads, CircuitBreakers, RateLimiters, and Retries. Finally, it allows configuration of metrics
+and even the building of Bulkheads, CircuitBreakers, RateLimiters, and Retries. See below for configuration details.
 
 Note: If you don't register a `CircuitBreakerRegistry` or `RateLimiterRegistry` or `RetryRegistry`, the defaults
 will be used.
@@ -93,6 +93,18 @@ Ratpack promises provide the means by which an application can become fully non-
 Resilience4j provides transformers that can be applied to Promises. This is ideal when promising a value
 that is coming from some sort of I/O source.
 
+===== Bulkhead
+
+You can easily apply a Bulkhead to any Ratpack Promise.
+
+[source,java]
+----
+public Promise<String> methodWhichReturnsAPromise() {
+    return backendBConnector.methodWhichReturnsAPromise()
+            .transform(BulkheadTransformer.of(bulkhead).recover(t -> "recovered"));
+}
+----
+
 ===== CircuitBreaker
 
 You can easily apply a CircuitBreaker to any Ratpack Promise.
@@ -140,6 +152,23 @@ methods returning types:
 * Observable
 * Flowable
 * Single
+
+===== Bulkhead
+The demo shows how to use the `Bulkhead` annotation to have your Ratpack application limiting number of method calls.
+You can either annotate a class in order to protect all public methods or just some specific methods.
+For example:
+
+[source,java]
+----
+@Bulkhead(name = "backendA", recovery = MyRecoveryFunction.class)
+@Singleton
+public class BackendAConnector implements Connector {
+    ...
+}
+----
+Where `MyRecoveryFunction` is implements `io.github.resilience4j.ratpack.RecoveryFunction` and provides
+a fallback value that is returned when the bulkhead identified by `name` is full or call ends in exception.
+
 
 ===== CircuitBreaker
 The demo shows how to use the `CircuitBreaker` annotation to make your Ratpack application more fault tolerant.
@@ -191,7 +220,7 @@ a fallback value that is returned when the rate limiter rate limit identified by
 
 ==== Functional style
 
-You can still use a functional programming style for CircuitBreaker, Retry, and RateLimiter. For example:
+You can still use a functional programming style for Bulkhead, CircuitBreaker, Retry, and RateLimiter. For example:
 
 [source,java]
 ----
@@ -212,7 +241,7 @@ public class BusinessBService implements BusinessService  {
 }
 ----
 
-==== Adding CircuitBreakers, RateLimiters, and Retries
+==== Adding Bulkheads, CircuitBreakers, RateLimiters, and Retries
 These can be defined in the module configuration or in an external configuration.
 Note that the module only provide default registries, which you can replace by
 binding your own.
@@ -227,7 +256,12 @@ public class MyModule extends AbstractModule {
     protected void configure() {
         Resilience4jModule module = new Resilience4jModule();
         module.configure(c -> c
-            .circuitBreaker("test1", cb -> cb
+            .bulkhead("test1", b -> b
+                .defaults(true)
+            ).bulkhead("test2", b -> b
+                .maxConcurrentCalls(100)
+                .maxWaitTime(1000)
+            ).circuitBreaker("test1", cb -> cb
                 .defaults(true)
             ).circuitBreaker("test2", cb -> cb
                 .failureRateThreshold(50)
@@ -275,6 +309,12 @@ ratpack {
 [source,yaml]
 ----
 resilience4j:
+    bulkheads:
+        test1:
+            defaults: true
+        test2:
+            maxConcurrentCalls: 100
+            maxWaitTime: 1000
     circuitBreakers:
         test1:
             defaults: true
@@ -300,7 +340,7 @@ resilience4j:
 
 ==== Metrics
 Both dropwizard and prometheus metrics can be auto configured and enabled for all registered
-circuitbreaker instances, ratelimiter instances, and retry instances.
+bulkhead instances, circuitbreaker instances, ratelimiter instances, and retry instances.
 
 For dropwizard metrics to work, add a compile dependency on resilience4j-metrics and
 bind a MetricRegistry instance.
@@ -341,6 +381,41 @@ public class MyModule extends AbstractModule {
 ----
 
 ==== Event Monitoring
+
+===== Bulkhead
+These are the same endpoints as implemented for Bulkhead,
+so for detailed documentation please refer to previous sections.
+
+List of available endpoints:
+
+* `/bulkhead/events`
+* `/bulkhead/stream/events`
+* `/bulkhead/events/{bulkheadName}`
+* `/bulkhead/stream/events/{bulkheadName}`
+* `/bulkhead/events/{bulkheadName}/{eventType}`
+* `/bulkhead/stream/events/{bulkheadName}/{eventType}`
+
+Example of response:
+----
+{
+  "bulkheadEvents": [
+    {
+      "bulkheadName": "backendA",
+      "type": "CALL_PERMITTED",
+      "creationTime": "2017-05-05T21:29:40.463+03:00[Europe/Uzhgorod]"
+    },
+    {
+      "bulkheadName": "backendA",
+      "type": "CALL_REJECTED",
+      "creationTime": "2017-05-05T21:29:40.469+03:00[Europe/Uzhgorod]"
+    },
+    {
+      "bulkheadName": "backendA",
+      "type": "CALL_FINISHED",
+      "creationTime": "2017-05-05T21:29:41.268+03:00[Europe/Uzhgorod]"
+    }
+  ]
+}
 
 ===== CircuitBreaker
 

--- a/resilience4j-documentation/src/docs/asciidoc/core_guides/bulkhead.adoc
+++ b/resilience4j-documentation/src/docs/asciidoc/core_guides/bulkhead.adoc
@@ -94,13 +94,14 @@ include::../../../../../resilience4j-bulkhead/src/test/java/io/github/resilience
 
 ===== Consume emitted BulkheadEvents
 
-The BulkHead emits a stream of BulkHeadEvents. There are two types of events emitted: permitted execution & rejected execution. If you want to consume these events, you have to register an event consumer.
+The BulkHead emits a stream of BulkHeadEvents. There are two types of events emitted: permitted execution, rejected execution & finished execution. If you want to consume these events, you have to register an event consumer.
 
 [source,java]
 ----
 bulkhead.getEventPublisher()
     .onCallPermitted(event -> logger.info(...))
-    .onCallRejected(event -> logger.info(...));
+    .onCallRejected(event -> logger.info(...))
+    .onCallFinished(event -> logger.info(...));
 ----
 
 ==== Monitoring

--- a/resilience4j-ratpack/build.gradle
+++ b/resilience4j-ratpack/build.gradle
@@ -17,7 +17,3 @@ dependencies {
     testCompile project(':resilience4j-prometheus')
     testCompile project(':resilience4j-metrics')
 }
-
-test {
-    maxParallelForks = 1
-}

--- a/resilience4j-ratpack/build.gradle
+++ b/resilience4j-ratpack/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'groovy'
 
 dependencies {
     compile ( libraries.ratpack )
+    compile project(':resilience4j-bulkhead')
     compile project(':resilience4j-circuitbreaker')
     compile project(':resilience4j-ratelimiter')
     compile project(':resilience4j-retry')

--- a/resilience4j-ratpack/out/test/resources/application.yml
+++ b/resilience4j-ratpack/out/test/resources/application.yml
@@ -12,6 +12,10 @@ resilience4j:
             enabled: true
             path: retry
             eventConsumerBufferSize: 100
+        bulkheads:
+            enabled: true
+            path: bulkhead
+            eventConsumerBufferSize: 100
     circuitBreakers:
         test1:
             defaults: true
@@ -33,3 +37,9 @@ resilience4j:
         test2:
             maxAttempts: 3
             waitDurationInMillis: 1000
+    bulkheads:
+        test1:
+            defaults: true
+        test2:
+            maxConcurrentCalls: 100
+            maxWaitTime: 1000

--- a/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/EndpointsConfig.java
+++ b/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/EndpointsConfig.java
@@ -25,6 +25,7 @@ public class EndpointsConfig {
     private EndpointConfig circuitBreakers = new EndpointConfig("circuitbreaker");
     private EndpointConfig rateLimiters = new EndpointConfig("ratelimiter");
     private EndpointConfig retries = new EndpointConfig("retry");
+    private EndpointConfig bulkheads = new EndpointConfig("bulkhead");
 
     public EndpointConfig getCircuitBreakers() {
         return circuitBreakers;
@@ -59,6 +60,19 @@ public class EndpointsConfig {
     public EndpointsConfig retries(Function<? super EndpointConfig, ? extends EndpointConfig> configure) {
         try {
             retries = configure.apply(new EndpointConfig("retry"));
+            return this;
+        } catch (Exception e) {
+            throw uncheck(e);
+        }
+    }
+
+    public EndpointConfig getBulkheads() {
+        return bulkheads;
+    }
+
+    public EndpointsConfig bulkheads(Function<? super EndpointConfig, ? extends EndpointConfig> configure) {
+        try {
+            bulkheads = configure.apply(new EndpointConfig("bulkhead"));
             return this;
         } catch (Exception e) {
             throw uncheck(e);

--- a/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/Resilience4jConfig.java
+++ b/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/Resilience4jConfig.java
@@ -16,6 +16,7 @@
 
 package io.github.resilience4j.ratpack;
 
+import io.github.resilience4j.ratpack.bulkhead.BulkheadConfig;
 import io.github.resilience4j.ratpack.circuitbreaker.CircuitBreakerConfig;
 import io.github.resilience4j.ratpack.ratelimiter.RateLimiterConfig;
 import io.github.resilience4j.ratpack.retry.RetryConfig;
@@ -30,6 +31,7 @@ public class Resilience4jConfig {
     private Map<String, CircuitBreakerConfig> circuitBreakers = new HashMap<>();
     private Map<String, RateLimiterConfig> rateLimiters = new HashMap<>();
     private Map<String, RetryConfig> retries = new HashMap<>();
+    private Map<String, BulkheadConfig> bulkheads = new HashMap<>();
     private boolean metrics = false;
     private boolean prometheus = false;
     private EndpointsConfig endpoints = new EndpointsConfig();
@@ -58,6 +60,16 @@ public class Resilience4jConfig {
         try {
             RetryConfig finalConfig = configure.apply(new RetryConfig());
             retries.put(name, finalConfig);
+            return this;
+        } catch (Exception e) {
+            throw uncheck(e);
+        }
+    }
+
+    public Resilience4jConfig bulkhead(String name, Function<? super BulkheadConfig, ? extends BulkheadConfig> configure) {
+        try {
+            BulkheadConfig finalConfig = configure.apply(new BulkheadConfig());
+            bulkheads.put(name, finalConfig);
             return this;
         } catch (Exception e) {
             throw uncheck(e);
@@ -93,6 +105,10 @@ public class Resilience4jConfig {
 
     public Map<String, RetryConfig> getRetries() {
         return retries;
+    }
+
+    public Map<String, BulkheadConfig> getBulkheads() {
+        return bulkheads;
     }
 
     public boolean isMetrics() {

--- a/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/bulkhead/Bulkhead.java
+++ b/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/bulkhead/Bulkhead.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Jan Sykora
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.ratpack.bulkhead;
+
+import io.github.resilience4j.ratpack.recovery.DefaultRecoveryFunction;
+import io.github.resilience4j.ratpack.recovery.RecoveryFunction;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation for marking a method of an annotated object as bulkhead enabled.
+ * Given a method like this:
+ * <pre><code>
+ *     {@literal @}Bulkhead(name = "myService")
+ *     public String fancyName(String name) {
+ *         return "Sir Captain " + name;
+ *     }
+ * </code></pre>
+ * each time the {@code #fancyName(String)} method is invoked, the method's execution will pass through a
+ * a bulkhead (concurrent limiting) according to the given bulkhead policy.
+ */
+@Inherited
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+public @interface Bulkhead {
+    /**
+     * @return The name of the bulkhead. It will be looked up the bulkhead registry.
+     */
+    String name() default "";
+
+    /**
+     * The Function class that returns a fallback value. The default is a noop.
+     *
+     * @return the function
+     */
+    Class<? extends RecoveryFunction> recovery() default DefaultRecoveryFunction.class;
+}

--- a/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/bulkhead/BulkheadConfig.java
+++ b/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/bulkhead/BulkheadConfig.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 Jan Sykora
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.ratpack.bulkhead;
+
+/**
+ * Bulkhead config adapter for integration with Ratpack. {@link #maxWaitTime} should
+ * almost always be set to 0, so the compute threads would not be blocked upon execution.
+ */
+public class BulkheadConfig {
+
+    private boolean defaults = false;
+    private int maxConcurrentCalls;
+    private long maxWaitTime;
+
+    public BulkheadConfig defaults(boolean defaults) {
+        this.defaults = defaults;
+        return this;
+    }
+
+    public BulkheadConfig maxConcurrentCalls(int maxConcurrentCalls) {
+        this.maxConcurrentCalls = maxConcurrentCalls;
+        return this;
+    }
+
+    public BulkheadConfig maxWaitTime(int maxWaitTime) {
+        this.maxWaitTime = maxWaitTime;
+        return this;
+    }
+
+    public boolean getDefaults() {
+        return defaults;
+    }
+
+    public int getMaxConcurrentCalls() {
+        return maxConcurrentCalls;
+    }
+
+    public long getMaxWaitTime() {
+        return maxWaitTime;
+    }
+}

--- a/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/bulkhead/BulkheadMethodInterceptor.java
+++ b/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/bulkhead/BulkheadMethodInterceptor.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2017 Jan Sykora
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.ratpack.bulkhead;
+
+import com.google.inject.Inject;
+import io.github.resilience4j.bulkhead.BulkheadFullException;
+import io.github.resilience4j.bulkhead.BulkheadRegistry;
+import io.github.resilience4j.bulkhead.operator.BulkheadOperator;
+import io.github.resilience4j.ratpack.recovery.RecoveryFunction;
+import io.reactivex.Flowable;
+import io.reactivex.Observable;
+import io.reactivex.Single;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import ratpack.exec.Promise;
+import ratpack.util.Exceptions;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * A {@link MethodInterceptor} to handle all methods annotated with {@link Bulkhead}. It will
+ * handle methods that return a Promise only. It will add a transform to the promise with the bulkhead and
+ * fallback found in the annotation.
+ */
+public class BulkheadMethodInterceptor implements MethodInterceptor {
+
+    @Inject(optional = true)
+    private BulkheadRegistry registry;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Object invoke(MethodInvocation invocation) throws Throwable {
+        Bulkhead annotation = invocation.getMethod().getAnnotation(Bulkhead.class);
+        RecoveryFunction<?> recoveryFunction = annotation.recovery().newInstance();
+        if (registry == null) {
+            registry = BulkheadRegistry.ofDefaults();
+        }
+        io.github.resilience4j.bulkhead.Bulkhead bulkhead = registry.bulkhead(annotation.name());
+        if (bulkhead == null) {
+            return invocation.proceed();
+        }
+        Class<?> returnType = invocation.getMethod().getReturnType();
+        if (Promise.class.isAssignableFrom(returnType)) {
+            Promise<?> result = (Promise<?>) invocation.proceed();
+            if (result != null) {
+                BulkheadTransformer transformer = BulkheadTransformer.of(bulkhead).recover(recoveryFunction);
+                result = result.transform(transformer);
+            }
+            return result;
+        } else if (Observable.class.isAssignableFrom(returnType)) {
+            Observable<?> result = (Observable<?>) invocation.proceed();
+            if (result != null) {
+                BulkheadOperator operator = BulkheadOperator.of(bulkhead);
+                result = result.lift(operator).onErrorReturn(t -> recoveryFunction.apply((Throwable) t));
+            }
+            return result;
+        } else if (Flowable.class.isAssignableFrom(returnType)) {
+            Flowable<?> result = (Flowable<?>) invocation.proceed();
+            if (result != null) {
+                BulkheadOperator operator = BulkheadOperator.of(bulkhead);
+                result = result.lift(operator).onErrorReturn(t -> recoveryFunction.apply((Throwable) t));
+            }
+            return result;
+        } else if (Single.class.isAssignableFrom(returnType)) {
+            Single<?> result = (Single<?>) invocation.proceed();
+            if (result != null) {
+                BulkheadOperator operator = BulkheadOperator.of(bulkhead);
+                result = result.lift(operator).onErrorReturn(t -> recoveryFunction.apply((Throwable) t));
+            }
+            return result;
+        } else if (CompletionStage.class.isAssignableFrom(returnType)) {
+            if (bulkhead.isCallPermitted()) {
+                return ((CompletionStage<?>) invocation.proceed()).handle((o, throwable) -> {
+                    bulkhead.onComplete();
+                    if (throwable != null) {
+                        try {
+                            return recoveryFunction.apply(throwable);
+                        } catch (Exception e) {
+                            throw Exceptions.uncheck(throwable);
+                        }
+                    } else {
+                        return o;
+                    }
+                });
+            } else {
+                final CompletableFuture promise = new CompletableFuture<>();
+                Throwable t = new BulkheadFullException(String.format("Bulkhead '%s' is full", bulkhead.getName()));
+                try {
+                    promise.complete(recoveryFunction.apply(t));
+                } catch (Throwable t2) {
+                    promise.completeExceptionally(t2);
+                }
+                return promise;
+            }
+        }
+        return handleOther(invocation, bulkhead, recoveryFunction);
+    }
+
+    private Object handleOther(MethodInvocation invocation, io.github.resilience4j.bulkhead.Bulkhead bulkhead, RecoveryFunction<?> recoveryFunction) throws Throwable {
+        boolean permission = bulkhead.isCallPermitted();
+
+        if (!permission) {
+            Throwable t = new BulkheadFullException(String.format("Bulkhead '%s' is full", bulkhead.getName()));
+            return recoveryFunction.apply(t);
+        }
+
+        try {
+            if (Thread.interrupted()) {
+                throw new IllegalStateException("Thread was interrupted during permission wait");
+            }
+
+            return invocation.proceed();
+        } catch (Exception e) {
+            return recoveryFunction.apply(e);
+        } finally {
+            bulkhead.onComplete();
+        }
+    }
+}

--- a/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/bulkhead/BulkheadTransformer.java
+++ b/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/bulkhead/BulkheadTransformer.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2017 Jan Sykora
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.ratpack.bulkhead;
+
+import io.github.resilience4j.bulkhead.Bulkhead;
+import io.github.resilience4j.bulkhead.BulkheadFullException;
+import ratpack.exec.Downstream;
+import ratpack.exec.Upstream;
+import ratpack.func.Function;
+
+
+public class BulkheadTransformer <T> implements Function<Upstream<? extends T>, Upstream<T>> {
+
+    private final Bulkhead bulkhead;
+    private Function<Throwable, ? extends T> recover;
+
+    private BulkheadTransformer(Bulkhead bulkhead) {
+        this.bulkhead = bulkhead;
+    }
+
+    /**
+     * Create a new transformer that can be applied to the {@link ratpack.exec.Promise#transform(Function)} method.
+     * The Promised value will pass through the bulkhead, potentially causing it to throw error on reaching
+     * limit of concurrent calls.
+     *
+     * @param bulkhead the bulkhead to use
+     * @param <T>         the type of object
+     * @return the transformer
+     */
+    public static <T> BulkheadTransformer<T> of(Bulkhead bulkhead) {
+        return new BulkheadTransformer<>(bulkhead);
+    }
+
+    /**
+     * Set a recovery function that will execute when the rateLimiter limit is exceeded.
+     *
+     * @param recover the recovery function
+     * @return the transformer
+     */
+    public BulkheadTransformer<T> recover(Function<Throwable, ? extends T> recover) {
+        this.recover = recover;
+        return this;
+    }
+
+    @Override
+    public Upstream<T> apply(Upstream<? extends T> upstream) throws Exception {
+        return down -> {
+            if (bulkhead.isCallPermitted()) {
+                // do not allow permits to leak
+                upstream.connect(new Downstream<T>() {
+
+                    @Override
+                    public void success(T value) {
+                        bulkhead.onComplete();
+                        down.success(value);
+                    }
+
+                    @Override
+                    public void error(Throwable throwable) {
+                        bulkhead.onComplete();
+                        try {
+                            if (recover != null) {
+                                down.success(recover.apply(throwable));
+                            } else {
+                                down.error(throwable);
+                            }
+                        } catch (Throwable t) {
+                            down.error(t);
+                        }
+                    }
+
+                    @Override
+                    public void complete() {
+                        bulkhead.onComplete();
+                        down.complete();
+                    }
+                });
+            } else {
+                Throwable t = new BulkheadFullException(String.format("Bulkhead '%s' is full", bulkhead.getName()));
+                if (recover != null) {
+                    try {
+                        down.success(recover.apply(t));
+                    } catch (Throwable t2) {
+                        down.error(t2);
+                    }
+                } else {
+                    down.error(t);
+                }
+            }
+        };
+    }
+}

--- a/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/bulkhead/endpoint/BulkheadChain.java
+++ b/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/bulkhead/endpoint/BulkheadChain.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017 Jan Sykora
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.ratpack.bulkhead.endpoint;
+
+import io.github.resilience4j.adapter.RxJava2Adapter;
+import io.github.resilience4j.bulkhead.Bulkhead;
+import io.github.resilience4j.bulkhead.BulkheadRegistry;
+import io.github.resilience4j.bulkhead.event.BulkheadEvent;
+import io.github.resilience4j.consumer.CircularEventConsumer;
+import io.github.resilience4j.consumer.EventConsumerRegistry;
+import io.github.resilience4j.ratpack.Resilience4jConfig;
+import io.reactivex.Flowable;
+import io.vavr.collection.Seq;
+import ratpack.exec.Promise;
+import ratpack.func.Action;
+import ratpack.func.Function;
+import ratpack.handling.Chain;
+import ratpack.jackson.Jackson;
+import ratpack.sse.ServerSentEvents;
+
+import javax.inject.Inject;
+import java.util.Comparator;
+
+/**
+ * Provides event and stream event endpoints for bulkhead events.
+ */
+public class BulkheadChain implements Action<Chain> {
+
+    private final EventConsumerRegistry<BulkheadEvent> eventConsumerRegistry;
+    private final BulkheadRegistry bulkheadRegistry;
+
+    @Inject
+    public BulkheadChain(EventConsumerRegistry<BulkheadEvent> eventConsumerRegistry, BulkheadRegistry bulkheadRegistry) {
+        this.eventConsumerRegistry = eventConsumerRegistry;
+        this.bulkheadRegistry = bulkheadRegistry;
+    }
+
+    @Override
+    public void execute(Chain chain) throws Exception {
+        String prefix = chain.getRegistry().get(Resilience4jConfig.class).getEndpoints().getBulkheads().getPath();
+        chain.prefix(prefix, chain1 -> {
+            chain1.get("events", ctx ->
+                    Promise.<BulkheadEventsEndpointResponse>async(d -> {
+                        BulkheadEventsEndpointResponse response = new BulkheadEventsEndpointResponse(eventConsumerRegistry
+                                .getAllEventConsumer()
+                                .flatMap(CircularEventConsumer::getBufferedEvents)
+                                .sorted(Comparator.comparing(BulkheadEvent::getCreationTime))
+                                .map(BulkheadEventDTO::createEventDTO).toJavaList());
+                        d.success(response);
+                    }).then(r -> ctx.render(Jackson.json(r)))
+            );
+            chain1.get("stream/events", ctx -> {
+                Seq<Flowable<BulkheadEvent>> eventStreams = bulkheadRegistry.getAllBulkheads().map(bulkhead -> RxJava2Adapter.toFlowable(bulkhead.getEventPublisher()));
+                Function<BulkheadEvent, String> data = b -> Jackson.getObjectWriter(chain1.getRegistry()).writeValueAsString(BulkheadEventDTO.createEventDTO(b));
+                ServerSentEvents events = ServerSentEvents.serverSentEvents(Flowable.merge(eventStreams), e -> e.id(BulkheadEvent::getBulkheadName).event(c -> c.getEventType().name()).data(data));
+                ctx.render(events);
+            });
+            chain1.get("events/:name", ctx -> {
+                        String bulkheadName = ctx.getPathTokens().get("name");
+                        Promise.<BulkheadEventsEndpointResponse>async(d -> {
+                            BulkheadEventsEndpointResponse response = new BulkheadEventsEndpointResponse(eventConsumerRegistry
+                                    .getEventConsumer(bulkheadName)
+                                    .getBufferedEvents()
+                                    .map(BulkheadEventDTO::createEventDTO).toJavaList());
+                            d.success(response);
+                        }).then(r -> ctx.render(Jackson.json(r)));
+                    }
+            );
+            chain1.get("stream/events/:name", ctx -> {
+                String bulkheadName = ctx.getPathTokens().get("name");
+                Bulkhead bulkhead = bulkheadRegistry.getAllBulkheads().find(b -> b.getName().equals(bulkheadName))
+                        .getOrElseThrow(() -> new IllegalArgumentException(String.format("bulkhead with name %s not found", bulkheadName)));
+                Function<BulkheadEvent, String> data = b -> Jackson.getObjectWriter(chain1.getRegistry()).writeValueAsString(BulkheadEventDTO.createEventDTO(b));
+                ServerSentEvents events = ServerSentEvents.serverSentEvents(RxJava2Adapter.toFlowable(bulkhead.getEventPublisher()), e -> e.id(BulkheadEvent::getBulkheadName).event(c -> c.getEventType().name()).data(data));
+                ctx.render(events);
+            });
+            chain1.get("events/:name/:type", ctx -> {
+                        String bulkheadName = ctx.getPathTokens().get("name");
+                        String eventType = ctx.getPathTokens().get("type");
+                        Promise.<BulkheadEventsEndpointResponse>async(d -> {
+                            BulkheadEventsEndpointResponse response = new BulkheadEventsEndpointResponse(eventConsumerRegistry
+                                    .getEventConsumer(bulkheadName)
+                                    .getBufferedEvents()
+                                    .filter(event -> event.getEventType() == BulkheadEvent.Type.valueOf(eventType.toUpperCase()))
+                                    .map(BulkheadEventDTO::createEventDTO).toJavaList());
+                            d.success(response);
+                        }).then(r -> ctx.render(Jackson.json(r)));
+                    }
+            );
+            chain1.get("stream/events/:name/:type", ctx -> {
+                String bulkheadName = ctx.getPathTokens().get("name");
+                String eventType = ctx.getPathTokens().get("type");
+                Bulkhead bulkhead = bulkheadRegistry.getAllBulkheads().find(b -> b.getName().equals(bulkheadName))
+                        .getOrElseThrow(() -> new IllegalArgumentException(String.format("bulkhead with name %s not found", bulkheadName)));
+                Flowable<BulkheadEvent> eventStream = RxJava2Adapter.toFlowable(bulkhead.getEventPublisher())
+                        .filter(event -> event.getEventType() == BulkheadEvent.Type.valueOf(eventType.toUpperCase()));
+                Function<BulkheadEvent, String> data = b -> Jackson.getObjectWriter(chain1.getRegistry()).writeValueAsString(BulkheadEventDTO.createEventDTO(b));
+                ServerSentEvents events = ServerSentEvents.serverSentEvents(eventStream, e -> e.id(BulkheadEvent::getBulkheadName).event(c -> c.getEventType().name()).data(data));
+                ctx.render(events);
+            });
+        });
+    }
+}

--- a/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/bulkhead/endpoint/BulkheadEventDTO.java
+++ b/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/bulkhead/endpoint/BulkheadEventDTO.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Jan Sykora
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.ratpack.bulkhead.endpoint;
+
+import io.github.resilience4j.bulkhead.event.BulkheadEvent;
+
+/**
+ * DTO to class for publishing bulkhead events.
+ */
+public class BulkheadEventDTO {
+
+    private String bulkheadName;
+    private BulkheadEvent.Type type;
+    private String creationTime;
+
+    BulkheadEventDTO() {
+    }
+
+    BulkheadEventDTO(String bulkheadName, BulkheadEvent.Type type, String creationTime) {
+        this.bulkheadName = bulkheadName;
+        this.type = type;
+        this.creationTime = creationTime;
+    }
+
+    public static BulkheadEventDTO createEventDTO(BulkheadEvent bulkheadEvent) {
+        return new BulkheadEventDTO(bulkheadEvent.getBulkheadName(), bulkheadEvent.getEventType(), bulkheadEvent.getCreationTime().toString());
+    }
+
+    public String getBulkheadName() {
+        return bulkheadName;
+    }
+
+    public void setBulkheadName(String bulkheadName) {
+        this.bulkheadName = bulkheadName;
+    }
+
+    public BulkheadEvent.Type getType() {
+        return type;
+    }
+
+    public void setType(BulkheadEvent.Type type) {
+        this.type = type;
+    }
+
+    public String getCreationTime() {
+        return creationTime;
+    }
+
+    public void setCreationTime(String creationTime) {
+        this.creationTime = creationTime;
+    }
+}

--- a/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/bulkhead/endpoint/BulkheadEventsEndpointResponse.java
+++ b/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/bulkhead/endpoint/BulkheadEventsEndpointResponse.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 Jan Sykora
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.ratpack.bulkhead.endpoint;
+
+import java.util.List;
+
+public class BulkheadEventsEndpointResponse {
+    private List<BulkheadEventDTO> bulkheadEvents;
+
+    public BulkheadEventsEndpointResponse() {
+    }
+
+    public BulkheadEventsEndpointResponse(List<BulkheadEventDTO> bulkheadEvents) {
+        this.bulkheadEvents = bulkheadEvents;
+    }
+
+    public List<BulkheadEventDTO> getBulkheadEvents() {
+        return bulkheadEvents;
+    }
+
+    public void setBulkheadEvents(List<BulkheadEventDTO> bulkheadEvents) {
+        this.bulkheadEvents = bulkheadEvents;
+    }
+}

--- a/resilience4j-ratpack/src/test/groovy/io/github/resilience4j/ratpack/bulkhead/BulkheadSpec.groovy
+++ b/resilience4j-ratpack/src/test/groovy/io/github/resilience4j/ratpack/bulkhead/BulkheadSpec.groovy
@@ -1,0 +1,514 @@
+/*
+ * Copyright 2017 Jan Sykora
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.ratpack.bulkhead
+
+import io.github.resilience4j.bulkhead.BulkheadRegistry
+import io.github.resilience4j.ratpack.Resilience4jModule
+import io.github.resilience4j.ratpack.recovery.RecoveryFunction
+import io.reactivex.BackpressureStrategy
+import io.reactivex.Flowable
+import io.reactivex.Observable
+import io.reactivex.Single
+import io.reactivex.functions.Consumer
+import io.reactivex.functions.Function
+import ratpack.exec.Promise
+import ratpack.http.client.ReceivedResponse
+import ratpack.test.embed.EmbeddedApp
+import ratpack.test.http.TestHttpClient
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.util.concurrent.Callable
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+import static ratpack.groovy.test.embed.GroovyEmbeddedApp.ratpack
+
+@Unroll
+class BulkheadSpec extends Specification {
+
+    @AutoCleanup
+    EmbeddedApp app
+
+    @AutoCleanup(value = "shutdown")
+    ExecutorService executor = Executors.newCachedThreadPool()
+
+    @Delegate
+    TestHttpClient client
+
+    def "test no bulkhead registry installed, app still works"() {
+        given:
+        app = ratpack {
+            bindings {
+                module(Resilience4jModule)
+                bind(Something)
+            }
+            handlers {
+                get('promise') { Something something ->
+                    something.simpleBulkheadPromise().then {
+                        render it
+                    }
+                }
+            }
+        }
+        client = testHttpClient(app)
+
+        when:
+        def actual = get('promise')
+
+        then:
+        actual.body.text == 'bulkhead promise'
+        actual.statusCode == 200
+    }
+
+    def "test bulkhead a method via annotation - path=#path"() {
+        given:
+        BulkheadRegistry registry = BulkheadRegistry.of(buildConfig())
+        def latch = new CountDownLatch(1)
+        def blockLatch = new CountDownLatch(1)
+        app = ratpack {
+            bindings {
+                bindInstance(BulkheadRegistry, registry)
+                bind(Something)
+                module(Resilience4jModule)
+            }
+            handlers {
+                get('promise') { Something something ->
+                    something.bulkheadPromise(latch, blockLatch).then {
+                        render it
+                    }
+                }
+                get('observable') { Something something ->
+                    something.bulkheadObservable(latch, blockLatch).subscribe {
+                        render it
+                    } {
+                        response.status(500).send(it.cause.cause.toString())
+                    }
+                }
+                get('flowable') { Something something ->
+                    something.bulkheadFlowable(latch, blockLatch).subscribe {
+                        render it
+                    } {
+                        response.status(500).send(it.cause.cause.toString())
+                    }
+                }
+                get('single') { Something something ->
+                    something.bulkheadSingle(latch, blockLatch).subscribe({
+                        render it
+                    } as Consumer<String>) {
+                        response.status(500).send(it.cause.cause.toString())
+                    }
+                }
+                get('stage') { Something something ->
+                    render something.bulkheadStage(latch, blockLatch).toCompletableFuture().get()
+                }
+                get('normal') { Something something ->
+                    render something.bulkheadNormal(latch, blockLatch)
+                }
+            }
+        }
+        client = testHttpClient(app)
+
+        when:
+        def blockedResponse = executor.submit({
+            client.get(path)
+        } as Callable<ReceivedResponse>)
+
+        and:
+        assert blockLatch.await(10, TimeUnit.SECONDS)
+        def rejectedResponse = executor.submit({
+            client.get(path)
+        } as Callable<ReceivedResponse>)
+
+        and:
+        rejectedResponse.get(10, TimeUnit.SECONDS)
+        latch.countDown() // unblock blocked response
+        def permittedResponse = executor.submit({
+            client.get(path)
+        } as Callable<ReceivedResponse>)
+
+        then:
+        blockedResponse.get().statusCode == 200
+        rejectedResponse.get().body.text.contains("io.github.resilience4j.bulkhead.BulkheadFullException: Bulkhead 'test' is full")
+        rejectedResponse.get().statusCode == 500
+        permittedResponse.get().statusCode == 200
+
+        where:
+        path << [
+                'promise',
+                'observable',
+                'flowable',
+                'single',
+                'stage',
+                'normal'
+        ]
+    }
+
+    def "test bulkhead a method via annotation with exception - path=#path"() {
+        given:
+        BulkheadRegistry registry = BulkheadRegistry.of(buildConfig())
+        def latch = new CountDownLatch(1)
+        def blockLatch = new CountDownLatch(1)
+        app = ratpack {
+            bindings {
+                bindInstance(BulkheadRegistry, registry)
+                bind(Something)
+                module(Resilience4jModule)
+            }
+            handlers {
+                get('promise') { Something something ->
+                    something.bulkheadPromiseException(latch, blockLatch).then {
+                        render it
+                    }
+                }
+                get('observable') { Something something ->
+                    something.bulkheadObservableException(latch, blockLatch).subscribe {
+                        render it
+                    } {
+                        response.status(500).send(it.cause.cause.toString())
+                    }
+                }
+                get('flowable') { Something something ->
+                    something.bulkheadFlowableException(latch, blockLatch).subscribe {
+                        render it
+                    } {
+                        response.status(500).send(it.cause.cause.toString())
+                    }
+                }
+                get('single') { Something something ->
+                    something.bulkheadSingleException(latch, blockLatch).subscribe({
+                        render it
+                    } as Consumer<Void>) {
+                        response.status(500).send(it.cause.cause.toString())
+                    }
+                }
+                get('stage') { Something something ->
+                    try {
+                        render something.bulkheadStageException(latch, blockLatch).toCompletableFuture().get()
+                    } catch (ExecutionException e) {
+                        throw e.getCause() // unwrap exception
+                    }
+                }
+                get('normal') { Something something ->
+                    render something.bulkheadNormalException(latch, blockLatch)
+                }
+            }
+        }
+        client = testHttpClient(app)
+
+        when:
+        def blockedResponse = executor.submit({
+            client.get(path)
+        } as Callable<ReceivedResponse>)
+
+        and:
+        assert blockLatch.await(10, TimeUnit.SECONDS)
+        def rejectedResponse = executor.submit({
+            client.get(path)
+        } as Callable<ReceivedResponse>)
+
+        and:
+        rejectedResponse.get(10, TimeUnit.SECONDS)
+        latch.countDown() // unblock blocked response
+        def permittedResponse = executor.submit({
+            client.get(path)
+        } as Callable<ReceivedResponse>)
+
+        then:
+        blockedResponse.get().body.text.contains(message)
+        blockedResponse.get().statusCode == 500
+        rejectedResponse.get().body.text.contains("io.github.resilience4j.bulkhead.BulkheadFullException: Bulkhead 'test' is full")
+        rejectedResponse.get().statusCode == 500
+        permittedResponse.get().body.text.contains(message)
+        permittedResponse.get().statusCode == 500
+
+        where:
+        path         | message
+        'promise'    | 'bulkhead promise exception'
+        'observable' | 'bulkhead observable exception'
+        'flowable'   | 'bulkhead flowable exception'
+        'single'     | 'bulkhead single exception'
+        'stage'      | 'bulkhead stage exception'
+        'normal'     | 'bulkhead normal exception'
+    }
+
+    def "test rate limit a method via annotation with fallback - path=#path"() {
+        given:
+        BulkheadRegistry registry = BulkheadRegistry.of(buildConfig())
+        def latch = new CountDownLatch(1)
+        def blockLatch = new CountDownLatch(1)
+        app = ratpack {
+            bindings {
+                bindInstance(BulkheadRegistry, registry)
+                bind(Something)
+                module(Resilience4jModule)
+            }
+            handlers {
+                get('promise') { Something something ->
+                    something.bulkheadPromiseFallback(latch, blockLatch).then {
+                        render it
+                    }
+                }
+                get('observable') { Something something ->
+                    something.bulkheadObservableFallback(latch, blockLatch).subscribe {
+                        render it
+                    }
+                }
+                get('flowable') { Something something ->
+                    something.bulkheadFlowableFallback(latch, blockLatch).subscribe {
+                        render it
+                    }
+                }
+                get('single') { Something something ->
+                    something.bulkheadSingleFallback(latch, blockLatch).subscribe({
+                        render it
+                    } as Consumer<Void>)
+                }
+                get('stage') { Something something ->
+                    render something.bulkheadStageFallback(latch, blockLatch).toCompletableFuture().get()
+                }
+                get('normal') { Something something ->
+                    render something.bulkheadNormalFallback(latch, blockLatch)
+                }
+            }
+        }
+        client = testHttpClient(app)
+
+        when:
+        def blockedResponse = executor.submit({
+            client.get(path)
+        } as Callable<ReceivedResponse>)
+
+        and:
+        assert blockLatch.await(10, TimeUnit.SECONDS)
+        def rejectedResponse = executor.submit({
+            client.get(path)
+        } as Callable<ReceivedResponse>)
+
+        and:
+        rejectedResponse.get(10, TimeUnit.SECONDS)
+        latch.countDown() // unblock blocked response
+        def permittedResponse = executor.submit({
+            client.get(path)
+        } as Callable<ReceivedResponse>)
+
+        then:
+        blockedResponse.get().body.text == "recovered"
+        blockedResponse.get().statusCode == 200
+        rejectedResponse.get().body.text == "recovered"
+        rejectedResponse.get().statusCode == 200
+        permittedResponse.get().body.text == "recovered"
+        permittedResponse.get().statusCode == 200
+
+        where:
+        path << [
+                'promise',
+                'observable',
+                'flowable',
+                'single',
+                'stage',
+                'normal'
+        ]
+    }
+
+    // 1 concurrent call
+    def buildConfig() {
+        io.github.resilience4j.bulkhead.BulkheadConfig.custom()
+                .maxConcurrentCalls(1)
+                .maxWaitTime(0)
+                .build()
+    }
+
+    // both latches are unblocked on later calls
+    static class Something {
+
+        @Bulkhead(name = "test")
+        Promise<String> simpleBulkheadPromise() {
+            Promise.async {
+                it.success("bulkhead promise")
+            }
+        }
+
+        @Bulkhead(name = "test")
+        Promise<String> bulkheadPromise(CountDownLatch latch, CountDownLatch blockLatch) {
+            Promise.async {
+                blockLatch.countDown()
+                assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                it.success("bulkhead promise")
+            }
+        }
+
+        @Bulkhead(name = "test")
+        Observable<String> bulkheadObservable(CountDownLatch latch, CountDownLatch blockLatch) {
+            Observable.just("bulkhead observable").map({ it ->
+                blockLatch.countDown()
+                assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                it
+            })
+        }
+
+        @Bulkhead(name = "test")
+        Flowable<String> bulkheadFlowable(CountDownLatch latch, CountDownLatch blockLatch) {
+            Observable.just("bulkhead observable").map({ it ->
+                blockLatch.countDown()
+                assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                it
+            }).toFlowable(BackpressureStrategy.ERROR)
+        }
+
+        @Bulkhead(name = "test")
+        Single<String> bulkheadSingle(CountDownLatch latch, CountDownLatch blockLatch) {
+            Single.just("bulkhead single").map({ it ->
+                blockLatch.countDown()
+                assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                it
+            })
+        }
+
+        @Bulkhead(name = "test")
+        CompletionStage<String> bulkheadStage(CountDownLatch latch, CountDownLatch blockLatch) {
+            CompletableFuture.supplyAsync {
+                blockLatch.countDown()
+                assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                'bulkhead stage'
+            }
+        }
+
+        @Bulkhead(name = "test")
+        String bulkheadNormal(CountDownLatch latch, CountDownLatch blockLatch) {
+            blockLatch.countDown()
+            assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+            "bulkhead normal"
+        }
+
+        @Bulkhead(name = "test")
+        Promise<String> bulkheadPromiseException(CountDownLatch latch, CountDownLatch blockLatch) {
+            Promise.async {
+                blockLatch.countDown()
+                assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                it.error(new Exception("bulkhead promise exception"))
+            }
+        }
+
+        @Bulkhead(name = "test")
+        Observable<Void> bulkheadObservableException(CountDownLatch latch, CountDownLatch blockLatch) {
+            Observable.just("bulkhead observable").map({
+                blockLatch.countDown()
+                assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                throw new Exception("bulkhead observable exception")
+            } as Function<String, Void>)
+        }
+
+        @Bulkhead(name = "test")
+        Flowable<Void> bulkheadFlowableException(CountDownLatch latch, CountDownLatch blockLatch) {
+            Observable.just("bulkhead flowable").map({
+                blockLatch.countDown()
+                assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                throw new Exception("bulkhead flowable exception")
+            } as Function<String, Void>).toFlowable(BackpressureStrategy.ERROR)
+        }
+
+        @Bulkhead(name = "test")
+        Single<Void> bulkheadSingleException(CountDownLatch latch, CountDownLatch blockLatch) {
+            Single.just("bulkhead single").map({
+                blockLatch.countDown()
+                assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                throw new Exception("bulkhead single exception")
+            } as Function<String, Void>)
+        }
+
+        @Bulkhead(name = "test")
+        CompletionStage<Void> bulkheadStageException(CountDownLatch latch, CountDownLatch blockLatch) {
+            CompletableFuture.supplyAsync {
+                blockLatch.countDown()
+                assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                throw new Exception('bulkhead stage exception')
+            }
+        }
+
+        @Bulkhead(name = "test")
+        String bulkheadNormalException(CountDownLatch latch, CountDownLatch blockLatch) {
+            blockLatch.countDown()
+            assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+            throw new Exception("bulkhead normal exception")
+        }
+
+        @Bulkhead(name = "test", recovery = MyRecoveryFunction)
+        Promise<String> bulkheadPromiseFallback(CountDownLatch latch, CountDownLatch blockLatch) {
+            Promise.async {
+                blockLatch.countDown()
+                assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                it.error(new Exception("bulkhead promise exception"))
+            }
+        }
+
+        @Bulkhead(name = "test", recovery = MyRecoveryFunction)
+        Observable<Void> bulkheadObservableFallback(CountDownLatch latch, CountDownLatch blockLatch) {
+            Observable.just("bulkhead observable").map({
+                blockLatch.countDown()
+                assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                throw new Exception("bulkhead observable exception")
+            } as Function<String, Void>)
+        }
+
+        @Bulkhead(name = "test", recovery = MyRecoveryFunction)
+        Flowable<Void> bulkheadFlowableFallback(CountDownLatch latch, CountDownLatch blockLatch) {
+            Observable.just("bulkhead flowable").map({
+                blockLatch.countDown()
+                assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                throw new Exception("bulkhead flowable exception")
+            } as Function<String, Void>).toFlowable(BackpressureStrategy.ERROR)
+        }
+
+        @Bulkhead(name = "test", recovery = MyRecoveryFunction)
+        Single<Void> bulkheadSingleFallback(CountDownLatch latch, CountDownLatch blockLatch) {
+            Single.just("bulkhead single").map({
+                blockLatch.countDown()
+                assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                throw new Exception("bulkhead single exception")
+            } as Function<String, Void>)
+        }
+
+        @Bulkhead(name = "test", recovery = MyRecoveryFunction)
+        CompletionStage<Void> bulkheadStageFallback(CountDownLatch latch, CountDownLatch blockLatch) {
+            CompletableFuture.supplyAsync {
+                blockLatch.countDown()
+                assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                throw new Exception('bulkhead stage exception')
+            }
+        }
+
+        @Bulkhead(name = "test", recovery = MyRecoveryFunction)
+        String bulkheadNormalFallback(CountDownLatch latch, CountDownLatch blockLatch) {
+            blockLatch.countDown()
+            assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+            throw new Exception("bulkhead normal exception")
+        }
+    }
+
+    static class MyRecoveryFunction implements RecoveryFunction<String> {
+        @Override
+        String apply(Throwable t) throws Exception {
+            "recovered"
+        }
+    }
+}

--- a/resilience4j-ratpack/src/test/groovy/io/github/resilience4j/ratpack/bulkhead/BulkheadSpec.groovy
+++ b/resilience4j-ratpack/src/test/groovy/io/github/resilience4j/ratpack/bulkhead/BulkheadSpec.groovy
@@ -134,13 +134,13 @@ class BulkheadSpec extends Specification {
         } as Callable<ReceivedResponse>)
 
         and:
-        assert blockLatch.await(10, TimeUnit.SECONDS)
+        assert blockLatch.await(30, TimeUnit.SECONDS)
         def rejectedResponse = executor.submit({
             client.get(path)
         } as Callable<ReceivedResponse>)
 
         and:
-        rejectedResponse.get(10, TimeUnit.SECONDS)
+        rejectedResponse.get(30, TimeUnit.SECONDS)
         latch.countDown() // unblock blocked response
         def permittedResponse = executor.submit({
             client.get(path)
@@ -221,13 +221,13 @@ class BulkheadSpec extends Specification {
         } as Callable<ReceivedResponse>)
 
         and:
-        assert blockLatch.await(10, TimeUnit.SECONDS)
+        assert blockLatch.await(30, TimeUnit.SECONDS)
         def rejectedResponse = executor.submit({
             client.get(path)
         } as Callable<ReceivedResponse>)
 
         and:
-        rejectedResponse.get(10, TimeUnit.SECONDS)
+        rejectedResponse.get(30, TimeUnit.SECONDS)
         latch.countDown() // unblock blocked response
         def permittedResponse = executor.submit({
             client.get(path)
@@ -299,13 +299,13 @@ class BulkheadSpec extends Specification {
         } as Callable<ReceivedResponse>)
 
         and:
-        assert blockLatch.await(10, TimeUnit.SECONDS)
+        assert blockLatch.await(30, TimeUnit.SECONDS)
         def rejectedResponse = executor.submit({
             client.get(path)
         } as Callable<ReceivedResponse>)
 
         and:
-        rejectedResponse.get(10, TimeUnit.SECONDS)
+        rejectedResponse.get(30, TimeUnit.SECONDS)
         latch.countDown() // unblock blocked response
         def permittedResponse = executor.submit({
             client.get(path)
@@ -352,7 +352,7 @@ class BulkheadSpec extends Specification {
         Promise<String> bulkheadPromise(CountDownLatch latch, CountDownLatch blockLatch) {
             Promise.async {
                 blockLatch.countDown()
-                assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                assert latch.await(30, TimeUnit.SECONDS): "Timeout - test failure"
                 it.success("bulkhead promise")
             }
         }
@@ -361,7 +361,7 @@ class BulkheadSpec extends Specification {
         Observable<String> bulkheadObservable(CountDownLatch latch, CountDownLatch blockLatch) {
             Observable.just("bulkhead observable").map({ it ->
                 blockLatch.countDown()
-                assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                assert latch.await(30, TimeUnit.SECONDS): "Timeout - test failure"
                 it
             })
         }
@@ -370,7 +370,7 @@ class BulkheadSpec extends Specification {
         Flowable<String> bulkheadFlowable(CountDownLatch latch, CountDownLatch blockLatch) {
             Observable.just("bulkhead observable").map({ it ->
                 blockLatch.countDown()
-                assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                assert latch.await(30, TimeUnit.SECONDS): "Timeout - test failure"
                 it
             }).toFlowable(BackpressureStrategy.ERROR)
         }
@@ -379,7 +379,7 @@ class BulkheadSpec extends Specification {
         Single<String> bulkheadSingle(CountDownLatch latch, CountDownLatch blockLatch) {
             Single.just("bulkhead single").map({ it ->
                 blockLatch.countDown()
-                assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                assert latch.await(30, TimeUnit.SECONDS): "Timeout - test failure"
                 it
             })
         }
@@ -388,7 +388,7 @@ class BulkheadSpec extends Specification {
         CompletionStage<String> bulkheadStage(CountDownLatch latch, CountDownLatch blockLatch) {
             CompletableFuture.supplyAsync {
                 blockLatch.countDown()
-                assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                assert latch.await(30, TimeUnit.SECONDS): "Timeout - test failure"
                 'bulkhead stage'
             }
         }
@@ -396,7 +396,7 @@ class BulkheadSpec extends Specification {
         @Bulkhead(name = "test")
         String bulkheadNormal(CountDownLatch latch, CountDownLatch blockLatch) {
             blockLatch.countDown()
-            assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+            assert latch.await(30, TimeUnit.SECONDS): "Timeout - test failure"
             "bulkhead normal"
         }
 
@@ -404,7 +404,7 @@ class BulkheadSpec extends Specification {
         Promise<String> bulkheadPromiseException(CountDownLatch latch, CountDownLatch blockLatch) {
             Promise.async {
                 blockLatch.countDown()
-                assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                assert latch.await(30, TimeUnit.SECONDS): "Timeout - test failure"
                 it.error(new Exception("bulkhead promise exception"))
             }
         }
@@ -413,7 +413,7 @@ class BulkheadSpec extends Specification {
         Observable<Void> bulkheadObservableException(CountDownLatch latch, CountDownLatch blockLatch) {
             Observable.just("bulkhead observable").map({
                 blockLatch.countDown()
-                assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                assert latch.await(30, TimeUnit.SECONDS): "Timeout - test failure"
                 throw new Exception("bulkhead observable exception")
             } as Function<String, Void>)
         }
@@ -422,7 +422,7 @@ class BulkheadSpec extends Specification {
         Flowable<Void> bulkheadFlowableException(CountDownLatch latch, CountDownLatch blockLatch) {
             Observable.just("bulkhead flowable").map({
                 blockLatch.countDown()
-                assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                assert latch.await(30, TimeUnit.SECONDS): "Timeout - test failure"
                 throw new Exception("bulkhead flowable exception")
             } as Function<String, Void>).toFlowable(BackpressureStrategy.ERROR)
         }
@@ -431,7 +431,7 @@ class BulkheadSpec extends Specification {
         Single<Void> bulkheadSingleException(CountDownLatch latch, CountDownLatch blockLatch) {
             Single.just("bulkhead single").map({
                 blockLatch.countDown()
-                assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                assert latch.await(30, TimeUnit.SECONDS): "Timeout - test failure"
                 throw new Exception("bulkhead single exception")
             } as Function<String, Void>)
         }
@@ -440,7 +440,7 @@ class BulkheadSpec extends Specification {
         CompletionStage<Void> bulkheadStageException(CountDownLatch latch, CountDownLatch blockLatch) {
             CompletableFuture.supplyAsync {
                 blockLatch.countDown()
-                assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                assert latch.await(30, TimeUnit.SECONDS): "Timeout - test failure"
                 throw new Exception('bulkhead stage exception')
             }
         }
@@ -448,7 +448,7 @@ class BulkheadSpec extends Specification {
         @Bulkhead(name = "test")
         String bulkheadNormalException(CountDownLatch latch, CountDownLatch blockLatch) {
             blockLatch.countDown()
-            assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+            assert latch.await(30, TimeUnit.SECONDS): "Timeout - test failure"
             throw new Exception("bulkhead normal exception")
         }
 
@@ -456,7 +456,7 @@ class BulkheadSpec extends Specification {
         Promise<String> bulkheadPromiseFallback(CountDownLatch latch, CountDownLatch blockLatch) {
             Promise.async {
                 blockLatch.countDown()
-                assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                assert latch.await(30, TimeUnit.SECONDS): "Timeout - test failure"
                 it.error(new Exception("bulkhead promise exception"))
             }
         }
@@ -465,7 +465,7 @@ class BulkheadSpec extends Specification {
         Observable<Void> bulkheadObservableFallback(CountDownLatch latch, CountDownLatch blockLatch) {
             Observable.just("bulkhead observable").map({
                 blockLatch.countDown()
-                assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                assert latch.await(30, TimeUnit.SECONDS): "Timeout - test failure"
                 throw new Exception("bulkhead observable exception")
             } as Function<String, Void>)
         }
@@ -474,7 +474,7 @@ class BulkheadSpec extends Specification {
         Flowable<Void> bulkheadFlowableFallback(CountDownLatch latch, CountDownLatch blockLatch) {
             Observable.just("bulkhead flowable").map({
                 blockLatch.countDown()
-                assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                assert latch.await(30, TimeUnit.SECONDS): "Timeout - test failure"
                 throw new Exception("bulkhead flowable exception")
             } as Function<String, Void>).toFlowable(BackpressureStrategy.ERROR)
         }
@@ -483,7 +483,7 @@ class BulkheadSpec extends Specification {
         Single<Void> bulkheadSingleFallback(CountDownLatch latch, CountDownLatch blockLatch) {
             Single.just("bulkhead single").map({
                 blockLatch.countDown()
-                assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                assert latch.await(30, TimeUnit.SECONDS): "Timeout - test failure"
                 throw new Exception("bulkhead single exception")
             } as Function<String, Void>)
         }
@@ -492,7 +492,7 @@ class BulkheadSpec extends Specification {
         CompletionStage<Void> bulkheadStageFallback(CountDownLatch latch, CountDownLatch blockLatch) {
             CompletableFuture.supplyAsync {
                 blockLatch.countDown()
-                assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                assert latch.await(30, TimeUnit.SECONDS): "Timeout - test failure"
                 throw new Exception('bulkhead stage exception')
             }
         }
@@ -500,7 +500,7 @@ class BulkheadSpec extends Specification {
         @Bulkhead(name = "test", recovery = MyRecoveryFunction)
         String bulkheadNormalFallback(CountDownLatch latch, CountDownLatch blockLatch) {
             blockLatch.countDown()
-            assert latch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+            assert latch.await(30, TimeUnit.SECONDS): "Timeout - test failure"
             throw new Exception("bulkhead normal exception")
         }
     }

--- a/resilience4j-ratpack/src/test/groovy/io/github/resilience4j/ratpack/bulkhead/BulkheadTransformerSpec.groovy
+++ b/resilience4j-ratpack/src/test/groovy/io/github/resilience4j/ratpack/bulkhead/BulkheadTransformerSpec.groovy
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2017 Jan Sykora
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.ratpack.bulkhead
+
+import io.github.resilience4j.bulkhead.Bulkhead
+import io.github.resilience4j.bulkhead.BulkheadConfig
+import io.github.resilience4j.bulkhead.BulkheadFullException
+import ratpack.exec.Blocking
+import ratpack.exec.ExecResult
+import ratpack.test.exec.ExecHarness
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.util.concurrent.Callable
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class BulkheadTransformerSpec extends Specification {
+
+    @Shared
+    @AutoCleanup(value = "shutdown")
+    ExecutorService executor = Executors.newCachedThreadPool()
+
+    def "execution is permitted and completes"() {
+        given:
+        def bulkhead = buildBulkhead()
+        BulkheadTransformer<String> transformer = BulkheadTransformer.of(bulkhead)
+        AtomicInteger times = new AtomicInteger(0)
+
+        when:
+        def r = ExecHarness.yieldSingle {
+            Blocking.<String> get { times.getAndIncrement(); "s" }
+                    .transform(transformer)
+        }
+
+        then:
+        r.with {
+            value == "s"
+            !error
+            throwable == null
+        }
+        times.get() == 1
+    }
+
+    def "transformer can be reused multiple times"() {
+        given:
+        def bulkhead = buildBulkhead()
+        BulkheadTransformer<String> transformer = BulkheadTransformer.of(bulkhead)
+        AtomicInteger times = new AtomicInteger(0)
+
+        when:
+        def r1 = ExecHarness.yieldSingle {
+            Blocking.<String> get { times.getAndIncrement(); "r1" }
+                    .transform(transformer)
+        }
+
+        and:
+        def r2 = ExecHarness.yieldSingle {
+            Blocking.<String> get { times.getAndIncrement(); "r2" }
+                    .transform(transformer)
+        }
+
+        then:
+        r1.with {
+            value == "r1"
+            !error
+            throwable == null
+        }
+
+        and:
+        r2.with {
+            value == "r2"
+            !error
+            throwable == null
+        }
+
+        and:
+        times.get() == 2
+    }
+
+    def "transformer can be reused multiple times on execution error"() {
+        given:
+        def bulkhead = buildBulkhead()
+        BulkheadTransformer<String> transformer = BulkheadTransformer.of(bulkhead)
+        AtomicInteger times = new AtomicInteger(0)
+
+        when:
+        def r1 = ExecHarness.yieldSingle {
+            Blocking.<String> get { times.getAndIncrement(); throw new RuntimeException("Expected") }
+                    .transform(transformer)
+        }
+
+        and:
+        def r2 = ExecHarness.yieldSingle {
+            Blocking.<String> get { times.getAndIncrement(); "r2" }
+                    .transform(transformer)
+        }
+
+        then:
+        r1.with {
+            value == null
+            error
+            throwable.message == "Expected"
+        }
+
+        and:
+        r2.with {
+            value == "r2"
+            !error
+            throwable == null
+        }
+
+        and:
+        times.get() == 2
+    }
+
+    def "exception is thrown when execution is blocked with one execution"() {
+        given:
+        def bulkhead = buildBulkhead()
+        BulkheadTransformer<String> transformer = BulkheadTransformer.of(bulkhead)
+        AtomicInteger times = new AtomicInteger(0)
+
+        and:
+        def orderLatch = new CountDownLatch(1)
+        def blockingLatch = new CountDownLatch(1)
+
+        when:
+        def acceptedFuture = executor.submit({
+            ExecHarness.yieldSingle {
+                Blocking.<String> get {
+                    orderLatch.countDown()
+                    assert blockingLatch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                    times.getAndIncrement()
+                    "r"
+                }
+                .transform(transformer)
+            }
+        } as Callable<ExecResult<String>>)
+
+        and:
+        assert orderLatch.await(10, TimeUnit.SECONDS)
+        def denied = ExecHarness.yieldSingle {
+            Blocking.<String> get { assert false: "Should never be called" }
+                    .transform(transformer)
+        }
+
+        then:
+        denied.with {
+            error
+            throwable instanceof BulkheadFullException
+            throwable.message == "Bulkhead 'test' is full"
+        }
+
+        and:
+        blockingLatch.countDown()
+        acceptedFuture.get().with {
+            !error
+            value == "r"
+            throwable == null
+        }
+
+        and:
+        times.get() == 1
+    }
+
+    def "recovery function is called when execution is blocked"() {
+        given:
+        def bulkhead = buildBulkhead()
+        BulkheadTransformer<String> transformer = BulkheadTransformer.of(bulkhead).recover { "recover" }
+        AtomicInteger times = new AtomicInteger(0)
+
+        and:
+        def orderLatch = new CountDownLatch(1)
+        def blockingLatch = new CountDownLatch(1)
+
+        when:
+        def acceptedFuture = executor.submit({
+            ExecHarness.yieldSingle {
+                Blocking.<String> get {
+                    orderLatch.countDown()
+                    assert blockingLatch.await(10, TimeUnit.SECONDS): "Timeout - test failure"
+                    times.getAndIncrement()
+                    "r"
+                }
+                .transform(transformer)
+            }
+        } as Callable<ExecResult<String>>)
+
+        and:
+        assert orderLatch.await(10, TimeUnit.SECONDS)
+        def recovered = ExecHarness.yieldSingle {
+            Blocking.<String> get { assert false: "Should never be called" }
+                    .transform(transformer)
+        }
+
+        then:
+        recovered.with {
+            !error
+            value == "recover"
+        }
+
+        and:
+        blockingLatch.countDown()
+        acceptedFuture.get().with {
+            !error
+            value == "r"
+            throwable == null
+        }
+
+        and:
+        times.get() == 1
+    }
+
+    def buildBulkhead() {
+        def config = BulkheadConfig.custom()
+                .maxConcurrentCalls(1)
+                .maxWaitTime(0)
+                .build()
+        Bulkhead.of("test", config)
+    }
+}

--- a/resilience4j-ratpack/src/test/groovy/io/github/resilience4j/ratpack/bulkhead/BulkheadTransformerSpec.groovy
+++ b/resilience4j-ratpack/src/test/groovy/io/github/resilience4j/ratpack/bulkhead/BulkheadTransformerSpec.groovy
@@ -51,7 +51,7 @@ class BulkheadTransformerSpec extends Specification {
         }
 
         then:
-        r.with {
+        with(r) {
             value == "s"
             !error
             throwable == null
@@ -78,14 +78,14 @@ class BulkheadTransformerSpec extends Specification {
         }
 
         then:
-        r1.with {
+        with(r1) {
             value == "r1"
             !error
             throwable == null
         }
 
         and:
-        r2.with {
+        with(r2) {
             value == "r2"
             !error
             throwable == null
@@ -114,14 +114,14 @@ class BulkheadTransformerSpec extends Specification {
         }
 
         then:
-        r1.with {
+        with(r1) {
             value == null
             error
             throwable.message == "Expected"
         }
 
         and:
-        r2.with {
+        with(r2) {
             value == "r2"
             !error
             throwable == null
@@ -162,7 +162,7 @@ class BulkheadTransformerSpec extends Specification {
         }
 
         then:
-        denied.with {
+        with(denied) {
             error
             throwable instanceof BulkheadFullException
             throwable.message == "Bulkhead 'test' is full"
@@ -170,7 +170,7 @@ class BulkheadTransformerSpec extends Specification {
 
         and:
         blockingLatch.countDown()
-        acceptedFuture.get().with {
+        with(acceptedFuture.get()) {
             !error
             value == "r"
             throwable == null
@@ -211,14 +211,14 @@ class BulkheadTransformerSpec extends Specification {
         }
 
         then:
-        recovered.with {
+        with(recovered) {
             !error
             value == "recover"
         }
 
         and:
         blockingLatch.countDown()
-        acceptedFuture.get().with {
+        with(acceptedFuture.get()) {
             !error
             value == "r"
             throwable == null

--- a/resilience4j-ratpack/src/test/groovy/io/github/resilience4j/ratpack/bulkhead/BulkheadTransformerSpec.groovy
+++ b/resilience4j-ratpack/src/test/groovy/io/github/resilience4j/ratpack/bulkhead/BulkheadTransformerSpec.groovy
@@ -46,8 +46,11 @@ class BulkheadTransformerSpec extends Specification {
 
         when:
         def r = ExecHarness.yieldSingle {
-            Blocking.<String> get { times.getAndIncrement(); "s" }
-                    .transform(transformer)
+            Blocking.<String> get {
+                times.getAndIncrement();
+                "s"
+            }
+            .transform(transformer)
         }
 
         then:
@@ -67,14 +70,20 @@ class BulkheadTransformerSpec extends Specification {
 
         when:
         def r1 = ExecHarness.yieldSingle {
-            Blocking.<String> get { times.getAndIncrement(); "r1" }
-                    .transform(transformer)
+            Blocking.<String> get {
+                times.getAndIncrement();
+                "r1"
+            }
+            .transform(transformer)
         }
 
         and:
         def r2 = ExecHarness.yieldSingle {
-            Blocking.<String> get { times.getAndIncrement(); "r2" }
-                    .transform(transformer)
+            Blocking.<String> get {
+                times.getAndIncrement();
+                "r2"
+            }
+            .transform(transformer)
         }
 
         then:
@@ -103,14 +112,20 @@ class BulkheadTransformerSpec extends Specification {
 
         when:
         def r1 = ExecHarness.yieldSingle {
-            Blocking.<String> get { times.getAndIncrement(); throw new RuntimeException("Expected") }
-                    .transform(transformer)
+            Blocking.<String> get {
+                times.getAndIncrement();
+                throw new RuntimeException("Expected")
+            }
+            .transform(transformer)
         }
 
         and:
         def r2 = ExecHarness.yieldSingle {
-            Blocking.<String> get { times.getAndIncrement(); "r2" }
-                    .transform(transformer)
+            Blocking.<String> get {
+                times.getAndIncrement();
+                "r2"
+            }
+            .transform(transformer)
         }
 
         then:
@@ -157,8 +172,10 @@ class BulkheadTransformerSpec extends Specification {
         and:
         assert orderLatch.await(10, TimeUnit.SECONDS)
         def denied = ExecHarness.yieldSingle {
-            Blocking.<String> get { assert false: "Should never be called" }
-                    .transform(transformer)
+            Blocking.<String> get {
+                assert false: "Should never be called"
+            }
+            .transform(transformer)
         }
 
         then:
@@ -206,8 +223,10 @@ class BulkheadTransformerSpec extends Specification {
         and:
         assert orderLatch.await(10, TimeUnit.SECONDS)
         def recovered = ExecHarness.yieldSingle {
-            Blocking.<String> get { assert false: "Should never be called" }
-                    .transform(transformer)
+            Blocking.<String> get {
+                assert false: "Should never be called"
+            }
+            .transform(transformer)
         }
 
         then:

--- a/resilience4j-ratpack/src/test/groovy/io/github/resilience4j/ratpack/bulkhead/endpoint/BulkheadChainSpec.groovy
+++ b/resilience4j-ratpack/src/test/groovy/io/github/resilience4j/ratpack/bulkhead/endpoint/BulkheadChainSpec.groovy
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2017 Jan Sykora
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.ratpack.bulkhead.endpoint
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.github.resilience4j.bulkhead.BulkheadRegistry
+import io.github.resilience4j.ratpack.Resilience4jModule
+import ratpack.http.client.HttpClient
+import ratpack.test.embed.EmbeddedApp
+import ratpack.test.exec.ExecHarness
+import ratpack.test.http.TestHttpClient
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+
+import static ratpack.groovy.test.embed.GroovyEmbeddedApp.ratpack
+
+class BulkheadChainSpec extends Specification {
+    @AutoCleanup
+    EmbeddedApp app
+
+    @Delegate
+    TestHttpClient client
+
+    HttpClient streamer = HttpClient.of { it.poolSize(8) }
+
+    def mapper = new ObjectMapper()
+
+    def "test events"() {
+        given: "an app"
+        def bulkheadRegistry = BulkheadRegistry.ofDefaults()
+        app = ratpack {
+            serverConfig {
+                development(false)
+            }
+            bindings {
+                bindInstance(BulkheadRegistry, bulkheadRegistry)
+                module(Resilience4jModule) {
+                    it.bulkhead('test1') {
+                        it.maxConcurrentCalls(10).maxWaitTime(0)
+                    }.bulkhead('test2') {
+                        it.maxConcurrentCalls(20).maxWaitTime(0)
+                    }
+                }
+            }
+            handlers {
+                get {
+                    render 'ok'
+                }
+            }
+        }
+        client = testHttpClient(app)
+        app.server.start() // override lazy start
+
+        and: "some bulkhead events"
+        ['test1', 'test2'].each {
+            bulkheadRegistry.bulkhead(it).with {
+                isCallPermitted()
+                isCallPermitted()
+                onComplete()
+            }
+        }
+
+        when: "we do a sanity check"
+        def actual = client.get()
+
+        then: "it works"
+        actual.statusCode == 200
+        actual.body.text == 'ok'
+        bulkheadRegistry.bulkhead('test1').metrics.availableConcurrentCalls == 9 // 10 - 1
+        bulkheadRegistry.bulkhead('test2').metrics.availableConcurrentCalls == 19 // 20 - 1
+
+        when: "we get all bulkhead events"
+        actual = client.get('bulkhead/events')
+        def dto = mapper.readValue(actual.body.text, BulkheadEventsEndpointResponse)
+
+        then: "it works"
+        dto.bulkheadEvents.size() == 6
+
+        when: "we get events for a single bulkhead"
+        actual = client.get('bulkhead/events/test1')
+        dto = mapper.readValue(actual.body.text, BulkheadEventsEndpointResponse)
+
+        then: "it works"
+        dto.bulkheadEvents.size() == 3
+
+        when: "we get events for a single bulkhead by call finished type"
+        actual = client.get('bulkhead/events/test1/call_finished')
+        dto = mapper.readValue(actual.body.text, BulkheadEventsEndpointResponse)
+
+        then: "it works"
+        dto.bulkheadEvents.size() == 1
+
+        when: "we get events for a single bulkhead by call permitted type"
+        actual = client.get('bulkhead/events/test1/call_permitted')
+        dto = mapper.readValue(actual.body.text, BulkheadEventsEndpointResponse)
+
+        then: "it works"
+        dto.bulkheadEvents.size() == 2
+
+        when: "we get events for a single bulkhead by call rejected type"
+        actual = client.get('bulkhead/events/test1/call_rejected')
+        dto = mapper.readValue(actual.body.text, BulkheadEventsEndpointResponse)
+
+        then: "it works"
+        dto.bulkheadEvents.size() == 0
+    }
+
+    def "test stream events"() {
+        given: "an app"
+        def bulkheadRegistry = BulkheadRegistry.ofDefaults()
+        app = ratpack {
+            serverConfig {
+                development(false)
+            }
+            bindings {
+                bindInstance(BulkheadRegistry, bulkheadRegistry)
+                module(Resilience4jModule) {
+                    it.bulkhead('test1') {
+                        it.maxConcurrentCalls(10).maxWaitTime(9)
+                    }.bulkhead('test2') {
+                        it.maxConcurrentCalls(20).maxWaitTime(0)
+                    }
+                }
+            }
+            handlers {
+                get {
+                    render 'ok'
+                }
+            }
+        }
+        app.server.start() // override lazy start
+
+        when: "we get all bulkhead events"
+        ['test1', 'test2'].each {
+            bulkheadRegistry.bulkhead(it).with {
+                isCallPermitted()
+                isCallPermitted()
+                onComplete()
+            }
+        }
+        def actual = ExecHarness.yieldSingle {
+            streamer.requestStream(new URI("http://$app.server.bindHost:$app.server.bindPort/bulkhead/stream/events")) {
+                it.get()
+            }
+        }
+
+        then: "it works"
+        "text/event-stream;charset=UTF-8" == actual.value.headers["Content-Type"]
+
+        when: "we get bulkhead events by name"
+        actual = ExecHarness.yieldSingle {
+            streamer.requestStream(new URI("http://$app.server.bindHost:$app.server.bindPort/bulkhead/stream/events/test1")) {
+                it.get()
+            }
+        }
+
+        then: "it works"
+        "text/event-stream;charset=UTF-8" == actual.value.headers["Content-Type"]
+
+        when: "we get bulkhead events by name and error"
+        actual = ExecHarness.yieldSingle {
+            streamer.requestStream(new URI("http://$app.server.bindHost:$app.server.bindPort/bulkhead/stream/events/test1/error")) {
+                it.get()
+            }
+        }
+
+        then: "it works"
+        "text/event-stream;charset=UTF-8" == actual.value.headers["Content-Type"]
+
+        when: "we get bulkhead events by name and success"
+        actual = ExecHarness.yieldSingle {
+            streamer.requestStream(new URI("http://$app.server.bindHost:$app.server.bindPort/bulkhead/stream/events/test1/success")) {
+                it.get()
+            }
+        }
+
+        then: "it works"
+        "text/event-stream;charset=UTF-8" == actual.value.headers["Content-Type"]
+    }
+
+    def "test disabled"() {
+        given: "an app"
+        def bulkheadRegistry = BulkheadRegistry.ofDefaults()
+        app = ratpack {
+            serverConfig {
+                development(false)
+            }
+            bindings {
+                bindInstance(BulkheadRegistry, bulkheadRegistry)
+                module(Resilience4jModule) {
+                    it.bulkhead('test1') {
+                        it.maxConcurrentCalls(10).maxWaitTime(0)
+                    }.bulkhead('test2') {
+                        it.maxConcurrentCalls(20).maxWaitTime(0)
+                    }.endpoints {
+                        it.bulkheads {
+                            it.enabled(false)
+                        }
+                    }
+                }
+            }
+        }
+        client = testHttpClient(app)
+        app.server.start() // override lazy start
+
+        and: "some bulkhead events"
+        ['test1', 'test2'].each {
+            bulkheadRegistry.bulkhead(it).with {
+                isCallPermitted()
+                isCallPermitted()
+                onComplete()
+            }
+        }
+
+        when: "we get all bulkhead events"
+        def actual = client.get('bulkhead/events')
+
+        then: "it fails"
+        actual.statusCode == 404
+    }
+}

--- a/resilience4j-ratpack/src/test/resources/application.yml
+++ b/resilience4j-ratpack/src/test/resources/application.yml
@@ -12,6 +12,10 @@ resilience4j:
             enabled: true
             path: retry
             eventConsumerBufferSize: 100
+        bulkheads:
+            enabled: true
+            path: bulkhead
+            eventConsumerBufferSize: 100
     circuitBreakers:
         test1:
             defaults: true
@@ -33,3 +37,9 @@ resilience4j:
         test2:
             maxAttempts: 3
             waitDurationInMillis: 1000
+    bulkheads:
+        test1:
+            defaults: true
+        test2:
+            maxConcurrentCalls: 100
+            maxWaitTime: 1000


### PR DESCRIPTION
* adding integration of Bulkhead with Ratpack via annotation(AOP/method interceptor)
* adding bulkhead finish event (to monitor whether the bulkhead is leaking permits or not)

I will add doc tomorrow. 


Notes:
* I am not sure about calling recovery function on both failed and rejected executions in transformer and method interceptor. IMO only rejected call should be handled by recovery function.
* I am not pleased with the tests I wrote... - not much support for asynchronous testing by Ratpack(both ExecHarness and TestingHttpClient have blocking methods) - working around it with executor and latches (to hit the bulkhead limit)