### PR TITLE
Allow Spring to bind MeterBinders instead of directly binding

### DIFF
--- a/libraries.gradle
+++ b/libraries.gradle
@@ -24,7 +24,7 @@ ext {
     prometheusSimpleClientVersion = '0.3.0'
     reactorVersion = '3.1.5.RELEASE'
     reactiveStreamsVersion = '1.0.2'
-    micrometerVersion = '1.0.4'
+    micrometerVersion = '1.0.5'
     hibernateValidatorVersion = '6.0.9.Final'
 
     libraries = [

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/circuitbreaker/autoconfigure/CircuitBreakerMetricsAutoConfiguration.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/circuitbreaker/autoconfigure/CircuitBreakerMetricsAutoConfiguration.java
@@ -15,16 +15,14 @@
  */
 package io.github.resilience4j.circuitbreaker.autoconfigure;
 
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.micrometer.CircuitBreakerMetrics;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
-import io.github.resilience4j.micrometer.CircuitBreakerMetrics;
-import io.micrometer.core.instrument.MeterRegistry;
 
 /**
  * {@link org.springframework.boot.autoconfigure.EnableAutoConfiguration
@@ -37,9 +35,7 @@ public class CircuitBreakerMetricsAutoConfiguration {
 
     @Bean
     @ConditionalOnProperty(value = "resilience4j.circuitbreaker.metrics.enabled", matchIfMissing = true)
-    public CircuitBreakerMetrics registerCircuitBreakerMetrics(CircuitBreakerRegistry circuitBreakerRegistry, MeterRegistry meterRegistry){
-        CircuitBreakerMetrics circuitBreakerMetrics = CircuitBreakerMetrics.ofCircuitBreakerRegistry(circuitBreakerRegistry);
-        circuitBreakerMetrics.bindTo(meterRegistry);
-        return circuitBreakerMetrics;
+    public CircuitBreakerMetrics registerCircuitBreakerMetrics(CircuitBreakerRegistry circuitBreakerRegistry) {
+        return CircuitBreakerMetrics.ofCircuitBreakerRegistry(circuitBreakerRegistry);
     }
 }

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/ratelimiter/autoconfigure/RateLimiterMetricsAutoConfiguration.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/ratelimiter/autoconfigure/RateLimiterMetricsAutoConfiguration.java
@@ -15,16 +15,14 @@
  */
 package io.github.resilience4j.ratelimiter.autoconfigure;
 
+import io.github.resilience4j.circuitbreaker.autoconfigure.CircuitBreakerAutoConfiguration;
+import io.github.resilience4j.micrometer.RateLimiterMetrics;
+import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import io.github.resilience4j.circuitbreaker.autoconfigure.CircuitBreakerAutoConfiguration;
-import io.github.resilience4j.micrometer.RateLimiterMetrics;
-import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
-import io.micrometer.core.instrument.MeterRegistry;
 
 /**
  * {@link org.springframework.boot.autoconfigure.EnableAutoConfiguration
@@ -35,9 +33,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 @AutoConfigureAfter(value = {CircuitBreakerAutoConfiguration.class, MetricsAutoConfiguration.class})
 public class RateLimiterMetricsAutoConfiguration {
     @Bean
-    public RateLimiterMetrics registerRateLimiterMetrics(RateLimiterRegistry rateLimiterRegistry, MeterRegistry meterRegistry) {
-        RateLimiterMetrics rateLimiterMetrics = RateLimiterMetrics.ofRateLimiterRegistry(rateLimiterRegistry);
-        rateLimiterMetrics.bindTo(meterRegistry);
-        return rateLimiterMetrics;
+    public RateLimiterMetrics registerRateLimiterMetrics(RateLimiterRegistry rateLimiterRegistry) {
+        return RateLimiterMetrics.ofRateLimiterRegistry(rateLimiterRegistry);
     }
 }


### PR DESCRIPTION
When binding directly to a registry we create our initial meters without any additional tags that might be applied by meter filters. This causes the meter to be duplicated, once with no tags and again with
the common tags.

Resolve: #242