### PR TITLE
#245 Fix CircuitBreakerSubscriber for Reactor doesn't count successes…

### DIFF
--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/circuitbreaker/operator/CircuitBreakerSubscriber.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/circuitbreaker/operator/CircuitBreakerSubscriber.java
@@ -22,6 +22,8 @@ import io.github.resilience4j.reactor.ResilienceBaseSubscriber;
 import org.reactivestreams.Subscriber;
 import reactor.core.CoreSubscriber;
 
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -33,15 +35,28 @@ class CircuitBreakerSubscriber<T> extends ResilienceBaseSubscriber<T> {
 
     private final CircuitBreaker circuitBreaker;
     private StopWatch stopWatch;
+    private final boolean singleProducer;
+
+    private volatile int successSignaled = 0;
+    private static final AtomicIntegerFieldUpdater<CircuitBreakerSubscriber> SUCCESS_SIGNALED =
+            AtomicIntegerFieldUpdater.newUpdater(CircuitBreakerSubscriber.class, "successSignaled");
 
     public CircuitBreakerSubscriber(CircuitBreaker circuitBreaker,
-                                    CoreSubscriber<? super T> actual) {
+                                    CoreSubscriber<? super T> actual,
+                                    boolean singleProducer) {
         super(actual);
         this.circuitBreaker = requireNonNull(circuitBreaker);
+        this.singleProducer = singleProducer;
     }
 
     @Override
     protected void hookOnNext(T value) {
+        if (singleProducer) {
+            if (SUCCESS_SIGNALED.compareAndSet(this, 0, 1)) {
+                markSuccess();
+            }
+        }
+
         if (notCancelled() && wasCallPermitted()) {
             actual.onNext(value);
         }
@@ -49,7 +64,10 @@ class CircuitBreakerSubscriber<T> extends ResilienceBaseSubscriber<T> {
 
     @Override
     protected void hookOnComplete() {
-        markSuccess();
+        if (SUCCESS_SIGNALED.compareAndSet(this, 0, 1)) {
+            markSuccess();
+        }
+
         if (wasCallPermitted()) {
             actual.onComplete();
         }

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/circuitbreaker/operator/FluxCircuitBreaker.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/circuitbreaker/operator/FluxCircuitBreaker.java
@@ -31,7 +31,7 @@ public class FluxCircuitBreaker<T> extends FluxOperator<T, T> {
 
     @Override
     public void subscribe(CoreSubscriber<? super T> actual) {
-        source.subscribe(new CircuitBreakerSubscriber<>(circuitBreaker, actual));
+        source.subscribe(new CircuitBreakerSubscriber<>(circuitBreaker, actual, false));
     }
 
 }

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/circuitbreaker/operator/MonoCircuitBreaker.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/circuitbreaker/operator/MonoCircuitBreaker.java
@@ -30,6 +30,6 @@ public class MonoCircuitBreaker<T> extends MonoOperator<T, T> {
 
     @Override
     public void subscribe(CoreSubscriber<? super T> actual) {
-        source.subscribe(new CircuitBreakerSubscriber<>(circuitBreaker, actual));
+        source.subscribe(new CircuitBreakerSubscriber<>(circuitBreaker, actual, true));
     }
 }

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/CircuitBreakerSubscriberWhiteboxVerification.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/CircuitBreakerSubscriberWhiteboxVerification.java
@@ -31,7 +31,7 @@ public class CircuitBreakerSubscriberWhiteboxVerification extends
 
     @Override
     public Subscriber<Integer> createSubscriber(WhiteboxSubscriberProbe<Integer> probe) {
-        return new CircuitBreakerSubscriber<Integer>(CircuitBreaker.ofDefaults("verification"), MonoProcessor.create()) {
+        return new CircuitBreakerSubscriber<Integer>(CircuitBreaker.ofDefaults("verification"), MonoProcessor.create(), false) {
 
             @Override
             protected void hookOnSubscribe(Subscription subscription) {


### PR DESCRIPTION
… when using Mono/Flux.toFuture()

Circuit breaker on Mono will count success onNext or onComplete.