### PR TITLE
Add tag based micrometer metric binders

### DIFF
--- a/resilience4j-documentation/src/docs/asciidoc/addon_guides/micrometer.adoc
+++ b/resilience4j-documentation/src/docs/asciidoc/addon_guides/micrometer.adoc
@@ -18,12 +18,20 @@ final Bulkhead boo = bulkheadRegistry.bulkhead("boo");
 // Register all bulkheads at once
 BulkheadMetrics bulkheadMetrics = BulkheadMetrics.ofBulkheadRegistry(bulkheadRegistry);
 bulkheadMetrics.bindTo(meterRegistry);
+
+// Or for tag based metrics
+TaggedBulkheadMetrics.ofBulkheadRegistry(bulkheadRegistry).bindTo(meterRegistry);
 --
 
 For each bulkhead this registry will export:
 
 * `available_concurrent_calls` - instantaneous read of the number of currently available concurrent calls `[int]`
 * `max_allowed_concurrent_calls` - maximum number of allowed concurrent calls `[int]`
+
+Tag based metrics:
+
+* `resilience4j_bulkhead_available_concurrent_calls{name="name of bulkhead"}` - number of available concurrent calls
+* `resilience4j_bulkhead_max_allowed_concurrent_calls{name="name of bulkhead"}` - maximum number of allowed concurrent calls
 
 ===== CircuitBreaker
 
@@ -36,6 +44,9 @@ final CircuitBreaker boo = circuitBreakerRegistry.circuitBreaker("boo");
 // Register all circuit breakers at once
 CircuitBreakerMetrics circuitBreakerMetrics = CircuitBreakerMetrics.ofCircuitBreakerRegistry(circuitBreakerRegistry);
 circuitBreakerMetrics.bindTo(meterRegistry);
+
+// Or for tag based metrics
+TaggedCircuitBreakerMetrics.ofCircuitBreakerRegistry(circuitBreakerRegistry).bindTo(meterRegistry);
 --
 
 For each circuit breaker this registry will export:
@@ -47,6 +58,16 @@ For each circuit breaker this registry will export:
 * `buffered_max` - maximum number of buffered calls `[int]`
 * `not_permitted` - current number of not permitted calls `[int]`
 
+Tag based metrics:
+
+* `resilience4j_circuitbreaker_state{name="name of circuitbreaker"}` - the state of the circuit breaker where 0-CLOSED, 1-OPEN, 2-HALF-OPEN
+* `resilience4j_circuitbreaker_calls{name="name of circuitbreaker", kind="one of the values below"}` - the number of calls of a certain kind
+  - `successful` - indicates successful calls
+  - `failed` - indicates failed calls
+  - `not_permitted` - indicates not permitted calls
+* `resilience4j_circuitbreaker_buffered_calls{name="name of circuitbreaker"}` - the number of buffered calls
+* `resilience4j_circuitbreaker_max_buffered_calls{name="name of circuitbreaker"}` - the maximum number of buffered calls
+
 ===== RateLimiter
 
 [source,java]
@@ -57,12 +78,20 @@ final RateLimiter rateLimiter = rateLimiterRegistry.rateLimiter("testLimit");
 // Register rate limiters at once
 RateLimiterMetrics rateLimiterMetrics = RateLimiterMetrics.ofRateLimiterRegistry(rateLimiterRegistry);
 rateLimiterMetrics.bindTo(meterRegistry);
+
+// Or for tag based metrics
+TaggedRateLimiterMetrics.ofRateLimiterRegistry(rateLimiterRegistry).bindTo(meterRegistry);
 --
 
 For each rate limiter this registry will export:
 
 * `available_permissions` - current number of available permissions `[int]`
 * `number_of_waiting_threads` - current number of threads waiting for permission `[int]`
+
+Tag based metrics:
+
+* `resilience4j_ratelimiter_available_permissions{name="name of ratelimiter"}` - the number of available permissions
+* `resilience4j_ratelimiter_waiting_threads{name="name of ratelimiter"}` - the number of threads waiting for permission
 
 ===== Retry
 
@@ -75,6 +104,9 @@ final Retry retry = retryRegistry.retry("testLimit");
 // Register all retries at once
 RetryMetrics retryMetrics = RetryMetrics.ofRetryRegistry(retryRegistry);
 retryMetrics.bindTo(meterRegistry);
+
+// Or for tag baed metrics
+TaggedRetryMetrics.ofRetryRegistry(retryRegistry).bindTo(meterRegistry);
 --
 
 For each retry this registry will export:
@@ -84,3 +116,12 @@ For each retry this registry will export:
 * `failed_calls_without_retry` - the number of failed calls without a retry attempt `[long]`
 * `failed_calls_with_retry` - the number of failed calls after all retry attempts `[long]`
 
