### PR TITLE
Add the Automatic-Module-Name for each project.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,6 +106,17 @@ subprojects {
             property "sonar.jacoco.reportPaths", allTestCoverageFile
         }
     }
+    afterEvaluate {
+        // exclude subprojects that don't produce a jar file.
+        if(!project.name.equals('resilience4j-bom') && !project.name.equals('resilience4j-documentation') && !project.name.equals('resilience4j-test')) {
+            jar {
+                inputs.property('moduleName', moduleName)
+                manifest.attributes(
+                    'Automatic-Module-Name': moduleName
+                )
+            }
+        }
+    }
 }
 
 tasks.check.dependsOn tasks.jacocoTestReport

--- a/resilience4j-all/build.gradle
+++ b/resilience4j-all/build.gradle
@@ -11,3 +11,4 @@ dependencies {
     compile project(':resilience4j-timelimiter')
     testCompile project(':resilience4j-test')
 }
+ext.moduleName='io.github.resilience4j.all'

--- a/resilience4j-annotations/build.gradle
+++ b/resilience4j-annotations/build.gradle
@@ -2,3 +2,4 @@ dependencies {
     compileOnly project(':resilience4j-circuitbreaker')
     compileOnly project(':resilience4j-ratelimiter')
 }
+ext.moduleName='io.github.resilience4j.annotations'

--- a/resilience4j-bulkhead/build.gradle
+++ b/resilience4j-bulkhead/build.gradle
@@ -5,3 +5,4 @@ dependencies {
     jmh project(':resilience4j-rxjava2')
     testCompile ( libraries.rxjava2)
 }
+ext.moduleName='io.github.resilience4j.bulkhead'

--- a/resilience4j-cache/build.gradle
+++ b/resilience4j-cache/build.gradle
@@ -4,3 +4,4 @@ dependencies {
     testCompile project(':resilience4j-rxjava2')
     testCompile ( libraries.rxjava2)
 }
+ext.moduleName='io.github.resilience4j.cache'

--- a/resilience4j-circuitbreaker/build.gradle
+++ b/resilience4j-circuitbreaker/build.gradle
@@ -4,3 +4,4 @@ dependencies {
     jmh project(':resilience4j-rxjava2')
     testCompile ( libraries.rxjava2 )
 }
+ext.moduleName='io.github.resilience4j.circuitbreaker'

--- a/resilience4j-circularbuffer/build.gradle
+++ b/resilience4j-circularbuffer/build.gradle
@@ -1,0 +1,1 @@
+ext.moduleName='io.github.resilience4j.circularbuffer'

--- a/resilience4j-consumer/build.gradle
+++ b/resilience4j-consumer/build.gradle
@@ -3,3 +3,4 @@ dependencies {
     compile project(':resilience4j-circularbuffer')
     testCompile project(':resilience4j-circuitbreaker')
 }
+ext.moduleName='io.github.resilience4j.consumer'

--- a/resilience4j-core/build.gradle
+++ b/resilience4j-core/build.gradle
@@ -1,0 +1,1 @@
+ext.moduleName='io.github.resilience4j.core'

--- a/resilience4j-feign/build.gradle
+++ b/resilience4j-feign/build.gradle
@@ -5,3 +5,4 @@ dependencies {
     testCompile ( libraries.feign_wiremock )
     testCompile ( libraries.feign )
 }
+ext.moduleName='io.github.resilience4j.feign'

--- a/resilience4j-metrics/build.gradle
+++ b/resilience4j-metrics/build.gradle
@@ -13,3 +13,4 @@ dependencies {
     testCompile project(':resilience4j-circuitbreaker')
     testCompile (libraries.metrics)
 }
+ext.moduleName='io.github.resilience4j.metrics'

--- a/resilience4j-micrometer/build.gradle
+++ b/resilience4j-micrometer/build.gradle
@@ -13,3 +13,4 @@ dependencies {
     testCompile project(':resilience4j-circuitbreaker')
     testCompile (libraries.micrometer)
 }
