### PR TITLE
#162 Add support for Micrometer

### DIFF
--- a/libraries.gradle
+++ b/libraries.gradle
@@ -21,6 +21,7 @@ ext {
     prometheusSimpleClientVersion = '0.0.21'
     reactorVersion = '3.1.3.RELEASE'
     reactiveStreamsVersion = '1.0.2'
+    micrometerVersion = '1.0.0'
 
     libraries = [
             // compile
@@ -66,6 +67,9 @@ ext {
 
             // Metrics addon
             metrics: "io.dropwizard.metrics:metrics-core:${metricsVersion}",
+
+            // Micrometers addon
+            micrometer: "io.micrometer:micrometer-core:${micrometerVersion}",
 
             // CircuitBreaker documentation
             metrics_healthcheck: "io.dropwizard.metrics:metrics-healthchecks:${metricsVersion}",

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/utils/MetricNames.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/utils/MetricNames.java
@@ -1,0 +1,6 @@
+package io.github.resilience4j.bulkhead.utils;
+
+public class MetricNames {
+    public static final String DEFAULT_PREFIX = "resilience4j.bulkhead";
+    public static final String AVAILABLE_CONCURRENT_CALLS = "available_concurrent_calls";
+}

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/utils/MetricNames.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/utils/MetricNames.java
@@ -1,0 +1,11 @@
+package io.github.resilience4j.circuitbreaker.utils;
+
+public class MetricNames {
+    public static final String DEFAULT_PREFIX = "resilience4j.circuitbreaker";
+    public static final String SUCCESSFUL = "successful";
+    public static final String FAILED = "failed";
+    public static final String NOT_PERMITTED = "not_permitted";
+    public static final String BUFFERED = "buffered";
+    public static final String BUFFERED_MAX = "buffered_max";
+    public static final String STATE = "state";
+}

--- a/resilience4j-documentation/src/docs/asciidoc/addon_guides/micrometer.adoc
+++ b/resilience4j-documentation/src/docs/asciidoc/addon_guides/micrometer.adoc
@@ -1,0 +1,85 @@
+=== Micrometer Metrics exporter
+
+==== Introduction
+
+Integration with http://micrometer.io/[Micrometer].
+With this add-on you can easily add your bulkhead, circuit breaker, rate limiter, retry metrics in Micrometer `MeterRegistry`.
+
+==== Usage
+
+===== Bulkhead
+
+[source,java]
+--
+final BulkheadRegistry bulkheadRegistry = BulkheadRegistry.ofDefaults();
+final Bulkhead foo = bulkheadRegistry.bulkhead("foo");
+final Bulkhead boo = bulkheadRegistry.bulkhead("boo");
+
+// Register all bulkheads at once
+BulkheadMetrics bulkheadMetrics = BulkheadMetrics.ofBulkheadRegistry(bulkheadRegistry);
+bulkheadMetrics.bindTo(meterRegistry);
+--
+
+For each bulkhead this registry will export:
+
+* `available_concurrent_calls` - instantaneous read of the number of currently available concurrent calls `[int]`
+
+===== CircuitBreaker
+
+[source,java]
+--
+final CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
+final CircuitBreaker foo = circuitBreakerRegistry.circuitBreaker("foo");
+final CircuitBreaker boo = circuitBreakerRegistry.circuitBreaker("boo");
+
+// Register all circuit breakers at once
+CircuitBreakerMetrics circuitBreakerMetrics = CircuitBreakerMetrics.ofCircuitBreakerRegistry(circuitBreakerRegistry);
+circuitBreakerMetrics.bindTo(meterRegistry);
+--
+
+For each circuit breaker this registry will export:
+
+* `state` - instantaneous read of the current state where 0-CLOSED, 1-OPEN, 2-HALF-OPEN `[int]`
+* `successful` - current number of successful calls `[int]`
+* `failed` - current number of failed calls `[int]`
+* `buffered` - current number of buffered calls `[int]`
+* `buffered_max` - maximum number of buffered calls `[int]`
+* `not_permitted` - current number of not permitted calls `[int]`
+
+===== RateLimiter
+
+[source,java]
+--
+final RateLimiterRegistry rateLimiterRegistry = RateLimiterRegistry.ofDefaults();
+final RateLimiter rateLimiter = rateLimiterRegistry.rateLimiter("testLimit");
+
+// Register rate limiters at once
+RateLimiterMetrics rateLimiterMetrics = RateLimiterMetrics.ofRateLimiterRegistry(rateLimiterRegistry);
+rateLimiterMetrics.bindTo(meterRegistry);
+--
+
+For each rate limiter this registry will export:
+
+* `available_permissions` - current number of available permissions `[int]`
+* `number_of_waiting_threads` - current number of threads waiting for permission `[int]`
+
+===== Retry
+
+[source,java]
+--
+final MetricRegistry metricRegistry = new MetricRegistry();
+final RetryRegistry retryRegistry = RetryRegistry.ofDefaults();
+final Retry retry = retryRegistry.retry("testLimit");
+
+// Register all retries at once
+RetryMetrics retryMetrics = RetryMetrics.ofRetryRegistry(retryRegistry);
+retryMetrics.bindTo(meterRegistry);
+--
+
+For each retry this registry will export:
+
+* `successful_calls_without_retry` - the number of successful calls without a retry attempt `[long]`
+* `successful_calls_with_retry` - the number of successful calls after a retry attempt `[long]`
+* `failed_calls_without_retry` - the number of failed calls without a retry attempt `[long]`
+* `failed_calls_with_retry` - the number of failed calls after all retry attempts `[long]`
+

--- a/resilience4j-documentation/src/docs/asciidoc/addons_guide.adoc
+++ b/resilience4j-documentation/src/docs/asciidoc/addons_guide.adoc
@@ -9,3 +9,5 @@ include::addon_guides/retrofit.adoc[]
 include::addon_guides/dropwizard.adoc[]
 
 include::addon_guides/prometheus.adoc[]
+
+include::addon_guides/micrometer.adoc[]

--- a/resilience4j-metrics/src/main/java/io/github/resilience4j/metrics/BulkheadMetrics.java
+++ b/resilience4j-metrics/src/main/java/io/github/resilience4j/metrics/BulkheadMetrics.java
@@ -26,15 +26,14 @@ import io.vavr.collection.Array;
 import java.util.Map;
 
 import static com.codahale.metrics.MetricRegistry.name;
+import static io.github.resilience4j.bulkhead.utils.MetricNames.AVAILABLE_CONCURRENT_CALLS;
+import static io.github.resilience4j.bulkhead.utils.MetricNames.DEFAULT_PREFIX;
 import static java.util.Objects.requireNonNull;
 
 /**
  * An adapter which exports {@link Bulkhead.Metrics} as Dropwizard Metrics Gauges.
  */
 public class BulkheadMetrics implements MetricSet {
-    private static final String DEFAULT_PREFIX = "resilience4j.bulkhead";
-    private static final String AVAILABLE_CONCURRENT_CALLS = "available_concurrent_calls";
-
     private final MetricRegistry metricRegistry = new MetricRegistry();
 
     private BulkheadMetrics(Iterable<Bulkhead> bulkheads) {

--- a/resilience4j-metrics/src/main/java/io/github/resilience4j/metrics/CircuitBreakerMetrics.java
+++ b/resilience4j-metrics/src/main/java/io/github/resilience4j/metrics/CircuitBreakerMetrics.java
@@ -29,20 +29,13 @@ import io.vavr.collection.Array;
 import java.util.Map;
 
 import static com.codahale.metrics.MetricRegistry.name;
+import static io.github.resilience4j.circuitbreaker.utils.MetricNames.*;
 import static java.util.Objects.requireNonNull;
 
 /**
  * An adapter which exports {@link CircuitBreaker.Metrics} as Dropwizard Metrics Gauges.
  */
 public class CircuitBreakerMetrics implements MetricSet {
-
-    private static final String DEFAULT_PREFIX = "resilience4j.circuitbreaker";
-    public static final String SUCCESSFUL = "successful";
-    public static final String FAILED = "failed";
-    public static final String NOT_PERMITTED = "not_permitted";
-    public static final String BUFFERED = "buffered";
-    public static final String BUFFERED_MAX = "buffered_max";
-    public static final String STATE = "state";
 
     private final MetricRegistry metricRegistry = new MetricRegistry();
 

--- a/resilience4j-metrics/src/main/java/io/github/resilience4j/metrics/RateLimiterMetrics.java
+++ b/resilience4j-metrics/src/main/java/io/github/resilience4j/metrics/RateLimiterMetrics.java
@@ -29,6 +29,9 @@ import io.vavr.collection.Array;
 import java.util.Map;
 
 import static com.codahale.metrics.MetricRegistry.name;
+import static io.github.resilience4j.ratelimiter.utils.MetricNames.AVAILABLE_PERMISSIONS;
+import static io.github.resilience4j.ratelimiter.utils.MetricNames.DEFAULT_PREFIX;
+import static io.github.resilience4j.ratelimiter.utils.MetricNames.WAITING_THREADS;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -38,8 +41,6 @@ public class RateLimiterMetrics implements MetricSet {
 
     private static final String PREFIX_NULL = "Prefix must not be null";
     private static final String ITERABLE_NULL = "RateLimiters iterable must not be null";
-
-    private static final String DEFAULT_PREFIX = "resilience4j.ratelimiter";
 
     private final MetricRegistry metricRegistry = new MetricRegistry();
 
@@ -53,9 +54,9 @@ public class RateLimiterMetrics implements MetricSet {
 
         rateLimiters.forEach(rateLimiter -> {
                 String name = rateLimiter.getName();
-            metricRegistry.register(name(prefix, name, "number_of_waiting_threads"),
+                metricRegistry.register(name(prefix, name, WAITING_THREADS),
                     (Gauge<Integer>) rateLimiter.getMetrics()::getNumberOfWaitingThreads);
-                metricRegistry.register(name(prefix, name, "available_permissions"),
+                metricRegistry.register(name(prefix, name, AVAILABLE_PERMISSIONS),
                     (Gauge<Integer>) rateLimiter.getMetrics()::getAvailablePermissions);
             }
         );

--- a/resilience4j-metrics/src/main/java/io/github/resilience4j/metrics/RetryMetrics.java
+++ b/resilience4j-metrics/src/main/java/io/github/resilience4j/metrics/RetryMetrics.java
@@ -8,6 +8,7 @@ import io.vavr.collection.Array;
 import java.util.Map;
 
 import static com.codahale.metrics.MetricRegistry.name;
+import static io.github.resilience4j.retry.utils.MetricNames.*;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -15,12 +16,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class RetryMetrics implements MetricSet {
 
-    public static final String SUCCESSFUL_CALLS_WITHOUT_RETRY = "successful_calls_without_retry";
-    public static final String SUCCESSFUL_CALLS_WITH_RETRY = "successful_calls_with_retry";
-    public static final String FAILED_CALLS_WITHOUT_RETRY = "failed_calls_without_retry";
-    public static final String FAILED_CALLS_WITH_RETRY = "failed_calls_with_retry";
     private final MetricRegistry metricRegistry = new MetricRegistry();
-    private static final String DEFAULT_PREFIX = "resilience4j.retry";
 
     private RetryMetrics(Iterable<Retry> retries){
         this(DEFAULT_PREFIX, retries);

--- a/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/RetryMetricsTest.java
+++ b/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/RetryMetricsTest.java
@@ -11,6 +11,7 @@ import org.mockito.BDDMockito;
 
 import javax.xml.ws.WebServiceException;
 
+import static io.github.resilience4j.retry.utils.MetricNames.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -44,10 +45,10 @@ public class RetryMetricsTest {
         // Then the helloWorldService should be invoked 1 time
         BDDMockito.then(helloWorldService).should(times(1)).returnHelloWorld();
         assertThat(metricRegistry.getMetrics()).hasSize(4);
-        assertThat(metricRegistry.getGauges().get("resilience4j.retry.testName." + RetryMetrics.SUCCESSFUL_CALLS_WITH_RETRY).getValue()).isEqualTo(0L);
-        assertThat(metricRegistry.getGauges().get("resilience4j.retry.testName." + RetryMetrics.SUCCESSFUL_CALLS_WITHOUT_RETRY).getValue()).isEqualTo(1L);
-        assertThat(metricRegistry.getGauges().get("resilience4j.retry.testName." + RetryMetrics.FAILED_CALLS_WITH_RETRY).getValue()).isEqualTo(0L);
-        assertThat(metricRegistry.getGauges().get("resilience4j.retry.testName." + RetryMetrics.FAILED_CALLS_WITHOUT_RETRY).getValue()).isEqualTo(0L);
+        assertThat(metricRegistry.getGauges().get("resilience4j.retry.testName." + SUCCESSFUL_CALLS_WITH_RETRY).getValue()).isEqualTo(0L);
+        assertThat(metricRegistry.getGauges().get("resilience4j.retry.testName." + SUCCESSFUL_CALLS_WITHOUT_RETRY).getValue()).isEqualTo(1L);
+        assertThat(metricRegistry.getGauges().get("resilience4j.retry.testName." + FAILED_CALLS_WITH_RETRY).getValue()).isEqualTo(0L);
+        assertThat(metricRegistry.getGauges().get("resilience4j.retry.testName." + FAILED_CALLS_WITHOUT_RETRY).getValue()).isEqualTo(0L);
     }
 
     @Test
@@ -74,10 +75,10 @@ public class RetryMetricsTest {
         // Then the helloWorldService should be invoked 1 time
         BDDMockito.then(helloWorldService).should(times(5)).returnHelloWorld();
         assertThat(metricRegistry.getMetrics()).hasSize(4);
-        assertThat(metricRegistry.getGauges().get("resilience4j.retry.testName." + RetryMetrics.SUCCESSFUL_CALLS_WITH_RETRY).getValue()).isEqualTo(1L);
-        assertThat(metricRegistry.getGauges().get("resilience4j.retry.testName." + RetryMetrics.SUCCESSFUL_CALLS_WITHOUT_RETRY).getValue()).isEqualTo(0L);
-        assertThat(metricRegistry.getGauges().get("resilience4j.retry.testName." + RetryMetrics.FAILED_CALLS_WITH_RETRY).getValue()).isEqualTo(1L);
-        assertThat(metricRegistry.getGauges().get("resilience4j.retry.testName." + RetryMetrics.FAILED_CALLS_WITHOUT_RETRY).getValue()).isEqualTo(0L);
+        assertThat(metricRegistry.getGauges().get("resilience4j.retry.testName." + SUCCESSFUL_CALLS_WITH_RETRY).getValue()).isEqualTo(1L);
+        assertThat(metricRegistry.getGauges().get("resilience4j.retry.testName." + SUCCESSFUL_CALLS_WITHOUT_RETRY).getValue()).isEqualTo(0L);
+        assertThat(metricRegistry.getGauges().get("resilience4j.retry.testName." + FAILED_CALLS_WITH_RETRY).getValue()).isEqualTo(1L);
+        assertThat(metricRegistry.getGauges().get("resilience4j.retry.testName." + FAILED_CALLS_WITHOUT_RETRY).getValue()).isEqualTo(0L);
     }
 
     @Test
@@ -97,9 +98,9 @@ public class RetryMetricsTest {
         // Then the helloWorldService should be invoked 1 time
         BDDMockito.then(helloWorldService).should(times(1)).returnHelloWorld();
         assertThat(metricRegistry.getMetrics()).hasSize(4);
-        assertThat(metricRegistry.getGauges().get("testPrefix.testName." + RetryMetrics.SUCCESSFUL_CALLS_WITH_RETRY).getValue()).isEqualTo(0L);
-        assertThat(metricRegistry.getGauges().get("testPrefix.testName." + RetryMetrics.SUCCESSFUL_CALLS_WITHOUT_RETRY).getValue()).isEqualTo(1L);
-        assertThat(metricRegistry.getGauges().get("testPrefix.testName." + RetryMetrics.FAILED_CALLS_WITH_RETRY).getValue()).isEqualTo(0L);
-        assertThat(metricRegistry.getGauges().get("testPrefix.testName." + RetryMetrics.FAILED_CALLS_WITHOUT_RETRY).getValue()).isEqualTo(0L);
+        assertThat(metricRegistry.getGauges().get("testPrefix.testName." + SUCCESSFUL_CALLS_WITH_RETRY).getValue()).isEqualTo(0L);
+        assertThat(metricRegistry.getGauges().get("testPrefix.testName." + SUCCESSFUL_CALLS_WITHOUT_RETRY).getValue()).isEqualTo(1L);
+        assertThat(metricRegistry.getGauges().get("testPrefix.testName." + FAILED_CALLS_WITH_RETRY).getValue()).isEqualTo(0L);
+        assertThat(metricRegistry.getGauges().get("testPrefix.testName." + FAILED_CALLS_WITHOUT_RETRY).getValue()).isEqualTo(0L);
     }
 }

--- a/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/TimerTest.java
+++ b/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/TimerTest.java
@@ -39,6 +39,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static com.jayway.awaitility.Awaitility.await;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -158,9 +160,12 @@ public class TimerTest {
 
         assertThat(value).isEqualTo("Hello world");
 
-        assertThat(timer.getMetrics().getNumberOfTotalCalls()).isEqualTo(1);
-        assertThat(timer.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(1);
-        assertThat(timer.getMetrics().getNumberOfFailedCalls()).isEqualTo(0);
+        await().atMost(1, SECONDS)
+                .until(() -> {
+                    assertThat(timer.getMetrics().getNumberOfTotalCalls()).isEqualTo(1);
+                    assertThat(timer.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(1);
+                    assertThat(timer.getMetrics().getNumberOfFailedCalls()).isEqualTo(0);
+                });
 
         // Then the helloWorldService should be invoked 1 time
         BDDMockito.then(helloWorldService).should(times(1)).returnHelloWorld();

--- a/resilience4j-micrometer/README.adoc
+++ b/resilience4j-micrometer/README.adoc
@@ -1,0 +1,15 @@
+= resilience4j-micrometer
+
+Integration of bulkhead, circuit breaker, rate limiter and retry metrics with http://micrometer.io/[Micrometer].
+
+NOTE: For detailed documentation look at our *http://resilience4j.github.io/resilience4j/#_micrometer_metrics_exporter[Usage Guide]*
+
+== License
+
+Copyright 2018 Julien Hoarau
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/resilience4j-micrometer/build.gradle
+++ b/resilience4j-micrometer/build.gradle
@@ -1,0 +1,14 @@
+dependencies {
+    compile (libraries.micrometer)
+    compileOnly project(':resilience4j-bulkhead')
+    compileOnly project(':resilience4j-circuitbreaker')
+    compileOnly project(':resilience4j-retry')
+    compileOnly project(':resilience4j-ratelimiter')
+    testCompile project(':resilience4j-test')
+    testCompile project(':resilience4j-bulkhead')
+    testCompile project(':resilience4j-circuitbreaker')
+    testCompile project(':resilience4j-ratelimiter')
+    testCompile project(':resilience4j-retry')
+    testCompile project(':resilience4j-test')
+    testCompile project(':resilience4j-circuitbreaker')
+}

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/BulkheadMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/BulkheadMetrics.java
@@ -1,0 +1,46 @@
+package io.github.resilience4j.micrometer;
+
+import io.github.resilience4j.bulkhead.Bulkhead;
+import io.github.resilience4j.bulkhead.BulkheadRegistry;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+import static io.github.resilience4j.bulkhead.utils.MetricNames.AVAILABLE_CONCURRENT_CALLS;
+import static io.github.resilience4j.bulkhead.utils.MetricNames.DEFAULT_PREFIX;
+import static io.github.resilience4j.micrometer.MetricUtils.getName;
+import static java.util.Objects.requireNonNull;
+
+public class BulkheadMetrics implements MeterBinder {
+
+    private final Iterable<Bulkhead> bulkheads;
+    private final String prefix;
+
+    private BulkheadMetrics(Iterable<Bulkhead> bulkheads) {
+        this(bulkheads, DEFAULT_PREFIX);
+    }
+
+    private BulkheadMetrics(Iterable<Bulkhead> bulkheads, String prefix) {
+        this.bulkheads = requireNonNull(bulkheads);
+        this.prefix = requireNonNull(prefix);
+    }
+
+    /**
+     * Creates a new instance BulkheadMetrics {@link BulkheadMetrics} with
+     * a {@link BulkheadRegistry} as a source.
+     *
+     * @param bulkheadRegistry the registry of bulkheads
+     */
+    public static BulkheadMetrics ofBulkheadRegistry(BulkheadRegistry bulkheadRegistry) {
+        return new BulkheadMetrics(bulkheadRegistry.getAllBulkheads());
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        for (Bulkhead bulkhead : bulkheads) {
+            final String name = bulkhead.getName();
+            Gauge.builder(getName(prefix, name, AVAILABLE_CONCURRENT_CALLS), bulkhead, (cb) -> cb.getMetrics().getAvailableConcurrentCalls())
+                    .register(registry);
+        }
+    }
+}

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/CircuitBreakerMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/CircuitBreakerMetrics.java
@@ -1,0 +1,55 @@
+package io.github.resilience4j.micrometer;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+import static io.github.resilience4j.circuitbreaker.utils.MetricNames.*;
+import static io.github.resilience4j.micrometer.MetricUtils.getName;
+import static java.util.Objects.requireNonNull;
+
+public class CircuitBreakerMetrics implements MeterBinder {
+
+    private final Iterable<CircuitBreaker> circuitBreakers;
+    private final String prefix;
+
+    private CircuitBreakerMetrics(Iterable<CircuitBreaker> circuitBreakers) {
+        this(circuitBreakers, DEFAULT_PREFIX);
+    }
+
+    private CircuitBreakerMetrics(Iterable<CircuitBreaker> circuitBreakers, String prefix) {
+        this.circuitBreakers = requireNonNull(circuitBreakers);
+        this.prefix = requireNonNull(prefix);
+    }
+
+    /**
+     * Creates a new instance CircuitBreakerMetrics {@link CircuitBreakerMetrics} with
+     * a {@link CircuitBreakerRegistry} as a source.
+     *
+     * @param circuitBreakerRegistry the registry of circuit breakers
+     */
+    public static CircuitBreakerMetrics ofCircuitBreakerRegistry(CircuitBreakerRegistry circuitBreakerRegistry) {
+        return new CircuitBreakerMetrics(circuitBreakerRegistry.getAllCircuitBreakers());
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        for (CircuitBreaker circuitBreaker : circuitBreakers) {
+            final String name = circuitBreaker.getName();
+            Gauge.builder(getName(prefix, name, STATE), circuitBreaker, (cb) -> cb.getState().getOrder())
+                    .register(registry);
+            Gauge.builder(getName(prefix, name, BUFFERED_MAX), circuitBreaker, (cb) -> cb.getMetrics().getMaxNumberOfBufferedCalls())
+                    .register(registry);
+            Gauge.builder(getName(prefix, name, BUFFERED), circuitBreaker, (cb) -> cb.getMetrics().getNumberOfBufferedCalls())
+                    .register(registry);
+            Gauge.builder(getName(prefix, name, FAILED), circuitBreaker, (cb) -> cb.getMetrics().getNumberOfFailedCalls())
+                    .register(registry);
+            Gauge.builder(getName(prefix, name, NOT_PERMITTED), circuitBreaker, (cb) -> cb.getMetrics().getNumberOfNotPermittedCalls())
+                    .register(registry);
+            Gauge.builder(getName(prefix, name, SUCCESSFUL), circuitBreaker, (cb) -> cb.getMetrics().getNumberOfSuccessfulCalls())
+                    .register(registry);
+        }
+    }
+}

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/MetricUtils.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/MetricUtils.java
@@ -1,0 +1,7 @@
+package io.github.resilience4j.micrometer;
+
+public class MetricUtils {
+    public static String getName(String prefix, String name, String type) {
+        return prefix + '.' + name + '.' + type;
+    }
+}

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/RateLimiterMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/RateLimiterMetrics.java
@@ -1,0 +1,49 @@
+package io.github.resilience4j.micrometer;
+
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+import static io.github.resilience4j.micrometer.MetricUtils.getName;
+import static io.github.resilience4j.ratelimiter.utils.MetricNames.DEFAULT_PREFIX;
+import static io.github.resilience4j.ratelimiter.utils.MetricNames.AVAILABLE_PERMISSIONS;
+import static io.github.resilience4j.ratelimiter.utils.MetricNames.WAITING_THREADS;
+import static java.util.Objects.requireNonNull;
+
+public class RateLimiterMetrics implements MeterBinder {
+
+    private final Iterable<RateLimiter> rateLimiters;
+    private final String prefix;
+
+    private RateLimiterMetrics(Iterable<RateLimiter> rateLimiters) {
+        this(rateLimiters, DEFAULT_PREFIX);
+    }
+
+    private RateLimiterMetrics(Iterable<RateLimiter> rateLimiters, String prefix) {
+        this.rateLimiters = requireNonNull(rateLimiters);
+        this.prefix = requireNonNull(prefix);
+    }
+
+    /**
+     * Creates a new instance RateLimiterMetrics {@link RateLimiterMetrics} with
+     * a {@link RateLimiterRegistry} as a source.
+     *
+     * @param rateLimiterRegistry the registry of rate limiters
+     */
+    public static RateLimiterMetrics ofRateLimiterRegistry(RateLimiterRegistry rateLimiterRegistry) {
+        return new RateLimiterMetrics(rateLimiterRegistry.getAllRateLimiters());
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        for (RateLimiter rateLimiter : rateLimiters) {
+            final String name = rateLimiter.getName();
+            Gauge.builder(getName(prefix, name, AVAILABLE_PERMISSIONS), rateLimiter, (cb) -> cb.getMetrics().getAvailablePermissions())
+                    .register(registry);
+            Gauge.builder(getName(prefix, name, WAITING_THREADS), rateLimiter, (cb) -> cb.getMetrics().getNumberOfWaitingThreads())
+                    .register(registry);
+        }
+    }
+}

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/RetryMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/RetryMetrics.java
@@ -1,0 +1,52 @@
+package io.github.resilience4j.micrometer;
+
+import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryRegistry;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+import static io.github.resilience4j.micrometer.MetricUtils.getName;
+import static io.github.resilience4j.retry.utils.MetricNames.*;
+import static java.util.Objects.requireNonNull;
+
+public class RetryMetrics implements MeterBinder {
+
+    private final Iterable<Retry> retries;
+    private final String prefix;
+
+    private RetryMetrics(Iterable<Retry> retries) {
+        this(retries, DEFAULT_PREFIX);
+    }
+
+    private RetryMetrics(Iterable<Retry> retries, String prefix) {
+        this.retries = requireNonNull(retries);
+        this.prefix = requireNonNull(prefix);
+    }
+
+    /**
+     * Creates a new instance RetryMetrics {@link RetryMetrics} with
+     * a {@link RateLimiterRegistry} as a source.
+     *
+     * @param retryRegistry the registry of retries
+     */
+    public static RetryMetrics ofRetryRegistry(RetryRegistry retryRegistry) {
+        return new RetryMetrics(retryRegistry.getAllRetries());
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        for (Retry retry : retries) {
+            final String name = retry.getName();
+            Gauge.builder(getName(prefix, name, SUCCESSFUL_CALLS_WITHOUT_RETRY), retry, (cb) -> cb.getMetrics().getNumberOfSuccessfulCallsWithoutRetryAttempt())
+                    .register(registry);
+            Gauge.builder(getName(prefix, name, SUCCESSFUL_CALLS_WITH_RETRY), retry, (cb) -> cb.getMetrics().getNumberOfSuccessfulCallsWithRetryAttempt())
+                    .register(registry);
+            Gauge.builder(getName(prefix, name, FAILED_CALLS_WITHOUT_RETRY), retry, (cb) -> cb.getMetrics().getNumberOfFailedCallsWithoutRetryAttempt())
+                    .register(registry);
+            Gauge.builder(getName(prefix, name, FAILED_CALLS_WITH_RETRY), retry, (cb) -> cb.getMetrics().getNumberOfFailedCallsWithRetryAttempt())
+                    .register(registry);
+        }
+    }
+}

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/BulkheadMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/BulkheadMetricsTest.java
@@ -1,0 +1,46 @@
+package io.github.resilience4j.micrometer;
+
+import io.github.resilience4j.bulkhead.BulkheadRegistry;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Lists.newArrayList;
+
+public class BulkheadMetricsTest {
+
+    private MeterRegistry meterRegistry;
+
+    @Before
+    public void setUp() throws Exception {
+        meterRegistry = new SimpleMeterRegistry();
+    }
+
+    @Test
+    public void shouldRegisterMetrics() {
+        BulkheadRegistry bulkheadRegistry = BulkheadRegistry.ofDefaults();
+        bulkheadRegistry.bulkhead("testName");
+
+        BulkheadMetrics bulkheadMetrics = BulkheadMetrics.ofBulkheadRegistry(bulkheadRegistry);
+        bulkheadMetrics.bindTo(meterRegistry);
+
+        final List<String> metricNames = meterRegistry.getMeters()
+                .stream()
+                .map(Meter::getId)
+                .map(Meter.Id::getName)
+                .collect(Collectors.toList());
+
+        final List<String> expectedMetrics = newArrayList(
+                "resilience4j.bulkhead.testName.available_concurrent_calls");
+        assertThat(metricNames).hasSameElementsAs(expectedMetrics);
+
+    }
+
+
+}

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/CircuitBreakerMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/CircuitBreakerMetricsTest.java
@@ -1,0 +1,51 @@
+package io.github.resilience4j.micrometer;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Lists.newArrayList;
+
+public class CircuitBreakerMetricsTest {
+
+    private MeterRegistry meterRegistry;
+
+    @Before
+    public void setUp() throws Exception {
+        meterRegistry = new SimpleMeterRegistry();
+    }
+
+    @Test
+    public void shouldRegisterMetrics() {
+        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
+        circuitBreakerRegistry.circuitBreaker("testName");
+
+        CircuitBreakerMetrics circuitBreakerMetrics = CircuitBreakerMetrics.ofCircuitBreakerRegistry(circuitBreakerRegistry);
+        circuitBreakerMetrics.bindTo(meterRegistry);
+
+        final List<String> metricNames = meterRegistry.getMeters()
+                .stream()
+                .map(Meter::getId)
+                .map(Meter.Id::getName)
+                .collect(Collectors.toList());
+
+        final List<String> expectedMetrics = newArrayList(
+                "resilience4j.circuitbreaker.testName.successful",
+                "resilience4j.circuitbreaker.testName.failed",
+                "resilience4j.circuitbreaker.testName.not_permitted",
+                "resilience4j.circuitbreaker.testName.state",
+                "resilience4j.circuitbreaker.testName.buffered",
+                "resilience4j.circuitbreaker.testName.buffered_max");
+        assertThat(metricNames).hasSameElementsAs(expectedMetrics);
+
+    }
+
+
+}

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/RateLimiterMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/RateLimiterMetricsTest.java
@@ -1,0 +1,47 @@
+package io.github.resilience4j.micrometer;
+
+import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Lists.newArrayList;
+
+public class RateLimiterMetricsTest {
+
+    private MeterRegistry meterRegistry;
+
+    @Before
+    public void setUp() throws Exception {
+        meterRegistry = new SimpleMeterRegistry();
+    }
+
+    @Test
+    public void shouldRegisterMetrics() {
+        RateLimiterRegistry rateLimiterRegistry = RateLimiterRegistry.ofDefaults();
+        rateLimiterRegistry.rateLimiter("testName");
+
+        RateLimiterMetrics rateLimiterMetrics = RateLimiterMetrics.ofRateLimiterRegistry(rateLimiterRegistry);
+        rateLimiterMetrics.bindTo(meterRegistry);
+
+        final List<String> metricNames = meterRegistry.getMeters()
+                .stream()
+                .map(Meter::getId)
+                .map(Meter.Id::getName)
+                .collect(Collectors.toList());
+
+        final List<String> expectedMetrics = newArrayList(
+                "resilience4j.ratelimiter.testName.available_permissions",
+                "resilience4j.ratelimiter.testName.number_of_waiting_threads");
+        assertThat(metricNames).hasSameElementsAs(expectedMetrics);
+
+    }
+
+
+}

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/RetryMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/RetryMetricsTest.java
@@ -1,0 +1,49 @@
+package io.github.resilience4j.micrometer;
+
+import io.github.resilience4j.retry.RetryRegistry;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Lists.newArrayList;
+
+public class RetryMetricsTest {
+
+    private MeterRegistry meterRegistry;
+
+    @Before
+    public void setUp() throws Exception {
+        meterRegistry = new SimpleMeterRegistry();
+    }
+
+    @Test
+    public void shouldRegisterMetrics() {
+        RetryRegistry retryRegistry = RetryRegistry.ofDefaults();
+        retryRegistry.retry("testName");
+
+        RetryMetrics retryMetrics = RetryMetrics.ofRetryRegistry(retryRegistry);
+        retryMetrics.bindTo(meterRegistry);
+
+        final List<String> metricNames = meterRegistry.getMeters()
+                .stream()
+                .map(Meter::getId)
+                .map(Meter.Id::getName)
+                .collect(Collectors.toList());
+
+        final List<String> expectedMetrics = newArrayList(
+                "resilience4j.retry.testName.successful_calls_with_retry",
+                "resilience4j.retry.testName.failed_calls_with_retry",
+                "resilience4j.retry.testName.successful_calls_without_retry",
+                "resilience4j.retry.testName.failed_calls_without_retry");
+        assertThat(metricNames).hasSameElementsAs(expectedMetrics);
+
+    }
+
+
+}

--- a/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/utils/MetricNames.java
+++ b/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/utils/MetricNames.java
@@ -1,0 +1,7 @@
+package io.github.resilience4j.ratelimiter.utils;
+
+public class MetricNames {
+    public static final String DEFAULT_PREFIX = "resilience4j.ratelimiter";
+    public static final String WAITING_THREADS = "number_of_waiting_threads";
+    public static final String AVAILABLE_PERMISSIONS = "available_permissions";
+}

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/utils/MetricNames.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/utils/MetricNames.java
@@ -1,0 +1,9 @@
+package io.github.resilience4j.retry.utils;
+
+public class MetricNames {
+    public static final String DEFAULT_PREFIX = "resilience4j.retry";
+    public static final String SUCCESSFUL_CALLS_WITHOUT_RETRY = "successful_calls_without_retry";
+    public static final String SUCCESSFUL_CALLS_WITH_RETRY = "successful_calls_with_retry";
+    public static final String FAILED_CALLS_WITHOUT_RETRY = "failed_calls_without_retry";
+    public static final String FAILED_CALLS_WITH_RETRY = "failed_calls_with_retry";
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,4 +19,5 @@ include 'resilience4j-prometheus'
 include 'resilience4j-timelimiter'
 include 'resilience4j-rxjava2'
 include 'resilience4j-reactor'
+include 'resilience4j-micrometer'
 


### PR DESCRIPTION
Adding support for [Micrometer](micrometer.io) to record metrics. Micrometer is the library used in Spring boot 2 to record metrics.