### PR TITLE
Issue #354: [Draft] Implementation for Micrometer CircuitBreaker.

### DIFF
--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/utils/MetricNames.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/utils/MetricNames.java
@@ -8,4 +8,10 @@ public class MetricNames {
     public static final String BUFFERED = "buffered";
     public static final String BUFFERED_MAX = "buffered_max";
     public static final String STATE = "state";
+    public static final String CALLS = "calls";
+    public static final String BUFFER = "buffer";
+    public static final String CONFIG_BUFFER_MAX = "config.buffer.max";
+    public static final String NAME_TAG = "name";
+    public static final String CALL_RESULT_TAG = "call_result";
+
 }

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/CircuitBreakerMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/CircuitBreakerMetrics.java
@@ -19,6 +19,7 @@ import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.MeterBinder;
 
 import static io.github.resilience4j.circuitbreaker.utils.MetricNames.*;
@@ -73,17 +74,31 @@ public class CircuitBreakerMetrics implements MeterBinder {
     public void bindTo(MeterRegistry registry) {
         for (CircuitBreaker circuitBreaker : circuitBreakers) {
             final String name = circuitBreaker.getName();
-            Gauge.builder(getName(prefix, name, STATE), circuitBreaker, (cb) -> cb.getState().getOrder())
+            Gauge.builder(getName(prefix, STATE), circuitBreaker, (cb) -> cb.getState().getOrder())
+                    .tag(NAME_TAG, name)
                     .register(registry);
-            Gauge.builder(getName(prefix, name, BUFFERED_MAX), circuitBreaker, (cb) -> cb.getMetrics().getMaxNumberOfBufferedCalls())
+
+            Gauge.builder(getName(prefix, CALLS), circuitBreaker, (cb) -> cb.getMetrics().getNumberOfFailedCalls())
+                    .tag(NAME_TAG, name)
+                    .tag(CALL_RESULT_TAG, FAILED)
                     .register(registry);
-            Gauge.builder(getName(prefix, name, BUFFERED), circuitBreaker, (cb) -> cb.getMetrics().getNumberOfBufferedCalls())
+
+            Gauge.builder(getName(prefix, CALLS), circuitBreaker, (cb) -> cb.getMetrics().getNumberOfSuccessfulCalls())
+                    .tag(NAME_TAG, name)
+                    .tag(CALL_RESULT_TAG, SUCCESSFUL)
                     .register(registry);
-            Gauge.builder(getName(prefix, name, FAILED), circuitBreaker, (cb) -> cb.getMetrics().getNumberOfFailedCalls())
+
+            Gauge.builder(getName(prefix, CALLS), circuitBreaker, (cb) -> cb.getMetrics().getNumberOfNotPermittedCalls())
+                    .tag(NAME_TAG, name)
+                    .tag(CALL_RESULT_TAG, NOT_PERMITTED)
                     .register(registry);
-            Gauge.builder(getName(prefix, name, NOT_PERMITTED), circuitBreaker, (cb) -> cb.getMetrics().getNumberOfNotPermittedCalls())
+
+            Gauge.builder(getName(prefix, BUFFER), circuitBreaker, (cb) -> cb.getMetrics().getNumberOfBufferedCalls())
+                    .tag(NAME_TAG, name)
                     .register(registry);
-            Gauge.builder(getName(prefix, name, SUCCESSFUL), circuitBreaker, (cb) -> cb.getMetrics().getNumberOfSuccessfulCalls())
+
+            Gauge.builder(getName(prefix, CONFIG_BUFFER_MAX), circuitBreaker, (cb) -> cb.getMetrics().getMaxNumberOfBufferedCalls())
+                    .tag(NAME_TAG, name)
                     .register(registry);
         }
     }

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/MetricUtils.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/MetricUtils.java
@@ -19,4 +19,8 @@ public class MetricUtils {
     public static String getName(String prefix, String name, String type) {
         return prefix + '.' + name + '.' + type;
     }
+
+    public static String getName(String prefix, String type) {
+        return prefix + '.' + type;
+    }
 }

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/CircuitBreakerMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/CircuitBreakerMetricsTest.java
@@ -19,10 +19,13 @@ import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.assertj.core.api.AbstractCharSequenceAssert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,37 +33,113 @@ import static org.assertj.core.util.Lists.newArrayList;
 
 public class CircuitBreakerMetricsTest {
 
+    private static final String CIRCUIT_BREAKER_NAME = "testCircuitBreaker";
+
     private MeterRegistry meterRegistry;
 
-    @Before
-    public void setUp() throws Exception {
-        meterRegistry = new SimpleMeterRegistry();
+    private static boolean isAGauge(Meter meter) {
+
+        return meter.getId().getType().equals(Meter.Type.GAUGE);
     }
 
-    @Test
-    public void shouldRegisterMetrics() {
+    private static boolean isTaggedWithCircuitBreakerName(Meter meter) {
+
+        return Objects.equals(meter.getId().getTag("name"), CircuitBreakerMetricsTest.CIRCUIT_BREAKER_NAME);
+    }
+
+    private List<Meter> getMetersWithNamesEndingIn(final String state) {
+
+        return meterRegistry.getMeters()
+                .stream()
+                .filter(meter -> meter.getId().getName().endsWith(state))
+                .collect(Collectors.toList());
+    }
+
+    private List<String> meterTagValues(final List<Meter> callMeters, String tagKey) {
+
+        return callMeters
+                .stream()
+                .map(meter -> meter.getId().getTag(tagKey))
+                .collect(Collectors.toList());
+    }
+
+    private void assertThatForAllMeters(Predicate<Meter> predicate) {
+
+        assertThat(meterRegistry.getMeters().stream().allMatch(predicate)).isTrue();
+    }
+
+    @Before
+    public void setUp() {
+
+        meterRegistry = new SimpleMeterRegistry();
         CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
-        circuitBreakerRegistry.circuitBreaker("testName");
+
+        circuitBreakerRegistry.circuitBreaker(CIRCUIT_BREAKER_NAME);
 
         CircuitBreakerMetrics circuitBreakerMetrics = CircuitBreakerMetrics.ofCircuitBreakerRegistry(circuitBreakerRegistry);
         circuitBreakerMetrics.bindTo(meterRegistry);
-
-        final List<String> metricNames = meterRegistry.getMeters()
-                .stream()
-                .map(Meter::getId)
-                .map(Meter.Id::getName)
-                .collect(Collectors.toList());
-
-        final List<String> expectedMetrics = newArrayList(
-                "resilience4j.circuitbreaker.testName.successful",
-                "resilience4j.circuitbreaker.testName.failed",
-                "resilience4j.circuitbreaker.testName.not_permitted",
-                "resilience4j.circuitbreaker.testName.state",
-                "resilience4j.circuitbreaker.testName.buffered",
-                "resilience4j.circuitbreaker.testName.buffered_max");
-        assertThat(metricNames).hasSameElementsAs(expectedMetrics);
-
     }
 
+    @Test
+    public void shouldRegisterMetersWithDefaultPrefix() {
 
+        assertThatForAllMeters(meter -> meter.getId().getName().startsWith("resilience4j.circuitbreaker"));
+    }
+
+    @Test
+    public void shouldRegisterMetersAsGauge() {
+
+        assertThatForAllMeters(CircuitBreakerMetricsTest::isAGauge);
+    }
+
+    @Test
+    public void shouldRegisterMetersWithNameTag() {
+
+        assertThatForAllMeters(CircuitBreakerMetricsTest::isTaggedWithCircuitBreakerName);
+    }
+
+    @Test
+    public void shouldRegisterStateMeters() {
+
+        final List<Meter> stateMeters = getMetersWithNamesEndingIn("state");
+
+        assertThat(stateMeters.size()).isEqualTo(1);
+        assertMeterNameIs(stateMeters.get(0), "resilience4j.circuitbreaker.state");
+    }
+
+    private AbstractCharSequenceAssert<?, String> assertMeterNameIs(Meter meter, String expectedName) {
+
+        return assertThat(meter.getId().getName()).isEqualTo(expectedName);
+    }
+
+    @Test
+    public void shouldRegisterCallsMeters() {
+
+        final List<Meter> callMeters = getMetersWithNamesEndingIn("calls");
+        final List<String> allCallResultValues = meterTagValues(callMeters, "call_result");
+
+        assertThat(callMeters.size()).isEqualTo(3);
+        assertThat(callMeters.stream().allMatch( meter -> meter.getId().getName().equals("resilience4j.circuitbreaker.calls"))).isTrue();
+        assertThat(allCallResultValues)
+                .containsExactly("successful", "failed", "not_permitted");
+    }
+
+    @Test
+    public void shouldRegisterBufferMeter() {
+
+        final List<Meter> bufferMeters = getMetersWithNamesEndingIn("buffer");
+
+        assertThat(bufferMeters.size()).isEqualTo(1);
+        assertMeterNameIs(bufferMeters.get(0),"resilience4j.circuitbreaker.buffer");
+    }
+
+    @Test
+    public void shouldRegisterBufferConfigMaxMeter() {
+
+        final List<Meter> bufferMeters =
+                getMetersWithNamesEndingIn("config.buffer.max");
+
+        assertThat(bufferMeters.size()).isEqualTo(1);
+        assertMeterNameIs(bufferMeters.get(0),"resilience4j.circuitbreaker.config.buffer.max");
+    }
 }


### PR DESCRIPTION
Other Meters would be implemented in the same way, naming and
structure would also be adapted for resilience4j-prometheus and
resilience4j-metrics.

Note that I only added new names to `MetricNames.java` for now to keep changes small.