### PR TITLE
Refactor rxjava operators

### DIFF
--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/AbstractBulkheadOperator.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/AbstractBulkheadOperator.java
@@ -1,0 +1,203 @@
+package io.github.resilience4j.bulkhead.operator;
+
+import io.github.resilience4j.adapter.Permit;
+import io.github.resilience4j.bulkhead.Bulkhead;
+import io.github.resilience4j.bulkhead.BulkheadFullException;
+import io.reactivex.exceptions.ProtocolViolationException;
+import io.reactivex.plugins.RxJavaPlugins;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A disposable bulkhead acting as a base class for bulkhead operators.
+ *
+ * @param <T>          the type of the emitted event
+ * @param <DISPOSABLE> the actual type of the disposable/subscription
+ */
+abstract class AbstractBulkheadOperator<T, DISPOSABLE> extends AtomicReference<DISPOSABLE> {
+    private final Bulkhead bulkhead;
+    private final AtomicReference<Permit> permitted = new AtomicReference<>(Permit.PENDING);
+
+    AbstractBulkheadOperator(Bulkhead bulkhead) {
+        this.bulkhead = requireNonNull(bulkhead);
+    }
+
+    /**
+     * Disposes this operator exactly once.
+     */
+    protected void dispose() {
+        if (disposeOnce()) {
+            releaseBulkhead();
+        }
+    }
+
+    /**
+     * Gets whether this operator was already disposed or not.
+     *
+     * @return true if the operator was disposed, otherwise false
+     */
+    protected boolean isDisposed() {
+        return get() == getDisposedDisposable();
+    }
+
+    /**
+     * Gets the current disposable.
+     *
+     * @return the disposable
+     */
+    protected abstract DISPOSABLE getDisposable();
+
+    /**
+     * Gets the reference of the one and only disposed disposable.
+     *
+     * @return the disposed disposable
+     */
+    protected abstract DISPOSABLE getDisposedDisposable();
+
+    /**
+     * Disposes a disposable.
+     *
+     * @param disposable the disposable to dispose
+     */
+    protected abstract void dispose(DISPOSABLE disposable);
+
+    /**
+     * onSuccess ensured to be called only when safe.
+     *
+     * @param disposable the disposable
+     */
+    protected void onSubscribeInner(DISPOSABLE disposable) {
+        //Override when needed.
+    }
+
+    protected final void onSubscribeWithPermit(DISPOSABLE disposable) {
+        if (setDisposableOnce(disposable)) {
+            if (acquireCallPermit()) {
+                onSubscribeInner(getDisposable());
+            } else {
+                dispose();
+                onSubscribeInner(getDisposable());
+                permittedOnError(bulkheadFullException());
+            }
+        }
+    }
+
+    /**
+     * onError ensured to be called only when permitted.
+     *
+     * @param e the error
+     */
+    protected void permittedOnError(Throwable e) {
+        //Override when needed.
+    }
+
+    protected final void onErrorInner(Throwable e) {
+        if (isInvocationPermitted()) {
+            releaseBulkhead();
+            permittedOnError(e);
+        }
+    }
+
+    /**
+     * onComplete ensured to be called only when permitted.
+     */
+    protected void permittedOnComplete() {
+        //Override when needed.
+    }
+
+    protected final void onCompleteInner() {
+        if (isInvocationPermitted()) {
+            releaseBulkhead();
+            permittedOnComplete();
+        }
+    }
+
+    /**
+     * onSuccess ensured to be called only when permitted.
+     *
+     * @param value the value
+     */
+    protected void permittedOnSuccess(T value) {
+        //Override when needed.
+    }
+
+    protected final void onSuccessInner(T value) {
+        if (isInvocationPermitted()) {
+            releaseBulkhead();
+            permittedOnSuccess(value);
+        }
+    }
+
+    /**
+     * onNext ensured to be called only when permitted.
+     *
+     * @param value the value
+     */
+    protected void permittedOnNext(T value) {
+        //Override when needed.
+    }
+
+    protected final void onNextInner(T value) {
+        if (isInvocationPermitted()) {
+            permittedOnNext(value);
+        }
+    }
+
+    private boolean setDisposableOnce(DISPOSABLE DISPOSABLE) {
+        requireNonNull(DISPOSABLE, "DISPOSABLE is null");
+        if (!compareAndSet(null, DISPOSABLE)) {
+            dispose(DISPOSABLE);
+            if (get() != getDisposedDisposable()) {
+                RxJavaPlugins.onError(new ProtocolViolationException("Disposable/subscription already set!"));
+            }
+            return false;
+        }
+        return true;
+    }
+
+    private boolean disposeOnce() {
+        DISPOSABLE current = get();
+        DISPOSABLE disposed = getDisposedDisposable();
+        if (current != disposed) {
+            current = getAndSet(disposed);
+            if (current != disposed) {
+                if (current != null) {
+                    dispose(current);
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isInvocationPermitted() {
+        return !isDisposed() && wasCallPermitted();
+    }
+
+    private boolean acquireCallPermit() {
+        boolean callPermitted = false;
+        if (permitted.compareAndSet(Permit.PENDING, Permit.ACQUIRED)) {
+            callPermitted = bulkhead.isCallPermitted();
+            if (!callPermitted) {
+                permitted.set(Permit.REJECTED);
+            }
+        }
+        return callPermitted;
+    }
+
+    private Exception bulkheadFullException() {
+        return new BulkheadFullException(String.format("Bulkhead '%s' is full", bulkhead.getName()));
+    }
+
+    private boolean wasCallPermitted() {
+        return permitted.get() == Permit.ACQUIRED;
+    }
+
+    private void releaseBulkhead() {
+        if (permitted.compareAndSet(Permit.ACQUIRED, Permit.RELEASED)) {
+            bulkhead.onComplete();
+        }
+    }
+}

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/AbstractBulkheadOperator.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/AbstractBulkheadOperator.java
@@ -40,7 +40,7 @@ abstract class AbstractBulkheadOperator<T, DISPOSABLE> extends PermittedOperator
     }
 
     @Override
-    protected void doOnRelease() {
+    protected void doOnDispose() {
         bulkhead.onComplete();
     }
 }

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/AbstractBulkheadOperator.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/AbstractBulkheadOperator.java
@@ -9,10 +9,10 @@ import static java.util.Objects.requireNonNull;
 /**
  * A disposable bulkhead acting as a base class for bulkhead operators.
  *
- * @param <T>          the type of the emitted event
- * @param <DISPOSABLE> the actual type of the disposable/subscription
+ * @param <T> the type of the emitted event
+ * @param <D> the actual type of the disposable/subscription
  */
-abstract class AbstractBulkheadOperator<T, DISPOSABLE> extends PermittedOperator<T, DISPOSABLE> {
+abstract class AbstractBulkheadOperator<T, D> extends PermittedOperator<T, D> {
     private final Bulkhead bulkhead;
 
     AbstractBulkheadOperator(Bulkhead bulkhead) {

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/AbstractBulkheadOperator.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/AbstractBulkheadOperator.java
@@ -1,12 +1,8 @@
 package io.github.resilience4j.bulkhead.operator;
 
-import io.github.resilience4j.adapter.Permit;
 import io.github.resilience4j.bulkhead.Bulkhead;
 import io.github.resilience4j.bulkhead.BulkheadFullException;
-import io.reactivex.exceptions.ProtocolViolationException;
-import io.reactivex.plugins.RxJavaPlugins;
-
-import java.util.concurrent.atomic.AtomicReference;
+import io.github.resilience4j.internal.PermittedOperator;
 
 import static java.util.Objects.requireNonNull;
 
@@ -16,188 +12,35 @@ import static java.util.Objects.requireNonNull;
  * @param <T>          the type of the emitted event
  * @param <DISPOSABLE> the actual type of the disposable/subscription
  */
-abstract class AbstractBulkheadOperator<T, DISPOSABLE> extends AtomicReference<DISPOSABLE> {
+abstract class AbstractBulkheadOperator<T, DISPOSABLE> extends PermittedOperator<T, DISPOSABLE> {
     private final Bulkhead bulkhead;
-    private final AtomicReference<Permit> permitted = new AtomicReference<>(Permit.PENDING);
 
     AbstractBulkheadOperator(Bulkhead bulkhead) {
         this.bulkhead = requireNonNull(bulkhead);
     }
 
-    /**
-     * Disposes this operator exactly once.
-     */
-    protected void dispose() {
-        if (disposeOnce()) {
-            releaseBulkhead();
-        }
+    @Override
+    protected boolean tryCallPermit() {
+        return bulkhead.isCallPermitted();
     }
 
-    /**
-     * Gets whether this operator was already disposed or not.
-     *
-     * @return true if the operator was disposed, otherwise false
-     */
-    protected boolean isDisposed() {
-        return get() == getDisposedDisposable();
-    }
-
-    /**
-     * Gets the current disposable.
-     *
-     * @return the disposable
-     */
-    protected abstract DISPOSABLE getDisposable();
-
-    /**
-     * Gets the reference of the one and only disposed disposable.
-     *
-     * @return the disposed disposable
-     */
-    protected abstract DISPOSABLE getDisposedDisposable();
-
-    /**
-     * Disposes a disposable.
-     *
-     * @param disposable the disposable to dispose
-     */
-    protected abstract void dispose(DISPOSABLE disposable);
-
-    /**
-     * onSuccess ensured to be called only when safe.
-     *
-     * @param disposable the disposable
-     */
-    protected void onSubscribeInner(DISPOSABLE disposable) {
-        //Override when needed.
-    }
-
-    protected final void onSubscribeWithPermit(DISPOSABLE disposable) {
-        if (setDisposableOnce(disposable)) {
-            if (acquireCallPermit()) {
-                onSubscribeInner(getDisposable());
-            } else {
-                dispose();
-                onSubscribeInner(getDisposable());
-                permittedOnError(bulkheadFullException());
-            }
-        }
-    }
-
-    /**
-     * onError ensured to be called only when permitted.
-     *
-     * @param e the error
-     */
-    protected void permittedOnError(Throwable e) {
-        //Override when needed.
-    }
-
-    protected final void onErrorInner(Throwable e) {
-        if (isInvocationPermitted()) {
-            releaseBulkhead();
-            permittedOnError(e);
-        }
-    }
-
-    /**
-     * onComplete ensured to be called only when permitted.
-     */
-    protected void permittedOnComplete() {
-        //Override when needed.
-    }
-
-    protected final void onCompleteInner() {
-        if (isInvocationPermitted()) {
-            releaseBulkhead();
-            permittedOnComplete();
-        }
-    }
-
-    /**
-     * onSuccess ensured to be called only when permitted.
-     *
-     * @param value the value
-     */
-    protected void permittedOnSuccess(T value) {
-        //Override when needed.
-    }
-
-    protected final void onSuccessInner(T value) {
-        if (isInvocationPermitted()) {
-            releaseBulkhead();
-            permittedOnSuccess(value);
-        }
-    }
-
-    /**
-     * onNext ensured to be called only when permitted.
-     *
-     * @param value the value
-     */
-    protected void permittedOnNext(T value) {
-        //Override when needed.
-    }
-
-    protected final void onNextInner(T value) {
-        if (isInvocationPermitted()) {
-            permittedOnNext(value);
-        }
-    }
-
-    private boolean setDisposableOnce(DISPOSABLE DISPOSABLE) {
-        requireNonNull(DISPOSABLE, "DISPOSABLE is null");
-        if (!compareAndSet(null, DISPOSABLE)) {
-            dispose(DISPOSABLE);
-            if (get() != getDisposedDisposable()) {
-                RxJavaPlugins.onError(new ProtocolViolationException("Disposable/subscription already set!"));
-            }
-            return false;
-        }
-        return true;
-    }
-
-    private boolean disposeOnce() {
-        DISPOSABLE current = get();
-        DISPOSABLE disposed = getDisposedDisposable();
-        if (current != disposed) {
-            current = getAndSet(disposed);
-            if (current != disposed) {
-                if (current != null) {
-                    dispose(current);
-                }
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private boolean isInvocationPermitted() {
-        return !isDisposed() && wasCallPermitted();
-    }
-
-    private boolean acquireCallPermit() {
-        boolean callPermitted = false;
-        if (permitted.compareAndSet(Permit.PENDING, Permit.ACQUIRED)) {
-            callPermitted = bulkhead.isCallPermitted();
-            if (!callPermitted) {
-                permitted.set(Permit.REJECTED);
-            }
-        }
-        return callPermitted;
-    }
-
-    private Exception bulkheadFullException() {
+    @Override
+    protected Exception notPermittedException() {
         return new BulkheadFullException(String.format("Bulkhead '%s' is full", bulkhead.getName()));
     }
 
-    private boolean wasCallPermitted() {
-        return permitted.get() == Permit.ACQUIRED;
+    @Override
+    protected void doOnSuccess() {
+        bulkhead.onComplete();
     }
 
-    private void releaseBulkhead() {
-        if (permitted.compareAndSet(Permit.ACQUIRED, Permit.RELEASED)) {
-            bulkhead.onComplete();
-        }
+    @Override
+    protected void doOnError(Throwable e) {
+        bulkhead.onComplete();
+    }
+
+    @Override
+    protected void doOnRelease() {
+        bulkhead.onComplete();
     }
 }

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/BulkheadCompletableObserver.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/BulkheadCompletableObserver.java
@@ -1,10 +1,10 @@
 package io.github.resilience4j.bulkhead.operator;
 
-import static java.util.Objects.requireNonNull;
-
 import io.github.resilience4j.bulkhead.Bulkhead;
 import io.reactivex.CompletableObserver;
 import io.reactivex.disposables.Disposable;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * A RxJava {@link CompletableObserver} to wrap another observer in a bulkhead.
@@ -29,7 +29,7 @@ final class BulkheadCompletableObserver extends DisposableBulkhead<Object> imple
 
     @Override
     public void onComplete() {
-        onCompleteInner();
+        safeOnComplete();
     }
 
     @Override
@@ -39,7 +39,7 @@ final class BulkheadCompletableObserver extends DisposableBulkhead<Object> imple
 
     @Override
     public void onError(Throwable e) {
-        onErrorInner(e);
+        safeOnError(e);
     }
 
     @Override

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/BulkheadCompletableObserver.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/BulkheadCompletableObserver.java
@@ -9,7 +9,7 @@ import io.reactivex.disposables.Disposable;
 /**
  * A RxJava {@link CompletableObserver} to wrap another observer in a bulkhead.
  */
-final class BulkheadCompletableObserver extends DisposableBulkhead implements CompletableObserver {
+final class BulkheadCompletableObserver extends DisposableBulkhead<Object> implements CompletableObserver {
     private final CompletableObserver childObserver;
 
     BulkheadCompletableObserver(Bulkhead bulkhead, CompletableObserver childObserver) {

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/BulkheadMaybeObserver.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/BulkheadMaybeObserver.java
@@ -31,7 +31,7 @@ final class BulkheadMaybeObserver<T> extends DisposableBulkhead<T> implements Ma
 
     @Override
     public void onComplete() {
-        onCompleteInner();
+        safeOnComplete();
     }
 
     @Override
@@ -41,7 +41,7 @@ final class BulkheadMaybeObserver<T> extends DisposableBulkhead<T> implements Ma
 
     @Override
     public void onSuccess(T value) {
-        onSuccessInner(value);
+        safeOnSuccess(value);
     }
 
     @Override
@@ -51,7 +51,7 @@ final class BulkheadMaybeObserver<T> extends DisposableBulkhead<T> implements Ma
 
     @Override
     public void onError(Throwable e) {
-        onErrorInner(e);
+        safeOnError(e);
     }
 
     @Override

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/BulkheadObserver.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/BulkheadObserver.java
@@ -31,7 +31,7 @@ final class BulkheadObserver<T> extends DisposableBulkhead<T> implements Observe
 
     @Override
     public void onNext(T value) {
-        onNextInner(value);
+        safeOnNext(value);
     }
 
     @Override
@@ -41,7 +41,7 @@ final class BulkheadObserver<T> extends DisposableBulkhead<T> implements Observe
 
     @Override
     public void onComplete() {
-        onCompleteInner();
+        safeOnComplete();
     }
 
     @Override
@@ -51,7 +51,7 @@ final class BulkheadObserver<T> extends DisposableBulkhead<T> implements Observe
 
     @Override
     public void onError(Throwable e) {
-        onErrorInner(e);
+        safeOnError(e);
     }
 
     @Override

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/BulkheadOperator.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/BulkheadOperator.java
@@ -33,6 +33,7 @@ import org.reactivestreams.Subscriber;
 
 /**
  * A RxJava operator which wraps a reactive type in a bulkhead.
+ * Please note that Bulkhead shouldn't use wait time as it may block while acquiring the permit.
  *
  * @param <T> the value type of the upstream and downstream
  */

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/BulkheadSingleObserver.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/BulkheadSingleObserver.java
@@ -31,7 +31,7 @@ final class BulkheadSingleObserver<T> extends DisposableBulkhead<T> implements S
 
     @Override
     public void onSuccess(T value) {
-        onSuccessInner(value);
+        safeOnSuccess(value);
     }
 
     @Override
@@ -41,7 +41,7 @@ final class BulkheadSingleObserver<T> extends DisposableBulkhead<T> implements S
 
     @Override
     public void onError(Throwable e) {
-        onErrorInner(e);
+        safeOnError(e);
     }
 
     @Override

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/BulkheadSubscriber.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/BulkheadSubscriber.java
@@ -1,13 +1,11 @@
 package io.github.resilience4j.bulkhead.operator;
 
-import static java.util.Objects.requireNonNull;
-
-import io.github.resilience4j.adapter.Permit;
 import io.github.resilience4j.bulkhead.Bulkhead;
-import io.github.resilience4j.bulkhead.BulkheadFullException;
-import io.reactivex.internal.subscriptions.SubscriptionHelper;
+import io.github.resilience4j.internal.DisposedSubscription;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * A RxJava {@link Subscriber} to wrap another subscriber in a bulkhead.
@@ -34,7 +32,7 @@ final class BulkheadSubscriber<T> extends AbstractBulkheadOperator<T, Subscripti
 
     @Override
     public void onNext(T value) {
-        onNextInner(value);
+        safeOnNext(value);
     }
 
     @Override
@@ -44,7 +42,7 @@ final class BulkheadSubscriber<T> extends AbstractBulkheadOperator<T, Subscripti
 
     @Override
     public void onComplete() {
-        onCompleteInner();
+        safeOnComplete();
     }
 
     @Override
@@ -54,7 +52,7 @@ final class BulkheadSubscriber<T> extends AbstractBulkheadOperator<T, Subscripti
 
     @Override
     public void onError(Throwable e) {
-        onErrorInner(e);
+        safeOnError(e);
     }
 
     @Override
@@ -78,26 +76,12 @@ final class BulkheadSubscriber<T> extends AbstractBulkheadOperator<T, Subscripti
     }
 
     @Override
-    protected Subscription getDisposable() {
+    protected Subscription currentDisposable() {
         return this;
     }
 
     @Override
     protected void dispose(Subscription disposable) {
         disposable.cancel();
-    }
-
-    private enum DisposedSubscription implements Subscription {
-        CANCELLED;
-
-        @Override
-        public void request(long n) {
-
-        }
-
-        @Override
-        public void cancel() {
-
-        }
     }
 }

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/DisposableBulkhead.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/DisposableBulkhead.java
@@ -2,147 +2,56 @@ package io.github.resilience4j.bulkhead.operator;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.concurrent.atomic.AtomicReference;
-
-import io.github.resilience4j.adapter.Permit;
 import io.github.resilience4j.bulkhead.Bulkhead;
-import io.github.resilience4j.bulkhead.BulkheadFullException;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.disposables.DisposableHelper;
 
 /**
  * A disposable bulkhead acting as a base class for bulkhead operators.
  *
  * @param <T> the type of the emitted event
  */
-abstract class DisposableBulkhead<T> extends AtomicReference<Disposable> implements Disposable {
-    private final Bulkhead bulkhead;
-    private final AtomicReference<Permit> permitted = new AtomicReference<>(Permit.PENDING);
+abstract class DisposableBulkhead<T> extends AbstractBulkheadOperator<T, Disposable> implements Disposable {
 
     DisposableBulkhead(Bulkhead bulkhead) {
-        this.bulkhead = requireNonNull(bulkhead);
+        super(bulkhead);
     }
 
     @Override
     public final void dispose() {
-        if (DisposableHelper.dispose(this)) {
-            releaseBulkhead();
-        }
+        super.dispose();
     }
 
     @Override
     public final boolean isDisposed() {
-        return DisposableHelper.isDisposed(get());
+        return super.isDisposed();
     }
 
-    /**
-     * onSuccess ensured to be called only when safe.
-     *
-     * @param disposable the disposable
-     */
-    protected void onSubscribeInner(Disposable disposable) {
-        //Override when needed.
+    @Override
+    protected Disposable getDisposedDisposable() {
+        return DisposedDisposable.DISPOSED;
     }
 
-    protected final void onSubscribeWithPermit(Disposable disposable) {
-        if (DisposableHelper.setOnce(this, disposable)) {
-            if (acquireCallPermit()) {
-                onSubscribeInner(this);
-            } else {
-                dispose();
-                onSubscribeInner(this);
-                permittedOnError(bulkheadFullException());
-            }
+    @Override
+    protected Disposable getDisposable() {
+        return this;
+    }
+
+    @Override
+    protected void dispose(Disposable disposable) {
+        disposable.dispose();
+    }
+
+    private enum DisposedDisposable implements Disposable {
+        DISPOSED;
+
+        @Override
+        public void dispose() {
+
         }
-    }
 
-    /**
-     * onError ensured to be called only when permitted.
-     *
-     * @param e the error
-     */
-    protected void permittedOnError(Throwable e) {
-        //Override when needed.
-    }
-
-    protected final void onErrorInner(Throwable e) {
-        if (isInvocationPermitted()) {
-            releaseBulkhead();
-            permittedOnError(e);
-        }
-    }
-
-    /**
-     * onComplete ensured to be called only when permitted.
-     */
-    protected void permittedOnComplete() {
-        //Override when needed.
-    }
-
-    protected final void onCompleteInner() {
-        if (isInvocationPermitted()) {
-            releaseBulkhead();
-            permittedOnComplete();
-        }
-    }
-
-    /**
-     * onSuccess ensured to be called only when permitted.
-     *
-     * @param value the value
-     */
-    protected void permittedOnSuccess(T value) {
-        //Override when needed.
-    }
-
-    protected final void onSuccessInner(T value) {
-        if (isInvocationPermitted()) {
-            releaseBulkhead();
-            permittedOnSuccess(value);
-        }
-    }
-
-    /**
-     * onNext ensured to be called only when permitted.
-     *
-     * @param value the value
-     */
-    protected void permittedOnNext(T value) {
-        //Override when needed.
-    }
-
-    protected final void onNextInner(T value) {
-        if (isInvocationPermitted()) {
-            permittedOnNext(value);
-        }
-    }
-
-    private boolean isInvocationPermitted() {
-        return !isDisposed() && wasCallPermitted();
-    }
-
-    private boolean acquireCallPermit() {
-        boolean callPermitted = false;
-        if (permitted.compareAndSet(Permit.PENDING, Permit.ACQUIRED)) {
-            callPermitted = bulkhead.isCallPermitted();
-            if (!callPermitted) {
-                permitted.set(Permit.REJECTED);
-            }
-        }
-        return callPermitted;
-    }
-
-    private Exception bulkheadFullException() {
-        return new BulkheadFullException(String.format("Bulkhead '%s' is full", bulkhead.getName()));
-    }
-
-    private boolean wasCallPermitted() {
-        return permitted.get() == Permit.ACQUIRED;
-    }
-
-    private void releaseBulkhead() {
-        if (permitted.compareAndSet(Permit.ACQUIRED, Permit.RELEASED)) {
-            bulkhead.onComplete();
+        @Override
+        public boolean isDisposed() {
+            return true;
         }
     }
 }

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/DisposableBulkhead.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/DisposableBulkhead.java
@@ -1,7 +1,5 @@
 package io.github.resilience4j.bulkhead.operator;
 
-import static java.util.Objects.requireNonNull;
-
 import io.github.resilience4j.bulkhead.Bulkhead;
 import io.github.resilience4j.internal.DisposedDisposable;
 import io.reactivex.disposables.Disposable;

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/DisposableBulkhead.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/DisposableBulkhead.java
@@ -3,6 +3,7 @@ package io.github.resilience4j.bulkhead.operator;
 import static java.util.Objects.requireNonNull;
 
 import io.github.resilience4j.bulkhead.Bulkhead;
+import io.github.resilience4j.internal.DisposedDisposable;
 import io.reactivex.disposables.Disposable;
 
 /**
@@ -32,26 +33,12 @@ abstract class DisposableBulkhead<T> extends AbstractBulkheadOperator<T, Disposa
     }
 
     @Override
-    protected Disposable getDisposable() {
+    protected Disposable currentDisposable() {
         return this;
     }
 
     @Override
     protected void dispose(Disposable disposable) {
         disposable.dispose();
-    }
-
-    private enum DisposedDisposable implements Disposable {
-        DISPOSED;
-
-        @Override
-        public void dispose() {
-
-        }
-
-        @Override
-        public boolean isDisposed() {
-            return true;
-        }
     }
 }

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/AbstractCircuitBreakerOperator.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/AbstractCircuitBreakerOperator.java
@@ -10,10 +10,10 @@ import static java.util.Objects.requireNonNull;
 /**
  * A disposable circuit-breaker acting as a base class for circuit-breaker operators.
  *
- * @param <T>          the type of the emitted event
- * @param <DISPOSABLE> the actual type of the disposable/subscription
+ * @param <T> the type of the emitted event
+ * @param <D> the actual type of the disposable/subscription
  */
-abstract class AbstractCircuitBreakerOperator<T, DISPOSABLE> extends PermittedOperator<T, DISPOSABLE> {
+abstract class AbstractCircuitBreakerOperator<T, D> extends PermittedOperator<T, D> {
     private final CircuitBreaker circuitBreaker;
     private StopWatch stopWatch;
 

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/AbstractCircuitBreakerOperator.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/AbstractCircuitBreakerOperator.java
@@ -1,0 +1,211 @@
+package io.github.resilience4j.circuitbreaker.operator;
+
+import io.github.resilience4j.adapter.Permit;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerOpenException;
+import io.github.resilience4j.core.StopWatch;
+import io.reactivex.exceptions.ProtocolViolationException;
+import io.reactivex.plugins.RxJavaPlugins;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A disposable circuit-breaker acting as a base class for circuit-breaker operators.
+ *
+ * @param <T>          the type of the emitted event
+ * @param <DISPOSABLE> the actual type of the disposable/subscription
+ */
+abstract class AbstractCircuitBreakerOperator<T, DISPOSABLE> extends AtomicReference<DISPOSABLE> {
+    private final CircuitBreaker circuitBreaker;
+    private StopWatch stopWatch;
+    private final AtomicReference<Permit> permitted = new AtomicReference<>(Permit.PENDING);
+
+    AbstractCircuitBreakerOperator(CircuitBreaker circuitBreaker) {
+        this.circuitBreaker = requireNonNull(circuitBreaker);
+    }
+
+    /**
+     * Disposes this operator exactly once.
+     */
+    protected void dispose() {
+        disposeOnce();
+    }
+
+    /**
+     * Gets whether this operator was already disposed or not.
+     *
+     * @return true if the operator was disposed, otherwise false
+     */
+    protected boolean isDisposed() {
+        return get() == getDisposedDisposable();
+    }
+
+    /**
+     * Gets the current disposable.
+     *
+     * @return the disposable
+     */
+    protected abstract DISPOSABLE getDisposable();
+
+    /**
+     * Gets the reference of the one and only disposed disposable.
+     *
+     * @return the disposed disposable
+     */
+    protected abstract DISPOSABLE getDisposedDisposable();
+
+    /**
+     * Disposes a disposable.
+     *
+     * @param disposable the disposable to dispose
+     */
+    protected abstract void dispose(DISPOSABLE disposable);
+
+    /**
+     * onSuccess ensured to be called only when safe.
+     *
+     * @param disposable the disposable
+     */
+    protected void onSubscribeInner(DISPOSABLE disposable) {
+        //Override when needed.
+    }
+
+    protected final void onSubscribeWithPermit(DISPOSABLE disposable) {
+        if (setDisposableOnce(disposable)) {
+            if (acquireCallPermit()) {
+                onSubscribeInner(getDisposable());
+            } else {
+                dispose();
+                onSubscribeInner(getDisposable());
+                permittedOnError(circuitBreakerOpenException());
+            }
+        }
+    }
+
+    /**
+     * onError ensured to be called only when permitted.
+     *
+     * @param e the error
+     */
+    protected void permittedOnError(Throwable e) {
+        //Override when needed.
+    }
+
+    protected final void onErrorInner(Throwable e) {
+        markFailure(e);
+        if (isInvocationPermitted()) {
+            permittedOnError(e);
+        }
+    }
+
+    /**
+     * onComplete ensured to be called only when permitted.
+     */
+    protected void permittedOnComplete() {
+        //Override when needed.
+    }
+
+    protected final void onCompleteInner() {
+        markSuccess();
+        if (isInvocationPermitted()) {
+            permittedOnComplete();
+        }
+    }
+
+    /**
+     * onSuccess ensured to be called only when permitted.
+     *
+     * @param value the value
+     */
+    protected void permittedOnSuccess(T value) {
+        //Override when needed.
+    }
+
+    protected final void onSuccessInner(T value) {
+        markSuccess();
+        if (isInvocationPermitted()) {
+            permittedOnSuccess(value);
+        }
+    }
+
+    /**
+     * onNext ensured to be called only when permitted.
+     *
+     * @param value the value
+     */
+    protected void permittedOnNext(T value) {
+        //Override when needed.
+    }
+
+    protected final void onNextInner(T value) {
+        if (isInvocationPermitted()) {
+            permittedOnNext(value);
+        }
+    }
+
+    private boolean setDisposableOnce(DISPOSABLE DISPOSABLE) {
+        requireNonNull(DISPOSABLE, "DISPOSABLE is null");
+        if (!compareAndSet(null, DISPOSABLE)) {
+            dispose(DISPOSABLE);
+            if (get() != getDisposedDisposable()) {
+                RxJavaPlugins.onError(new ProtocolViolationException("Disposable/subscription already set!"));
+            }
+            return false;
+        }
+        return true;
+    }
+
+    private boolean disposeOnce() {
+        DISPOSABLE current = get();
+        DISPOSABLE disposed = getDisposedDisposable();
+        if (current != disposed) {
+            current = getAndSet(disposed);
+            if (current != disposed) {
+                if (current != null) {
+                    dispose(current);
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean acquireCallPermit() {
+        boolean callPermitted = false;
+        if (permitted.compareAndSet(Permit.PENDING, Permit.ACQUIRED)) {
+            callPermitted = circuitBreaker.isCallPermitted();
+            if (!callPermitted) {
+                permitted.set(Permit.REJECTED);
+            } else {
+                stopWatch = StopWatch.start(circuitBreaker.getName());
+            }
+        }
+        return callPermitted;
+    }
+
+    private boolean isInvocationPermitted() {
+        return !isDisposed() && wasCallPermitted();
+    }
+
+    private Exception circuitBreakerOpenException() {
+        return new CircuitBreakerOpenException(String.format("CircuitBreaker '%s' is open", circuitBreaker.getName()));
+    }
+
+    private void markFailure(Throwable e) {
+        if (wasCallPermitted()) {
+            circuitBreaker.onError(stopWatch.stop().getProcessingDuration().toNanos(), e);
+        }
+    }
+
+    private void markSuccess() {
+        if (wasCallPermitted()) {
+            circuitBreaker.onSuccess(stopWatch.stop().getProcessingDuration().toNanos());
+        }
+    }
+
+    private boolean wasCallPermitted() {
+        return permitted.get() == Permit.ACQUIRED;
+    }
+}

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/AbstractCircuitBreakerOperator.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/AbstractCircuitBreakerOperator.java
@@ -1,13 +1,9 @@
 package io.github.resilience4j.circuitbreaker.operator;
 
-import io.github.resilience4j.adapter.Permit;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerOpenException;
 import io.github.resilience4j.core.StopWatch;
-import io.reactivex.exceptions.ProtocolViolationException;
-import io.reactivex.plugins.RxJavaPlugins;
-
-import java.util.concurrent.atomic.AtomicReference;
+import io.github.resilience4j.internal.PermittedOperator;
 
 import static java.util.Objects.requireNonNull;
 
@@ -17,195 +13,32 @@ import static java.util.Objects.requireNonNull;
  * @param <T>          the type of the emitted event
  * @param <DISPOSABLE> the actual type of the disposable/subscription
  */
-abstract class AbstractCircuitBreakerOperator<T, DISPOSABLE> extends AtomicReference<DISPOSABLE> {
+abstract class AbstractCircuitBreakerOperator<T, DISPOSABLE> extends PermittedOperator<T, DISPOSABLE> {
     private final CircuitBreaker circuitBreaker;
     private StopWatch stopWatch;
-    private final AtomicReference<Permit> permitted = new AtomicReference<>(Permit.PENDING);
 
     AbstractCircuitBreakerOperator(CircuitBreaker circuitBreaker) {
         this.circuitBreaker = requireNonNull(circuitBreaker);
     }
 
-    /**
-     * Disposes this operator exactly once.
-     */
-    protected void dispose() {
-        disposeOnce();
+    @Override
+    protected boolean tryCallPermit() {
+        stopWatch = StopWatch.start(circuitBreaker.getName());
+        return circuitBreaker.isCallPermitted();
     }
 
-    /**
-     * Gets whether this operator was already disposed or not.
-     *
-     * @return true if the operator was disposed, otherwise false
-     */
-    protected boolean isDisposed() {
-        return get() == getDisposedDisposable();
-    }
-
-    /**
-     * Gets the current disposable.
-     *
-     * @return the disposable
-     */
-    protected abstract DISPOSABLE getDisposable();
-
-    /**
-     * Gets the reference of the one and only disposed disposable.
-     *
-     * @return the disposed disposable
-     */
-    protected abstract DISPOSABLE getDisposedDisposable();
-
-    /**
-     * Disposes a disposable.
-     *
-     * @param disposable the disposable to dispose
-     */
-    protected abstract void dispose(DISPOSABLE disposable);
-
-    /**
-     * onSuccess ensured to be called only when safe.
-     *
-     * @param disposable the disposable
-     */
-    protected void onSubscribeInner(DISPOSABLE disposable) {
-        //Override when needed.
-    }
-
-    protected final void onSubscribeWithPermit(DISPOSABLE disposable) {
-        if (setDisposableOnce(disposable)) {
-            if (acquireCallPermit()) {
-                onSubscribeInner(getDisposable());
-            } else {
-                dispose();
-                onSubscribeInner(getDisposable());
-                permittedOnError(circuitBreakerOpenException());
-            }
-        }
-    }
-
-    /**
-     * onError ensured to be called only when permitted.
-     *
-     * @param e the error
-     */
-    protected void permittedOnError(Throwable e) {
-        //Override when needed.
-    }
-
-    protected final void onErrorInner(Throwable e) {
-        markFailure(e);
-        if (isInvocationPermitted()) {
-            permittedOnError(e);
-        }
-    }
-
-    /**
-     * onComplete ensured to be called only when permitted.
-     */
-    protected void permittedOnComplete() {
-        //Override when needed.
-    }
-
-    protected final void onCompleteInner() {
-        markSuccess();
-        if (isInvocationPermitted()) {
-            permittedOnComplete();
-        }
-    }
-
-    /**
-     * onSuccess ensured to be called only when permitted.
-     *
-     * @param value the value
-     */
-    protected void permittedOnSuccess(T value) {
-        //Override when needed.
-    }
-
-    protected final void onSuccessInner(T value) {
-        markSuccess();
-        if (isInvocationPermitted()) {
-            permittedOnSuccess(value);
-        }
-    }
-
-    /**
-     * onNext ensured to be called only when permitted.
-     *
-     * @param value the value
-     */
-    protected void permittedOnNext(T value) {
-        //Override when needed.
-    }
-
-    protected final void onNextInner(T value) {
-        if (isInvocationPermitted()) {
-            permittedOnNext(value);
-        }
-    }
-
-    private boolean setDisposableOnce(DISPOSABLE DISPOSABLE) {
-        requireNonNull(DISPOSABLE, "DISPOSABLE is null");
-        if (!compareAndSet(null, DISPOSABLE)) {
-            dispose(DISPOSABLE);
-            if (get() != getDisposedDisposable()) {
-                RxJavaPlugins.onError(new ProtocolViolationException("Disposable/subscription already set!"));
-            }
-            return false;
-        }
-        return true;
-    }
-
-    private boolean disposeOnce() {
-        DISPOSABLE current = get();
-        DISPOSABLE disposed = getDisposedDisposable();
-        if (current != disposed) {
-            current = getAndSet(disposed);
-            if (current != disposed) {
-                if (current != null) {
-                    dispose(current);
-                }
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private boolean acquireCallPermit() {
-        boolean callPermitted = false;
-        if (permitted.compareAndSet(Permit.PENDING, Permit.ACQUIRED)) {
-            callPermitted = circuitBreaker.isCallPermitted();
-            if (!callPermitted) {
-                permitted.set(Permit.REJECTED);
-            } else {
-                stopWatch = StopWatch.start(circuitBreaker.getName());
-            }
-        }
-        return callPermitted;
-    }
-
-    private boolean isInvocationPermitted() {
-        return !isDisposed() && wasCallPermitted();
-    }
-
-    private Exception circuitBreakerOpenException() {
+    @Override
+    protected Exception notPermittedException() {
         return new CircuitBreakerOpenException(String.format("CircuitBreaker '%s' is open", circuitBreaker.getName()));
     }
 
-    private void markFailure(Throwable e) {
-        if (wasCallPermitted()) {
-            circuitBreaker.onError(stopWatch.stop().getProcessingDuration().toNanos(), e);
-        }
+    @Override
+    protected void doOnSuccess() {
+        circuitBreaker.onSuccess(stopWatch.stop().getProcessingDuration().toNanos());
     }
 
-    private void markSuccess() {
-        if (wasCallPermitted()) {
-            circuitBreaker.onSuccess(stopWatch.stop().getProcessingDuration().toNanos());
-        }
-    }
-
-    private boolean wasCallPermitted() {
-        return permitted.get() == Permit.ACQUIRED;
+    @Override
+    protected void doOnError(Throwable e) {
+        circuitBreaker.onError(stopWatch.stop().getProcessingDuration().toNanos(), e);
     }
 }

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/CircuitBreakerCompletableObserver.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/CircuitBreakerCompletableObserver.java
@@ -27,7 +27,7 @@ final class CircuitBreakerCompletableObserver extends DisposableCircuitBreaker<O
 
     @Override
     public void onComplete() {
-        onCompleteInner();
+        safeOnComplete();
     }
 
     @Override
@@ -37,7 +37,7 @@ final class CircuitBreakerCompletableObserver extends DisposableCircuitBreaker<O
 
     @Override
     public void onError(Throwable e) {
-        onErrorInner(e);
+        safeOnError(e);
     }
 
     @Override

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/CircuitBreakerCompletableObserver.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/CircuitBreakerCompletableObserver.java
@@ -7,7 +7,7 @@ import io.reactivex.disposables.Disposable;
 /**
  * A RxJava {@link CompletableObserver} to protect another observer by a CircuitBreaker.
  */
-final class CircuitBreakerCompletableObserver extends DisposableCircuitBreaker implements CompletableObserver {
+final class CircuitBreakerCompletableObserver extends DisposableCircuitBreaker<Object> implements CompletableObserver {
     private final CompletableObserver childObserver;
 
     CircuitBreakerCompletableObserver(CircuitBreaker circuitBreaker, CompletableObserver childObserver) {

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/CircuitBreakerMaybeObserver.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/CircuitBreakerMaybeObserver.java
@@ -31,7 +31,7 @@ final class CircuitBreakerMaybeObserver<T> extends DisposableCircuitBreaker<T> i
 
     @Override
     public void onComplete() {
-        onCompleteInner();
+        safeOnComplete();
     }
 
     @Override
@@ -41,7 +41,7 @@ final class CircuitBreakerMaybeObserver<T> extends DisposableCircuitBreaker<T> i
 
     @Override
     public void onSuccess(T value) {
-        onSuccessInner(value);
+        safeOnSuccess(value);
     }
 
     @Override
@@ -51,7 +51,7 @@ final class CircuitBreakerMaybeObserver<T> extends DisposableCircuitBreaker<T> i
 
     @Override
     public void onError(Throwable e) {
-        onErrorInner(e);
+        safeOnError(e);
     }
 
     @Override

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/CircuitBreakerObserver.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/CircuitBreakerObserver.java
@@ -31,7 +31,7 @@ final class CircuitBreakerObserver<T> extends DisposableCircuitBreaker<T> implem
 
     @Override
     public void onNext(T value) {
-        onNextInner(value);
+        safeOnNext(value);
     }
 
     @Override
@@ -41,7 +41,7 @@ final class CircuitBreakerObserver<T> extends DisposableCircuitBreaker<T> implem
 
     @Override
     public void onComplete() {
-        onCompleteInner();
+        safeOnComplete();
     }
 
     @Override
@@ -51,7 +51,7 @@ final class CircuitBreakerObserver<T> extends DisposableCircuitBreaker<T> implem
 
     @Override
     public void onError(Throwable e) {
-        onErrorInner(e);
+        safeOnError(e);
     }
 
     @Override

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/CircuitBreakerSingleObserver.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/CircuitBreakerSingleObserver.java
@@ -31,7 +31,7 @@ final class CircuitBreakerSingleObserver<T> extends DisposableCircuitBreaker<T> 
 
     @Override
     public void onSuccess(T value) {
-        onSuccessInner(value);
+        safeOnSuccess(value);
     }
 
     @Override
@@ -41,7 +41,7 @@ final class CircuitBreakerSingleObserver<T> extends DisposableCircuitBreaker<T> 
 
     @Override
     public void onError(Throwable e) {
-        onErrorInner(e);
+        safeOnError(e);
     }
 
     @Override

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/CircuitBreakerSubscriber.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/CircuitBreakerSubscriber.java
@@ -1,6 +1,7 @@
 package io.github.resilience4j.circuitbreaker.operator;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.internal.DisposedSubscription;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
@@ -31,7 +32,7 @@ final class CircuitBreakerSubscriber<T> extends AbstractCircuitBreakerOperator<T
 
     @Override
     public void onNext(T value) {
-        onNextInner(value);
+        safeOnNext(value);
     }
 
     @Override
@@ -41,7 +42,7 @@ final class CircuitBreakerSubscriber<T> extends AbstractCircuitBreakerOperator<T
 
     @Override
     public void onComplete() {
-        onCompleteInner();
+        safeOnComplete();
     }
 
     @Override
@@ -51,7 +52,7 @@ final class CircuitBreakerSubscriber<T> extends AbstractCircuitBreakerOperator<T
 
     @Override
     public void onError(Throwable e) {
-        onErrorInner(e);
+        safeOnError(e);
     }
 
     @Override
@@ -75,26 +76,12 @@ final class CircuitBreakerSubscriber<T> extends AbstractCircuitBreakerOperator<T
     }
 
     @Override
-    protected Subscription getDisposable() {
+    protected Subscription currentDisposable() {
         return this;
     }
 
     @Override
     protected void dispose(Subscription disposable) {
         disposable.cancel();
-    }
-
-    private enum DisposedSubscription implements Subscription {
-        CANCELLED;
-
-        @Override
-        public void request(long n) {
-
-        }
-
-        @Override
-        public void cancel() {
-
-        }
     }
 }

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/DisposableCircuitBreaker.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/DisposableCircuitBreaker.java
@@ -1,156 +1,55 @@
 package io.github.resilience4j.circuitbreaker.operator;
 
-import static java.util.Objects.requireNonNull;
-
-import java.util.concurrent.atomic.AtomicReference;
-
-import io.github.resilience4j.adapter.Permit;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
-import io.github.resilience4j.circuitbreaker.CircuitBreakerOpenException;
-import io.github.resilience4j.core.StopWatch;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.disposables.DisposableHelper;
 
 /**
  * A disposable circuit-breaker.
  *
  * @param <T> the type of the emitted event
  */
-class DisposableCircuitBreaker<T> extends AtomicReference<Disposable> implements Disposable {
-    private final CircuitBreaker circuitBreaker;
-    private StopWatch stopWatch;
-    private final AtomicReference<Permit> permitted = new AtomicReference<>(Permit.PENDING);
+class DisposableCircuitBreaker<T> extends AbstractCircuitBreakerOperator<T, Disposable> implements Disposable {
 
     DisposableCircuitBreaker(CircuitBreaker circuitBreaker) {
-        this.circuitBreaker = requireNonNull(circuitBreaker);
+        super(circuitBreaker);
     }
 
     @Override
     public final void dispose() {
-        DisposableHelper.dispose(this);
+        super.dispose();
     }
 
     @Override
     public final boolean isDisposed() {
-        return DisposableHelper.isDisposed(get());
+        return super.isDisposed();
     }
 
-    /**
-     * onSuccess ensured to be called only when safe.
-     *
-     * @param disposable the disposable
-     */
-    protected void onSubscribeInner(Disposable disposable) {
-        //Override when needed.
+    @Override
+    protected Disposable getDisposedDisposable() {
+        return DisposedDisposable.DISPOSED;
     }
 
-    protected final void onSubscribeWithPermit(Disposable disposable) {
-        if (DisposableHelper.setOnce(this, disposable)) {
-            if (acquireCallPermit()) {
-                onSubscribeInner(this);
-            } else {
-                dispose();
-                onSubscribeInner(this);
-                permittedOnError(circuitBreakerOpenException());
-            }
+    @Override
+    protected Disposable getDisposable() {
+        return this;
+    }
+
+    @Override
+    protected void dispose(Disposable disposable) {
+        disposable.dispose();
+    }
+
+    private enum DisposedDisposable implements Disposable {
+        DISPOSED;
+
+        @Override
+        public void dispose() {
+
         }
-    }
 
-    /**
-     * onError ensured to be called only when permitted.
-     *
-     * @param e the error
-     */
-    protected void permittedOnError(Throwable e) {
-        //Override when needed.
-    }
-
-    protected final void onErrorInner(Throwable e) {
-        markFailure(e);
-        if (isInvocationPermitted()) {
-            permittedOnError(e);
+        @Override
+        public boolean isDisposed() {
+            return true;
         }
-    }
-
-    /**
-     * onComplete ensured to be called only when permitted.
-     */
-    protected void permittedOnComplete() {
-        //Override when needed.
-    }
-
-    protected final void onCompleteInner() {
-        markSuccess();
-        if (isInvocationPermitted()) {
-            permittedOnComplete();
-        }
-    }
-
-    /**
-     * onSuccess ensured to be called only when permitted.
-     *
-     * @param value the value
-     */
-    protected void permittedOnSuccess(T value) {
-        //Override when needed.
-    }
-
-    protected final void onSuccessInner(T value) {
-        markSuccess();
-        if (isInvocationPermitted()) {
-            permittedOnSuccess(value);
-        }
-    }
-
-    /**
-     * onNext ensured to be called only when permitted.
-     *
-     * @param value the value
-     */
-    protected void permittedOnNext(T value) {
-        //Override when needed.
-    }
-
-    protected final void onNextInner(T value) {
-        if (isInvocationPermitted()) {
-            permittedOnNext(value);
-        }
-    }
-
-    private boolean acquireCallPermit() {
-        boolean callPermitted = false;
-        if (permitted.compareAndSet(Permit.PENDING, Permit.ACQUIRED)) {
-            callPermitted = circuitBreaker.isCallPermitted();
-            if (!callPermitted) {
-                permitted.set(Permit.REJECTED);
-            } else {
-                stopWatch = StopWatch.start(circuitBreaker.getName());
-            }
-        }
-        return callPermitted;
-    }
-
-    private boolean isInvocationPermitted() {
-        return !isDisposed() && wasCallPermitted();
-    }
-
-    private Exception circuitBreakerOpenException() {
-        return new CircuitBreakerOpenException(String.format("CircuitBreaker '%s' is open", circuitBreaker.getName()));
-    }
-
-    private void markFailure(Throwable e) {
-        if (wasCallPermitted()) {
-            circuitBreaker.onError(stopWatch.stop().getProcessingDuration().toNanos(), e);
-        }
-    }
-
-    private void markSuccess() {
-        if (wasCallPermitted()) {
-            circuitBreaker.onSuccess(stopWatch.stop().getProcessingDuration().toNanos());
-        }
-    }
-
-    private boolean wasCallPermitted() {
-        return permitted.get() == Permit.ACQUIRED;
     }
 }

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/DisposableCircuitBreaker.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/DisposableCircuitBreaker.java
@@ -1,6 +1,7 @@
 package io.github.resilience4j.circuitbreaker.operator;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.internal.DisposedDisposable;
 import io.reactivex.disposables.Disposable;
 
 /**
@@ -8,7 +9,7 @@ import io.reactivex.disposables.Disposable;
  *
  * @param <T> the type of the emitted event
  */
-class DisposableCircuitBreaker<T> extends AbstractCircuitBreakerOperator<T, Disposable> implements Disposable {
+abstract class DisposableCircuitBreaker<T> extends AbstractCircuitBreakerOperator<T, Disposable> implements Disposable {
 
     DisposableCircuitBreaker(CircuitBreaker circuitBreaker) {
         super(circuitBreaker);
@@ -30,26 +31,12 @@ class DisposableCircuitBreaker<T> extends AbstractCircuitBreakerOperator<T, Disp
     }
 
     @Override
-    protected Disposable getDisposable() {
+    protected Disposable currentDisposable() {
         return this;
     }
 
     @Override
     protected void dispose(Disposable disposable) {
         disposable.dispose();
-    }
-
-    private enum DisposedDisposable implements Disposable {
-        DISPOSED;
-
-        @Override
-        public void dispose() {
-
-        }
-
-        @Override
-        public boolean isDisposed() {
-            return true;
-        }
     }
 }

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/internal/DisposedDisposable.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/internal/DisposedDisposable.java
@@ -10,7 +10,7 @@ public enum DisposedDisposable implements Disposable {
 
     @Override
     public void dispose() {
-
+        // it is already disposed
     }
 
     @Override

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/internal/DisposedDisposable.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/internal/DisposedDisposable.java
@@ -1,0 +1,20 @@
+package io.github.resilience4j.internal;
+
+import io.reactivex.disposables.Disposable;
+
+/**
+ * A disposed disposable.
+ */
+public enum DisposedDisposable implements Disposable {
+    DISPOSED;
+
+    @Override
+    public void dispose() {
+
+    }
+
+    @Override
+    public boolean isDisposed() {
+        return true;
+    }
+}

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/internal/DisposedSubscription.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/internal/DisposedSubscription.java
@@ -1,0 +1,20 @@
+package io.github.resilience4j.internal;
+
+import org.reactivestreams.Subscription;
+
+/**
+ * A disposed subscription.
+ */
+public enum DisposedSubscription implements Subscription {
+    CANCELLED;
+
+    @Override
+    public void request(long n) {
+
+    }
+
+    @Override
+    public void cancel() {
+
+    }
+}

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/internal/DisposedSubscription.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/internal/DisposedSubscription.java
@@ -10,11 +10,11 @@ public enum DisposedSubscription implements Subscription {
 
     @Override
     public void request(long n) {
-
+        // does nothing as it is disposed
     }
 
     @Override
     public void cancel() {
-
+        // it is already disposed
     }
 }

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/internal/PermittedOperator.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/internal/PermittedOperator.java
@@ -4,6 +4,7 @@ import io.github.resilience4j.adapter.Permit;
 import io.reactivex.exceptions.ProtocolViolationException;
 import io.reactivex.plugins.RxJavaPlugins;
 
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Objects.requireNonNull;
@@ -222,9 +223,9 @@ public abstract class PermittedOperator<T, D> extends AtomicReference<D> {
     private boolean disposeOnce() {
         D current = get();
         D disposed = getDisposedDisposable();
-        if (current != disposed) {
+        if (!Objects.equals(current, disposed)) {
             current = getAndSet(disposed);
-            if (current != disposed) {
+            if (!Objects.equals(current, disposed)) {
                 if (current != null) {
                     dispose(current);
                 }

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/internal/PermittedOperator.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/internal/PermittedOperator.java
@@ -1,0 +1,258 @@
+package io.github.resilience4j.internal;
+
+import io.github.resilience4j.adapter.Permit;
+import io.reactivex.exceptions.ProtocolViolationException;
+import io.reactivex.plugins.RxJavaPlugins;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A disposable operator acting as a base class for permitted operators.
+ *
+ * @param <T>          the type of the emitted event
+ * @param <DISPOSABLE> the actual type of the disposable/subscription
+ */
+public abstract class PermittedOperator<T, DISPOSABLE> extends AtomicReference<DISPOSABLE> {
+    private final AtomicReference<Permit> permitted = new AtomicReference<>(Permit.PENDING);
+
+    /**
+     * Disposes this operator exactly once.
+     */
+    protected void dispose() {
+        if (disposeOnce()) {
+            release();
+        }
+    }
+
+    /**
+     * Gets whether this operator was already disposed or not.
+     *
+     * @return true if the operator was disposed, otherwise false
+     */
+    protected boolean isDisposed() {
+        return get() == getDisposedDisposable();
+    }
+
+    /**
+     * Gets the current disposable.
+     *
+     * @return the disposable
+     */
+    protected abstract DISPOSABLE currentDisposable();
+
+    /**
+     * Gets the reference of the one and only disposed disposable.
+     *
+     * @return the disposed disposable
+     */
+    protected abstract DISPOSABLE getDisposedDisposable();
+
+    /**
+     * Disposes a disposable.
+     *
+     * @param disposable the disposable to dispose
+     */
+    protected abstract void dispose(DISPOSABLE disposable);
+
+    /**
+     * Tries getting a call permit.
+     *
+     * @return true if a call permit could be acquired, otherwise false
+     */
+    protected abstract boolean tryCallPermit();
+
+    /**
+     * Creates the exception thrown when the call was not permitted.
+     *
+     * @return the exception to be thrown
+     */
+    protected abstract Exception notPermittedException();
+
+    /**
+     * Releases any resources (e.g. permits) reserved after a permitted call finishes.
+     */
+    protected void doOnRelease() {
+        // override when needed
+    }
+
+    /**
+     * onSubscribe ensured to be called only when safe.
+     *
+     * @param disposable the disposable
+     */
+    protected abstract void onSubscribeInner(DISPOSABLE disposable);
+
+    /**
+     * onSubscribe safe to be called from operator's onSubscribe.
+     * Only subscribes if a permit could be acquired.
+     *
+     * @param disposable the disposable/subscription
+     */
+    protected final void onSubscribeWithPermit(DISPOSABLE disposable) {
+        if (setDisposableOnce(disposable)) {
+            if (acquireCallPermit()) {
+                onSubscribeInner(currentDisposable());
+            } else {
+                dispose();
+                onSubscribeInner(currentDisposable());
+                permittedOnError(notPermittedException());
+            }
+        }
+    }
+
+    /**
+     * onError safe to be called from operator's onError.
+     *
+     * @param e the error thrown
+     */
+    protected final void safeOnError(Throwable e) {
+        if (onlyOnceIfCallWasPermitted()) {
+            doOnError(e);
+            if (!isDisposed()) {
+                permittedOnError(e);
+            }
+        }
+    }
+
+    /**
+     * Called if a permitted execution ended up in an error.
+     *
+     * @param e the error thrown
+     */
+    protected void doOnError(Throwable e) {
+        // Override when needed.
+    }
+
+    /**
+     * onError ensured to be called only when permitted.
+     *
+     * @param e the error
+     */
+    protected void permittedOnError(Throwable e) {
+        // Override.
+    }
+
+    /**
+     * onComplete safe to be called from operator's onComplete.
+     */
+    protected final void safeOnComplete() {
+        if (onlyOnceIfCallWasPermitted()) {
+            doOnSuccess();
+            if (!isDisposed()) {
+                permittedOnComplete();
+            }
+        }
+    }
+
+    /**
+     * onComplete ensured to be called only when permitted.
+     */
+    protected void permittedOnComplete() {
+        // Override when needed.
+    }
+
+
+    /**
+     * Called if a permitted execution ended successfully.
+     */
+    protected void doOnSuccess() {
+        // override if needed
+    }
+
+    /**
+     * onSuccess safe to be called from operator's onSuccess.
+     *
+     * @param value the value
+     */
+    protected final void safeOnSuccess(T value) {
+        if (onlyOnceIfCallWasPermitted()) {
+            doOnSuccess();
+            if (!isDisposed()) {
+                permittedOnSuccess(value);
+            }
+        }
+    }
+
+    /**
+     * onSuccess ensured to be called only when permitted.
+     *
+     * @param value the value
+     */
+    protected void permittedOnSuccess(T value) {
+        //Override when needed.
+    }
+
+    /**
+     * onNext safe to be called from operator's onNext.
+     *
+     * @param value the value
+     */
+    protected final void safeOnNext(T value) {
+        if (wasCallPermitted() && !isDisposed()) {
+            permittedOnNext(value);
+        }
+    }
+
+    /**
+     * onNext ensured to be called only when permitted.
+     *
+     * @param value the value
+     */
+    protected void permittedOnNext(T value) {
+        //Override when needed.
+    }
+
+    private boolean setDisposableOnce(DISPOSABLE DISPOSABLE) {
+        requireNonNull(DISPOSABLE, "DISPOSABLE is null");
+        if (!compareAndSet(null, DISPOSABLE)) {
+            dispose(DISPOSABLE);
+            if (get() != getDisposedDisposable()) {
+                RxJavaPlugins.onError(new ProtocolViolationException("Disposable/subscription already set!"));
+            }
+            return false;
+        }
+        return true;
+    }
+
+    private boolean disposeOnce() {
+        DISPOSABLE current = get();
+        DISPOSABLE disposed = getDisposedDisposable();
+        if (current != disposed) {
+            current = getAndSet(disposed);
+            if (current != disposed) {
+                if (current != null) {
+                    dispose(current);
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean acquireCallPermit() {
+        boolean callPermitted = false;
+        if (permitted.compareAndSet(Permit.PENDING, Permit.ACQUIRED)) {
+            callPermitted = tryCallPermit();
+            if (!callPermitted) {
+                permitted.set(Permit.REJECTED);
+            }
+        }
+        return callPermitted;
+    }
+
+    private boolean wasCallPermitted() {
+        return permitted.get() == Permit.ACQUIRED;
+    }
+
+    private boolean onlyOnceIfCallWasPermitted() {
+        return permitted.compareAndSet(Permit.ACQUIRED, Permit.RELEASED);
+    }
+
+    private void release() {
+        if (onlyOnceIfCallWasPermitted()) {
+            doOnRelease();
+        }
+    }
+}

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/ratelimiter/operator/AbstractRateLimiterOperator.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/ratelimiter/operator/AbstractRateLimiterOperator.java
@@ -1,0 +1,31 @@
+package io.github.resilience4j.ratelimiter.operator;
+
+import io.github.resilience4j.internal.PermittedOperator;
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import io.github.resilience4j.ratelimiter.RequestNotPermitted;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A disposable rate limiter acting as a base class for rate limiter operators.
+ *
+ * @param <T>          the type of the emitted event
+ * @param <DISPOSABLE> the actual type of the disposable/subscription
+ */
+abstract class AbstractRateLimiterOperator<T, DISPOSABLE> extends PermittedOperator<T, DISPOSABLE> {
+    private final RateLimiter rateLimiter;
+
+    AbstractRateLimiterOperator(RateLimiter rateLimiter) {
+        this.rateLimiter = requireNonNull(rateLimiter);
+    }
+
+    @Override
+    protected boolean tryCallPermit() {
+        return rateLimiter.getPermission(rateLimiter.getRateLimiterConfig().getTimeoutDuration());
+    }
+
+    @Override
+    protected Exception notPermittedException() {
+        return new RequestNotPermitted("Request not permitted for limiter: " + rateLimiter.getName());
+    }
+}

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/ratelimiter/operator/AbstractRateLimiterOperator.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/ratelimiter/operator/AbstractRateLimiterOperator.java
@@ -9,10 +9,10 @@ import static java.util.Objects.requireNonNull;
 /**
  * A disposable rate limiter acting as a base class for rate limiter operators.
  *
- * @param <T>          the type of the emitted event
- * @param <DISPOSABLE> the actual type of the disposable/subscription
+ * @param <T> the type of the emitted event
+ * @param <D> the actual type of the disposable/subscription
  */
-abstract class AbstractRateLimiterOperator<T, DISPOSABLE> extends PermittedOperator<T, DISPOSABLE> {
+abstract class AbstractRateLimiterOperator<T, D> extends PermittedOperator<T, D> {
     private final RateLimiter rateLimiter;
 
     AbstractRateLimiterOperator(RateLimiter rateLimiter) {

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/ratelimiter/operator/DisposableRateLimiter.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/ratelimiter/operator/DisposableRateLimiter.java
@@ -1,142 +1,42 @@
 package io.github.resilience4j.ratelimiter.operator;
 
-import static java.util.Objects.requireNonNull;
-
-import java.util.concurrent.atomic.AtomicReference;
-
-import io.github.resilience4j.adapter.Permit;
+import io.github.resilience4j.internal.DisposedDisposable;
 import io.github.resilience4j.ratelimiter.RateLimiter;
-import io.github.resilience4j.ratelimiter.RequestNotPermitted;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.disposables.DisposableHelper;
 
 /**
  * A disposable rate limiter acting as a base class for rate limiter operators.
  *
  * @param <T> the type of the emitted event
  */
-abstract class DisposableRateLimiter<T> extends AtomicReference<Disposable> implements Disposable {
-    private final RateLimiter rateLimiter;
-    private final AtomicReference<Permit> permitted = new AtomicReference<>(Permit.PENDING);
+abstract class DisposableRateLimiter<T> extends AbstractRateLimiterOperator<T, Disposable> implements Disposable {
 
     DisposableRateLimiter(RateLimiter rateLimiter) {
-        this.rateLimiter = requireNonNull(rateLimiter);
+        super(rateLimiter);
     }
 
     @Override
     public final void dispose() {
-        DisposableHelper.dispose(this);
+        super.dispose();
     }
 
     @Override
     public final boolean isDisposed() {
-        return DisposableHelper.isDisposed(get());
+        return super.isDisposed();
     }
 
-    /**
-     * onSuccess ensured to be called only when safe.
-     *
-     * @param disposable the disposable
-     */
-    protected void onSubscribeInner(Disposable disposable) {
-        //Override when needed.
+    @Override
+    protected Disposable getDisposedDisposable() {
+        return DisposedDisposable.DISPOSED;
     }
 
-    protected final void onSubscribeWithPermit(Disposable disposable) {
-        if (DisposableHelper.setOnce(this, disposable)) {
-            if (acquireCallPermit()) {
-                onSubscribeInner(this);
-            } else {
-                dispose();
-                onSubscribeInner(this);
-                permittedOnError(rateLimitExceededException());
-            }
-        }
+    @Override
+    protected Disposable currentDisposable() {
+        return this;
     }
 
-    /**
-     * onError ensured to be called only when permitted.
-     *
-     * @param e the error
-     */
-    protected void permittedOnError(Throwable e) {
-        //Override when needed.
-    }
-
-    protected final void onErrorInner(Throwable e) {
-        if (isInvocationPermitted()) {
-            permittedOnError(e);
-        }
-    }
-
-    /**
-     * onComplete ensured to be called only when permitted.
-     */
-    protected void permittedOnComplete() {
-        //Override when needed.
-    }
-
-    protected final void onCompleteInner() {
-        if (isInvocationPermitted()) {
-            permittedOnComplete();
-        }
-    }
-
-    /**
-     * onSuccess ensured to be called only when permitted.
-     *
-     * @param value the value
-     */
-    protected void permittedOnSuccess(T value) {
-        //Override when needed.
-    }
-
-    protected final void onSuccessInner(T value) {
-        if (isInvocationPermitted()) {
-            permittedOnSuccess(value);
-        }
-    }
-
-    /**
-     * onNext ensured to be called only when permitted.
-     *
-     * @param value the value
-     */
-    protected void permittedOnNext(T value) {
-        //Override when needed.
-    }
-
-    protected final void onNextInner(T value, boolean firstEvent) {
-        if (isInvocationPermitted()) {
-            if (firstEvent || rateLimiter.getPermission(rateLimiter.getRateLimiterConfig().getTimeoutDuration())) {
-                permittedOnNext(value);
-            } else {
-                dispose();
-                permittedOnError(rateLimitExceededException());
-            }
-        }
-    }
-
-    private boolean isInvocationPermitted() {
-        return !isDisposed() && wasCallPermitted();
-    }
-
-    private boolean acquireCallPermit() {
-        boolean callPermitted = false;
-        if (permitted.compareAndSet(Permit.PENDING, Permit.ACQUIRED)) {
-            callPermitted = rateLimiter.getPermission(rateLimiter.getRateLimiterConfig().getTimeoutDuration());
-            if (!callPermitted) {
-                permitted.set(Permit.REJECTED);
-            }
-        }
-        return callPermitted;
-    }
-
-    private Exception rateLimitExceededException() {
-        return new RequestNotPermitted("Request not permitted for limiter: " + rateLimiter.getName());
-    }
-
-    private boolean wasCallPermitted() {
-        return permitted.get() == Permit.ACQUIRED;
+    @Override
+    protected void dispose(Disposable disposable) {
+        disposable.dispose();
     }
 }

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/ratelimiter/operator/RateLimiterCompletableObserver.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/ratelimiter/operator/RateLimiterCompletableObserver.java
@@ -8,7 +8,7 @@ import io.reactivex.disposables.Disposable;
  * A RxJava {@link CompletableObserver} to protect another observer by a {@link RateLimiter}.
  * Consumes one permit when subscribed.
  */
-final class RateLimiterCompletableObserver extends DisposableRateLimiter implements CompletableObserver {
+final class RateLimiterCompletableObserver extends DisposableRateLimiter<Object> implements CompletableObserver {
     private final CompletableObserver childObserver;
 
     RateLimiterCompletableObserver(RateLimiter rateLimiter, CompletableObserver childObserver) {
@@ -28,7 +28,7 @@ final class RateLimiterCompletableObserver extends DisposableRateLimiter impleme
 
     @Override
     public void onComplete() {
-        onCompleteInner();
+        safeOnComplete();
     }
 
     @Override
@@ -38,7 +38,7 @@ final class RateLimiterCompletableObserver extends DisposableRateLimiter impleme
 
     @Override
     public void onError(Throwable e) {
-        onErrorInner(e);
+        safeOnError(e);
     }
 
     @Override

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/ratelimiter/operator/RateLimiterMaybeObserver.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/ratelimiter/operator/RateLimiterMaybeObserver.java
@@ -32,7 +32,7 @@ final class RateLimiterMaybeObserver<T> extends DisposableRateLimiter<T> impleme
 
     @Override
     public void onComplete() {
-        onCompleteInner();
+        safeOnComplete();
     }
 
     @Override
@@ -42,7 +42,7 @@ final class RateLimiterMaybeObserver<T> extends DisposableRateLimiter<T> impleme
 
     @Override
     public void onSuccess(T value) {
-        onSuccessInner(value);
+        safeOnSuccess(value);
     }
 
     @Override
@@ -52,7 +52,7 @@ final class RateLimiterMaybeObserver<T> extends DisposableRateLimiter<T> impleme
 
     @Override
     public void onError(Throwable e) {
-        onErrorInner(e);
+        safeOnError(e);
     }
 
     @Override

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/ratelimiter/operator/RateLimiterOperator.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/ratelimiter/operator/RateLimiterOperator.java
@@ -33,6 +33,7 @@ import org.reactivestreams.Subscriber;
 /**
  * A RxJava operator which wraps a reactive type in a rate limiter.
  * All operators consumes one permit at subscription and one permit per emitted event except the first one.
+ * Please note that RateLimiter shouldn't use timeout as it may block while acquiring the permit.
  *
  * @param <T> the value type of the upstream and downstream
  */

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/ratelimiter/operator/RateLimiterSingleObserver.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/ratelimiter/operator/RateLimiterSingleObserver.java
@@ -1,10 +1,10 @@
 package io.github.resilience4j.ratelimiter.operator;
 
-import static java.util.Objects.requireNonNull;
-
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.reactivex.SingleObserver;
 import io.reactivex.disposables.Disposable;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * A RxJava {@link SingleObserver} to protect another observer by a {@link RateLimiter}.
@@ -32,7 +32,7 @@ final class RateLimiterSingleObserver<T> extends DisposableRateLimiter<T> implem
 
     @Override
     public void onSuccess(T value) {
-        onSuccessInner(value);
+        safeOnSuccess(value);
     }
 
     @Override
@@ -42,7 +42,7 @@ final class RateLimiterSingleObserver<T> extends DisposableRateLimiter<T> implem
 
     @Override
     public void onError(Throwable e) {
-        onErrorInner(e);
+        safeOnError(e);
     }
 
     @Override

--- a/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/CircuitBreakerCompletableObserverTest.java
+++ b/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/CircuitBreakerCompletableObserverTest.java
@@ -69,7 +69,7 @@ public class CircuitBreakerCompletableObserverTest extends CircuitBreakerAsserti
 
         // Then
         verify(childObserver, never()).onComplete();
-        assertSingleSuccessfulCall();
+        assertNoRegisteredCall();
     }
 
     @Test
@@ -86,7 +86,7 @@ public class CircuitBreakerCompletableObserverTest extends CircuitBreakerAsserti
 
         // Then
         verify(childObserver, never()).onError(any());
-        assertSingleFailedCall();
+        assertNoRegisteredCall();
     }
 
     @Test

--- a/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/CircuitBreakerMaybeObserverTest.java
+++ b/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/CircuitBreakerMaybeObserverTest.java
@@ -68,7 +68,7 @@ public class CircuitBreakerMaybeObserverTest extends CircuitBreakerAssertions {
 
         // Then
         verify(childObserver, never()).onSuccess(any());
-        assertSingleSuccessfulCall();
+        assertNoRegisteredCall();
     }
 
     @Test
@@ -85,7 +85,7 @@ public class CircuitBreakerMaybeObserverTest extends CircuitBreakerAssertions {
 
         // Then
         verify(childObserver, never()).onError(any());
-        assertSingleFailedCall();
+        assertNoRegisteredCall();
     }
 
     @Test
@@ -102,7 +102,7 @@ public class CircuitBreakerMaybeObserverTest extends CircuitBreakerAssertions {
 
         // Then
         verify(childObserver, never()).onComplete();
-        assertSingleSuccessfulCall();
+        assertNoRegisteredCall();
     }
 
     @Test

--- a/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/CircuitBreakerObserverTest.java
+++ b/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/CircuitBreakerObserverTest.java
@@ -87,7 +87,7 @@ public class CircuitBreakerObserverTest extends CircuitBreakerAssertions {
 
         // Then
         verify(childObserver, never()).onComplete();
-        assertSingleSuccessfulCall();
+        assertNoRegisteredCall();
     }
 
     @Test
@@ -104,7 +104,7 @@ public class CircuitBreakerObserverTest extends CircuitBreakerAssertions {
 
         // Then
         verify(childObserver, never()).onError(any());
-        assertSingleFailedCall();
+        assertNoRegisteredCall();
     }
 
     @Test

--- a/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/CircuitBreakerSingleObserverTest.java
+++ b/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/CircuitBreakerSingleObserverTest.java
@@ -68,7 +68,7 @@ public class CircuitBreakerSingleObserverTest extends CircuitBreakerAssertions {
 
         // Then
         verify(childObserver, never()).onSuccess(any());
-        assertSingleSuccessfulCall();
+        assertNoRegisteredCall();
     }
 
     @Test
@@ -85,7 +85,7 @@ public class CircuitBreakerSingleObserverTest extends CircuitBreakerAssertions {
 
         // Then
         verify(childObserver, never()).onError(any());
-        assertSingleFailedCall();
+        assertNoRegisteredCall();
     }
 
     @Test

--- a/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/CircuitBreakerSubscriberTest.java
+++ b/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/CircuitBreakerSubscriberTest.java
@@ -88,7 +88,7 @@ public class CircuitBreakerSubscriberTest extends CircuitBreakerAssertions {
 
         // Then
         verify(childSubscriber, never()).onComplete();
-        assertSingleSuccessfulCall();
+        assertNoRegisteredCall();
     }
 
     @Test
@@ -105,7 +105,7 @@ public class CircuitBreakerSubscriberTest extends CircuitBreakerAssertions {
 
         // Then
         verify(childSubscriber, never()).onError(any());
-        assertSingleFailedCall();
+        assertNoRegisteredCall();
     }
 
     @Test


### PR DESCRIPTION
I've refactored rxjava operators and removed all internal rxjava references so it is working with newer versions of rxjava as well. I left the commits as is so it's easier to see what and how has changed.
I also made all operators use the same approach. This required a slight modification in the behavior of the circuitbreaker operator. It won't register the call if it completes after the subscription was cancelled but this is an edge case anyway.
I haven't touched RetryTransformator as I saw another PR addressing it.