### PR TITLE
Use new metrics collectors for spring-boot and spring-boot2

### DIFF
--- a/resilience4j-spring-boot/src/main/java/io/github/resilience4j/bulkhead/autoconfigure/BulkheadPrometheusAutoConfiguration.java
+++ b/resilience4j-spring-boot/src/main/java/io/github/resilience4j/bulkhead/autoconfigure/BulkheadPrometheusAutoConfiguration.java
@@ -17,8 +17,10 @@ package io.github.resilience4j.bulkhead.autoconfigure;
 
 import io.github.resilience4j.bulkhead.BulkheadRegistry;
 import io.github.resilience4j.prometheus.BulkheadExports;
+import io.github.resilience4j.prometheus.collectors.BulkheadMetricsCollector;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -30,9 +32,23 @@ import org.springframework.context.annotation.Configuration;
 @AutoConfigureAfter(value = BulkheadAutoConfiguration.class)
 @ConditionalOnClass(BulkheadExports.class)
 public class BulkheadPrometheusAutoConfiguration {
+
     @Bean
-    public BulkheadExports bulkheadPrometheusCollector(BulkheadRegistry bulkheadRegistry){
+    @ConditionalOnProperty(value = "resilience4j.bulkhead.metrics.use_legacy_collector", havingValue = "true")
+    public BulkheadExports legacyBulkheadPrometheusCollector(BulkheadRegistry bulkheadRegistry) {
         BulkheadExports collector = BulkheadExports.ofBulkheadRegistry(bulkheadRegistry);
+        collector.register();
+        return collector;
+    }
+
+    @Bean
+    @ConditionalOnProperty(
+        value = "resilience4j.bulkhead.metrics.use_legacy_collector",
+        havingValue = "false",
+        matchIfMissing = true
+    )
+    public BulkheadMetricsCollector bulkheadPrometheusCollector(BulkheadRegistry bulkheadRegistry) {
+        BulkheadMetricsCollector collector = BulkheadMetricsCollector.ofBulkheadRegistry(bulkheadRegistry);
         collector.register();
         return collector;
     }

--- a/resilience4j-spring-boot/src/main/java/io/github/resilience4j/circuitbreaker/autoconfigure/CircuitBreakerPrometheusAutoConfiguration.java
+++ b/resilience4j-spring-boot/src/main/java/io/github/resilience4j/circuitbreaker/autoconfigure/CircuitBreakerPrometheusAutoConfiguration.java
@@ -17,8 +17,10 @@ package io.github.resilience4j.circuitbreaker.autoconfigure;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.prometheus.CircuitBreakerExports;
+import io.github.resilience4j.prometheus.collectors.CircuitBreakerMetricsCollector;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -30,9 +32,23 @@ import org.springframework.context.annotation.Configuration;
 @AutoConfigureAfter(value = CircuitBreakerAutoConfiguration.class)
 @ConditionalOnClass(CircuitBreakerExports.class)
 public class CircuitBreakerPrometheusAutoConfiguration {
+
     @Bean
-    public CircuitBreakerExports circuitBreakerPrometheusCollector(CircuitBreakerRegistry circuitBreakerRegistry){
+    @ConditionalOnProperty(value = "resilience4j.circuitbreaker.metrics.use_legacy_collector", havingValue = "true")
+    public CircuitBreakerExports legacyCircuitBreakerPrometheusCollector(CircuitBreakerRegistry circuitBreakerRegistry) {
         CircuitBreakerExports collector = CircuitBreakerExports.ofCircuitBreakerRegistry(circuitBreakerRegistry);
+        collector.register();
+        return collector;
+    }
+
+    @Bean
+    @ConditionalOnProperty(
+        value = "resilience4j.circuitbreaker.metrics.use_legacy_collector",
+        havingValue = "false",
+        matchIfMissing = true
+    )
+    public CircuitBreakerMetricsCollector circuitBreakerPrometheusCollector(CircuitBreakerRegistry circuitBreakerRegistry) {
+        CircuitBreakerMetricsCollector collector = CircuitBreakerMetricsCollector.ofCircuitBreakerRegistry(circuitBreakerRegistry);
         collector.register();
         return collector;
     }

--- a/resilience4j-spring-boot/src/main/java/io/github/resilience4j/ratelimiter/autoconfigure/RateLimiterPrometheusAutoConfiguration.java
+++ b/resilience4j-spring-boot/src/main/java/io/github/resilience4j/ratelimiter/autoconfigure/RateLimiterPrometheusAutoConfiguration.java
@@ -16,9 +16,11 @@
 package io.github.resilience4j.ratelimiter.autoconfigure;
 
 import io.github.resilience4j.prometheus.RateLimiterExports;
+import io.github.resilience4j.prometheus.collectors.RateLimiterMetricsCollector;
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -30,9 +32,23 @@ import org.springframework.context.annotation.Configuration;
 @AutoConfigureAfter(value = RateLimiterAutoConfiguration.class)
 @ConditionalOnClass(RateLimiterExports.class)
 public class RateLimiterPrometheusAutoConfiguration {
+
+    @ConditionalOnProperty(value = "resilience4j.ratelimiter.metrics.use_legacy_collector", havingValue = "true")
     @Bean
-    public RateLimiterExports rateLimiterPrometheusCollector(RateLimiterRegistry rateLimiterRegistry){
+    public RateLimiterExports legacyRateLimiterPrometheusCollector(RateLimiterRegistry rateLimiterRegistry){
         RateLimiterExports collector = RateLimiterExports.ofRateLimiterRegistry(rateLimiterRegistry);
+        collector.register();
+        return collector;
+    }
+
+    @Bean
+    @ConditionalOnProperty(
+        value = "resilience4j.ratelimiter.metrics.use_legacy_collector",
+        havingValue = "false",
+        matchIfMissing = true
+    )
+    public RateLimiterMetricsCollector rateLimiterPrometheusCollector(RateLimiterRegistry rateLimiterRegistry) {
+        RateLimiterMetricsCollector collector = RateLimiterMetricsCollector.ofRateLimiterRegistry(rateLimiterRegistry);
         collector.register();
         return collector;
     }

--- a/resilience4j-spring-boot/src/test/java/io/github/resilience4j/MetricsAutoConfigurationTest.java
+++ b/resilience4j-spring-boot/src/test/java/io/github/resilience4j/MetricsAutoConfigurationTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 Yevhenii Voievodin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j;
+
+import io.github.resilience4j.prometheus.BulkheadExports;
+import io.github.resilience4j.prometheus.CircuitBreakerExports;
+import io.github.resilience4j.prometheus.RateLimiterExports;
+import io.github.resilience4j.prometheus.collectors.BulkheadMetricsCollector;
+import io.github.resilience4j.prometheus.collectors.CircuitBreakerMetricsCollector;
+import io.github.resilience4j.prometheus.collectors.RateLimiterMetricsCollector;
+import io.github.resilience4j.service.test.TestApplication;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = TestApplication.class)
+public class MetricsAutoConfigurationTest {
+
+    @Autowired(required = false)
+    CircuitBreakerExports circuitBreakerExports;
+
+    @Autowired(required = false)
+    BulkheadExports bulkheadExports;
+
+    @Autowired(required = false)
+    RateLimiterExports rateLimiterExports;
+
+    @Autowired(required = false)
+    CircuitBreakerMetricsCollector circuitBreakerMetricsCollector;
+
+    @Autowired(required = false)
+    BulkheadMetricsCollector bulkheadMetricsCollector;
+
+    @Autowired(required = false)
+    RateLimiterMetricsCollector rateLimiterMetricsCollector;
+
+    @Test
+    public void legacyCircuitBreakerCollectorIsNotBound() {
+        assertThat(circuitBreakerExports).isNull();
+    }
+
+    @Test
+    public void legacyBulkheadCollectorIsNotBound() {
+        assertThat(bulkheadExports).isNull();
+    }
+
+    @Test
+    public void legacyRateLimiterCollectorIsNotBound() {
+        assertThat(bulkheadExports).isNull();
+    }
+
+    @Test
+    public void newCircuitBreakerCollectorIsBound() {
+        assertThat(circuitBreakerMetricsCollector).isNotNull();
+    }
+
+    @Test
+    public void newBulkheadCollectorIsBound() {
+        assertThat(bulkheadMetricsCollector).isNotNull();
+    }
+
+    @Test
+    public void newRateLimiterCollectorIsBound() {
+        assertThat(rateLimiterMetricsCollector).isNotNull();
+    }
+}

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/circuitbreaker/autoconfigure/CircuitBreakerMetricsAutoConfiguration.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/circuitbreaker/autoconfigure/CircuitBreakerMetricsAutoConfiguration.java
@@ -17,6 +17,7 @@ package io.github.resilience4j.circuitbreaker.autoconfigure;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.micrometer.CircuitBreakerMetrics;
+import io.github.resilience4j.micrometer.tagged.TaggedCircuitBreakerMetrics;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -31,11 +32,22 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ConditionalOnClass(MetricsAutoConfiguration.class)
 @AutoConfigureAfter(value = {CircuitBreakerAutoConfiguration.class, MetricsAutoConfiguration.class})
+@ConditionalOnProperty(value = "resilience4j.circuitbreaker.metrics.enabled", matchIfMissing = true)
 public class CircuitBreakerMetricsAutoConfiguration {
 
     @Bean
-    @ConditionalOnProperty(value = "resilience4j.circuitbreaker.metrics.enabled", matchIfMissing = true)
-    public CircuitBreakerMetrics registerCircuitBreakerMetrics(CircuitBreakerRegistry circuitBreakerRegistry) {
+    @ConditionalOnProperty(value = "resilience4j.circuitbreaker.metrics.use_legacy_binder", havingValue = "true")
+    public CircuitBreakerMetrics registerLegacyCircuitBreakerMetrics(CircuitBreakerRegistry circuitBreakerRegistry) {
         return CircuitBreakerMetrics.ofCircuitBreakerRegistry(circuitBreakerRegistry);
+    }
+
+    @Bean
+    @ConditionalOnProperty(
+        value = "resilience4j.circuitbreaker.metrics.use_legacy_binder",
+        havingValue = "false",
+        matchIfMissing = true
+    )
+    public TaggedCircuitBreakerMetrics registerCircuitBreakerMetrics(CircuitBreakerRegistry circuitBreakerRegistry) {
+        return TaggedCircuitBreakerMetrics.ofCircuitBreakerRegistry(circuitBreakerRegistry);
     }
 }

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/ratelimiter/autoconfigure/RateLimiterMetricsAutoConfiguration.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/ratelimiter/autoconfigure/RateLimiterMetricsAutoConfiguration.java
@@ -17,10 +17,12 @@ package io.github.resilience4j.ratelimiter.autoconfigure;
 
 import io.github.resilience4j.circuitbreaker.autoconfigure.CircuitBreakerAutoConfiguration;
 import io.github.resilience4j.micrometer.RateLimiterMetrics;
+import io.github.resilience4j.micrometer.tagged.TaggedRateLimiterMetrics;
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -31,9 +33,22 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ConditionalOnClass(MetricsAutoConfiguration.class)
 @AutoConfigureAfter(value = {CircuitBreakerAutoConfiguration.class, MetricsAutoConfiguration.class})
+@ConditionalOnProperty(value = "resilience4j.ratelimiter.metrics.enabled", matchIfMissing = true)
 public class RateLimiterMetricsAutoConfiguration {
+
     @Bean
-    public RateLimiterMetrics registerRateLimiterMetrics(RateLimiterRegistry rateLimiterRegistry) {
+    @ConditionalOnProperty(value = "resilience4j.ratelimiter.metrics.use_legacy_binder", havingValue = "true")
+    public RateLimiterMetrics registerLegacyRateLimiterMetrics(RateLimiterRegistry rateLimiterRegistry) {
         return RateLimiterMetrics.ofRateLimiterRegistry(rateLimiterRegistry);
+    }
+
+    @Bean
+    @ConditionalOnProperty(
+        value = "resilience4j.ratelimiter.metrics.use_legacy_binder",
+        havingValue = "false",
+        matchIfMissing = true
+    )
+    public TaggedRateLimiterMetrics registerRateLimiterMetrics(RateLimiterRegistry rateLimiterRegistry) {
+        return TaggedRateLimiterMetrics.ofRateLimiterRegistry(rateLimiterRegistry);
     }
 }

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/retry/autoconfigure/AsyncRetryMetricsAutoConfiguration.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/retry/autoconfigure/AsyncRetryMetricsAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 lespinsideg
+ * Copyright 2019 Yevhenii Voievodin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.github.resilience4j.bulkhead.autoconfigure;
+package io.github.resilience4j.retry.autoconfigure;
 
-import io.github.resilience4j.bulkhead.BulkheadRegistry;
-import io.github.resilience4j.micrometer.BulkheadMetrics;
-import io.github.resilience4j.micrometer.tagged.TaggedBulkheadMetrics;
+import io.github.resilience4j.micrometer.AsyncRetryMetrics;
+import io.github.resilience4j.micrometer.tagged.TaggedAsyncRetryMetrics;
+import io.github.resilience4j.retry.AsyncRetryRegistry;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -25,29 +25,25 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-/**
- * {@link org.springframework.boot.autoconfigure.EnableAutoConfiguration
- * Auto-configuration} for resilience4j-metrics.
- */
 @Configuration
 @ConditionalOnClass(MetricsAutoConfiguration.class)
-@AutoConfigureAfter(value = {BulkheadMetricsAutoConfiguration.class, MetricsAutoConfiguration.class})
-@ConditionalOnProperty(value = "resilience4j.bulkhead.metrics.enabled", matchIfMissing = true)
-public class BulkheadMetricsAutoConfiguration {
+@AutoConfigureAfter(value = {RetryAutoConfiguration.class, MetricsAutoConfiguration.class})
+@ConditionalOnProperty(value = "resilience4j.async_retry.metrics.enabled", matchIfMissing = true)
+public class AsyncRetryMetricsAutoConfiguration {
 
     @Bean
-    @ConditionalOnProperty(value = "resilience4j.bulkhead.metrics.use_legacy_binder", havingValue = "true")
-    public BulkheadMetrics registerLegacyBulkheadMetrics(BulkheadRegistry bulkheadRegistry) {
-        return BulkheadMetrics.ofBulkheadRegistry(bulkheadRegistry);
+    @ConditionalOnProperty(value = "resilience4j.async_retry.metrics.use_legacy_binder", havingValue = "true")
+    public AsyncRetryMetrics registerLegacyAsyncRetryMetrics(AsyncRetryRegistry asyncRetryRegistry) {
+        return AsyncRetryMetrics.ofRetryRegistry(asyncRetryRegistry);
     }
 
     @Bean
     @ConditionalOnProperty(
-        value = "resilience4j.bulkhead.metrics.use_legacy_binder",
+        value = "resilience4j.async_retry.metrics.use_legacy_binder",
         havingValue = "false",
         matchIfMissing = true
     )
-    public TaggedBulkheadMetrics registerBulkheadMetrics(BulkheadRegistry bulkheadRegistry) {
-        return TaggedBulkheadMetrics.ofBulkheadRegistry(bulkheadRegistry);
+    public TaggedAsyncRetryMetrics registerAsyncRetryMetrics(AsyncRetryRegistry asyncRetryRegistry) {
+        return TaggedAsyncRetryMetrics.ofAsyncRetryRegistry(asyncRetryRegistry);
     }
 }

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/retry/autoconfigure/RetryMetricsAutoConfiguration.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/retry/autoconfigure/RetryMetricsAutoConfiguration.java
@@ -15,17 +15,15 @@
  */
 package io.github.resilience4j.retry.autoconfigure;
 
+import io.github.resilience4j.micrometer.RetryMetrics;
+import io.github.resilience4j.micrometer.tagged.TaggedRetryMetrics;
+import io.github.resilience4j.retry.RetryRegistry;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import io.github.resilience4j.micrometer.AsyncRetryMetrics;
-import io.github.resilience4j.micrometer.RetryMetrics;
-import io.github.resilience4j.retry.AsyncRetryRegistry;
-import io.github.resilience4j.retry.RetryRegistry;
 
 /**
  * {@link org.springframework.boot.autoconfigure.EnableAutoConfiguration
@@ -34,19 +32,22 @@ import io.github.resilience4j.retry.RetryRegistry;
 @Configuration
 @ConditionalOnClass(MetricsAutoConfiguration.class)
 @AutoConfigureAfter(value = {RetryAutoConfiguration.class, MetricsAutoConfiguration.class})
+@ConditionalOnProperty(value = "resilience4j.retry.metrics.enabled", matchIfMissing = true)
 public class RetryMetricsAutoConfiguration {
 
 	@Bean
-	@ConditionalOnProperty(value = "resilience4j.retry.metrics.enabled", matchIfMissing = true)
-	public RetryMetrics registerRetryMetrics(RetryRegistry retryRegistry) {
+	@ConditionalOnProperty(value = "resilience4j.retry.metrics.use_legacy_binder", havingValue = "true")
+	public RetryMetrics registerLegacyRetryMetrics(RetryRegistry retryRegistry) {
 		return RetryMetrics.ofRetryRegistry(retryRegistry);
 	}
 
 	@Bean
-	@ConditionalOnProperty(value = "resilience4j.retry.metrics.enabled", matchIfMissing = true)
-	public AsyncRetryMetrics asyncRetryMetrics(AsyncRetryRegistry asyncRetryRegistry) {
-		return AsyncRetryMetrics.ofRetryRegistry(asyncRetryRegistry);
-
+	@ConditionalOnProperty(
+		value = "resilience4j.retry.metrics.use_legacy_binder",
+		havingValue = "false",
+		matchIfMissing = true
+	)
+	public TaggedRetryMetrics registerRetryMetrics(RetryRegistry retryRegistry) {
+		return TaggedRetryMetrics.ofRetryRegistry(retryRegistry);
 	}
-
 }

--- a/resilience4j-spring-boot2/src/main/resources/META-INF/spring.factories
+++ b/resilience4j-spring-boot2/src/main/resources/META-INF/spring.factories
@@ -1,6 +1,7 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 io.github.resilience4j.retry.autoconfigure.RetryAutoConfiguration,\
 io.github.resilience4j.retry.autoconfigure.RetryMetricsAutoConfiguration,\
+io.github.resilience4j.retry.autoconfigure.AsyncRetryMetricsAutoConfiguration,\
 io.github.resilience4j.circuitbreaker.autoconfigure.CircuitBreakerAutoConfiguration,\
 io.github.resilience4j.circuitbreaker.autoconfigure.CircuitBreakerMetricsAutoConfiguration,\
 io.github.resilience4j.ratelimiter.autoconfigure.RateLimiterAutoConfiguration,\

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/MetricsAutoConfigurationTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/MetricsAutoConfigurationTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2019 Yevhenii Voievodin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j;
+
+import io.github.resilience4j.micrometer.AsyncRetryMetrics;
+import io.github.resilience4j.micrometer.BulkheadMetrics;
+import io.github.resilience4j.micrometer.CircuitBreakerMetrics;
+import io.github.resilience4j.micrometer.RateLimiterMetrics;
+import io.github.resilience4j.micrometer.RetryMetrics;
+import io.github.resilience4j.micrometer.tagged.TaggedAsyncRetryMetrics;
+import io.github.resilience4j.micrometer.tagged.TaggedBulkheadMetrics;
+import io.github.resilience4j.micrometer.tagged.TaggedCircuitBreakerMetrics;
+import io.github.resilience4j.micrometer.tagged.TaggedRateLimiterMetrics;
+import io.github.resilience4j.micrometer.tagged.TaggedRetryMetrics;
+import io.github.resilience4j.service.test.TestApplication;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = TestApplication.class)
+public class MetricsAutoConfigurationTest {
+
+    @Autowired(required = false)
+    CircuitBreakerMetrics circuitBreakerMetrics;
+
+    @Autowired(required = false)
+    BulkheadMetrics bulkheadMetrics;
+
+    @Autowired(required = false)
+    RateLimiterMetrics rateLimiterMetrics;
+
+    @Autowired(required = false)
+    RetryMetrics retryMetrics;
+
+    @Autowired(required = false)
+    AsyncRetryMetrics asyncRetryMetrics;
+
+    @Autowired(required = false)
+    TaggedCircuitBreakerMetrics taggedCircuitBreakerMetrics;
+
+    @Autowired(required = false)
+    TaggedBulkheadMetrics taggedBulkheadMetrics;
+
+    @Autowired(required = false)
+    TaggedRateLimiterMetrics taggedRateLimiterMetrics;
+
+    @Autowired(required = false)
+    TaggedRetryMetrics taggedRetryMetrics;
+
+    @Autowired(required = false)
+    TaggedAsyncRetryMetrics taggedAsyncRetryMetrics;
+
+    @Test
+    public void legacyCircuitBreakerBinderIsNotBound() {
+        assertThat(circuitBreakerMetrics).isNull();
+    }
+
+    @Test
+    public void legacyBulkheadBinderIsNotBound() {
+        assertThat(bulkheadMetrics).isNull();
+    }
+
+    @Test
+    public void legacyRateLimiterBinderIsNotBound() {
+        assertThat(bulkheadMetrics).isNull();
+    }
+
+    @Test
+    public void legacyRetryBinderIsNotBound() {
+        assertThat(retryMetrics).isNull();
+    }
+
+    @Test
+    public void legacyAsyncRetryBinderIsNotBound() {
+        assertThat(asyncRetryMetrics).isNull();
+    }
+
+    @Test
+    public void newCircuitBreakerBinderIsBound() {
+        assertThat(taggedCircuitBreakerMetrics).isNotNull();
+    }
+
+    @Test
+    public void mewBulkheadBinderIsBound() {
+        assertThat(taggedBulkheadMetrics).isNotNull();
+    }
+
+    @Test
+    public void newRateLimiterBinderIsBound() {
+        assertThat(taggedBulkheadMetrics).isNotNull();
+    }
+
+    @Test
+    public void newRetryBinderIsBound() {
+        assertThat(taggedRetryMetrics).isNotNull();
+    }
+
+    @Test
+    public void newAsyncRetryBinderIsBound() {
+        assertThat(taggedAsyncRetryMetrics).isNotNull();
+    }
+}


### PR DESCRIPTION
Basically adapting the spring auto configuration to cover the changes introduced in #375 and #355.

The changes within this PR are not backward compatible in a sense that default metrics format is different as described within #355. But there is a back port for those who want to keep using the old naming, it can be controlled by the following properties:

For spring boot 1 (prometheus)
```properties
resilience4j.circuitbreaker.metrics.use_legacy_collector=true
resilience4j.bulkhead.metrics.use_legacy_collector=true
resilience4j.ratelimiter.metrics.use_legacy_collector=true
```

For spring boot 2 (micrometer)
```properties
resilience4j.circuitbreaker.metrics.use_legacy_binder=true
resilience4j.bulkhead.metrics.use_legacy_binder=true
resilience4j.ratelimiter.metrics.use_legacy_binder=true
resilience4j.retry.metrics.use_legacy_binder=true
resilience4j.async_retry.metrics.use_legacy_binder=true
```