### PR TITLE
Removing usage of fork join pool in CircuitBreakerMethodInterceptor

### DIFF
--- a/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/circuitbreaker/CircuitBreakerMethodInterceptor.java
+++ b/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/circuitbreaker/CircuitBreakerMethodInterceptor.java
@@ -87,7 +87,7 @@ public class CircuitBreakerMethodInterceptor implements MethodInterceptor {
                 CompletionStage<?> result = (CompletionStage<?>) proceed(invocation, breaker, recoveryFunction);
                 if (result != null) {
                     long start = System.nanoTime();
-                    result.whenCompleteAsync((v, t) -> {
+                    result.whenComplete((v, t) -> {
                         long durationInNanos = System.nanoTime() - start;
                         if (t != null) {
                             breaker.onError(durationInNanos, t);


### PR DESCRIPTION
I have noticed that `CircuitBreakerMethodInterceptor` uses `whenCompleteAsync`. IMO it should be replaced with `whenComplete` to avoid using  fork-join pool.