+Tag based metrics:
+
+* `resilience4j_retry_calls{name="retry name", kind="one of the values below"}` - the number of calls of a certain kind
+  - `successful_without_retry` - indicates successful calls without retry
+  - `successful_with_retry` - indicates successful calls with retry
+  - `failed_without_retry` - indicates failed calls without retry
+  - `failed_with_retry` - indicates failed calls with retry
+
+Note the same set of metrics is exposed for async retry, metric name is `resilience4j_async_retry_calls`.

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TagNames.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TagNames.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 Yevhenii Voievodin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.micrometer.tagged;
+
+/** Common constants for metric binder implementations based on tags. */
+public final class TagNames {
+    public static final String NAME = "name";
+    public static final String KIND = "kind";
+}

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedAsyncRetryMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedAsyncRetryMetrics.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2019 Yevhenii Voievodin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.micrometer.tagged;
+
+import io.github.resilience4j.micrometer.AsyncRetryMetrics;
+import io.github.resilience4j.retry.AsyncRetry;
+import io.github.resilience4j.retry.AsyncRetry.Metrics;
+import io.github.resilience4j.retry.AsyncRetryRegistry;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A micrometer binder that is used to register retry exposed {@link Metrics metrics}.
+ * The main difference from {@link AsyncRetryMetrics} is that this binder uses tags
+ * to distinguish between metrics.
+ */
+public class TaggedAsyncRetryMetrics implements MeterBinder {
+
+    /**
+     * Creates a new binder that uses given {@code registry} as source of retries.
+     *
+     * @param registry the source of async retries
+     */
+    public static TaggedAsyncRetryMetrics ofAsyncRetryRegistry(AsyncRetryRegistry registry) {
+        return new TaggedAsyncRetryMetrics(MetricNames.ofDefaults(), registry.getAllRetries());
+    }
+
+    /**
+     * Creates a new binder that uses given {@code registry} as source of retries.
+     *
+     * @param names custom metric names
+     * @param registry the source of retries
+     */
+    public static TaggedAsyncRetryMetrics ofAsyncRetryRegistry(MetricNames names, AsyncRetryRegistry registry) {
+        return new TaggedAsyncRetryMetrics(names, registry.getAllRetries());
+    }
+
+    private final MetricNames names;
+    private final Iterable<? extends AsyncRetry> asyncRetries;
+
+    private TaggedAsyncRetryMetrics(MetricNames names, Iterable<? extends AsyncRetry> asyncRetries) {
+        this.names = requireNonNull(names);
+        this.asyncRetries = requireNonNull(asyncRetries);
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        for (AsyncRetry asyncRetry : asyncRetries) {
+            Gauge.builder(names.getCallsMetricName(), asyncRetry, (art) -> art.getMetrics().getNumberOfSuccessfulCallsWithoutRetryAttempt())
+                    .tag(TagNames.NAME, asyncRetry.getName())
+                    .tag(TagNames.KIND, "successful_without_retry")
+                    .register(registry);
+            Gauge.builder(names.getCallsMetricName(), asyncRetry, (art) -> art.getMetrics().getNumberOfSuccessfulCallsWithRetryAttempt())
+                    .tag(TagNames.NAME, asyncRetry.getName())
+                    .tag(TagNames.KIND, "successful_with_retry")
+                    .register(registry);
+            Gauge.builder(names.getCallsMetricName(), asyncRetry, (art) -> art.getMetrics().getNumberOfFailedCallsWithoutRetryAttempt())
+                    .tag(TagNames.NAME, asyncRetry.getName())
+                    .tag(TagNames.KIND, "failed_without_retry")
+                    .register(registry);
+            Gauge.builder(names.getCallsMetricName(), asyncRetry, (art) -> art.getMetrics().getNumberOfFailedCallsWithRetryAttempt())
+                    .tag(TagNames.NAME, asyncRetry.getName())
+                    .tag(TagNames.KIND, "failed_with_retry")
+                    .register(registry);
+        }
+    }
+
+    /** Defines possible configuration for metric names. */
+    public static class MetricNames {
+
+        public static final String DEFAULT_ASYNC_RETRY_CALLS = "resilience4j_async_retry_calls";
+
+        /**
+         * Returns a builder for creating custom metric names.
+         * Note that names have default values, so only desired metrics can be renamed.
+         */
+        public static Builder custom() {
+            return new Builder();
+        }
+
+        /** Returns default metric names. */
+        public static MetricNames ofDefaults() {
+            return new MetricNames();
+        }
+
+        private String callsMetricName = DEFAULT_ASYNC_RETRY_CALLS;
+
+        private MetricNames() {}
+
+        /** Returns the metric name for async retry calls, defaults to {@value DEFAULT_ASYNC_RETRY_CALLS}. */
+        public String getCallsMetricName() {
+            return callsMetricName;
+        }
+
+        /** Helps building custom instance of {@link MetricNames}. */
+        public static class Builder {
+            private final MetricNames metricNames = new MetricNames();
+
+            /** Overrides the default metric name {@value MetricNames#DEFAULT_ASYNC_RETRY_CALLS} with a given one. */
+            public Builder callsMetricName(String callsMetricName) {
+                metricNames.callsMetricName = requireNonNull(callsMetricName);
+                return this;
+            }
+
+            /** Builds {@link MetricNames} instance. */
+            public MetricNames build() {
+                return metricNames;
+            }
+        }
+    }
+}

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedBulkheadMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedBulkheadMetrics.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2019 Yevhenii Voievodin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.micrometer.tagged;
+
+import io.github.resilience4j.bulkhead.Bulkhead;
+import io.github.resilience4j.bulkhead.Bulkhead.Metrics;
+import io.github.resilience4j.bulkhead.BulkheadRegistry;
+import io.github.resilience4j.micrometer.BulkheadMetrics;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A micrometer binder that is used to register bulkhead exposed {@link Metrics metrics}.
+ * The main difference from {@link BulkheadMetrics} is that this binder uses tags
+ * to distinguish between metrics.
+ */
+public class TaggedBulkheadMetrics implements MeterBinder {
+
+    /**
+     * Creates a new binder that uses given {@code registry} as source of bulkheads.
+     *
+     * @param registry the source of bulkheads
+     */
+    public static TaggedBulkheadMetrics ofBulkheadRegistry(BulkheadRegistry registry) {
+        return new TaggedBulkheadMetrics(MetricNames.ofDefaults(), registry.getAllBulkheads());
+    }
+
+    /**
+     * Creates a new binder defining custom metric names and
+     * using given {@code registry} as source of bulkheads.
+     *
+     * @param names custom names of the metrics
+     * @param registry the source of bulkheads
+     */
+    public static TaggedBulkheadMetrics ofBulkheadRegistry(MetricNames names, BulkheadRegistry registry) {
+        return new TaggedBulkheadMetrics(names, registry.getAllBulkheads());
+    }
+
+    private final MetricNames names;
+    private final Iterable<? extends Bulkhead> bulkheads;
+
+    private TaggedBulkheadMetrics(MetricNames names, Iterable<? extends Bulkhead> bulkheads) {
+        this.names = requireNonNull(names);
+        this.bulkheads = requireNonNull(bulkheads);
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        for (Bulkhead bulkhead : bulkheads) {
+            Gauge.builder(names.getAvailableConcurrentCallsMetricName(), bulkhead, (bh) -> bh.getMetrics().getAvailableConcurrentCalls())
+                    .tag(TagNames.NAME, bulkhead.getName())
+                    .register(registry);
+            Gauge.builder(names.getMaxAllowedConcurrentCallsMetricName(), bulkhead, (bh) -> bh.getMetrics().getMaxAllowedConcurrentCalls())
+                    .tag(TagNames.NAME, bulkhead.getName())
+                    .register(registry);
+        }
+    }
+
+    /** Defines possible configuration for metric names. */
+    public static class MetricNames {
+
+        public static final String DEFAULT_BULKHEAD_AVAILABLE_CONCURRENT_CALLS_METRIC_NAME = "resilience4j_bulkhead_available_concurrent_calls";
+        public static final String DEFAULT_BULKHEAD_MAX_ALLOWED_CONCURRENT_CALLS_METRIC_NAME = "resilience4j_bulkhead_max_allowed_concurrent_calls";
+
+        /**
+         * Returns a builder for creating custom metric names.
+         * Note that names have default values, so only desired metrics can be renamed.
+         */
+        public static Builder custom() {
+            return new Builder();
+        }
+
+        /** Returns default metric names. */
+        public static MetricNames ofDefaults() {
+            return new MetricNames();
+        }
+
+        private String availableConcurrentCallsMetricName = DEFAULT_BULKHEAD_AVAILABLE_CONCURRENT_CALLS_METRIC_NAME;
+        private String maxAllowedConcurrentCallsMetricName = DEFAULT_BULKHEAD_MAX_ALLOWED_CONCURRENT_CALLS_METRIC_NAME;
+
+        private MetricNames() {}
+
+        /**
+         * Returns the metric name for bulkhead concurrent calls,
+         * defaults to {@value DEFAULT_BULKHEAD_AVAILABLE_CONCURRENT_CALLS_METRIC_NAME}.
+         */
+        public String getAvailableConcurrentCallsMetricName() {
+            return availableConcurrentCallsMetricName;
+        }
+
+        /**
+         * Returns the metric name for bulkhead max available concurrent calls,
+         * defaults to {@value DEFAULT_BULKHEAD_MAX_ALLOWED_CONCURRENT_CALLS_METRIC_NAME}.
+         */
+        public String getMaxAllowedConcurrentCallsMetricName() {
+            return maxAllowedConcurrentCallsMetricName;
+        }
+
+        /** Helps building custom instance of {@link MetricNames}. */
+        public static class Builder {
+
+            private final MetricNames metricNames = new MetricNames();
+
+            /** Overrides the default metric name {@value MetricNames#DEFAULT_BULKHEAD_AVAILABLE_CONCURRENT_CALLS_METRIC_NAME} with a given one. */
+            public Builder availableConcurrentCallsMetricName(String availableConcurrentCallsMetricNames) {
+                metricNames.availableConcurrentCallsMetricName = requireNonNull(availableConcurrentCallsMetricNames);
+                return this;
+            }
+
+            /** Overrides the default metric name {@value MetricNames#DEFAULT_BULKHEAD_MAX_ALLOWED_CONCURRENT_CALLS_METRIC_NAME} with a given one. */
+            public Builder maxAllowedConcurrentCallsMetricName(String maxAllowedConcurrentCallsMetricName) {
+                metricNames.maxAllowedConcurrentCallsMetricName = requireNonNull(maxAllowedConcurrentCallsMetricName);
+                return this;
+            }
+
+            /** Builds {@link MetricNames} instance. */
+            public MetricNames build() {
+                return metricNames;
+            }
+        }
+    }
+}

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetrics.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2019 Yevhenii Voievodin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.micrometer.tagged;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker.Metrics;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.micrometer.CircuitBreakerMetrics;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A micrometer binder that is used to register circuit breaker exposed {@link Metrics metrics}.
+ * The main difference from {@link CircuitBreakerMetrics} is that this binder uses tags
+ * to distinguish between circuit breaker instances.
+ */
+public class TaggedCircuitBreakerMetrics implements MeterBinder {
+
+    /**
+     * Creates a new binder that uses given {@code registry} as source of circuit breakers.
+     *
+     * @param metricNames custom metric names
+     * @param registry the source of circuit breakers
+     */
+    public static TaggedCircuitBreakerMetrics ofCircuitBreakerRegistry(MetricNames metricNames, CircuitBreakerRegistry registry) {
+        return new TaggedCircuitBreakerMetrics(metricNames, registry.getAllCircuitBreakers());
+    }
+
+    /**
+     * Creates a new binder that uses given {@code registry} as source of circuit breakers.
+     *
+     * @param registry the source of circuit breakers
+     */
+    public static TaggedCircuitBreakerMetrics ofCircuitBreakerRegistry(CircuitBreakerRegistry registry) {
+        return ofCircuitBreakerRegistry(MetricNames.ofDefaults(), registry);
+    }
+
+    private final MetricNames names;
+    private final Iterable<? extends CircuitBreaker> circuitBreakers;
+
+    private TaggedCircuitBreakerMetrics(MetricNames names, Iterable<? extends CircuitBreaker> circuitBreakers) {
+        this.names = requireNonNull(names);
+        this.circuitBreakers = requireNonNull(circuitBreakers);
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        for (CircuitBreaker circuitBreaker : circuitBreakers) {
+            Gauge.builder(names.getStateMetricName(), circuitBreaker, (cb) -> cb.getState().getOrder())
+                    .tag(TagNames.NAME, circuitBreaker.getName())
+                    .register(registry);
+
+            Gauge.builder(names.getCallsMetricName(), circuitBreaker, (cb) -> cb.getMetrics().getNumberOfFailedCalls())
+                    .tag(TagNames.NAME, circuitBreaker.getName())
+                    .tag(TagNames.KIND, "failed")
+                    .register(registry);
+            Gauge.builder(names.getCallsMetricName(), circuitBreaker, (cb) -> cb.getMetrics().getNumberOfNotPermittedCalls())
+                    .tag(TagNames.NAME, circuitBreaker.getName())
+                    .tag(TagNames.KIND, "not_permitted")
+                    .register(registry);
+            Gauge.builder(names.getCallsMetricName(), circuitBreaker, (cb) -> cb.getMetrics().getNumberOfSuccessfulCalls())
+                    .tag(TagNames.NAME, circuitBreaker.getName())
+                    .tag(TagNames.KIND, "successful")
+                    .register(registry);
+
+            Gauge.builder(names.getBufferedCallsMetricName(), circuitBreaker, (cb) -> cb.getMetrics().getNumberOfBufferedCalls())
+                    .tag(TagNames.NAME, circuitBreaker.getName())
+                    .register(registry);
+
+            Gauge.builder(names.getMaxBufferedCallsMetricName(), circuitBreaker, (cb) -> cb.getMetrics().getMaxNumberOfBufferedCalls())
+                    .tag(TagNames.NAME, circuitBreaker.getName())
+                    .register(registry);
+        }
+    }
+
+    /** Defines possible configuration for metric names. */
+    public static class MetricNames {
+
+        public static final String DEFAULT_CIRCUIT_BREAKER_CALLS_METRIC_NAME = "resilience4j_circuitbreaker_calls";
+        public static final String DEFAULT_CIRCUIT_BREAKER_STATE_METRIC_NAME = "resilience4j_circuitbreaker_state";
+        public static final String DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS = "resilience4j_circuitbreaker_buffered_calls";
+        public static final String DEFAULT_CIRCUIT_BREAKER_MAX_BUFFERED_CALLS = "resilience4j_circuitbreaker_max_buffered_calls";
+
+        /**
+         * Returns a builder for creating custom metric names.
+         * Note that names have default values, so only desired metrics can be renamed.
+         */
+        public static Builder custom() {
+            return new Builder();
+        }
+
+        /** Returns default metric names. */
+        public static MetricNames ofDefaults() {
+            return new MetricNames();
+        }
+
+        private String callsMetricName = DEFAULT_CIRCUIT_BREAKER_CALLS_METRIC_NAME;
+        private String stateMetricName = DEFAULT_CIRCUIT_BREAKER_STATE_METRIC_NAME;
+        private String bufferedCallsMetricName = DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS;
+        private String maxBufferedCallsMetricName = DEFAULT_CIRCUIT_BREAKER_MAX_BUFFERED_CALLS;
+
+        private MetricNames() {}
+
+        /** Returns the metric name for circuit breaker calls, defaults to {@value DEFAULT_CIRCUIT_BREAKER_STATE_METRIC_NAME}. */
+        public String getCallsMetricName() {
+            return callsMetricName;
+        }
+
+        /** Returns the metric name for currently buffered calls, defaults to {@value DEFAULT_CIRCUIT_BREAKER_STATE_METRIC_NAME}. */
+        public String getBufferedCallsMetricName() {
+            return bufferedCallsMetricName;
+        }
+
+        /** Returns the metric name for max buffered calls, defaults to {@value DEFAULT_CIRCUIT_BREAKER_STATE_METRIC_NAME}. */
+        public String getMaxBufferedCallsMetricName() {
+            return maxBufferedCallsMetricName;
+        }
+
+        /** Returns the metric name for state, defaults to {@value DEFAULT_CIRCUIT_BREAKER_STATE_METRIC_NAME}. */
+        public String getStateMetricName() {
+            return stateMetricName;
+        }
+
+        /** Helps building custom instance of {@link MetricNames}. */
+        public static class Builder {
+            private final MetricNames metricNames = new MetricNames();
+
+            /** Overrides the default metric name {@value MetricNames#DEFAULT_CIRCUIT_BREAKER_CALLS_METRIC_NAME} with a given one. */
+            public Builder callsMetricName(String callsMetricName) {
+                metricNames.callsMetricName = requireNonNull(callsMetricName);
+                return this;
+            }
+
+            /** Overrides the default metric name {@value MetricNames#DEFAULT_CIRCUIT_BREAKER_STATE_METRIC_NAME} with a given one. */
+            public Builder stateMetricName(String stateMetricName) {
+                metricNames.stateMetricName = requireNonNull(stateMetricName);
+                return this;
+            }
+
+            /** Overrides the default metric name {@value MetricNames#DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS} with a given one. */
+            public Builder bufferedCallsMetricName(String bufferedCallsMetricName) {
+                metricNames.bufferedCallsMetricName = requireNonNull(bufferedCallsMetricName);
+                return this;
+            }
+
+            /** Overrides the default metric name {@value MetricNames#DEFAULT_CIRCUIT_BREAKER_MAX_BUFFERED_CALLS} with a given one. */
+            public Builder maxBufferedCallsMetricName(String maxBufferedCallsMetricName) {
+                metricNames.maxBufferedCallsMetricName = requireNonNull(maxBufferedCallsMetricName);
+                return this;
+            }
+
+            /** Builds {@link MetricNames} instance. */
+            public MetricNames build() {
+                return metricNames;
+            }
+        }
+    }
+}

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedRateLimiterMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedRateLimiterMetrics.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2019 Yevhenii Voievodin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.micrometer.tagged;
+
+import io.github.resilience4j.micrometer.RateLimiterMetrics;
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import io.github.resilience4j.ratelimiter.RateLimiter.Metrics;
+import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A micrometer binder that is used to register retry exposed {@link Metrics metrics}.
+ * The main difference from {@link RateLimiterMetrics} is that this binder uses tags
+ * to distinguish between metrics.
+ */
+public class TaggedRateLimiterMetrics implements MeterBinder {
+
+    /**
+     * Creates a new binder that uses given {@code registry} as source of retries.
+     *
+     * @param registry the source of retries
+     */
+    public static TaggedRateLimiterMetrics ofRateLimiterRegistry(RateLimiterRegistry registry) {
+        return new TaggedRateLimiterMetrics(MetricNames.ofDefaults(), registry.getAllRateLimiters());
+    }
+
+    /**
+     * Creates a new binder that uses given {@code registry} as source of retries.
+     *
+     * @param names custom metric names
+     * @param registry the source of rate limiters
+     */
+    public static TaggedRateLimiterMetrics ofRateLimiterRegistry(MetricNames names, RateLimiterRegistry registry) {
+        return new TaggedRateLimiterMetrics(names, registry.getAllRateLimiters());
+    }
+
+    private final MetricNames names;
+    private final Iterable<? extends RateLimiter> rateLimiters;
+
+    private TaggedRateLimiterMetrics(MetricNames names, Iterable<? extends RateLimiter> rateLimiters) {
+        this.names = Objects.requireNonNull(names);
+        this.rateLimiters = Objects.requireNonNull(rateLimiters);
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        for (RateLimiter rateLimiter : rateLimiters) {
+            Gauge.builder(names.getAvailablePermissionsMetricName(), rateLimiter, (rl) -> rl.getMetrics().getAvailablePermissions())
+                    .tag(TagNames.NAME, rateLimiter.getName())
+                    .register(registry);
+            Gauge.builder(names.getWaitingThreadsMetricName(), rateLimiter, (rl) -> rl.getMetrics().getNumberOfWaitingThreads())
+                    .tag(TagNames.NAME, rateLimiter.getName())
+                    .register(registry);
+        }
+    }
+
+    /** Defines possible configuration for metric names. */
+    public static class MetricNames {
+
+        public static final String DEFAULT_AVAILABLE_PERMISSIONS_METRIC_NAME = "resilience4j_ratelimiter_available_permissions";
+        public static final String DEFAULT_WAITING_THREADS_METRIC_NAME = "resilience4j_ratelimiter_waiting_threads";
+
+        /**
+         * Returns a builder for creating custom metric names.
+         * Note that names have default values, so only desired metrics can be renamed.
+         */
+        public static Builder custom() {
+            return new Builder();
+        }
+
+        /** Returns default metric names. */
+        public static MetricNames ofDefaults() {
+            return new MetricNames();
+        }
+
+        private String availablePermissionsMetricName = DEFAULT_AVAILABLE_PERMISSIONS_METRIC_NAME;
+        private String waitingThreadsMetricName = DEFAULT_WAITING_THREADS_METRIC_NAME;
+
+        /** Returns the metric name for available permissions, defaults to {@value DEFAULT_AVAILABLE_PERMISSIONS_METRIC_NAME}. */
+        public String getAvailablePermissionsMetricName() {
+            return availablePermissionsMetricName;
+        }
+
+        /** Returns the metric name for waiting threads, defaults to {@value DEFAULT_WAITING_THREADS_METRIC_NAME}. */
+        public String getWaitingThreadsMetricName() {
+            return waitingThreadsMetricName;
+        }
+
+        /** Helps building custom instance of {@link MetricNames}. */
+        public static class Builder {
+
+            private final MetricNames metricNames = new MetricNames();
+
+            /** Overrides the default metric name {@value MetricNames#DEFAULT_AVAILABLE_PERMISSIONS_METRIC_NAME} with a given one. */
+            public Builder availablePermissionsMetricName(String availablePermissionsMetricName) {
+                metricNames.availablePermissionsMetricName = requireNonNull(availablePermissionsMetricName);
+                return this;
+            }
+
+            /** Overrides the default metric name {@value MetricNames#DEFAULT_WAITING_THREADS_METRIC_NAME} with a given one. */
+            public Builder waitingThreadsMetricName(String waitingThreadsMetricName) {
+                metricNames.waitingThreadsMetricName = requireNonNull(waitingThreadsMetricName);
+                return this;
+            }
+
+            /** Builds {@link MetricNames} instance. */
+            public MetricNames build() {
+                return metricNames;
+            }
+        }
+    }
+}

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedRetryMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedRetryMetrics.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2019 Yevhenii Voievodin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.micrometer.tagged;
+
+import io.github.resilience4j.micrometer.RetryMetrics;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryRegistry;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+import static io.github.resilience4j.retry.Retry.Metrics;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A micrometer binder that is used to register retry exposed {@link Metrics metrics}.
+ * The main difference from {@link RetryMetrics} is that this binder uses tags
+ * to distinguish between metrics.
+ */
+public class TaggedRetryMetrics implements MeterBinder {
+
+    /**
+     * Creates a new binder that uses given {@code registry} as source of retries.
+     *
+     * @param registry the source of retries
+     */
+    public static TaggedRetryMetrics ofRetryRegistry(RetryRegistry registry) {
+        return new TaggedRetryMetrics(MetricNames.ofDefaults(), registry.getAllRetries());
+    }
+
+    /**
+     * Creates a new binder that uses given {@code registry} as source of retries.
+     *
+     * @param names custom metric names
+     * @param registry the source of retries
+     */
+    public static TaggedRetryMetrics ofRetryRegistry(MetricNames names, RetryRegistry registry) {
+        return new TaggedRetryMetrics(names, registry.getAllRetries());
+    }
+
+    private final MetricNames names;
+    private final Iterable<? extends Retry> retries;
+
+    private TaggedRetryMetrics(MetricNames names, Iterable<? extends Retry> retries) {
+        this.names = requireNonNull(names);
+        this.retries = requireNonNull(retries);
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        for (Retry retry : retries) {
+            Gauge.builder(names.getCallsMetricName(), retry, (rt) -> rt.getMetrics().getNumberOfSuccessfulCallsWithoutRetryAttempt())
+                    .tag(TagNames.NAME, retry.getName())
+                    .tag(TagNames.KIND, "successful_without_retry")
+                    .register(registry);
+            Gauge.builder(names.getCallsMetricName(), retry, (rt) -> rt.getMetrics().getNumberOfSuccessfulCallsWithRetryAttempt())
+                    .tag(TagNames.NAME, retry.getName())
+                    .tag(TagNames.KIND, "successful_with_retry")
+                    .register(registry);
+            Gauge.builder(names.getCallsMetricName(), retry, (rt) -> rt.getMetrics().getNumberOfFailedCallsWithoutRetryAttempt())
+                    .tag(TagNames.NAME, retry.getName())
+                    .tag(TagNames.KIND, "failed_without_retry")
+                    .register(registry);
+            Gauge.builder(names.getCallsMetricName(), retry, (rt) -> rt.getMetrics().getNumberOfFailedCallsWithRetryAttempt())
+                    .tag(TagNames.NAME, retry.getName())
+                    .tag(TagNames.KIND, "failed_with_retry")
+                    .register(registry);
+        }
+    }
+
+    /** Defines possible configuration for metric names. */
+    public static class MetricNames {
+
+        public static final String DEFAULT_RETRY_CALLS = "resilience4j_retry_calls";
+
+        /**
+         * Returns a builder for creating custom metric names.
+         * Note that names have default values, so only desired metrics can be renamed.
+         */
+        public static Builder custom() {
+            return new Builder();
+        }
+
+        /** Returns default metric names. */
+        public static MetricNames ofDefaults() {
+            return new MetricNames();
+        }
+
+        private String callsMetricName = DEFAULT_RETRY_CALLS;
+
+        private MetricNames() {}
+
+        /** Returns the metric name for retry calls, defaults to {@value DEFAULT_RETRY_CALLS}. */
+        public String getCallsMetricName() {
+            return callsMetricName;
+        }
+
+        /** Helps building custom instance of {@link MetricNames}. */
+        public static class Builder {
+            private final MetricNames metricNames = new MetricNames();
+
+            /** Overrides the default metric name {@value MetricNames#DEFAULT_RETRY_CALLS} with a given one. */
+            public Builder callsMetricName(String callsMetricName) {
+                metricNames.callsMetricName = requireNonNull(callsMetricName);
+                return this;
+            }
+
+            /** Builds {@link MetricNames} instance. */
+            public MetricNames build() {
+                return metricNames;
+            }
+        }
+    }
+}

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/MetricsTestHelper.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/MetricsTestHelper.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 Yevhenii Voievodin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.micrometer.tagged;
+
+import io.micrometer.core.instrument.Gauge;
+
+import java.util.Collection;
+import java.util.Optional;
+
+final class MetricsTestHelper {
+    static Optional<Gauge> findGaugeByKindAndNameTags(Collection<Gauge> gauges, String kind, String name) {
+        return gauges.stream()
+                .filter(g -> kind.equals(g.getId().getTag(TagNames.KIND)))
+                .filter(g -> name.equals(g.getId().getTag(TagNames.NAME)))
+                .findAny();
+    }
+}

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedAsyncRetryMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedAsyncRetryMetricsTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2019 Yevhenii Voievodin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.micrometer.tagged;
+
+import io.github.resilience4j.retry.AsyncRetry;
+import io.github.resilience4j.retry.AsyncRetryRegistry;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findGaugeByKindAndNameTags;
+import static io.github.resilience4j.micrometer.tagged.TaggedAsyncRetryMetrics.MetricNames.DEFAULT_ASYNC_RETRY_CALLS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TaggedAsyncRetryMetricsTest {
+    private MeterRegistry meterRegistry;
+    private AsyncRetry asyncRetry;
+
+    @Before
+    public void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        AsyncRetryRegistry asyncRetryRegistry = AsyncRetryRegistry.ofDefaults();
+
+        asyncRetry = asyncRetryRegistry.retry("backendA");
+        // record some basic stats
+        asyncRetry.context().onSuccess();
+        asyncRetry.context().onError(new RuntimeException("oops"));
+
+        TaggedAsyncRetryMetrics.ofAsyncRetryRegistry(asyncRetryRegistry).bindTo(meterRegistry);
+    }
+
+    @Test
+    public void successfulWithoutRetryCallsGaugeReportsCorrespondingValue() {
+        Collection<Gauge> gauges = meterRegistry.get(DEFAULT_ASYNC_RETRY_CALLS).gauges();
+
+        Optional<Gauge> successfulWithoutRetry = findGaugeByKindAndNameTags(gauges, "successful_without_retry", asyncRetry.getName());
+        assertThat(successfulWithoutRetry).isPresent();
+        assertThat(successfulWithoutRetry.get().value()).isEqualTo(asyncRetry.getMetrics().getNumberOfSuccessfulCallsWithoutRetryAttempt());
+    }
+
+    @Test
+    public void successfulWithRetryCallsGaugeReportsCorrespondingValue() {
+        Collection<Gauge> gauges = meterRegistry.get(DEFAULT_ASYNC_RETRY_CALLS).gauges();
+
+        Optional<Gauge> successfulWithRetry = findGaugeByKindAndNameTags(gauges, "successful_with_retry", asyncRetry.getName());
+        assertThat(successfulWithRetry).isPresent();
+        assertThat(successfulWithRetry.get().value()).isEqualTo(asyncRetry.getMetrics().getNumberOfSuccessfulCallsWithRetryAttempt());
+    }
+
+    @Test
+    public void failedWithoutRetryCallsGaugeReportsCorrespondingValue() {
+        Collection<Gauge> gauges = meterRegistry.get(DEFAULT_ASYNC_RETRY_CALLS).gauges();
+
+        Optional<Gauge> failedWithoutRetry = findGaugeByKindAndNameTags(gauges, "failed_without_retry", asyncRetry.getName());
+        assertThat(failedWithoutRetry).isPresent();
+        assertThat(failedWithoutRetry.get().value()).isEqualTo(asyncRetry.getMetrics().getNumberOfFailedCallsWithoutRetryAttempt());
+    }
+
+    @Test
+    public void failedWithRetryCallsGaugeReportsCorrespondingValue() {
+        Collection<Gauge> gauges = meterRegistry.get(DEFAULT_ASYNC_RETRY_CALLS).gauges();
+
+        Optional<Gauge> failedWithRetry = findGaugeByKindAndNameTags(gauges, "failed_with_retry", asyncRetry.getName());
+        assertThat(failedWithRetry).isPresent();
+        assertThat(failedWithRetry.get().value()).isEqualTo(asyncRetry.getMetrics().getNumberOfFailedCallsWithRetryAttempt());
+    }
+
+    @Test
+    public void metricsAreRegisteredWithCustomNames() {
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        AsyncRetryRegistry retryRegistry = AsyncRetryRegistry.ofDefaults();
+        retryRegistry.retry("backendA");
+        TaggedAsyncRetryMetrics.ofAsyncRetryRegistry(
+                TaggedAsyncRetryMetrics.MetricNames.custom()
+                        .callsMetricName("custom_calls")
+                        .build(),
+                retryRegistry
+        ).bindTo(meterRegistry);
+
+        Set<String> metricNames = meterRegistry.getMeters()
+                .stream()
+                .map(Meter::getId)
+                .map(Meter.Id::getName)
+                .collect(Collectors.toSet());
+
+        assertThat(metricNames).hasSameElementsAs(Collections.singletonList("custom_calls"));
+    }
+}

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedBulkheadMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedBulkheadMetricsTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 Yevhenii Voievodin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.micrometer.tagged;
+
+import io.github.resilience4j.bulkhead.Bulkhead;
+import io.github.resilience4j.bulkhead.BulkheadRegistry;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static io.github.resilience4j.micrometer.tagged.TaggedBulkheadMetrics.MetricNames.DEFAULT_BULKHEAD_AVAILABLE_CONCURRENT_CALLS_METRIC_NAME;
+import static io.github.resilience4j.micrometer.tagged.TaggedBulkheadMetrics.MetricNames.DEFAULT_BULKHEAD_MAX_ALLOWED_CONCURRENT_CALLS_METRIC_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TaggedBulkheadMetricsTest {
+
+    private MeterRegistry meterRegistry;
+    private Bulkhead bulkhead;
+
+    @Before
+    public void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        BulkheadRegistry bulkheadRegistry = BulkheadRegistry.ofDefaults();
+        bulkhead = bulkheadRegistry.bulkhead("backendA");
+
+        // record some basic stats
+        bulkhead.isCallPermitted();
+        bulkhead.isCallPermitted();
+
+        TaggedBulkheadMetrics.ofBulkheadRegistry(bulkheadRegistry).bindTo(meterRegistry);
+    }
+
+    @Test
+    public void availableConcurrentCallsGaugeIsRegistered() {
+        Gauge available = meterRegistry.get(DEFAULT_BULKHEAD_AVAILABLE_CONCURRENT_CALLS_METRIC_NAME).gauge();
+
+        assertThat(available).isNotNull();
+        assertThat(available.value()).isEqualTo(bulkhead.getMetrics().getAvailableConcurrentCalls());
+    }
+
+    @Test
+    public void maxAllowedConcurrentCallsGaugeIsRegistered() {
+        Gauge maxAllowed = meterRegistry.get(DEFAULT_BULKHEAD_MAX_ALLOWED_CONCURRENT_CALLS_METRIC_NAME).gauge();
+
+        assertThat(maxAllowed).isNotNull();
+        assertThat(maxAllowed.value()).isEqualTo(bulkhead.getMetrics().getMaxAllowedConcurrentCalls());
+        assertThat(maxAllowed.getId().getTag(TagNames.NAME)).isEqualTo(bulkhead.getName());
+    }
+
+    @Test
+    public void customMetricNamesGetApplied() {
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        BulkheadRegistry bulkheadRegistry = BulkheadRegistry.ofDefaults();
+        bulkhead = bulkheadRegistry.bulkhead("backendA");
+        TaggedBulkheadMetrics.ofBulkheadRegistry(
+                TaggedBulkheadMetrics.MetricNames.custom()
+                        .availableConcurrentCallsMetricName("custom_available_calls")
+                        .maxAllowedConcurrentCallsMetricName("custom_max_allowed_calls")
+                        .build(),
+                bulkheadRegistry
+        ).bindTo(meterRegistry);
+
+        Set<String> metricNames = meterRegistry.getMeters()
+                .stream()
+                .map(Meter::getId)
+                .map(Meter.Id::getName)
+                .collect(Collectors.toSet());
+
+        assertThat(metricNames).hasSameElementsAs(Arrays.asList(
+                "custom_available_calls",
+                "custom_max_allowed_calls"
+        ));
+    }
+}

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetricsTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2019 Yevhenii Voievodin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.micrometer.tagged;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findGaugeByKindAndNameTags;
+import static io.github.resilience4j.micrometer.tagged.TaggedCircuitBreakerMetrics.MetricNames.DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS;
+import static io.github.resilience4j.micrometer.tagged.TaggedCircuitBreakerMetrics.MetricNames.DEFAULT_CIRCUIT_BREAKER_CALLS_METRIC_NAME;
+import static io.github.resilience4j.micrometer.tagged.TaggedCircuitBreakerMetrics.MetricNames.DEFAULT_CIRCUIT_BREAKER_MAX_BUFFERED_CALLS;
+import static io.github.resilience4j.micrometer.tagged.TaggedCircuitBreakerMetrics.MetricNames.DEFAULT_CIRCUIT_BREAKER_STATE_METRIC_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TaggedCircuitBreakerMetricsTest {
+
+    private MeterRegistry meterRegistry;
+    private CircuitBreaker circuitBreaker;
+
+    @Before
+    public void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
+
+        circuitBreaker = circuitBreakerRegistry.circuitBreaker("backendA");
+        // record some basic stats
+        circuitBreaker.onError(0, new RuntimeException("oops"));
+        circuitBreaker.onSuccess(0);
+
+        TaggedCircuitBreakerMetrics.ofCircuitBreakerRegistry(circuitBreakerRegistry).bindTo(meterRegistry);
+    }
+
+    @Test
+    public void notPermittedCallsGaugeReportsCorrespondingValue() {
+        Collection<Gauge> gauges = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_CALLS_METRIC_NAME).gauges();
+
+        Optional<Gauge> notPermitted = findGaugeByKindAndNameTags(gauges, "not_permitted", circuitBreaker.getName());
+        assertThat(notPermitted).isPresent();
+        assertThat(notPermitted.get().value()).isEqualTo(circuitBreaker.getMetrics().getNumberOfNotPermittedCalls());
+    }
+
+    @Test
+    public void failedCallsGaugeReportsCorrespondingValue() {
+        Collection<Gauge> gauges = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_CALLS_METRIC_NAME).gauges();
+
+        Optional<Gauge> failed = findGaugeByKindAndNameTags(gauges, "failed", circuitBreaker.getName());
+        assertThat(failed).isPresent();
+        assertThat(failed.get().value()).isEqualTo((circuitBreaker.getMetrics().getNumberOfFailedCalls()));
+    }
+
+    @Test
+    public void successfulCallsGaugeReportsCorrespondingValue() {
+        Collection<Gauge> gauges = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_CALLS_METRIC_NAME).gauges();
+
+        Optional<Gauge> successful = findGaugeByKindAndNameTags(gauges, "successful", circuitBreaker.getName());
+        assertThat(successful).isPresent();
+        assertThat(successful.get().value()).isEqualTo((circuitBreaker.getMetrics().getNumberOfSuccessfulCalls()));
+    }
+
+    @Test
+    public void bufferedCallsGaugeReportsCorrespondingValue() {
+        Gauge bufferedCalls = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS).gauge();
+
+        assertThat(bufferedCalls).isNotNull();
+        assertThat(bufferedCalls.value()).isEqualTo((circuitBreaker.getMetrics().getNumberOfBufferedCalls()));
+    }
+
+    @Test
+    public void maxBufferedCallsGaugeReportsCorrespondingValue() {
+        Gauge maxBuffered = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_MAX_BUFFERED_CALLS).gauge();
+
+        assertThat(maxBuffered).isNotNull();
+        assertThat(maxBuffered.value()).isEqualTo((circuitBreaker.getMetrics().getMaxNumberOfBufferedCalls()));
+        assertThat(maxBuffered.getId().getTag(TagNames.NAME)).isEqualTo(circuitBreaker.getName());
+    }
+
+    @Test
+    public void stateGaugeReportsCorrespondingValue() {
+        Gauge state = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_STATE_METRIC_NAME).gauge();
+
+        assertThat(state.value()).isEqualTo(circuitBreaker.getState().getOrder());
+        assertThat(state.getId().getTag(TagNames.NAME)).isEqualTo(circuitBreaker.getName());
+    }
+
+    @Test
+    public void metricsAreRegisteredWithCustomName() {
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
+        circuitBreakerRegistry.circuitBreaker("backendA");
+        TaggedCircuitBreakerMetrics.ofCircuitBreakerRegistry(
+                TaggedCircuitBreakerMetrics.MetricNames.custom()
+                        .callsMetricName("custom_calls")
+                        .stateMetricName("custom_state")
+                        .bufferedCallsMetricName("custom_buffered_calls")
+                        .maxBufferedCallsMetricName("custom_max_buffered_calls")
+                        .build(),
+                circuitBreakerRegistry
+        ).bindTo(meterRegistry);
+
+        Set<String> metricNames = meterRegistry.getMeters()
+                .stream()
+                .map(Meter::getId)
+                .map(Meter.Id::getName)
+                .collect(Collectors.toSet());
+
+        assertThat(metricNames).hasSameElementsAs(Arrays.asList(
+                "custom_calls",
+                "custom_state",
+                "custom_buffered_calls",
+                "custom_max_buffered_calls"
+        ));
+    }
+
+}

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRateLimiterMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRateLimiterMetricsTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019 Yevhenii Voievodin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.micrometer.tagged;
+
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static io.github.resilience4j.micrometer.tagged.TaggedRateLimiterMetrics.MetricNames.DEFAULT_AVAILABLE_PERMISSIONS_METRIC_NAME;
+import static io.github.resilience4j.micrometer.tagged.TaggedRateLimiterMetrics.MetricNames.DEFAULT_WAITING_THREADS_METRIC_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TaggedRateLimiterMetricsTest {
+
+    private MeterRegistry meterRegistry;
+    private RateLimiter rateLimiter;
+
+    @Before
+    public void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        RateLimiterRegistry rateLimiterRegistry = RateLimiterRegistry.ofDefaults();
+
+        rateLimiter = rateLimiterRegistry.rateLimiter("backendA");
+        TaggedRateLimiterMetrics.ofRateLimiterRegistry(rateLimiterRegistry).bindTo(meterRegistry);
+    }
+
+    @Test
+    public void availablePermissionsGaugeIsRegistered() {
+        Gauge availablePermissions = meterRegistry.get(DEFAULT_AVAILABLE_PERMISSIONS_METRIC_NAME).gauge();
+
+        assertThat(availablePermissions).isNotNull();
+        assertThat(availablePermissions.value()).isEqualTo(rateLimiter.getMetrics().getAvailablePermissions());
+        assertThat(availablePermissions.getId().getTag(TagNames.NAME)).isEqualTo(rateLimiter.getName());
+    }
+
+    @Test
+    public void waitingThreadsGaugeIsRegistered() {
+        Gauge waitingThreads = meterRegistry.get(DEFAULT_WAITING_THREADS_METRIC_NAME).gauge();
+
+        assertThat(waitingThreads).isNotNull();
+        assertThat(waitingThreads.value()).isEqualTo(rateLimiter.getMetrics().getNumberOfWaitingThreads());
+        assertThat(waitingThreads.getId().getTag(TagNames.NAME)).isEqualTo(rateLimiter.getName());
+    }
+
+    @Test
+    public void customMetricNamesGetApplied() {
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        RateLimiterRegistry rateLimiterRegistry = RateLimiterRegistry.ofDefaults();
+        rateLimiterRegistry.rateLimiter("backendA");
+        TaggedRateLimiterMetrics.ofRateLimiterRegistry(
+                TaggedRateLimiterMetrics.MetricNames.custom()
+                        .availablePermissionsMetricName("custom_available_permissions")
+                        .waitingThreadsMetricName("custom_waiting_threads")
+                        .build(),
+                rateLimiterRegistry
+        ).bindTo(meterRegistry);
+
+        Set<String> metricNames = meterRegistry.getMeters()
+                .stream()
+                .map(Meter::getId)
+                .map(Meter.Id::getName)
+                .collect(Collectors.toSet());
+
+        assertThat(metricNames).hasSameElementsAs(Arrays.asList(
+                "custom_available_permissions",
+                "custom_waiting_threads"
+        ));
+    }
+}

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRetryMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRetryMetricsTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2019 Yevhenii Voievodin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.micrometer.tagged;
+
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryRegistry;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findGaugeByKindAndNameTags;
+import static io.github.resilience4j.micrometer.tagged.TaggedRetryMetrics.MetricNames.DEFAULT_RETRY_CALLS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TaggedRetryMetricsTest {
+
+    private MeterRegistry meterRegistry;
+    private Retry retry;
+
+    @Before
+    public void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        RetryRegistry retryRegistry = RetryRegistry.ofDefaults();
+
+        retry = retryRegistry.retry("backendA");
+        // record some basic stats
+        retry.executeRunnable(() -> {});
+
+        TaggedRetryMetrics.ofRetryRegistry(retryRegistry).bindTo(meterRegistry);
+    }
+
+    @Test
+    public void successfulWithoutRetryCallsGaugeReportsCorrespondingValue() {
+        Collection<Gauge> gauges = meterRegistry.get(DEFAULT_RETRY_CALLS).gauges();
+
+        Optional<Gauge> successfulWithoutRetry = findGaugeByKindAndNameTags(gauges, "successful_without_retry", retry.getName());
+        assertThat(successfulWithoutRetry).isPresent();
+        assertThat(successfulWithoutRetry.get().value()).isEqualTo(retry.getMetrics().getNumberOfSuccessfulCallsWithoutRetryAttempt());
+    }
+
+    @Test
+    public void successfulWithRetryCallsGaugeReportsCorrespondingValue() {
+        Collection<Gauge> gauges = meterRegistry.get(DEFAULT_RETRY_CALLS).gauges();
+
+        Optional<Gauge> successfulWithRetry = findGaugeByKindAndNameTags(gauges, "successful_with_retry", retry.getName());
+        assertThat(successfulWithRetry).isPresent();
+        assertThat(successfulWithRetry.get().value()).isEqualTo(retry.getMetrics().getNumberOfSuccessfulCallsWithRetryAttempt());
+    }
+
+    @Test
+    public void failedWithoutRetryCallsGaugeReportsCorrespondingValue() {
+        Collection<Gauge> gauges = meterRegistry.get(DEFAULT_RETRY_CALLS).gauges();
+
+        Optional<Gauge> failedWithoutRetry = findGaugeByKindAndNameTags(gauges, "failed_without_retry", retry.getName());
+        assertThat(failedWithoutRetry).isPresent();
+        assertThat(failedWithoutRetry.get().value()).isEqualTo(retry.getMetrics().getNumberOfFailedCallsWithoutRetryAttempt());
+    }
+
+    @Test
+    public void failedWithRetryCallsGaugeReportsCorrespondingValue() {
+        Collection<Gauge> gauges = meterRegistry.get(DEFAULT_RETRY_CALLS).gauges();
+
+        Optional<Gauge> failedWithRetry = findGaugeByKindAndNameTags(gauges, "failed_with_retry", retry.getName());
+        assertThat(failedWithRetry).isPresent();
+        assertThat(failedWithRetry.get().value()).isEqualTo(retry.getMetrics().getNumberOfFailedCallsWithRetryAttempt());
+    }
+
+    @Test
+    public void metricsAreRegisteredWithCustomNames() {
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        RetryRegistry retryRegistry = RetryRegistry.ofDefaults();
+        retryRegistry.retry("backendA");
+        TaggedRetryMetrics.ofRetryRegistry(
+                TaggedRetryMetrics.MetricNames.custom()
+                        .callsMetricName("custom_calls")
+                        .build(),
+                retryRegistry
+        ).bindTo(meterRegistry);
+
+        Set<String> metricNames = meterRegistry.getMeters()
+                .stream()
+                .map(Meter::getId)
+                .map(Meter.Id::getName)
+                .collect(Collectors.toSet());
+
+        assertThat(metricNames).hasSameElementsAs(Collections.singletonList("custom_calls"));
+    }
+}


