### PR TITLE
Add validation to CircuitBreakerProperties

### DIFF
--- a/libraries.gradle
+++ b/libraries.gradle
@@ -23,6 +23,7 @@ ext {
     reactorVersion = '3.1.5.RELEASE'
     reactiveStreamsVersion = '1.0.2'
     micrometerVersion = '1.0.0'
+    hibernateValidatorVersion = '6.0.9.Final'
 
     libraries = [
             // compile
@@ -60,6 +61,7 @@ ext {
             spring_boot2_actuator: "org.springframework.boot:spring-boot-starter-actuator:${springBoot2Version}",
             spring_boot2_web: "org.springframework.boot:spring-boot-starter-web:${springBoot2Version}",
             spring_boot2_test:  "org.springframework.boot:spring-boot-starter-test:${springBoot2Version}",
+            hibernate_validator: "org.hibernate.validator:hibernate-validator:${hibernateValidatorVersion}",
 
             // ratpack addon
             ratpack: "io.ratpack:ratpack-guice:${ratpackVersion}",

--- a/resilience4j-spring-boot2/build.gradle
+++ b/resilience4j-spring-boot2/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     compile ( libraries.spring_boot2_aop )
     compile ( libraries.spring_boot2_actuator )
+    compile ( libraries.hibernate_validator )
     compile project(':resilience4j-micrometer')
     compile project(':resilience4j-circuitbreaker')
     compile project(':resilience4j-ratelimiter')

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/circuitbreaker/autoconfigure/CircuitBreakerMetricsAutoConfiguration.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/circuitbreaker/autoconfigure/CircuitBreakerMetricsAutoConfiguration.java
@@ -18,6 +18,7 @@ package io.github.resilience4j.circuitbreaker.autoconfigure;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -35,6 +36,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 public class CircuitBreakerMetricsAutoConfiguration {
 
     @Bean
+    @ConditionalOnProperty(value = "resilience4j.circuitbreaker.metrics.enabled", matchIfMissing = true)
     public CircuitBreakerMetrics registerCircuitBreakerMetrics(CircuitBreakerRegistry circuitBreakerRegistry, MeterRegistry meterRegistry){
         CircuitBreakerMetrics circuitBreakerMetrics = CircuitBreakerMetrics.ofCircuitBreakerRegistry(circuitBreakerRegistry);
         circuitBreakerMetrics.bindTo(meterRegistry);

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/circuitbreaker/autoconfigure/CircuitBreakerProperties.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/circuitbreaker/autoconfigure/CircuitBreakerProperties.java
@@ -17,21 +17,29 @@ package io.github.resilience4j.circuitbreaker.autoconfigure;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.*;
+import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
 
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.validation.Valid;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+@Validated
 @ConfigurationProperties(prefix = "resilience4j.circuitbreaker")
-@Component
 public class CircuitBreakerProperties {
     // This property gives you control over CircuitBreaker aspect application order.
     // By default CircuitBreaker will be executed BEFORE RateLimiter.
     // By adjusting RateLimiterProperties.rateLimiterAspectOrder and CircuitBreakerProperties.circuitBreakerAspectOrder
     // you explicitly define aspects CircuitBreaker and RateLimiter execution sequence.
     private int circuitBreakerAspectOrder = Integer.MAX_VALUE - 1;
+    
+    @Valid
     private Map<String, BackendProperties> backends = new HashMap<>();
 
     public int getCircuitBreakerAspectOrder() {
@@ -61,8 +69,8 @@ public class CircuitBreakerProperties {
 
         Builder circuitBreakerConfigBuilder = CircuitBreakerConfig.custom();
 
-        if (backendProperties.getWaitInterval() != null) {
-            circuitBreakerConfigBuilder.waitDurationInOpenState(Duration.ofMillis(backendProperties.getWaitInterval()));
+        if (backendProperties.getWaitDurationInOpenState() != null) {
+            circuitBreakerConfigBuilder.waitDurationInOpenState(backendProperties.getWaitDurationInOpenState());
         }
 
         if (backendProperties.getFailureRateThreshold() != null) {
@@ -88,35 +96,42 @@ public class CircuitBreakerProperties {
      */
     public static class BackendProperties {
 
-        private Integer waitInterval;
+    	@DurationMin(seconds = 1)
+        private Duration waitDurationInOpenState;
 
+    	@Min(1)
+		@Max(100)
         private Integer failureRateThreshold;
 
+    	@Min(1)
         private Integer ringBufferSizeInClosedState;
 
+    	@Min(1)
         private Integer ringBufferSizeInHalfOpenState;
 
+    	@Min(1)
         private Integer eventConsumerBufferSize = 100;
 
-        private Boolean registerHealthIndicator = false;
+    	@NotNull
+        private Boolean registerHealthIndicator = true;
 
 
         /**
-         * Returns the wait duration in seconds the CircuitBreaker will stay open, before it switches to half closed.
+         * Returns the wait duration the CircuitBreaker will stay open, before it switches to half closed.
          *
          * @return the wait duration
          */
-        public Integer getWaitInterval() {
-            return waitInterval;
+        public Duration getWaitDurationInOpenState() {
+            return waitDurationInOpenState;
         }
 
         /**
-         * Sets the wait duration in seconds the CircuitBreaker should stay open, before it switches to half closed.
+         * Sets the wait duration the CircuitBreaker should stay open, before it switches to half closed.
          *
-         * @param waitInterval the wait duration
+         * @param waitDurationInOpenState the wait duration
          */
-        public void setWaitInterval(Integer waitInterval) {
-            this.waitInterval = waitInterval;
+        public void setWaitDurationInOpenState(Duration waitDurationInOpenState) {
+            this.waitDurationInOpenState = waitDurationInOpenState;
         }
 
         /**

--- a/resilience4j-spring-boot2/src/test/resources/application.yaml
+++ b/resilience4j-spring-boot2/src/test/resources/application.yaml
@@ -2,21 +2,18 @@ resilience4j.circuitbreaker:
     circuitBreakerAspectOrder: 400
     backends:
         backendA:
-            registerHealthIndicator: true
             ringBufferSizeInClosedState: 6
             ringBufferSizeInHalfOpenState: 2
-            waitInterval: 5000
+            waitDurationInOpenState: 5s
             failureRateThreshold: 70
             eventConsumerBufferSize: 10
-            registerHealthIndicator: true
         backendB:
-            registerHealthIndicator: true
             ringBufferSizeInClosedState: 10
             ringBufferSizeInHalfOpenState: 5
-            waitInterval: 5000
+            waitDurationInOpenState: 5000
             failureRateThreshold: 50
             eventConsumerBufferSize: 10
-            registerHealthIndicator: true
+            registerHealthIndicator: false
 
 resilience4j.ratelimiter:
     rateLimiterAspectOrder: 401


### PR DESCRIPTION
`CircuitBreakerProperties`:
- removed `@Component` (not necessary due to usage of
`@EnableConfigurationProperties` in `CircuitBreakerAutoConfiguration`)
- Spring-Boot 2 supports using java.time.Duration as Property type, see [Spring-Boot documentation](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html#boot-features-external-config-conversion-duration). So I
changed the type of `waitDurationInOpenState` - and renamed it. This also fixes a
difference between the javadoc and the code (javadoc said it would be
seconds, but it was milliseconds).
- added validation for properties. Application should fail fast on
mis-configuration. For this feature I had to add the hibernate-validator
dependency.
- changed default behaviour to `registerHealthIndicator=true`. Convention
over configuration - if you provide a feature, you should activate by
default.

`CircuitBreakerMetricsAutoConfiguration`:
- add possibility to disable registering of circuitbreaker metrics

Changes related to #178 