### PR TITLE
generate BOM for resilience4j

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ artifactoryPublish.skip=true // apply to all projects except the root
 
 ext {
     coreProjects = subprojects.findAll {
-        p -> !p.name.contains("documentation")
+        p -> !p.name.contains("documentation") && !p.name.endsWith("-bom")
     }
 }
 

--- a/resilience4j-bom/README.adoc
+++ b/resilience4j-bom/README.adoc
@@ -1,0 +1,39 @@
+= resilience4j-bom
+
+generates BOM (Bill Of Materials) to control used version of resilence4j projects in a single place.
+
+Maven's example:
+
+```
+<dependencyManagement>
+    <dependencies>
+		<dependency>
+			<!-- Import dependency management from Resilience4j -->
+			<groupId>io.github.resilience4j</groupId>
+			<artifactId>resilience4j-bom</artifactId>
+			<version>0.14.0</version>
+			<type>pom</type>
+			<scope>import</scope>
+		</dependency>
+	</dependencies>
+</dependencyManagement>
+```
+
+Gradle example:
+```
+dependencies {
+    implementation 'io.github.resilience4j:resilience4j-bom:0.14.0'
+
+    implementation 'io.github.resilience4j:resilience4j-circuitbreaker'
+}
+```
+
+== License
+
+Copyright 2018 Alexey Shirmanov
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/resilience4j-bom/build.gradle
+++ b/resilience4j-bom/build.gradle
@@ -1,0 +1,29 @@
+description = "resilience4j bom"
+
+apply plugin: 'maven-publish'
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+            pom.withXml {
+                asNode().appendNode('packaging', 'pom')
+
+                def license = asNode().appendNode('licenses').appendNode('license')
+                license.appendNode('name', 'Apache-2.0')
+                license.appendNode('url', 'https://github.com/resilience4j/resilience4j/blob/master/LICENSE.txt')
+                license.appendNode('distribution', 'repo')
+
+                asNode().appendNode('scm').appendNode('url', 'https://github.com/resilience4j/resilience4j.git')
+
+                Node deps = asNode().appendNode('dependencyManagement').appendNode('dependencies')
+                coreProjects.each {
+                    Node dep = deps.appendNode('dependency')
+                    dep.appendNode('groupId').value = it.group
+                    dep.appendNode('artifactId').value = it.name
+                    dep.appendNode('version').value = it.version
+                }
+            }
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -23,4 +23,4 @@ include 'resilience4j-timelimiter'
 include 'resilience4j-rxjava2'
 include 'resilience4j-reactor'
 include 'resilience4j-micrometer'
-
+include 'resilience4j-bom'


### PR DESCRIPTION
Hi, I wish to propose to generate BOM for resilience4j library. It allows to use a kind of import feature in both of maven and gradle projects and avoid hardcoding of versions multiple times. Having said that it would simplify version management for projects where BOMs are used. Feel free to share your view I would be happy to discuss. thanks!