### PR TITLE
Error in RateLimiter usage example

### DIFF
--- a/resilience4j-documentation/src/docs/asciidoc/core_guides/ratelimiter.adoc
+++ b/resilience4j-documentation/src/docs/asciidoc/core_guides/ratelimiter.adoc
@@ -13,7 +13,7 @@ So it also have in-memory RateLimiterRegistry and RateLimiterConfig where you ca
 [source,java]
 ----
 // For example you want to restrict the calling rate of some method to be not higher than 10 req/ms.
-RateLimiterConfig config = RateLimiterConfig.builder()
+RateLimiterConfig config = RateLimiterConfig.custom()
     .limitRefreshPeriod(Duration.ofMillis(1))
     .limitForPeriod(10)
     .timeoutDuration(Duration.ofMillis(25))


### PR DESCRIPTION
The code example from the documentation at  http://resilience4j.github.io/resilience4j/#_examples_2 doesn't compile.