### PR TITLE
#35 Make sure the Reactor operators can be used together on a Flux

### DIFF
--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/CombinedOperatorsTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/CombinedOperatorsTest.java
@@ -1,0 +1,69 @@
+package io.github.resilience4j.reactor;
+
+import io.github.resilience4j.bulkhead.Bulkhead;
+import io.github.resilience4j.bulkhead.BulkheadConfig;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import io.github.resilience4j.ratelimiter.RateLimiterConfig;
+import io.github.resilience4j.reactor.bulkhead.operator.BulkheadOperator;
+import io.github.resilience4j.reactor.circuitbreaker.operator.CircuitBreakerOperator;
+import io.github.resilience4j.reactor.ratelimiter.operator.RateLimiterOperator;
+import org.junit.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+public class CombinedOperatorsTest {
+
+    private final RateLimiter rateLimiter = RateLimiter.of("test",
+            RateLimiterConfig.custom().limitForPeriod(5).timeoutDuration(Duration.ZERO).limitRefreshPeriod(Duration.ofSeconds(10)).build());
+
+    private final CircuitBreaker circuitBreaker = CircuitBreaker.of("test",
+            CircuitBreakerConfig.custom()
+                    .waitDurationInOpenState(Duration.of(10, ChronoUnit.SECONDS))
+                    .ringBufferSizeInClosedState(4)
+                    .ringBufferSizeInHalfOpenState(4)
+                    .build());
+
+    private Bulkhead bulkhead = Bulkhead
+            .of("test", BulkheadConfig.custom().maxConcurrentCalls(1).maxWaitTime(0).build());
+
+    @Test
+    public void shouldEmitEvents() {
+        StepVerifier.create(
+                Flux.just("Event 1", "Event 2")
+                        .transform(BulkheadOperator.of(bulkhead))
+                        .transform(RateLimiterOperator.of(rateLimiter))
+                        .transform(CircuitBreakerOperator.of(circuitBreaker))
+        ).expectNext("Event 1")
+                .expectNext("Event 2")
+                .verifyComplete();
+    }
+
+    @Test
+    public void shouldEmitEvent() {
+        StepVerifier.create(
+                Mono.just("Event 1")
+                        .transform(BulkheadOperator.of(bulkhead))
+                        .transform(RateLimiterOperator.of(rateLimiter))
+                        .transform(CircuitBreakerOperator.of(circuitBreaker))
+        ).expectNext("Event 1")
+                .verifyComplete();
+    }
+
+    @Test
+    public void shouldPropagateError() {
+        StepVerifier.create(
+                Flux.error(new IOException("BAM!"))
+                        .transform(BulkheadOperator.of(bulkhead))
+                        .transform(RateLimiterOperator.of(rateLimiter))
+                        .transform(CircuitBreakerOperator.of(circuitBreaker))
+        ).expectError(IOException.class)
+                .verify(Duration.ofSeconds(1));
+    }
+}

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/BulkheadSubscriberWhiteboxVerification.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/BulkheadSubscriberWhiteboxVerification.java
@@ -33,8 +33,8 @@ public class BulkheadSubscriberWhiteboxVerification extends
     public Subscriber<Integer> createSubscriber(WhiteboxSubscriberProbe<Integer> probe) {
         return new io.github.resilience4j.reactor.bulkhead.operator.BulkheadSubscriber<Integer>(Bulkhead.ofDefaults("verification"), MonoProcessor.create()) {
             @Override
-            public void onSubscribe(Subscription subscription) {
-                super.onSubscribe(subscription);
+            public void hookOnSubscribe(Subscription subscription) {
+                super.hookOnSubscribe(subscription);
 
                 // register a successful Subscription, and create a Puppet,
                 // for the WhiteboxVerification to be able to drive its tests:
@@ -53,20 +53,20 @@ public class BulkheadSubscriberWhiteboxVerification extends
             }
 
             @Override
-            public void onNext(Integer integer) {
-                super.onNext(integer);
+            public void hookOnNext(Integer integer) {
+                super.hookOnNext(integer);
                 probe.registerOnNext(integer);
             }
 
             @Override
-            public void onError(Throwable t) {
-                super.onError(t);
+            public void hookOnError(Throwable t) {
+                super.hookOnError(t);
                 probe.registerOnError(t);
             }
 
             @Override
-            public void onComplete() {
-                super.onComplete();
+            public void hookOnComplete() {
+                super.hookOnComplete();
                 probe.registerOnComplete();
             }
         };

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/CircuitBreakerSubscriberWhiteboxVerification.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/CircuitBreakerSubscriberWhiteboxVerification.java
@@ -32,9 +32,10 @@ public class CircuitBreakerSubscriberWhiteboxVerification extends
     @Override
     public Subscriber<Integer> createSubscriber(WhiteboxSubscriberProbe<Integer> probe) {
         return new CircuitBreakerSubscriber<Integer>(CircuitBreaker.ofDefaults("verification"), MonoProcessor.create()) {
+
             @Override
-            public void onSubscribe(Subscription subscription) {
-                super.onSubscribe(subscription);
+            protected void hookOnSubscribe(Subscription subscription) {
+                super.hookOnSubscribe(subscription);
 
                 // register a successful Subscription, and create a Puppet,
                 // for the WhiteboxVerification to be able to drive its tests:
@@ -53,20 +54,20 @@ public class CircuitBreakerSubscriberWhiteboxVerification extends
             }
 
             @Override
-            public void onNext(Integer integer) {
-                super.onNext(integer);
+            public void hookOnNext(Integer integer) {
+                super.hookOnNext(integer);
                 probe.registerOnNext(integer);
             }
 
             @Override
-            public void onError(Throwable t) {
-                super.onError(t);
+            public void hookOnError(Throwable t) {
+                super.hookOnError(t);
                 probe.registerOnError(t);
             }
 
             @Override
-            public void onComplete() {
-                super.onComplete();
+            public void hookOnComplete() {
+                super.hookOnComplete();
                 probe.registerOnComplete();
             }
         };

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/FluxCircuitBreakerTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/FluxCircuitBreakerTest.java
@@ -21,6 +21,7 @@ import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
 import java.io.IOException;
+import java.time.Duration;
 
 public class FluxCircuitBreakerTest extends CircuitBreakerAssertions {
 
@@ -42,7 +43,7 @@ public class FluxCircuitBreakerTest extends CircuitBreakerAssertions {
                 Flux.error(new IOException("BAM!"))
                         .transform(CircuitBreakerOperator.of(circuitBreaker)))
                 .expectError(IOException.class)
-                .verify();
+                .verify(Duration.ofSeconds(1));
 
         assertSingleFailedCall();
     }
@@ -54,7 +55,7 @@ public class FluxCircuitBreakerTest extends CircuitBreakerAssertions {
                 Flux.just("Event 1", "Event 2")
                         .transform(CircuitBreakerOperator.of(circuitBreaker)))
                 .expectError(CircuitBreakerOpenException.class)
-                .verify();
+                .verify(Duration.ofSeconds(1));
 
         assertNoRegisteredCall();
     }

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/MonoCircuitBreakerTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/MonoCircuitBreakerTest.java
@@ -21,6 +21,7 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.io.IOException;
+import java.time.Duration;
 
 public class MonoCircuitBreakerTest extends CircuitBreakerAssertions {
 
@@ -41,7 +42,7 @@ public class MonoCircuitBreakerTest extends CircuitBreakerAssertions {
                 Mono.error(new IOException("BAM!"))
                         .transform(CircuitBreakerOperator.of(circuitBreaker)))
                 .expectError(IOException.class)
-                .verify();
+                .verify(Duration.ofSeconds(1));
 
         assertSingleFailedCall();
     }
@@ -53,7 +54,7 @@ public class MonoCircuitBreakerTest extends CircuitBreakerAssertions {
                 Mono.just("Event")
                         .transform(CircuitBreakerOperator.of(circuitBreaker)))
                 .expectError(CircuitBreakerOpenException.class)
-                .verify();
+                .verify(Duration.ofSeconds(1));
 
         assertNoRegisteredCall();
     }

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/ratelimiter/operator/RateLimiterSubscriberWhiteboxVerification.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/ratelimiter/operator/RateLimiterSubscriberWhiteboxVerification.java
@@ -33,8 +33,8 @@ public class RateLimiterSubscriberWhiteboxVerification extends
     public Subscriber<Integer> createSubscriber(WhiteboxSubscriberProbe<Integer> probe) {
         return new RateLimiterSubscriber<Integer>(RateLimiter.ofDefaults("verification"), MonoProcessor.create()) {
             @Override
-            public void onSubscribe(Subscription subscription) {
-                super.onSubscribe(subscription);
+            public void hookOnSubscribe(Subscription subscription) {
+                super.hookOnSubscribe(subscription);
 
                 // register a successful Subscription, and create a Puppet,
                 // for the WhiteboxVerification to be able to drive its tests:
@@ -53,20 +53,20 @@ public class RateLimiterSubscriberWhiteboxVerification extends
             }
 
             @Override
-            public void onNext(Integer integer) {
-                super.onNext(integer);
+            public void hookOnNext(Integer integer) {
+                super.hookOnNext(integer);
                 probe.registerOnNext(integer);
             }
 
             @Override
-            public void onError(Throwable t) {
-                super.onError(t);
+            public void hookOnError(Throwable t) {
+                super.hookOnError(t);
                 probe.registerOnError(t);
             }
 
             @Override
-            public void onComplete() {
-                super.onComplete();
+            public void hookOnComplete() {
+                super.hookOnComplete();
                 probe.registerOnComplete();
             }
         };


### PR DESCRIPTION
Before this change this type of code would fail.

```
@Test
public void shouldEmitEvents() {
    StepVerifier.create(
            Flux.just("Event 1", "Event 2")
                    .transform(BulkheadOperator.of(bulkhead))
                    .transform(RateLimiterOperator.of(rateLimiter))
                    .transform(CircuitBreakerOperator.of(circuitBreaker))
    ).expectNext("Event 1")
            .expectNext("Event 2")
            .verifyComplete();
}
```

