### PR TITLE
Added circuit breaker status to health

### DIFF
--- a/resilience4j-spring-boot/src/main/java/io/github/resilience4j/circuitbreaker/monitoring/health/CircuitBreakerHealthIndicator.java
+++ b/resilience4j-spring-boot/src/main/java/io/github/resilience4j/circuitbreaker/monitoring/health/CircuitBreakerHealthIndicator.java
@@ -35,6 +35,7 @@ public class CircuitBreakerHealthIndicator implements HealthIndicator {
     private static final String FAILED_CALLS = "failedCalls";
     private static final String NOT_PERMITTED = "notPermittedCalls";
     private static final String MAX_BUFFERED_CALLS = "maxBufferedCalls";
+    private static final String STATE = "state";
     private CircuitBreaker circuitBreaker;
 
     public CircuitBreakerHealthIndicator(CircuitBreaker circuitBreaker) {
@@ -49,19 +50,20 @@ public class CircuitBreakerHealthIndicator implements HealthIndicator {
     }
 
     private Health mapBackendMonitorState(CircuitBreaker circuitBreaker) {
-        switch (circuitBreaker.getState()) {
+        CircuitBreaker.State state = circuitBreaker.getState();
+        switch (state) {
             case CLOSED:
-                return addDetails(Health.up(), circuitBreaker).build();
+                return addDetails(Health.up(), circuitBreaker, state).build();
             case OPEN:
-                return addDetails(Health.down(), circuitBreaker).build();
+                return addDetails(Health.down(), circuitBreaker, state).build();
             case HALF_OPEN:
-                return addDetails(Health.unknown(),circuitBreaker).build();
+                return addDetails(Health.unknown(),circuitBreaker, state).build();
             default:
-                return addDetails(Health.unknown(), circuitBreaker).build();
+                return addDetails(Health.unknown(), circuitBreaker, state).build();
         }
     }
 
-    private Health.Builder addDetails(Health.Builder builder, CircuitBreaker circuitBreaker) {
+    private Health.Builder addDetails(Health.Builder builder, CircuitBreaker circuitBreaker, CircuitBreaker.State state) {
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
         CircuitBreakerConfig config = circuitBreaker.getCircuitBreakerConfig();
         builder.withDetail(FAILURE_RATE, metrics.getFailureRate() + "%")
@@ -69,7 +71,8 @@ public class CircuitBreakerHealthIndicator implements HealthIndicator {
             .withDetail(MAX_BUFFERED_CALLS, metrics.getMaxNumberOfBufferedCalls())
             .withDetail(BUFFERED_CALLS, metrics.getNumberOfBufferedCalls())
             .withDetail(FAILED_CALLS, metrics.getNumberOfFailedCalls())
-            .withDetail(NOT_PERMITTED, metrics.getNumberOfNotPermittedCalls());
+            .withDetail(NOT_PERMITTED, metrics.getNumberOfNotPermittedCalls())
+            .withDetail(STATE, state);
         return builder;
     }
 }

--- a/resilience4j-spring-boot/src/main/java/io/github/resilience4j/circuitbreaker/monitoring/health/CircuitBreakerHealthIndicator.java
+++ b/resilience4j-spring-boot/src/main/java/io/github/resilience4j/circuitbreaker/monitoring/health/CircuitBreakerHealthIndicator.java
@@ -50,20 +50,19 @@ public class CircuitBreakerHealthIndicator implements HealthIndicator {
     }
 
     private Health mapBackendMonitorState(CircuitBreaker circuitBreaker) {
-        CircuitBreaker.State state = circuitBreaker.getState();
-        switch (state) {
+        switch (circuitBreaker.getState()) {
             case CLOSED:
-                return addDetails(Health.up(), circuitBreaker, state).build();
+                return addDetails(Health.up(), circuitBreaker).build();
             case OPEN:
-                return addDetails(Health.down(), circuitBreaker, state).build();
+                return addDetails(Health.down(), circuitBreaker).build();
             case HALF_OPEN:
-                return addDetails(Health.unknown(),circuitBreaker, state).build();
+                return addDetails(Health.unknown(),circuitBreaker).build();
             default:
-                return addDetails(Health.unknown(), circuitBreaker, state).build();
+                return addDetails(Health.unknown(), circuitBreaker).build();
         }
     }
 
-    private Health.Builder addDetails(Health.Builder builder, CircuitBreaker circuitBreaker, CircuitBreaker.State state) {
+    private Health.Builder addDetails(Health.Builder builder, CircuitBreaker circuitBreaker) {
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
         CircuitBreakerConfig config = circuitBreaker.getCircuitBreakerConfig();
         builder.withDetail(FAILURE_RATE, metrics.getFailureRate() + "%")
@@ -72,7 +71,7 @@ public class CircuitBreakerHealthIndicator implements HealthIndicator {
             .withDetail(BUFFERED_CALLS, metrics.getNumberOfBufferedCalls())
             .withDetail(FAILED_CALLS, metrics.getNumberOfFailedCalls())
             .withDetail(NOT_PERMITTED, metrics.getNumberOfNotPermittedCalls())
-            .withDetail(STATE, state);
+            .withDetail(STATE, circuitBreaker.getState());
         return builder;
     }
 }

--- a/resilience4j-spring-boot/src/test/java/io/github/resilience4j/circuitbreaker/monitoring/health/CircuitBreakerHealthIndicatorTest.java
+++ b/resilience4j-spring-boot/src/test/java/io/github/resilience4j/circuitbreaker/monitoring/health/CircuitBreakerHealthIndicatorTest.java
@@ -1,27 +1,27 @@
 package io.github.resilience4j.circuitbreaker.monitoring.health;
 
-import static io.github.resilience4j.circuitbreaker.CircuitBreaker.State.CLOSED;
-import static io.github.resilience4j.circuitbreaker.CircuitBreaker.State.HALF_OPEN;
-import static io.github.resilience4j.circuitbreaker.CircuitBreaker.State.OPEN;
-import static org.assertj.core.api.BDDAssertions.then;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.util.AbstractMap.SimpleEntry;
-
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import org.junit.Test;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.Status;
 
-import io.github.resilience4j.circuitbreaker.CircuitBreaker;
-import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.github.resilience4j.circuitbreaker.CircuitBreaker.State.*;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author bstorozhuk
  */
 public class CircuitBreakerHealthIndicatorTest {
+
     @Test
-    public void health() {
+    public void healthMetricsAndConfig() {
         // given
         CircuitBreakerConfig config = mock(CircuitBreakerConfig.class);
         CircuitBreaker.Metrics metrics = mock(CircuitBreaker.Metrics.class);
@@ -37,7 +37,6 @@ public class CircuitBreakerHealthIndicatorTest {
         when(metrics.getNumberOfFailedCalls()).thenReturn(20);
         when(metrics.getNumberOfNotPermittedCalls()).thenReturn(0L);
 
-
         when(circuitBreaker.getCircuitBreakerConfig()).thenReturn(config);
         when(circuitBreaker.getMetrics()).thenReturn(metrics);
         when(circuitBreaker.getState()).thenReturn(CLOSED, OPEN, HALF_OPEN, CLOSED);
@@ -52,29 +51,41 @@ public class CircuitBreakerHealthIndicatorTest {
                         entry("bufferedCalls", 100),
                         entry("failedCalls", 20),
                         entry("notPermittedCalls", 0L),
-                        entry("maxBufferedCalls", 100),
-                        entry("state", CLOSED)
+                        entry("maxBufferedCalls", 100)
                 );
+    }
 
-        health = healthIndicator.health();
-        then(health.getStatus()).isEqualTo(Status.DOWN);
+    @Test
+    public void testHealthStatus() {
+        Map<CircuitBreaker.State, Status> expectedStateToStatusMap = new HashMap<>();
+        expectedStateToStatusMap.put(OPEN, Status.DOWN);
+        expectedStateToStatusMap.put(HALF_OPEN, Status.UNKNOWN);
+        expectedStateToStatusMap.put(CLOSED, Status.UP);
+
+        // given
+        CircuitBreakerConfig config = mock(CircuitBreakerConfig.class);
+        CircuitBreaker.Metrics metrics = mock(CircuitBreaker.Metrics.class);
+        CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
+
+        when(circuitBreaker.getCircuitBreakerConfig()).thenReturn(config);
+        when(circuitBreaker.getMetrics()).thenReturn(metrics);
+
+        expectedStateToStatusMap.forEach((state, status) -> assertStatusForGivenState(circuitBreaker, state, status));
+    }
+
+    private void assertStatusForGivenState(CircuitBreaker circuitBreaker, CircuitBreaker.State givenState, Status expectedStatus) {
+        // given
+        when(circuitBreaker.getState()).thenReturn(givenState);
+        CircuitBreakerHealthIndicator healthIndicator = new CircuitBreakerHealthIndicator(circuitBreaker);
+
+        // when
+        Health health = healthIndicator.health();
+
+        // then
+        then(health.getStatus()).isEqualTo(expectedStatus);
         then(health.getDetails())
                 .contains(
-                        entry("state", OPEN)
-                );
-
-        health = healthIndicator.health();
-        then(health.getStatus()).isEqualTo(Status.UNKNOWN);
-        then(health.getDetails())
-                .contains(
-                        entry("state", HALF_OPEN)
-                );
-
-        health = healthIndicator.health();
-        then(health.getStatus()).isEqualTo(Status.UP);
-        then(health.getDetails())
-                .contains(
-                        entry("state", CLOSED)
+                        entry("state", givenState)
                 );
     }
 

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/circuitbreaker/monitoring/health/CircuitBreakerHealthIndicator.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/circuitbreaker/monitoring/health/CircuitBreakerHealthIndicator.java
@@ -35,6 +35,7 @@ public class CircuitBreakerHealthIndicator implements HealthIndicator {
     private static final String FAILED_CALLS = "failedCalls";
     private static final String NOT_PERMITTED = "notPermittedCalls";
     private static final String MAX_BUFFERED_CALLS = "maxBufferedCalls";
+    private static final String STATE = "state";
     private CircuitBreaker circuitBreaker;
 
     public CircuitBreakerHealthIndicator(CircuitBreaker circuitBreaker) {
@@ -49,19 +50,20 @@ public class CircuitBreakerHealthIndicator implements HealthIndicator {
     }
 
     private Health mapBackendMonitorState(CircuitBreaker circuitBreaker) {
-        switch (circuitBreaker.getState()) {
+        CircuitBreaker.State state = circuitBreaker.getState();
+        switch (state) {
             case CLOSED:
-                return addDetails(Health.up(), circuitBreaker).build();
+                return addDetails(Health.up(), circuitBreaker, state).build();
             case OPEN:
-                return addDetails(Health.down(), circuitBreaker).build();
+                return addDetails(Health.down(), circuitBreaker, state).build();
             case HALF_OPEN:
-                return addDetails(Health.unknown(),circuitBreaker).build();
+                return addDetails(Health.unknown(),circuitBreaker, state).build();
             default:
-                return addDetails(Health.unknown(), circuitBreaker).build();
+                return addDetails(Health.unknown(), circuitBreaker, state).build();
         }
     }
 
-    private Health.Builder addDetails(Health.Builder builder, CircuitBreaker circuitBreaker) {
+    private Health.Builder addDetails(Health.Builder builder, CircuitBreaker circuitBreaker, CircuitBreaker.State state) {
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
         CircuitBreakerConfig config = circuitBreaker.getCircuitBreakerConfig();
         builder.withDetail(FAILURE_RATE, metrics.getFailureRate() + "%")
@@ -69,7 +71,8 @@ public class CircuitBreakerHealthIndicator implements HealthIndicator {
             .withDetail(MAX_BUFFERED_CALLS, metrics.getMaxNumberOfBufferedCalls())
             .withDetail(BUFFERED_CALLS, metrics.getNumberOfBufferedCalls())
             .withDetail(FAILED_CALLS, metrics.getNumberOfFailedCalls())
-            .withDetail(NOT_PERMITTED, metrics.getNumberOfNotPermittedCalls());
+            .withDetail(NOT_PERMITTED, metrics.getNumberOfNotPermittedCalls())
+            .withDetail(STATE, state);
         return builder;
     }
 }

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/circuitbreaker/monitoring/health/CircuitBreakerHealthIndicator.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/circuitbreaker/monitoring/health/CircuitBreakerHealthIndicator.java
@@ -50,20 +50,19 @@ public class CircuitBreakerHealthIndicator implements HealthIndicator {
     }
 
     private Health mapBackendMonitorState(CircuitBreaker circuitBreaker) {
-        CircuitBreaker.State state = circuitBreaker.getState();
-        switch (state) {
+        switch (circuitBreaker.getState()) {
             case CLOSED:
-                return addDetails(Health.up(), circuitBreaker, state).build();
+                return addDetails(Health.up(), circuitBreaker).build();
             case OPEN:
-                return addDetails(Health.down(), circuitBreaker, state).build();
+                return addDetails(Health.down(), circuitBreaker).build();
             case HALF_OPEN:
-                return addDetails(Health.unknown(),circuitBreaker, state).build();
+                return addDetails(Health.unknown(),circuitBreaker).build();
             default:
-                return addDetails(Health.unknown(), circuitBreaker, state).build();
+                return addDetails(Health.unknown(), circuitBreaker).build();
         }
     }
 
-    private Health.Builder addDetails(Health.Builder builder, CircuitBreaker circuitBreaker, CircuitBreaker.State state) {
+    private Health.Builder addDetails(Health.Builder builder, CircuitBreaker circuitBreaker) {
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
         CircuitBreakerConfig config = circuitBreaker.getCircuitBreakerConfig();
         builder.withDetail(FAILURE_RATE, metrics.getFailureRate() + "%")
@@ -72,7 +71,7 @@ public class CircuitBreakerHealthIndicator implements HealthIndicator {
             .withDetail(BUFFERED_CALLS, metrics.getNumberOfBufferedCalls())
             .withDetail(FAILED_CALLS, metrics.getNumberOfFailedCalls())
             .withDetail(NOT_PERMITTED, metrics.getNumberOfNotPermittedCalls())
-            .withDetail(STATE, state);
+            .withDetail(STATE, circuitBreaker.getState());
         return builder;
     }
 }

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/circuitbreaker/monitoring/health/CircuitBreakerHealthIndicatorTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/circuitbreaker/monitoring/health/CircuitBreakerHealthIndicatorTest.java
@@ -62,7 +62,8 @@ public class CircuitBreakerHealthIndicatorTest {
                 entry("bufferedCalls", 100),
                 entry("failedCalls", 20),
                 entry("notPermittedCalls", 0L),
-                entry("maxBufferedCalls", 100)
+                entry("maxBufferedCalls", 100),
+                entry("state", CLOSED)
             );
     }
 

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/circuitbreaker/monitoring/health/CircuitBreakerHealthIndicatorTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/circuitbreaker/monitoring/health/CircuitBreakerHealthIndicatorTest.java
@@ -1,27 +1,27 @@
 package io.github.resilience4j.circuitbreaker.monitoring.health;
 
-import static io.github.resilience4j.circuitbreaker.CircuitBreaker.State.CLOSED;
-import static io.github.resilience4j.circuitbreaker.CircuitBreaker.State.HALF_OPEN;
-import static io.github.resilience4j.circuitbreaker.CircuitBreaker.State.OPEN;
-import static org.assertj.core.api.BDDAssertions.then;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.util.AbstractMap.SimpleEntry;
-
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import org.junit.Test;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.Status;
 
-import io.github.resilience4j.circuitbreaker.CircuitBreaker;
-import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.github.resilience4j.circuitbreaker.CircuitBreaker.State.*;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author bstorozhuk
  */
 public class CircuitBreakerHealthIndicatorTest {
+
     @Test
-    public void health() {
+    public void healthMetricsAndConfig() {
         // given
         CircuitBreakerConfig config = mock(CircuitBreakerConfig.class);
         CircuitBreaker.Metrics metrics = mock(CircuitBreaker.Metrics.class);
@@ -37,7 +37,6 @@ public class CircuitBreakerHealthIndicatorTest {
         when(metrics.getNumberOfFailedCalls()).thenReturn(20);
         when(metrics.getNumberOfNotPermittedCalls()).thenReturn(0L);
 
-
         when(circuitBreaker.getCircuitBreakerConfig()).thenReturn(config);
         when(circuitBreaker.getMetrics()).thenReturn(metrics);
         when(circuitBreaker.getState()).thenReturn(CLOSED, OPEN, HALF_OPEN, CLOSED);
@@ -52,29 +51,41 @@ public class CircuitBreakerHealthIndicatorTest {
                         entry("bufferedCalls", 100),
                         entry("failedCalls", 20),
                         entry("notPermittedCalls", 0L),
-                        entry("maxBufferedCalls", 100),
-                        entry("state", CLOSED)
+                        entry("maxBufferedCalls", 100)
                 );
+    }
 
-        health = healthIndicator.health();
-        then(health.getStatus()).isEqualTo(Status.DOWN);
+    @Test
+    public void testHealthStatus() {
+        Map<CircuitBreaker.State, Status> expectedStateToStatusMap = new HashMap<>();
+        expectedStateToStatusMap.put(OPEN, Status.DOWN);
+        expectedStateToStatusMap.put(HALF_OPEN, Status.UNKNOWN);
+        expectedStateToStatusMap.put(CLOSED, Status.UP);
+
+        // given
+        CircuitBreakerConfig config = mock(CircuitBreakerConfig.class);
+        CircuitBreaker.Metrics metrics = mock(CircuitBreaker.Metrics.class);
+        CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
+
+        when(circuitBreaker.getCircuitBreakerConfig()).thenReturn(config);
+        when(circuitBreaker.getMetrics()).thenReturn(metrics);
+
+        expectedStateToStatusMap.forEach((state, status) -> assertStatusForGivenState(circuitBreaker, state, status));
+    }
+
+    private void assertStatusForGivenState(CircuitBreaker circuitBreaker, CircuitBreaker.State givenState, Status expectedStatus) {
+        // given
+        when(circuitBreaker.getState()).thenReturn(givenState);
+        CircuitBreakerHealthIndicator healthIndicator = new CircuitBreakerHealthIndicator(circuitBreaker);
+
+        // when
+        Health health = healthIndicator.health();
+
+        // then
+        then(health.getStatus()).isEqualTo(expectedStatus);
         then(health.getDetails())
                 .contains(
-                        entry("state", OPEN)
-                );
-
-        health = healthIndicator.health();
-        then(health.getStatus()).isEqualTo(Status.UNKNOWN);
-        then(health.getDetails())
-                .contains(
-                        entry("state", HALF_OPEN)
-                );
-
-        health = healthIndicator.health();
-        then(health.getStatus()).isEqualTo(Status.UP);
-        then(health.getDetails())
-                .contains(
-                        entry("state", CLOSED)
+                        entry("state", givenState)
                 );
     }
 

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/circuitbreaker/monitoring/health/CircuitBreakerHealthIndicatorTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/circuitbreaker/monitoring/health/CircuitBreakerHealthIndicatorTest.java
@@ -21,7 +21,7 @@ import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
  */
 public class CircuitBreakerHealthIndicatorTest {
     @Test
-    public void health() throws Exception {
+    public void health() {
         // given
         CircuitBreakerConfig config = mock(CircuitBreakerConfig.class);
         CircuitBreaker.Metrics metrics = mock(CircuitBreaker.Metrics.class);
@@ -45,26 +45,37 @@ public class CircuitBreakerHealthIndicatorTest {
         // then
         Health health = healthIndicator.health();
         then(health.getStatus()).isEqualTo(Status.UP);
+        then(health.getDetails())
+                .contains(
+                        entry("failureRate", "0.2%"),
+                        entry("failureRateThreshold", "0.3%"),
+                        entry("bufferedCalls", 100),
+                        entry("failedCalls", 20),
+                        entry("notPermittedCalls", 0L),
+                        entry("maxBufferedCalls", 100),
+                        entry("state", CLOSED)
+                );
 
         health = healthIndicator.health();
         then(health.getStatus()).isEqualTo(Status.DOWN);
+        then(health.getDetails())
+                .contains(
+                        entry("state", OPEN)
+                );
 
         health = healthIndicator.health();
         then(health.getStatus()).isEqualTo(Status.UNKNOWN);
+        then(health.getDetails())
+                .contains(
+                        entry("state", HALF_OPEN)
+                );
 
         health = healthIndicator.health();
         then(health.getStatus()).isEqualTo(Status.UP);
-
         then(health.getDetails())
-            .contains(
-                entry("failureRate", "0.2%"),
-                entry("failureRateThreshold", "0.3%"),
-                entry("bufferedCalls", 100),
-                entry("failedCalls", 20),
-                entry("notPermittedCalls", 0L),
-                entry("maxBufferedCalls", 100),
-                entry("state", CLOSED)
-            );
+                .contains(
+                        entry("state", CLOSED)
+                );
     }
 
     private SimpleEntry<String, ?> entry(String key, Object value) {


### PR DESCRIPTION
**Motivation**
Make circuit breaker status (OPEN, CLOSED, HALF_CLOSED ...) easier to see.

Circuit breaker health shown in `actuator/health` path is limited to Spring Boots values of `UP`, `DOWN `and `UNDEFINED`, which is limiting. Another way of figuring it's status is to parse all STATE_TRANSITION events which is too much work for the task at hand.

**Solution**
Details section of the `org.springframework.boot.actuate.health.Health` class provides a way to add such data, so I've updated `CircuitBreakerHealthIndicator `and it's test to add that piece of info.

**Discussion**
The way that the test is written kind of disallows multiple calls to the `circuitBreaker.getState()` method, which resulted in `CircuitBreakerHealthIndicator` code that's a bit _weird_. Having it done right would on the other hand result with the test being weird and would require quite a lot of refactoring.

I don't consider this done work, and I'd like to get some feedback on this PR.