### PR TITLE
#35 Add Reactor support for circuit breaker, bulkhead and rate limiter.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -121,6 +121,20 @@ Observable.fromCallable(backendService::doSomething)
 
 NOTE: Resilience4j also provides RxJava operators for `RateLimiter`, `Bulkhead` and `Retry`. Find out more in our *http://resilience4j.github.io/resilience4j/[User Guide]*
 
+=== CircuitBreaker and Reactor
+
+The following example shows how to decorate a Mono by using the custom Reactor operator.
+
+[source,java]
+----
+CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
+Mono.fromCallable(backendService::doSomething)
+    .transform(CircuitBreakerOperator.of(circuitBreaker))
+----
+
+
+NOTE: Resilience4j also provides Reactor operators for `RateLimiter` and `Bulkhead`. Find out more in our *http://resilience4j.github.io/resilience4j/[User Guide]*
+
 
 [[ratelimiter]]
 === RateLimiter

--- a/libraries.gradle
+++ b/libraries.gradle
@@ -19,6 +19,8 @@ ext {
     spockVersion = '1.1-groovy-2.4-rc-4'
     retrofitVersion = '2.1.0'
     prometheusSimpleClientVersion = '0.0.21'
+    reactorVersion = '3.1.3.RELEASE'
+    reactiveStreamsVersion = '1.0.2'
 
     libraries = [
             // compile
@@ -26,6 +28,7 @@ ext {
             slf4j: "org.slf4j:slf4j-api:${slf4jVersion}",
             rxjava2: "io.reactivex.rxjava2:rxjava:${rxJavaVersion}",
             jcache: "javax.cache:cache-api:${jcacheVersion}",
+            reactor: "io.projectreactor:reactor-core:${reactorVersion}",
 
             // testCompile
             junit:           "junit:junit:${junitVersion}",
@@ -36,6 +39,8 @@ ext {
             powermock_api_mockito: "org.powermock:powermock-api-mockito:${powermockVersion}",
             powermock_module_junit4: "org.powermock:powermock-module-junit4:${powermockVersion}",
             awaitility: "com.jayway.awaitility:awaitility:${awaitilityVersion}",
+            reactor_test: "io.projectreactor:reactor-test:${reactorVersion}",
+            reactive_streams_tck: "org.reactivestreams:reactive-streams-tck:${reactiveStreamsVersion}",
 
             // Vert.x addon
             vertx: "io.vertx:vertx-core:${vertxVersion}",

--- a/resilience4j-documentation/src/docs/asciidoc/core_guides/bulkhead.adoc
+++ b/resilience4j-documentation/src/docs/asciidoc/core_guides/bulkhead.adoc
@@ -90,6 +90,19 @@ Observable.fromCallable(backendService::doSomething)
 
 Other reactive types (Flowable, Single, Maybe and Completable) are also supported.
 
+===== Bulkhead and RxJava
+
+The following example shows how to decorate a Mono by using the custom Reactor operator.
+
+[source,java]
+----
+Bulkhead bulkhead = Bulkhead.ofDefaults("backendName");
+Mono.fromCallable(backendService::doSomething)
+          .transform(BulkheadOperator.of(bulkhead));
+----
+
+Flux is also supported.
+
 ===== Saturated Bulkhead example
 
 In this example the decorated runnable is not executed because the Bulkhead is saturated and will not allow any more parallel executions. The call to `Try.run` returns a `Failure<Throwable>` Monad so that the chained function is not invoked.

--- a/resilience4j-documentation/src/docs/asciidoc/core_guides/circuitbreaker.adoc
+++ b/resilience4j-documentation/src/docs/asciidoc/core_guides/circuitbreaker.adoc
@@ -79,6 +79,19 @@ Observable.fromCallable(backendService::doSomething)
 
 Other reactive types (Flowable, Single, Maybe and Completable) are also supported.
 
+===== CircuitBreaker and Reactor
+
+The following example shows how to decorate a Mono by using the custom Reactor operator.
+
+[source,java]
+----
+CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("backendName");
+Mono.fromCallable(backendService::doSomething)
+    .transform(CircuitBreakerOperator.of(circuitBreaker))
+----
+
+Flux is also supported.
+
 ===== OPEN CircuitBreaker example
 
 In this example `map` is not invoked, because the CircuitBreaker is OPEN. The call to `Try.of` returns a `Failure<Throwable>` Monad so that the chained function is not invoked.

--- a/resilience4j-documentation/src/docs/asciidoc/core_guides/ratelimiter.adoc
+++ b/resilience4j-documentation/src/docs/asciidoc/core_guides/ratelimiter.adoc
@@ -79,6 +79,19 @@ Observable.fromCallable(backendService::doSomething)
 
 Other reactive types (Flowable, Single, Maybe and Completable) are also supported.
 
+===== RateLimiter and Reactor
+
+The following example shows how to decorate a Mono by using the custom Reactor operator.
+
+[source,java]
+----
+RateLimiter rateLimiter = RateLimiter.ofDefaults("backendName");
+Mono.fromCallable(backendService::doSomething)
+    .transform(RateLimiterOperator.of(rateLimiter))
+----
+
+Flux is also supported.
+
 ===== Consume emitted RateLimiterEvents
 
 The RateLimiter emits a stream of RateLimiterEvents. An event can be a successful permission acquire or acquire failure.

--- a/resilience4j-reactor/build.gradle
+++ b/resilience4j-reactor/build.gradle
@@ -1,0 +1,15 @@
+dependencies {
+    compileOnly project(':resilience4j-circuitbreaker')
+    compileOnly project(':resilience4j-ratelimiter')
+    compileOnly project(':resilience4j-bulkhead')
+    compileOnly project(':resilience4j-retry')
+    compile (libraries.reactor)
+    testCompile project(':resilience4j-test')
+    testCompile project(':resilience4j-circuitbreaker')
+    testCompile project(':resilience4j-ratelimiter')
+    testCompile project(':resilience4j-bulkhead')
+    testCompile project(':resilience4j-retry')
+    testCompile (libraries.reactor_test)
+    testCompile (libraries.assertj)
+    testCompile (libraries.reactive_streams_tck)
+}

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/FluxResilience.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/FluxResilience.java
@@ -1,0 +1,11 @@
+package io.github.resilience4j.reactor;
+
+import reactor.core.publisher.Flux;
+
+public abstract class FluxResilience<T> extends Flux<T> {
+
+    public static <T> Flux<T> onAssembly(Flux<T> source) {
+        return Flux.onAssembly(source);
+    }
+
+}

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/MonoResilience.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/MonoResilience.java
@@ -1,0 +1,10 @@
+package io.github.resilience4j.reactor;
+
+import reactor.core.publisher.Mono;
+
+public abstract class MonoResilience<T> extends Mono<T> {
+
+    public static <T> Mono<T> onAssembly(Mono<T> source) {
+        return Mono.onAssembly(source);
+    }
+}

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/Permit.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/Permit.java
@@ -1,0 +1,8 @@
+package io.github.resilience4j.reactor;
+
+/**
+ * Represents the possible states of a permit.
+ */
+public enum Permit {
+    PENDING, ACQUIRED, REJECTED
+}

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/BulkheadOperator.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/BulkheadOperator.java
@@ -1,0 +1,64 @@
+package io.github.resilience4j.reactor.bulkhead.operator;
+
+import io.github.resilience4j.bulkhead.Bulkhead;
+import io.github.resilience4j.reactor.FluxResilience;
+import io.github.resilience4j.reactor.MonoResilience;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+import java.util.function.Function;
+
+/**
+ * A Reactor operator which wraps a reactive type in a bulkhead.
+ *
+ * @param <T> the value type of the upstream and downstream
+ */
+public class BulkheadOperator<T> implements Function<Publisher<T>, Publisher<T>> {
+    private final Bulkhead bulkhead;
+    private final Scheduler scheduler;
+
+    private BulkheadOperator(Bulkhead bulkhead, Scheduler scheduler) {
+        this.bulkhead = bulkhead;
+        this.scheduler = scheduler;
+    }
+
+    /**
+     * Creates a BulkheadOperator.
+     *
+     * @param <T>      the value type of the upstream and downstream
+     * @param bulkhead the Bulkhead
+     * @return a BulkheadOperator
+     */
+    public static <T> BulkheadOperator<T> of(Bulkhead bulkhead) {
+        return of(bulkhead, Schedulers.parallel());
+    }
+
+    /**
+     * Creates a BulkheadOperator.
+     *
+     * @param <T>       the value type of the upstream and downstream
+     * @param bulkhead  the Bulkhead
+     * @param scheduler the {@link Scheduler} where to publish
+     * @return a BulkheadOperator
+     */
+    public static <T> BulkheadOperator<T> of(Bulkhead bulkhead, Scheduler scheduler) {
+        return new BulkheadOperator<>(bulkhead, scheduler);
+    }
+
+    @Override
+    public Publisher<T> apply(Publisher<T> publisher) {
+        if (publisher instanceof Mono) {
+            return MonoResilience
+                    .onAssembly(new MonoBulkhead<T>((Mono<? extends T>) publisher, bulkhead, scheduler));
+        } else if (publisher instanceof Flux) {
+            return FluxResilience
+                    .onAssembly(new FluxBulkhead<T>((Flux<? extends T>) publisher, bulkhead, scheduler));
+        }
+
+        throw new IllegalStateException("Publisher of type <" + publisher.getClass().getSimpleName()
+                + "> are not supported by this operator");
+    }
+}

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/BulkheadSubscriber.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/BulkheadSubscriber.java
@@ -1,0 +1,114 @@
+package io.github.resilience4j.reactor.bulkhead.operator;
+
+import io.github.resilience4j.bulkhead.Bulkhead;
+import io.github.resilience4j.bulkhead.BulkheadFullException;
+import io.github.resilience4j.reactor.Permit;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Operators;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A Reactor {@link Subscriber} to wrap another subscriber in a bulkhead.
+ *
+ * @param <T> the value type of the upstream and downstream
+ */
+class BulkheadSubscriber<T> extends Operators.MonoSubscriber<T, T> {
+
+    private final Bulkhead bulkhead;
+    private final AtomicReference<Permit> permitted = new AtomicReference<>(Permit.PENDING);
+
+    private Subscription subscription;
+
+    public BulkheadSubscriber(Bulkhead bulkhead,
+                              CoreSubscriber<? super T> actual) {
+        super(actual);
+        this.bulkhead = requireNonNull(bulkhead);
+    }
+
+    @Override
+    public void onSubscribe(Subscription subscription) {
+        if (Operators.validate(this.subscription, subscription)) {
+            this.subscription = subscription;
+            if (acquireCallPermit()) {
+                actual.onSubscribe(this);
+            } else {
+                cancel();
+                actual.onSubscribe(this);
+                actual.onError(new BulkheadFullException(
+                        String.format("Bulkhead '%s' is full", bulkhead.getName())));
+            }
+        }
+    }
+
+    @Override
+    public void onNext(T t) {
+        Objects.requireNonNull(t);
+
+        if (isInvocationPermitted()) {
+            actual.onNext(t);
+        }
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        Objects.requireNonNull(t);
+
+        if (isInvocationPermitted()) {
+            bulkhead.onComplete();
+            actual.onError(t);
+        }
+    }
+
+    @Override
+    public void onComplete() {
+        if (isInvocationPermitted()) {
+            releaseBulkhead();
+            actual.onComplete();
+        }
+    }
+
+    @Override
+    public void request(long n) {
+        subscription.request(n);
+    }
+
+    @Override
+    public void cancel() {
+        super.cancel();
+    }
+
+    private boolean acquireCallPermit() {
+        boolean callPermitted = false;
+        if (permitted.compareAndSet(Permit.PENDING, Permit.ACQUIRED)) {
+            callPermitted = bulkhead.isCallPermitted();
+            if (!callPermitted) {
+                permitted.set(Permit.REJECTED);
+            }
+        }
+        return callPermitted;
+    }
+
+    private boolean isInvocationPermitted() {
+        return notCancelled() && wasCallPermitted();
+    }
+
+    private boolean notCancelled() {
+        return !this.isCancelled();
+    }
+
+    private boolean wasCallPermitted() {
+        return permitted.get() == Permit.ACQUIRED;
+    }
+
+    private void releaseBulkhead() {
+        if (wasCallPermitted()) {
+            bulkhead.onComplete();
+        }
+    }
+}

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/BulkheadSubscriber.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/BulkheadSubscriber.java
@@ -8,7 +8,6 @@ import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Operators;
 
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Objects.requireNonNull;
@@ -48,7 +47,7 @@ class BulkheadSubscriber<T> extends Operators.MonoSubscriber<T, T> {
 
     @Override
     public void onNext(T t) {
-        Objects.requireNonNull(t);
+        requireNonNull(t);
 
         if (isInvocationPermitted()) {
             actual.onNext(t);
@@ -57,7 +56,7 @@ class BulkheadSubscriber<T> extends Operators.MonoSubscriber<T, T> {
 
     @Override
     public void onError(Throwable t) {
-        Objects.requireNonNull(t);
+        requireNonNull(t);
 
         if (isInvocationPermitted()) {
             bulkhead.onComplete();

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/FluxBulkhead.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/FluxBulkhead.java
@@ -1,0 +1,27 @@
+package io.github.resilience4j.reactor.bulkhead.operator;
+
+import io.github.resilience4j.bulkhead.Bulkhead;
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxOperator;
+import reactor.core.scheduler.Scheduler;
+
+public class FluxBulkhead<T> extends FluxOperator<T, T> {
+
+    private final Bulkhead bulkhead;
+    private final Scheduler scheduler;
+
+    public FluxBulkhead(Flux<? extends T> source, Bulkhead bulkhead,
+                        Scheduler scheduler) {
+        super(source);
+        this.bulkhead = bulkhead;
+        this.scheduler = scheduler;
+    }
+
+    @Override
+    public void subscribe(CoreSubscriber<? super T> actual) {
+        source.publishOn(scheduler)
+                .subscribe(new BulkheadSubscriber<>(bulkhead, actual));
+    }
+
+}

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/MonoBulkhead.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/MonoBulkhead.java
@@ -1,0 +1,25 @@
+package io.github.resilience4j.reactor.bulkhead.operator;
+
+import io.github.resilience4j.bulkhead.Bulkhead;
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.MonoOperator;
+import reactor.core.scheduler.Scheduler;
+
+public class MonoBulkhead<T> extends MonoOperator<T, T> {
+    private final Bulkhead bulkhead;
+    private final Scheduler scheduler;
+
+    public MonoBulkhead(Mono<? extends T> source, Bulkhead bulkhead,
+                        Scheduler scheduler) {
+        super(source);
+        this.bulkhead = bulkhead;
+        this.scheduler = scheduler;
+    }
+
+    @Override
+    public void subscribe(CoreSubscriber<? super T> actual) {
+        source.publishOn(scheduler)
+                .subscribe(new BulkheadSubscriber<>(bulkhead, actual));
+    }
+}

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/circuitbreaker/operator/CircuitBreakerOperator.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/circuitbreaker/operator/CircuitBreakerOperator.java
@@ -1,0 +1,49 @@
+package io.github.resilience4j.reactor.circuitbreaker.operator;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.reactor.FluxResilience;
+import io.github.resilience4j.reactor.MonoResilience;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.function.Function;
+
+/**
+ * A Reactor operator which wraps a reactive type in a circuit breaker.
+ *
+ * @param <T> the value type of the upstream and downstream
+ */
+public class CircuitBreakerOperator<T> implements Function<Publisher<T>, Publisher<T>> {
+
+    private final CircuitBreaker circuitBreaker;
+
+    private CircuitBreakerOperator(CircuitBreaker circuitBreaker) {
+        this.circuitBreaker = circuitBreaker;
+    }
+
+    /**
+     * Creates a CircuitBreakerOperator.
+     *
+     * @param <T>            the value type of the upstream and downstream
+     * @param circuitBreaker the circuit breaker
+     * @return a CircuitBreakerOperator
+     */
+    public static <T> CircuitBreakerOperator<T> of(CircuitBreaker circuitBreaker) {
+        return new CircuitBreakerOperator<>(circuitBreaker);
+    }
+
+    @Override
+    public Publisher<T> apply(Publisher<T> publisher) {
+        if (publisher instanceof Mono) {
+            return MonoResilience
+                    .onAssembly(new MonoCircuitBreaker<T>((Mono<? extends T>) publisher, circuitBreaker));
+        } else if (publisher instanceof Flux) {
+            return FluxResilience
+                    .onAssembly(new FluxCircuitBreaker<T>((Flux<? extends T>) publisher, circuitBreaker));
+        }
+
+        throw new IllegalStateException("Publisher of type <" + publisher.getClass().getSimpleName()
+                + "> are not supported by this operator");
+    }
+}

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/circuitbreaker/operator/CircuitBreakerSubscriber.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/circuitbreaker/operator/CircuitBreakerSubscriber.java
@@ -1,0 +1,115 @@
+package io.github.resilience4j.reactor.circuitbreaker.operator;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerOpenException;
+import io.github.resilience4j.core.StopWatch;
+import io.github.resilience4j.reactor.Permit;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Operators;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A Reactor {@link Subscriber} to wrap another subscriber in a circuit breaker.
+ *
+ * @param <T> the value type of the upstream and downstream
+ */
+class CircuitBreakerSubscriber<T> extends Operators.MonoSubscriber<T, T> {
+
+    private final CircuitBreaker circuitBreaker;
+    private final AtomicReference<Permit> permitted = new AtomicReference<>(Permit.PENDING);
+    private StopWatch stopWatch;
+    private Subscription subscription;
+
+    public CircuitBreakerSubscriber(CircuitBreaker circuitBreaker,
+                                    CoreSubscriber<? super T> actual) {
+        super(actual);
+        this.circuitBreaker = requireNonNull(circuitBreaker);
+    }
+
+    @Override
+    public void onSubscribe(Subscription subscription) {
+        if (Operators.validate(this.subscription, subscription)) {
+            this.subscription = subscription;
+
+            if (acquireCallPermit()) {
+                actual.onSubscribe(this);
+            } else {
+                cancel();
+                actual.onSubscribe(this);
+                actual.onError(new CircuitBreakerOpenException(
+                        String.format("CircuitBreaker '%s' is open", circuitBreaker.getName())));
+            }
+        }
+    }
+
+    @Override
+    public void onNext(T t) {
+        Objects.requireNonNull(t);
+
+        if (isInvocationPermitted()) {
+            actual.onNext(t);
+        }
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        Objects.requireNonNull(t);
+
+        markFailure(t);
+        if (isInvocationPermitted()) {
+            actual.onError(t);
+        }
+    }
+
+    @Override
+    public void onComplete() {
+        markSuccess();
+        if (isInvocationPermitted()) {
+            actual.onComplete();
+        }
+    }
+
+    @Override
+    public void request(long n) {
+        subscription.request(n);
+    }
+
+    private boolean acquireCallPermit() {
+        boolean callPermitted = false;
+        if (permitted.compareAndSet(Permit.PENDING, Permit.ACQUIRED)) {
+            callPermitted = circuitBreaker.isCallPermitted();
+            if (!callPermitted) {
+                permitted.set(Permit.REJECTED);
+            } else {
+                stopWatch = StopWatch.start(circuitBreaker.getName());
+            }
+        }
+        return callPermitted;
+    }
+
+    private boolean isInvocationPermitted() {
+        return !this.isCancelled() && wasCallPermitted();
+    }
+
+    private void markFailure(Throwable e) {
+        if (wasCallPermitted()) {
+            circuitBreaker.onError(stopWatch.stop().getProcessingDuration().toNanos(), e);
+        }
+    }
+
+    private void markSuccess() {
+        if (wasCallPermitted()) {
+            circuitBreaker.onSuccess(stopWatch.stop().getProcessingDuration().toNanos());
+        }
+    }
+
+    private boolean wasCallPermitted() {
+        return permitted.get() == Permit.ACQUIRED;
+    }
+}

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/circuitbreaker/operator/CircuitBreakerSubscriber.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/circuitbreaker/operator/CircuitBreakerSubscriber.java
@@ -9,7 +9,6 @@ import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Operators;
 
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Objects.requireNonNull;
@@ -50,7 +49,7 @@ class CircuitBreakerSubscriber<T> extends Operators.MonoSubscriber<T, T> {
 
     @Override
     public void onNext(T t) {
-        Objects.requireNonNull(t);
+        requireNonNull(t);
 
         if (isInvocationPermitted()) {
             actual.onNext(t);
@@ -59,7 +58,7 @@ class CircuitBreakerSubscriber<T> extends Operators.MonoSubscriber<T, T> {
 
     @Override
     public void onError(Throwable t) {
-        Objects.requireNonNull(t);
+        requireNonNull(t);
 
         markFailure(t);
         if (isInvocationPermitted()) {

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/circuitbreaker/operator/FluxCircuitBreaker.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/circuitbreaker/operator/FluxCircuitBreaker.java
@@ -1,0 +1,22 @@
+package io.github.resilience4j.reactor.circuitbreaker.operator;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxOperator;
+
+public class FluxCircuitBreaker<T> extends FluxOperator<T, T> {
+
+    private CircuitBreaker circuitBreaker;
+
+    public FluxCircuitBreaker(Flux<? extends T> source, CircuitBreaker circuitBreaker) {
+        super(source);
+        this.circuitBreaker = circuitBreaker;
+    }
+
+    @Override
+    public void subscribe(CoreSubscriber<? super T> actual) {
+        source.subscribe(new CircuitBreakerSubscriber<>(circuitBreaker, actual));
+    }
+
+}

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/circuitbreaker/operator/MonoCircuitBreaker.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/circuitbreaker/operator/MonoCircuitBreaker.java
@@ -1,0 +1,20 @@
+package io.github.resilience4j.reactor.circuitbreaker.operator;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.MonoOperator;
+
+public class MonoCircuitBreaker<T> extends MonoOperator<T, T> {
+    private CircuitBreaker circuitBreaker;
+
+    public MonoCircuitBreaker(Mono<? extends T> source, CircuitBreaker circuitBreaker) {
+        super(source);
+        this.circuitBreaker = circuitBreaker;
+    }
+
+    @Override
+    public void subscribe(CoreSubscriber<? super T> actual) {
+        source.subscribe(new CircuitBreakerSubscriber<>(circuitBreaker, actual));
+    }
+}

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/ratelimiter/operator/FluxRateLimiter.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/ratelimiter/operator/FluxRateLimiter.java
@@ -1,0 +1,27 @@
+package io.github.resilience4j.reactor.ratelimiter.operator;
+
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxOperator;
+import reactor.core.scheduler.Scheduler;
+
+public class FluxRateLimiter<T> extends FluxOperator<T, T> {
+
+    private final RateLimiter rateLimiter;
+    private final Scheduler scheduler;
+
+    public FluxRateLimiter(Flux<? extends T> source, RateLimiter rateLimiter,
+                           Scheduler scheduler) {
+        super(source);
+        this.rateLimiter = rateLimiter;
+        this.scheduler = scheduler;
+    }
+
+    @Override
+    public void subscribe(CoreSubscriber<? super T> actual) {
+        source.publishOn(scheduler)
+                .subscribe(new RateLimiterSubscriber<>(rateLimiter, actual));
+    }
+
+}

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/ratelimiter/operator/MonoRateLimiter.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/ratelimiter/operator/MonoRateLimiter.java
@@ -1,0 +1,25 @@
+package io.github.resilience4j.reactor.ratelimiter.operator;
+
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.MonoOperator;
+import reactor.core.scheduler.Scheduler;
+
+public class MonoRateLimiter<T> extends MonoOperator<T, T> {
+    private final RateLimiter rateLimiter;
+    private final Scheduler scheduler;
+
+    public MonoRateLimiter(Mono<? extends T> source, RateLimiter rateLimiter,
+                           Scheduler scheduler) {
+        super(source);
+        this.rateLimiter = rateLimiter;
+        this.scheduler = scheduler;
+    }
+
+    @Override
+    public void subscribe(CoreSubscriber<? super T> actual) {
+        source.publishOn(scheduler)
+                .subscribe(new RateLimiterSubscriber<>(rateLimiter, actual));
+    }
+}

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/ratelimiter/operator/RateLimiterOperator.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/ratelimiter/operator/RateLimiterOperator.java
@@ -1,0 +1,65 @@
+package io.github.resilience4j.reactor.ratelimiter.operator;
+
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import io.github.resilience4j.reactor.FluxResilience;
+import io.github.resilience4j.reactor.MonoResilience;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+import java.util.function.Function;
+
+
+/**
+ * A Reactor operator which wraps a reactive type in a rate limiter.
+ *
+ * @param <T> the value type of the upstream and downstream
+ */
+public class RateLimiterOperator<T> implements Function<Publisher<T>, Publisher<T>> {
+    private final RateLimiter rateLimiter;
+    private final Scheduler scheduler;
+
+    private RateLimiterOperator(RateLimiter rateLimiter, Scheduler scheduler) {
+        this.rateLimiter = rateLimiter;
+        this.scheduler = scheduler;
+    }
+
+    /**
+     * Creates a RateLimiterOperator.
+     *
+     * @param <T>         the value type of the upstream and downstream
+     * @param rateLimiter the Rate limiter
+     * @return a RateLimiterOperator
+     */
+    public static <T> RateLimiterOperator<T> of(RateLimiter rateLimiter) {
+        return of(rateLimiter, Schedulers.parallel());
+    }
+
+    /**
+     * Creates a RateLimiterOperator.
+     *
+     * @param <T>         the value type of the upstream and downstream
+     * @param rateLimiter the Rate limiter
+     * @param scheduler   the {@link Scheduler} where to publish
+     * @return a RateLimiterOperator
+     */
+    public static <T> RateLimiterOperator<T> of(RateLimiter rateLimiter, Scheduler scheduler) {
+        return new RateLimiterOperator<>(rateLimiter, scheduler);
+    }
+
+    @Override
+    public Publisher<T> apply(Publisher<T> publisher) {
+        if (publisher instanceof Mono) {
+            return MonoResilience
+                    .onAssembly(new MonoRateLimiter<T>((Mono<? extends T>) publisher, rateLimiter, scheduler));
+        } else if (publisher instanceof Flux) {
+            return FluxResilience
+                    .onAssembly(new FluxRateLimiter<T>((Flux<? extends T>) publisher, rateLimiter, scheduler));
+        }
+
+        throw new IllegalStateException("Publisher of type <" + publisher.getClass().getSimpleName()
+                + "> are not supported by this operator");
+    }
+}

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/ratelimiter/operator/RateLimiterSubscriber.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/ratelimiter/operator/RateLimiterSubscriber.java
@@ -1,0 +1,116 @@
+package io.github.resilience4j.reactor.ratelimiter.operator;
+
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import io.github.resilience4j.ratelimiter.RequestNotPermitted;
+import io.github.resilience4j.reactor.Permit;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Operators;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A Reactor {@link Subscriber} to wrap another subscriber in a bulkhead.
+ *
+ * @param <T> the value type of the upstream and downstream
+ */
+class RateLimiterSubscriber<T> extends Operators.MonoSubscriber<T, T> {
+
+    private final RateLimiter rateLimiter;
+    private final AtomicReference<Permit> permitted = new AtomicReference<>(Permit.PENDING);
+    private final AtomicBoolean firstEvent = new AtomicBoolean(true);
+
+    private Subscription subscription;
+
+    public RateLimiterSubscriber(RateLimiter rateLimiter,
+                                 CoreSubscriber<? super T> actual) {
+        super(actual);
+        this.rateLimiter = requireNonNull(rateLimiter);
+    }
+
+    @Override
+    public void onSubscribe(Subscription subscription) {
+        if (Operators.validate(this.subscription, subscription)) {
+            this.subscription = subscription;
+            if (acquireCallPermit()) {
+                actual.onSubscribe(this);
+            } else {
+                cancel();
+                actual.onSubscribe(this);
+                actual.onError(rateLimitExceededException());
+            }
+        }
+    }
+
+    @Override
+    public void onNext(T t) {
+        Objects.requireNonNull(t);
+
+        if (isInvocationPermitted()) {
+            if (firstEvent.getAndSet(false) || rateLimiter.getPermission(rateLimiter.getRateLimiterConfig().getTimeoutDuration())) {
+                actual.onNext(t);
+            } else {
+                cancel();
+                actual.onError(rateLimitExceededException());
+            }
+        }
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        Objects.requireNonNull(t);
+
+        if (isInvocationPermitted()) {
+            actual.onError(t);
+        }
+    }
+
+    @Override
+    public void onComplete() {
+        if (isInvocationPermitted()) {
+            actual.onComplete();
+        }
+    }
+
+    @Override
+    public void request(long n) {
+        subscription.request(n);
+    }
+
+    @Override
+    public void cancel() {
+        super.cancel();
+    }
+
+    private boolean acquireCallPermit() {
+        boolean callPermitted = false;
+        if (permitted.compareAndSet(Permit.PENDING, Permit.ACQUIRED)) {
+            callPermitted = rateLimiter.getPermission(rateLimiter.getRateLimiterConfig().getTimeoutDuration());
+            if (!callPermitted) {
+                permitted.set(Permit.REJECTED);
+            }
+        }
+        return callPermitted;
+    }
+
+    private boolean isInvocationPermitted() {
+        return notCancelled() && wasCallPermitted();
+    }
+
+    private boolean notCancelled() {
+        return !this.isCancelled();
+    }
+
+    private boolean wasCallPermitted() {
+        return permitted.get() == Permit.ACQUIRED;
+    }
+
+    private Exception rateLimitExceededException() {
+        return new RequestNotPermitted("Request not permitted for limiter: " + rateLimiter.getName());
+    }
+}

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/ratelimiter/operator/RateLimiterSubscriber.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/ratelimiter/operator/RateLimiterSubscriber.java
@@ -8,7 +8,6 @@ import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Operators;
 
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -49,7 +48,7 @@ class RateLimiterSubscriber<T> extends Operators.MonoSubscriber<T, T> {
 
     @Override
     public void onNext(T t) {
-        Objects.requireNonNull(t);
+        requireNonNull(t);
 
         if (isInvocationPermitted()) {
             if (firstEvent.getAndSet(false) || rateLimiter.getPermission(rateLimiter.getRateLimiterConfig().getTimeoutDuration())) {
@@ -63,7 +62,7 @@ class RateLimiterSubscriber<T> extends Operators.MonoSubscriber<T, T> {
 
     @Override
     public void onError(Throwable t) {
-        Objects.requireNonNull(t);
+        requireNonNull(t);
 
         if (isInvocationPermitted()) {
             actual.onError(t);

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/BulkheadSubscriberWhiteboxVerification.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/BulkheadSubscriberWhiteboxVerification.java
@@ -1,0 +1,64 @@
+package io.github.resilience4j.reactor.bulkhead.operator;
+
+import io.github.resilience4j.bulkhead.Bulkhead;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.reactivestreams.tck.SubscriberWhiteboxVerification;
+import org.reactivestreams.tck.TestEnvironment;
+import reactor.core.publisher.MonoProcessor;
+
+public class BulkheadSubscriberWhiteboxVerification extends
+    SubscriberWhiteboxVerification<Integer> {
+
+  public BulkheadSubscriberWhiteboxVerification() {
+    super(new TestEnvironment());
+  }
+
+  @Override
+  public Subscriber<Integer> createSubscriber(WhiteboxSubscriberProbe<Integer> probe) {
+    return new io.github.resilience4j.reactor.bulkhead.operator.BulkheadSubscriber<Integer>(Bulkhead.ofDefaults("verification"), MonoProcessor.create()) {
+      @Override
+      public void onSubscribe(Subscription subscription) {
+        super.onSubscribe(subscription);
+
+        // register a successful Subscription, and create a Puppet,
+        // for the WhiteboxVerification to be able to drive its tests:
+        probe.registerOnSubscribe(new SubscriberPuppet() {
+
+          @Override
+          public void triggerRequest(long elements) {
+            subscription.request(elements);
+          }
+
+          @Override
+          public void signalCancel() {
+            subscription.cancel();
+          }
+        });
+      }
+
+      @Override
+      public void onNext(Integer integer) {
+        super.onNext(integer);
+        probe.registerOnNext(integer);
+      }
+
+      @Override
+      public void onError(Throwable t) {
+        super.onError(t);
+        probe.registerOnError(t);
+      }
+
+      @Override
+      public void onComplete() {
+        super.onComplete();
+        probe.registerOnComplete();
+      }
+    };
+  }
+
+  @Override
+  public Integer createElement(int element) {
+    return element;
+  }
+}

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/FluxBulkheadTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/FluxBulkheadTest.java
@@ -5,10 +5,11 @@ import io.github.resilience4j.bulkhead.BulkheadConfig;
 import io.github.resilience4j.bulkhead.BulkheadFullException;
 import java.io.IOException;
 import java.time.Duration;
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class FluxBulkheadTest {
 
@@ -24,7 +25,7 @@ public class FluxBulkheadTest {
         .expectNext("Event 2")
         .verifyComplete();
 
-    Assertions.assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(1);
+    assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(1);
   }
 
   @Test
@@ -36,7 +37,7 @@ public class FluxBulkheadTest {
         .expectError(IOException.class)
         .verify(Duration.ofSeconds(1));
 
-    Assertions.assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(1);
+    assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(1);
   }
 
   @Test
@@ -50,7 +51,7 @@ public class FluxBulkheadTest {
         .expectError(BulkheadFullException.class)
         .verify(Duration.ofSeconds(1));
 
-    Assertions.assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(0);
+    assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(0);
 
   }
 }

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/FluxBulkheadTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/FluxBulkheadTest.java
@@ -1,0 +1,56 @@
+package io.github.resilience4j.reactor.bulkhead.operator;
+
+import io.github.resilience4j.bulkhead.Bulkhead;
+import io.github.resilience4j.bulkhead.BulkheadConfig;
+import io.github.resilience4j.bulkhead.BulkheadFullException;
+import java.io.IOException;
+import java.time.Duration;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+public class FluxBulkheadTest {
+
+  private Bulkhead bulkhead = Bulkhead
+      .of("test", BulkheadConfig.custom().maxConcurrentCalls(1).maxWaitTime(0).build());
+
+  @Test
+  public void shouldEmitEvent() {
+    StepVerifier.create(
+        Flux.just("Event 1", "Event 2")
+            .transform(io.github.resilience4j.reactor.bulkhead.operator.BulkheadOperator.of(bulkhead)))
+        .expectNext("Event 1")
+        .expectNext("Event 2")
+        .verifyComplete();
+
+    Assertions.assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldPropagateError() {
+    StepVerifier.create(
+        Flux.error(new IOException("BAM!"))
+            .transform(io.github.resilience4j.reactor.bulkhead.operator.BulkheadOperator.of(bulkhead)))
+        .expectSubscription()
+        .expectError(IOException.class)
+        .verify(Duration.ofSeconds(1));
+
+    Assertions.assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldEmitErrorWithBulkheadFullException() {
+    bulkhead.isCallPermitted();
+
+    StepVerifier.create(
+        Flux.just("Event")
+            .transform(BulkheadOperator.of(bulkhead)))
+        .expectSubscription()
+        .expectError(BulkheadFullException.class)
+        .verify(Duration.ofSeconds(1));
+
+    Assertions.assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(0);
+
+  }
+}

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/MonoBulkheadTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/MonoBulkheadTest.java
@@ -1,0 +1,55 @@
+package io.github.resilience4j.reactor.bulkhead.operator;
+
+import io.github.resilience4j.bulkhead.Bulkhead;
+import io.github.resilience4j.bulkhead.BulkheadConfig;
+import io.github.resilience4j.bulkhead.BulkheadFullException;
+import java.io.IOException;
+import java.time.Duration;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+public class MonoBulkheadTest {
+
+  private Bulkhead bulkhead = Bulkhead
+      .of("test", BulkheadConfig.custom().maxConcurrentCalls(1).maxWaitTime(0).build());
+
+  @Test
+  public void shouldEmitEvent() {
+    StepVerifier.create(
+        Mono.just("Event")
+            .transform(io.github.resilience4j.reactor.bulkhead.operator.BulkheadOperator.of(bulkhead)))
+        .expectNext("Event")
+        .verifyComplete();
+
+    Assertions.assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldPropagateError() {
+    StepVerifier.create(
+        Mono.error(new IOException("BAM!"))
+            .transform(io.github.resilience4j.reactor.bulkhead.operator.BulkheadOperator.of(bulkhead)))
+        .expectSubscription()
+        .expectError(IOException.class)
+        .verify(Duration.ofSeconds(1));
+
+    Assertions.assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldEmitErrorWithBulkheadFullException() {
+    bulkhead.isCallPermitted();
+
+    StepVerifier.create(
+        Mono.just("Event")
+            .transform(BulkheadOperator.of(bulkhead)))
+        .expectSubscription()
+        .expectError(BulkheadFullException.class)
+        .verify(Duration.ofSeconds(1));
+
+    Assertions.assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(0);
+
+  }
+}

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/MonoBulkheadTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/MonoBulkheadTest.java
@@ -5,10 +5,11 @@ import io.github.resilience4j.bulkhead.BulkheadConfig;
 import io.github.resilience4j.bulkhead.BulkheadFullException;
 import java.io.IOException;
 import java.time.Duration;
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MonoBulkheadTest {
 
@@ -23,7 +24,7 @@ public class MonoBulkheadTest {
         .expectNext("Event")
         .verifyComplete();
 
-    Assertions.assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(1);
+    assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(1);
   }
 
   @Test
@@ -35,7 +36,7 @@ public class MonoBulkheadTest {
         .expectError(IOException.class)
         .verify(Duration.ofSeconds(1));
 
-    Assertions.assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(1);
+    assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(1);
   }
 
   @Test
@@ -49,7 +50,7 @@ public class MonoBulkheadTest {
         .expectError(BulkheadFullException.class)
         .verify(Duration.ofSeconds(1));
 
-    Assertions.assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(0);
+    assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(0);
 
   }
 }

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/CircuitBreakerAssertions.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/CircuitBreakerAssertions.java
@@ -1,0 +1,38 @@
+package io.github.resilience4j.reactor.circuitbreaker.operator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * Helper class to test and assert circuit breakers.
+ */
+class CircuitBreakerAssertions {
+    protected final CircuitBreaker circuitBreaker = CircuitBreaker.of("test",
+        CircuitBreakerConfig.custom()
+            .waitDurationInOpenState(Duration.of(10, ChronoUnit.SECONDS))
+            .ringBufferSizeInClosedState(4)
+            .ringBufferSizeInHalfOpenState(4)
+            .build());
+
+    protected void assertSingleSuccessfulCall() {
+        assertThat(circuitBreaker.getMetrics().getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(circuitBreaker.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(1);
+        assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls()).isEqualTo(0);
+    }
+
+    protected void assertSingleFailedCall() {
+        assertThat(circuitBreaker.getMetrics().getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(circuitBreaker.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(0);
+        assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls()).isEqualTo(1);
+    }
+
+    protected void assertNoRegisteredCall() {
+        assertThat(circuitBreaker.getMetrics().getNumberOfBufferedCalls()).isEqualTo(0);
+        assertThat(circuitBreaker.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(0);
+        assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls()).isEqualTo(0);
+    }
+}

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/CircuitBreakerSubscriberWhiteboxVerification.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/CircuitBreakerSubscriberWhiteboxVerification.java
@@ -1,0 +1,64 @@
+package io.github.resilience4j.reactor.circuitbreaker.operator;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.reactivestreams.tck.SubscriberWhiteboxVerification;
+import org.reactivestreams.tck.TestEnvironment;
+import reactor.core.publisher.MonoProcessor;
+
+public class CircuitBreakerSubscriberWhiteboxVerification extends
+    SubscriberWhiteboxVerification<Integer> {
+
+  public CircuitBreakerSubscriberWhiteboxVerification() {
+    super(new TestEnvironment());
+  }
+
+  @Override
+  public Subscriber<Integer> createSubscriber(WhiteboxSubscriberProbe<Integer> probe) {
+    return new CircuitBreakerSubscriber<Integer>(CircuitBreaker.ofDefaults("verification"), MonoProcessor.create()) {
+      @Override
+      public void onSubscribe(Subscription subscription) {
+        super.onSubscribe(subscription);
+
+        // register a successful Subscription, and create a Puppet,
+        // for the WhiteboxVerification to be able to drive its tests:
+        probe.registerOnSubscribe(new SubscriberPuppet() {
+
+          @Override
+          public void triggerRequest(long elements) {
+            subscription.request(elements);
+          }
+
+          @Override
+          public void signalCancel() {
+            subscription.cancel();
+          }
+        });
+      }
+
+      @Override
+      public void onNext(Integer integer) {
+        super.onNext(integer);
+        probe.registerOnNext(integer);
+      }
+
+      @Override
+      public void onError(Throwable t) {
+        super.onError(t);
+        probe.registerOnError(t);
+      }
+
+      @Override
+      public void onComplete() {
+        super.onComplete();
+        probe.registerOnComplete();
+      }
+    };
+  }
+
+  @Override
+  public Integer createElement(int element) {
+    return element;
+  }
+}

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/FluxCircuitBreakerTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/FluxCircuitBreakerTest.java
@@ -1,0 +1,45 @@
+package io.github.resilience4j.reactor.circuitbreaker.operator;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreakerOpenException;
+import java.io.IOException;
+import org.junit.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+public class FluxCircuitBreakerTest extends CircuitBreakerAssertions {
+
+  @Test
+  public void shouldEmitEvent() {
+    StepVerifier.create(
+        Flux.just("Event 1", "Event 2")
+            .transform(CircuitBreakerOperator.of(circuitBreaker)))
+        .expectNext("Event 1")
+        .expectNext("Event 2")
+        .verifyComplete();
+
+    assertSingleSuccessfulCall();
+  }
+
+  @Test
+  public void shouldPropagateError() {
+    StepVerifier.create(
+        Flux.error(new IOException("BAM!"))
+            .transform(CircuitBreakerOperator.of(circuitBreaker)))
+        .expectError(IOException.class)
+        .verify();
+
+    assertSingleFailedCall();
+  }
+
+  @Test
+  public void shouldEmitErrorWithCircuitBreakerOpenException() {
+    circuitBreaker.transitionToOpenState();
+    StepVerifier.create(
+        Flux.just("Event 1", "Event 2")
+            .transform(CircuitBreakerOperator.of(circuitBreaker)))
+        .expectError(CircuitBreakerOpenException.class)
+        .verify();
+
+    assertNoRegisteredCall();
+  }
+}

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/MonoCircuitBreakerTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/MonoCircuitBreakerTest.java
@@ -1,0 +1,44 @@
+package io.github.resilience4j.reactor.circuitbreaker.operator;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreakerOpenException;
+import java.io.IOException;
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+public class MonoCircuitBreakerTest extends CircuitBreakerAssertions {
+
+  @Test
+  public void shouldEmitEvent() {
+    StepVerifier.create(
+        Mono.just("Event")
+            .transform(CircuitBreakerOperator.of(circuitBreaker)))
+        .expectNext("Event")
+        .verifyComplete();
+
+    assertSingleSuccessfulCall();
+  }
+
+  @Test
+  public void shouldPropagateError() {
+    StepVerifier.create(
+        Mono.error(new IOException("BAM!"))
+            .transform(CircuitBreakerOperator.of(circuitBreaker)))
+        .expectError(IOException.class)
+        .verify();
+
+    assertSingleFailedCall();
+  }
+
+  @Test
+  public void shouldEmitErrorWithCircuitBreakerOpenException() {
+    circuitBreaker.transitionToOpenState();
+    StepVerifier.create(
+        Mono.just("Event")
+            .transform(CircuitBreakerOperator.of(circuitBreaker)))
+        .expectError(CircuitBreakerOpenException.class)
+        .verify();
+
+    assertNoRegisteredCall();
+  }
+}

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/ratelimiter/operator/FluxRateLimiterTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/ratelimiter/operator/FluxRateLimiterTest.java
@@ -1,0 +1,50 @@
+package io.github.resilience4j.reactor.ratelimiter.operator;
+
+import io.github.resilience4j.ratelimiter.RequestNotPermitted;
+import org.junit.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import java.io.IOException;
+import java.time.Duration;
+
+public class FluxRateLimiterTest extends RateLimiterAssertions {
+
+    @Test
+    public void shouldEmitEvent() {
+        StepVerifier.create(
+                Flux.just("Event 1", "Event 2")
+                        .transform(RateLimiterOperator.of(rateLimiter)))
+                .expectNext("Event 1")
+                .expectNext("Event 2")
+                .verifyComplete();
+
+        assertUsedPermits(2);
+    }
+
+    @Test
+    public void shouldPropagateError() {
+        StepVerifier.create(
+                Flux.error(new IOException("BAM!"))
+                        .transform(RateLimiterOperator.of(rateLimiter)))
+                .expectSubscription()
+                .expectError(IOException.class)
+                .verify(Duration.ofSeconds(1));
+
+        assertSinglePermitUsed();
+    }
+
+    @Test
+    public void shouldEmitErrorWithBulkheadFullException() {
+        saturateRateLimiter();
+
+        StepVerifier.create(
+                Flux.just("Event")
+                        .transform(RateLimiterOperator.of(rateLimiter)))
+                .expectSubscription()
+                .expectError(RequestNotPermitted.class)
+                .verify(Duration.ofSeconds(1));
+
+        assertNoPermitLeft();
+    }
+}

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/ratelimiter/operator/MonoRateLimiterTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/ratelimiter/operator/MonoRateLimiterTest.java
@@ -1,0 +1,49 @@
+package io.github.resilience4j.reactor.ratelimiter.operator;
+
+import io.github.resilience4j.ratelimiter.RequestNotPermitted;
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.io.IOException;
+import java.time.Duration;
+
+public class MonoRateLimiterTest extends RateLimiterAssertions {
+
+    @Test
+    public void shouldEmitEvent() {
+        StepVerifier.create(
+                Mono.just("Event")
+                        .transform(RateLimiterOperator.of(rateLimiter)))
+                .expectNext("Event")
+                .verifyComplete();
+
+        assertSinglePermitUsed();
+    }
+
+    @Test
+    public void shouldPropagateError() {
+        StepVerifier.create(
+                Mono.error(new IOException("BAM!"))
+                        .transform(RateLimiterOperator.of(rateLimiter)))
+                .expectSubscription()
+                .expectError(IOException.class)
+                .verify(Duration.ofSeconds(1));
+
+        assertSinglePermitUsed();
+    }
+
+    @Test
+    public void shouldEmitErrorWithBulkheadFullException() {
+        saturateRateLimiter();
+
+        StepVerifier.create(
+                Mono.just("Event")
+                        .transform(RateLimiterOperator.of(rateLimiter)))
+                .expectSubscription()
+                .expectError(RequestNotPermitted.class)
+                .verify(Duration.ofSeconds(1));
+
+        assertNoPermitLeft();
+    }
+}

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/ratelimiter/operator/RateLimiterAssertions.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/ratelimiter/operator/RateLimiterAssertions.java
@@ -1,0 +1,35 @@
+package io.github.resilience4j.reactor.ratelimiter.operator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import io.github.resilience4j.ratelimiter.RateLimiterConfig;
+
+import java.time.Duration;
+import java.util.stream.IntStream;
+
+public class RateLimiterAssertions {
+    private static final int LIMIT_FOR_PERIOD = 5;
+
+    protected final RateLimiter rateLimiter = RateLimiter.of("test",
+            RateLimiterConfig.custom().limitForPeriod(LIMIT_FOR_PERIOD).timeoutDuration(Duration.ZERO).limitRefreshPeriod(Duration.ofSeconds(10)).build());
+
+    protected void assertUsedPermits(int used) {
+        RateLimiter.Metrics metrics = rateLimiter.getMetrics();
+        assertThat(metrics.getAvailablePermissions()).isEqualTo(LIMIT_FOR_PERIOD - used);
+        assertThat(metrics.getNumberOfWaitingThreads()).isEqualTo(0);
+    }
+
+    protected void assertSinglePermitUsed() {
+        assertUsedPermits(1);
+    }
+
+    protected void assertNoPermitLeft() {
+        assertUsedPermits(LIMIT_FOR_PERIOD);
+    }
+
+    protected void saturateRateLimiter() {
+        IntStream.range(0, 5).forEach(i -> assertThat(rateLimiter.getPermission(Duration.ofMillis(50))).isTrue());
+    }
+
+}

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/ratelimiter/operator/RateLimiterSubscriberWhiteboxVerification.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/ratelimiter/operator/RateLimiterSubscriberWhiteboxVerification.java
@@ -1,0 +1,64 @@
+package io.github.resilience4j.reactor.ratelimiter.operator;
+
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.reactivestreams.tck.SubscriberWhiteboxVerification;
+import org.reactivestreams.tck.TestEnvironment;
+import reactor.core.publisher.MonoProcessor;
+
+public class RateLimiterSubscriberWhiteboxVerification extends
+    SubscriberWhiteboxVerification<Integer> {
+
+  public RateLimiterSubscriberWhiteboxVerification() {
+    super(new TestEnvironment());
+  }
+
+  @Override
+  public Subscriber<Integer> createSubscriber(WhiteboxSubscriberProbe<Integer> probe) {
+    return new RateLimiterSubscriber<Integer>(RateLimiter.ofDefaults("verification"), MonoProcessor.create()) {
+      @Override
+      public void onSubscribe(Subscription subscription) {
+        super.onSubscribe(subscription);
+
+        // register a successful Subscription, and create a Puppet,
+        // for the WhiteboxVerification to be able to drive its tests:
+        probe.registerOnSubscribe(new SubscriberPuppet() {
+
+          @Override
+          public void triggerRequest(long elements) {
+            subscription.request(elements);
+          }
+
+          @Override
+          public void signalCancel() {
+            subscription.cancel();
+          }
+        });
+      }
+
+      @Override
+      public void onNext(Integer integer) {
+        super.onNext(integer);
+        probe.registerOnNext(integer);
+      }
+
+      @Override
+      public void onError(Throwable t) {
+        super.onError(t);
+        probe.registerOnError(t);
+      }
+
+      @Override
+      public void onComplete() {
+        super.onComplete();
+        probe.registerOnComplete();
+      }
+    };
+  }
+
+  @Override
+  public Integer createElement(int element) {
+    return element;
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,4 +18,5 @@ include 'resilience4j-ratpack'
 include 'resilience4j-prometheus'
 include 'resilience4j-timelimiter'
 include 'resilience4j-rxjava2'
+include 'resilience4j-reactor'
 


### PR DESCRIPTION
Having a try at adding Reactor supports for circuit breaker, bulkhead and rate limiter.

Current implementation is heavily inspired by the RxJava equivalent.

I'm not a reactor expert so feedback more than welcome.