+ext.moduleName='io.github.resilience4j.micrometer'

--- a/resilience4j-prometheus/build.gradle
+++ b/resilience4j-prometheus/build.gradle
@@ -8,3 +8,4 @@ dependencies {
     testCompile project(':resilience4j-bulkhead')
     testCompile (libraries.prometheus_simpleclient)
 }
+ext.moduleName='io.github.resilience4j.prometheus'

--- a/resilience4j-ratelimiter/build.gradle
+++ b/resilience4j-ratelimiter/build.gradle
@@ -1,3 +1,4 @@
 dependencies {
     compile project(':resilience4j-core')
 }
+ext.moduleName='io.github.resilience4j.ratelimiter'

--- a/resilience4j-ratpack/build.gradle
+++ b/resilience4j-ratpack/build.gradle
@@ -19,3 +19,4 @@ dependencies {
     testCompile project(':resilience4j-metrics')
     testCompile ( libraries.ratpack )
 }
+ext.moduleName='io.github.resilience4j.ratpack'

--- a/resilience4j-reactor/build.gradle
+++ b/resilience4j-reactor/build.gradle
@@ -14,3 +14,4 @@ dependencies {
     testCompile (libraries.assertj)
     testCompile (libraries.reactive_streams_tck)
 }
+ext.moduleName='io.github.resilience4j.reactor'

--- a/resilience4j-retrofit/build.gradle
+++ b/resilience4j-retrofit/build.gradle
@@ -6,3 +6,4 @@ dependencies {
     testCompile ( libraries.retrofit_wiremock )
     testCompile ( libraries.retrofit )
 }
+ext.moduleName='io.github.resilience4j.retrofit'

--- a/resilience4j-retry/build.gradle
+++ b/resilience4j-retry/build.gradle
@@ -4,3 +4,4 @@ dependencies {
     testCompile project(':resilience4j-rxjava2')
     testCompile ( libraries.rxjava2)
 }
+ext.moduleName='io.github.resilience4j.retry'

--- a/resilience4j-rxjava2/build.gradle
+++ b/resilience4j-rxjava2/build.gradle
@@ -11,3 +11,4 @@ dependencies {
     testCompile project(':resilience4j-retry')
     testCompile ( libraries.rxjava2)
 }
+ext.moduleName='io.github.resilience4j.rxjava2'

--- a/resilience4j-spring-boot/build.gradle
+++ b/resilience4j-spring-boot/build.gradle
@@ -29,3 +29,4 @@ dependencies {
 }
 
 compileJava.dependsOn(processResources)
+ext.moduleName='io.github.resilience4j.springboot'

--- a/resilience4j-spring-boot2/build.gradle
+++ b/resilience4j-spring-boot2/build.gradle
@@ -26,3 +26,4 @@ dependencies {
 }
 
 compileJava.dependsOn(processResources)
+ext.moduleName='io.github.resilience4j.springboot2'

--- a/resilience4j-spring/build.gradle
+++ b/resilience4j-spring/build.gradle
@@ -17,3 +17,4 @@ dependencies {
     testCompile project(':resilience4j-prometheus')
     testCompile project(':resilience4j-metrics')
 }
+ext.moduleName='io.github.resilience4j.spring'

--- a/resilience4j-timelimiter/build.gradle
+++ b/resilience4j-timelimiter/build.gradle
@@ -1,3 +1,4 @@
 dependencies {
     
 }
+ext.moduleName='io.github.resilience4j.timelimiter'

--- a/resilience4j-vertx/build.gradle
+++ b/resilience4j-vertx/build.gradle
@@ -4,3 +4,4 @@ dependencies {
     testCompile ( libraries.vertx_unit)
     testCompile ( libraries.vertx)
 }
+ext.moduleName='io.github.resilience4j.vertx'


### PR DESCRIPTION
Until proper support for modules is introduced, this PR adds the appropriate Automatic-Module-Name to every produced .jar file.  
For Java 8 this does not matter, but it helps people who are already using the JPMS introduced in Java 9.