### PR TITLE
Fix formatting of Bulkhead section in documentation, closes #306

### DIFF
--- a/resilience4j-documentation/src/docs/asciidoc/core_guides/bulkhead.adoc
+++ b/resilience4j-documentation/src/docs/asciidoc/core_guides/bulkhead.adoc
@@ -1,6 +1,3 @@
-
-
-
 === Bulkhead
 
 ==== Introduction

--- a/resilience4j-documentation/src/docs/asciidoc/core_guides/ratelimiter.adoc
+++ b/resilience4j-documentation/src/docs/asciidoc/core_guides/ratelimiter.adoc
@@ -137,3 +137,4 @@ long nanosToWaitForPermission = atomicLimiter.getNanosToWait();
 
 If you're interested in making your own thing on top of Resilience4j RateLimiter you'll possibly be interested in
 our lower level APIs like `getPermission` and `reservePermission` methods.
+


### PR DESCRIPTION
The extra blank line at the end of ratelimiter.adoc fixes the formatting for the Bulkhead section
(or any .adoc) included after it.
The end of ratelimiter.adoc was special because the other .adoc files in the same directory end
with a source block while ratelimiter.adoc ends with a simple paragraph.

Closes #306 