### PR TITLE
Add retrofit enqueue support for circuitbreaker and ratelimiter

### DIFF
--- a/resilience4j-retrofit/src/test/java/io/github/resilience4j/retrofit/EnqueueDecorator.java
+++ b/resilience4j-retrofit/src/test/java/io/github/resilience4j/retrofit/EnqueueDecorator.java
@@ -1,0 +1,36 @@
+package io.github.resilience4j.retrofit;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class EnqueueDecorator {
+
+    public static <T> Response<T> enqueue(Call<T> call) throws Throwable {
+        final CountDownLatch enqueueLatch = new CountDownLatch(1);
+        final AtomicReference<Response<T>> responseReference = new AtomicReference<>();
+        final AtomicReference<Throwable> failureReference = new AtomicReference<>();
+        call.enqueue(new Callback<T>() {
+            @Override
+            public void onResponse(final Call<T> call, final Response<T> response) {
+                responseReference.set(response);
+                enqueueLatch.countDown();
+            }
+
+            @Override
+            public void onFailure(final Call<T> call, final Throwable t) {
+                failureReference.set(t);
+                enqueueLatch.countDown();
+            }
+        });
+
+        enqueueLatch.await();
+        if (failureReference.get() != null) {
+            throw failureReference.get();
+        }
+        return responseReference.get();
+    }
+}


### PR DESCRIPTION
This is a retrofit feature that I use very often, and currently is not being protected by the provided decorators.