### PR DESCRIPTION
Motivation
--- 
The current implementation of micrometer binders exposes all the needed metrics to build monitoring around it, however it doesn't suit well for some of the provider implementations, such as Prometheus. The main inconvenience here is that values are inlined into the metric names, while tags would be more suitable. The tags basically mapped to the Prometheus [labels](https://prometheus.io/docs/practices/naming/#labels) and allow to build generic graphs and take advantage of monitoring tools features, like  Grafana variables.

Simply changing the existing binders to export tags doesn't work well because of a few reasons:
1. Most likely we want to keep things backward compatible, thus those who have graphs built around existing approach shouldn't suffer after they update the library.
2. I guess the current approach is perfectly fine for dropwizard (and maybe other) users, since it doesn't have tags concept at all [yet](https://github.com/dropwizard/metrics/issues/1175).
3. We could simply expose twice as many metrics from the existing binders, but the clients most likely need only one subset of those (with tags or without) thus it would be odd and polluting the monitoring system.

Naming
---
### Bulkhead
```
resilience4j_bulkhead_available_concurrent_calls{name="Backend1"}
resilience4j_bulkhead_max_allowed_concurrent_calls{name="Backend1"}
```

### Circuit Breaker
```
resilience4j_circuitbreaker_state{name="Backend1"}

resilience4j_circuitbreaker_calls{name="Backend1", kind="successful"}
resilience4j_circuitbreaker_calls{name="Backend1", kind="failed"}
resilience4j_circuitbreaker_calls{name="Backend1", kind="not_permitted"}

resilience4j_circuitbreaker_buffered_calls{name="Backend1"}
resilience4j_circuitbreaker_max_buffered_calls{name="Backend1"}
```

