### PR TITLE
make async retrofit call not make the request when circuit is open

### DIFF
--- a/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/RetrofitCircuitBreaker.java
+++ b/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/RetrofitCircuitBreaker.java
@@ -58,6 +58,7 @@ public interface RetrofitCircuitBreaker {
                     CircuitBreakerUtils.isCallPermitted(circuitBreaker);
                 } catch (CircuitBreakerOpenException cb) {
                     callback.onFailure(call, cb);
+                    return;
                 }
 
                 final StopWatch stopWatch = StopWatch.start(circuitBreaker.getName());

--- a/resilience4j-retrofit/src/test/java/io/github/resilience4j/retrofit/RetrofitCircuitBreakerTest.java
+++ b/resilience4j-retrofit/src/test/java/io/github/resilience4j/retrofit/RetrofitCircuitBreakerTest.java
@@ -224,7 +224,7 @@ public class RetrofitCircuitBreakerTest {
                         .withStatus(200)
                         .withHeader("Content-Type", "text/plain")
                         .withBody("hello world")));
-;
+
         circuitBreaker.transitionToOpenState();
 
         try {


### PR DESCRIPTION
Hi, when using the Retrofit binding in async mode, the request is fired regardless of the state of the circuit. This PR contains a test case and the fix.