### PR TITLE
fix(resilience4j-reactor): release semaphore on cancel

### DIFF
--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/BulkheadSubscriber.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/BulkheadSubscriber.java
@@ -46,6 +46,11 @@ class BulkheadSubscriber<T> extends ResilienceBaseSubscriber<T> {
     }
 
     @Override
+    public void hookOnCancel() {
+        releaseBulkhead();
+    }
+
+    @Override
     public void hookOnError(Throwable t) {
         if (wasCallPermitted()) {
             bulkhead.onComplete();

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/MonoBulkheadTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/MonoBulkheadTest.java
@@ -97,4 +97,18 @@ public class MonoBulkheadTest {
 
         assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(0);
     }
+
+    @Test
+    public void shouldReleaseBulkheadSemaphoreOnCancel() {
+        assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(1);
+        StepVerifier.create(
+                Mono.just("Event")
+                        .transform(BulkheadOperator.of(bulkhead)))
+                .expectSubscription()
+                .expectNext("Event")
+                .thenCancel()
+                .verify();
+        assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(1);
+    }
+
 }


### PR DESCRIPTION
fixes #332