### PR TITLE
Avoid creating unnecessary logging strings

### DIFF
--- a/resilience4j-cache/src/main/java/io/github/resilience4j/cache/internal/CacheImpl.java
+++ b/resilience4j-cache/src/main/java/io/github/resilience4j/cache/internal/CacheImpl.java
@@ -81,7 +81,7 @@ public class CacheImpl<K, V>  implements Cache<K,V> {
                 return result;
             }
         }catch (Exception exception){
-            LOG.warn(String.format("Failed to get a value from Cache %s", getName()), exception);
+            LOG.warn("Failed to get a value from Cache {}", getName(), exception);
             onError(exception);
             return Option.none();
         }
@@ -93,7 +93,7 @@ public class CacheImpl<K, V>  implements Cache<K,V> {
                 cache.put(cacheKey, value);
             }
         } catch (Exception exception){
-            LOG.warn(String.format("Failed to put a value into Cache %s", getName()), exception);
+            LOG.warn("Failed to put a value into Cache {}", getName(), exception);
             onError(exception);
         }
     }

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachine.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachine.java
@@ -106,9 +106,7 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
     @Override
     public void onError(long durationInNanos, Throwable throwable) {
         if (circuitBreakerConfig.getRecordFailurePredicate().test(throwable)) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug(String.format("CircuitBreaker '%s' recorded a failure:", name), throwable);
-            }
+            LOG.debug("CircuitBreaker '{}' recorded a failure:", name, throwable);
             publishCircuitErrorEvent(name, durationInNanos, throwable);
             stateReference.get().onError(throwable);
         } else {
@@ -224,17 +222,17 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
     private void publishEventIfPossible(CircuitBreakerEvent event) {
         if(shouldPublishEvents(event)) {
             if (eventProcessor.hasConsumers()) {
-                LOG.debug(String.format("Event %s published: %s", event.getEventType(), event));
+                LOG.debug("Event {} published: {}", event.getEventType(), event);
                 try{
                     eventProcessor.consumeEvent(event);
                 }catch (Throwable t){
-                    LOG.warn(String.format("Failed to handle event %s", event.getEventType()), t);
+                    LOG.warn("Failed to handle event {}", event.getEventType(), t);
                 }
             } else {
-                LOG.debug(String.format("No Consumers: Event %s not published", event.getEventType()));
+                LOG.debug("No Consumers: Event {} not published", event.getEventType());
             }
         } else {
-            LOG.debug(String.format("Publishing not allowed: Event %s not published", event.getEventType()));
+            LOG.debug("Publishing not allowed: Event {} not published", event.getEventType());
         }
     }
 


### PR DESCRIPTION
slf4j provides its own string formatting mechanism, which will avoid calling `toString()` on its parameters if the log message is below the current log level.

The previous approach generated a considerable amount of garbage, and caused a bit of GC pressure.

See https://www.slf4j.org/faq.html for more information.