### PR TITLE
Expose bulkhead max allowed concurrent calls metric

### DIFF
--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/Bulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/Bulkhead.java
@@ -414,6 +414,15 @@ public interface Bulkhead {
          * @return remaining bulkhead depth
          */
         int getAvailableConcurrentCalls();
+
+        /**
+         * Returns the configured max amount of concurrent calls
+         * allowed for this bulkhead, basically it's a top inclusive bound for
+         * the value returned from {@link #getAvailableConcurrentCalls()}.
+         *
+         * @return max allowed concurrent calls
+         */
+        int getMaxAllowedConcurrentCalls();
     }
 
     /**

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkhead.java
@@ -215,5 +215,10 @@ public class SemaphoreBulkhead implements Bulkhead {
         public int getAvailableConcurrentCalls() {
             return semaphore.availablePermits();
         }
+
+        @Override
+        public int getMaxAllowedConcurrentCalls() {
+            return config.getMaxConcurrentCalls();
+        }
     }
 }

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/utils/MetricNames.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/utils/MetricNames.java
@@ -3,4 +3,5 @@ package io.github.resilience4j.bulkhead.utils;
 public class MetricNames {
     public static final String DEFAULT_PREFIX = "resilience4j.bulkhead";
     public static final String AVAILABLE_CONCURRENT_CALLS = "available_concurrent_calls";
+    public static final String MAX_ALLOWED_CONCURRENT_CALLS = "max_allowed_concurrent_calls";
 }

--- a/resilience4j-documentation/src/docs/asciidoc/addon_guides/dropwizard.adoc
+++ b/resilience4j-documentation/src/docs/asciidoc/addon_guides/dropwizard.adoc
@@ -26,6 +26,7 @@ collectorRegistry.registerAll(BulkheadMetrics.ofBulkhead(foo));
 For each bulkhead this registry will export:
 
 * `available_concurrent_calls` - instantaneous read of the number of currently available concurrent calls `[int]`
+* `max_allowed_concurrent_calls` - maximum number of allowed concurrent calls `[int]`
 
 ===== CircuitBreaker
 

--- a/resilience4j-documentation/src/docs/asciidoc/addon_guides/micrometer.adoc
+++ b/resilience4j-documentation/src/docs/asciidoc/addon_guides/micrometer.adoc
@@ -23,6 +23,7 @@ bulkheadMetrics.bindTo(meterRegistry);
 For each bulkhead this registry will export:
 
 * `available_concurrent_calls` - instantaneous read of the number of currently available concurrent calls `[int]`
+* `max_allowed_concurrent_calls` - maximum number of allowed concurrent calls `[int]`
 
 ===== CircuitBreaker
 

--- a/resilience4j-metrics/src/main/java/io/github/resilience4j/metrics/BulkheadMetrics.java
+++ b/resilience4j-metrics/src/main/java/io/github/resilience4j/metrics/BulkheadMetrics.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import static com.codahale.metrics.MetricRegistry.name;
 import static io.github.resilience4j.bulkhead.utils.MetricNames.AVAILABLE_CONCURRENT_CALLS;
 import static io.github.resilience4j.bulkhead.utils.MetricNames.DEFAULT_PREFIX;
+import static io.github.resilience4j.bulkhead.utils.MetricNames.MAX_ALLOWED_CONCURRENT_CALLS;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -48,6 +49,8 @@ public class BulkheadMetrics implements MetricSet {
             //number of available concurrent calls as an integer
                     metricRegistry.register(name(prefix, name, AVAILABLE_CONCURRENT_CALLS),
                             (Gauge<Integer>) () -> bulkhead.getMetrics().getAvailableConcurrentCalls());
+                    metricRegistry.register(name(prefix, name, MAX_ALLOWED_CONCURRENT_CALLS),
+                            (Gauge<Integer>) () -> bulkhead.getMetrics().getMaxAllowedConcurrentCalls());
                 }
         );
     }

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/BulkheadMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/BulkheadMetrics.java
@@ -23,6 +23,7 @@ import io.micrometer.core.instrument.binder.MeterBinder;
 
 import static io.github.resilience4j.bulkhead.utils.MetricNames.AVAILABLE_CONCURRENT_CALLS;
 import static io.github.resilience4j.bulkhead.utils.MetricNames.DEFAULT_PREFIX;
+import static io.github.resilience4j.bulkhead.utils.MetricNames.MAX_ALLOWED_CONCURRENT_CALLS;
 import static io.github.resilience4j.micrometer.MetricUtils.getName;
 import static java.util.Objects.requireNonNull;
 
@@ -55,6 +56,8 @@ public class BulkheadMetrics implements MeterBinder {
         for (Bulkhead bulkhead : bulkheads) {
             final String name = bulkhead.getName();
             Gauge.builder(getName(prefix, name, AVAILABLE_CONCURRENT_CALLS), bulkhead, (cb) -> cb.getMetrics().getAvailableConcurrentCalls())
+                    .register(registry);
+            Gauge.builder(getName(prefix, name, MAX_ALLOWED_CONCURRENT_CALLS), bulkhead, (bh) -> bh.getMetrics().getMaxAllowedConcurrentCalls())
                     .register(registry);
         }
     }

--- a/resilience4j-ratpack/src/test/groovy/io/github/resilience4j/ratpack/Resilience4jModuleSpec.groovy
+++ b/resilience4j-ratpack/src/test/groovy/io/github/resilience4j/ratpack/Resilience4jModuleSpec.groovy
@@ -627,7 +627,7 @@ class Resilience4jModuleSpec extends Specification {
         timer.count == 3
 
         and:
-        registry.gauges.size() == 13
+        registry.gauges.size() == 14
         registry.gauges.keySet() == ['resilience4j.circuitbreaker.test.state',
                                      'resilience4j.circuitbreaker.test.buffered',
                                      'resilience4j.circuitbreaker.test.buffered_max',
@@ -640,7 +640,8 @@ class Resilience4jModuleSpec extends Specification {
                                      'resilience4j.retry.test.successful_calls_with_retry',
                                      'resilience4j.retry.test.failed_calls_without_retry',
                                      'resilience4j.retry.test.failed_calls_with_retry',
-                                     'resilience4j.bulkhead.test.available_concurrent_calls'].toSet()
+                                     'resilience4j.bulkhead.test.available_concurrent_calls',
+                                     'resilience4j.bulkhead.test.max_allowed_concurrent_calls'].toSet()
     }
 
     def "test prometheus"() {


### PR DESCRIPTION
Hi there :wave:

The idea behind these changes is to expose upper configured bound for bulkhead max concurrent calls, since bulkhead configuration might be dynamically changed the visibility of the value seems to be essential. Also it gives _a simple way_ to visualize data in other (meaning different than current available number of concurrent calls) manner, a few examples (prometheus + grafana):

```
[Current concurrent calls]
resilience4j_bulkhead_Backend_max_allowed_concurrent_calls - resilience4j_bulkhead_Backend_available_concurrent_calls

[Max allowed concurrent calls]
resilience4j_bulkhead_Backend_max_allowed_concurrent_calls 
```
![image](https://user-images.githubusercontent.com/4053805/53133135-bb874f00-357a-11e9-96bb-d3c5a113cdbb.png)

```
[Used concurrent calls in percent]
100 - 100 * resilience4j_bulkhead_Backend_available_concurrent_calls / resilience4j_bulkhead_Backend_max_allowed_concurrent_calls

80% Alert
```
![image](https://user-images.githubusercontent.com/4053805/53133241-0c974300-357b-11e9-8e7a-96f42e571344.png)

