### PR TITLE
Additional factory methods - issue #249

### DIFF
--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/CircuitBreakerMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/CircuitBreakerMetrics.java
@@ -49,6 +49,26 @@ public class CircuitBreakerMetrics implements MeterBinder {
         return new CircuitBreakerMetrics(circuitBreakerRegistry.getAllCircuitBreakers());
     }
 
+    /**
+     * Creates a new instance CircuitBreakerMetrics {@link CircuitBreakerMetrics} with
+     * an {@link Iterable} of circuit breakers as a source.
+     *
+     * @param circuitBreakers the circuit breakers
+     */
+    public static CircuitBreakerMetrics ofIterable(Iterable<CircuitBreaker> circuitBreakers) {
+        return new CircuitBreakerMetrics(circuitBreakers);
+    }
+
+    /**
+     * Creates a new instance CircuitBreakerMetrics {@link CircuitBreakerMetrics} with
+     * an {@link Iterable} of circuit breakers as a source.
+     *
+     * @param circuitBreakers the circuit breakers
+     */
+    public static CircuitBreakerMetrics ofIterable(String prefix, Iterable<CircuitBreaker> circuitBreakers) {
+        return new CircuitBreakerMetrics(circuitBreakers, prefix);
+    }
+
     @Override
     public void bindTo(MeterRegistry registry) {
         for (CircuitBreaker circuitBreaker : circuitBreakers) {


### PR DESCRIPTION
These factory methods are identical to the ones already existing in metrics/CircuitBreakerMetrics.java. Their purpose is to allow Spring Boot applications to instantiate CircuitBreakerMetrics and have fine-grained control over which circuit breakers are bound to metrics, in particular in scenarios where the CircuitBreakerRegistry may not be completely populated by the time the CircuitBreakerMetrics class is instantiated.

This is not a complete solution for issue #249 . In fact, applications experiencing the problem described in that issue will still suffer the problem. However, these changes allow those applications to define their own CircuitBreakerMetrics bean independently of the CircuitBreakerRegistry.

An ideal solution would involve changing CircuitBreakerMetricsAutoConfiguration to ensure that the provided CircuitBreakerMetrics bean performs the metrics binding only after all the circuit breakers have been registered with the CircuitBreakerRegistry. However, that approach might not be backwards compatible, so I have decided to leave it for later.