### PR TITLE
Change endpoint names to ensure compatibility with future SB releases

### DIFF
--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/circuitbreaker/monitoring/endpoint/CircuitBreakerEventsEndpoint.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/circuitbreaker/monitoring/endpoint/CircuitBreakerEventsEndpoint.java
@@ -27,7 +27,7 @@ import io.github.resilience4j.consumer.CircularEventConsumer;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
 
 
-@Endpoint(id = "circuitbreaker-events")
+@Endpoint(id = "circuitbreakerevents")
 public class CircuitBreakerEventsEndpoint {
 
     private final EventConsumerRegistry<CircuitBreakerEvent> eventConsumerRegistry;

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/ratelimiter/monitoring/endpoint/RateLimiterEventsEndpoint.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/ratelimiter/monitoring/endpoint/RateLimiterEventsEndpoint.java
@@ -28,7 +28,7 @@ import io.github.resilience4j.ratelimiter.event.RateLimiterEvent;
 import io.github.resilience4j.ratelimiter.monitoring.model.RateLimiterEventDTO;
 import io.github.resilience4j.ratelimiter.monitoring.model.RateLimiterEventsEndpointResponse;
 
-@Endpoint(id = "ratelimiter-events")
+@Endpoint(id = "ratelimiterevents")
 public class RateLimiterEventsEndpoint {
     private final EventConsumerRegistry<RateLimiterEvent> eventsConsumerRegistry;
 

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerAutoConfigurationTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerAutoConfigurationTest.java
@@ -90,10 +90,10 @@ public class CircuitBreakerAutoConfigurationTest {
         assertThat(circuitBreakerList.getBody().getCircuitBreakers()).hasSize(2).containsExactly("backendA", "backendB");
 
         // expect circuitbreaker-event actuator endpoint recorded both events
-        ResponseEntity<CircuitBreakerEventsEndpointResponse> circuitBreakerEventList = restTemplate.getForEntity("/actuator/circuitbreaker-events", CircuitBreakerEventsEndpointResponse.class);
+        ResponseEntity<CircuitBreakerEventsEndpointResponse> circuitBreakerEventList = restTemplate.getForEntity("/actuator/circuitbreakerevents", CircuitBreakerEventsEndpointResponse.class);
         assertThat(circuitBreakerEventList.getBody().getCircuitBreakerEvents()).hasSize(2);
 
-        circuitBreakerEventList = restTemplate.getForEntity("/actuator/circuitbreaker-events?name=backendA", CircuitBreakerEventsEndpointResponse.class);
+        circuitBreakerEventList = restTemplate.getForEntity("/actuator/circuitbreakerevents?name=backendA", CircuitBreakerEventsEndpointResponse.class);
         assertThat(circuitBreakerEventList.getBody().getCircuitBreakerEvents()).hasSize(2);
 
         // expect no health indicator for backendB, as it is disabled via properties

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/ratelimiter/RateLimiterAutoConfigurationTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/ratelimiter/RateLimiterAutoConfigurationTest.java
@@ -105,7 +105,7 @@ public class RateLimiterAutoConfigurationTest {
         }
 
         ResponseEntity<RateLimiterEventsEndpointResponse> rateLimiterEventList = restTemplate
-            .getForEntity("/actuator/ratelimiter-events", RateLimiterEventsEndpointResponse.class);
+            .getForEntity("/actuator/ratelimiterevents", RateLimiterEventsEndpointResponse.class);
 
         List<RateLimiterEventDTO> eventsList = rateLimiterEventList.getBody().getEventsList();
         assertThat(eventsList).isNotEmpty();


### PR DESCRIPTION
Since Spring Boot 2.1.x, the applications emit a warning on startup if the endpoint name contains a dash or a dot. Future versions of Spring Boot may ban these symbols completely.

This is a breaking change in at least two ways:
* This will change the default URL of the endpoints (from `/actuator/circuitbreaker-events` to `/actuator/circuitbreakerevents`). Note that this syntax is consistent with the actuators provided by Spring Boot, like `auditevents` or `scheduledtasks` (more examples at https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html ). This breaking change could be avoided by providing an implementation of `PathMapper` that converts the new endpoint names into the old paths. However, doing this may introduce confusion, so I have not implemented it.
* If an application has some configuration properties referencing the old endpoint names (like `management.endpoint.circuitbreaker-events.enabled: true`), these configuration properties will break. I am not aware of any strategy to maintain backwards compatibility.

Closes #286 .