### Retry
```
resilience4j_retry_calls{name="Backend1", kind="successful_with_retry"}
resilience4j_retry_calls{name="Backend1", kind="successful_without_retry"}
resilience4j_retry_calls{name="Backend1", kind="failed_with_retry"}
resilience4j_retry_calls{name="Backend1", kind="failed_without_retry"}
```

### Async Retry
```
resilience4j_async_retry_calls{name="Backend1", kind="successful_with_retry"}
resilience4j_async_retry_calls{name="Backend1", kind="successful_without_retry"}
resilience4j_async_retry_calls{name="Backend1", kind="failed_with_retry"}
resilience4j_async_retry_calls{name="Backend1", kind="failed_without_retry"}
```

### Rate Limiter
```
resilience4j_ratelimiter_available_permissions{name="Backend1"}
resilience4j_ratelimiter_waiting_threads{name="Backend1"}
```

Usage example
---
Taking advantage of grafana variables:
```
// backend is defined as 
label_values(resilience4j_bulkhead_available_concurrent_calls, name)

// the actual query
resilience4j_bulkhead_available_concurrent_calls{name=~"[[backend]]"}
```
![image](https://user-images.githubusercontent.com/4053805/54031657-08446a00-41b8-11e9-882d-533720c1a0f9.png)
