### PR TITLE
Fixes issue #439: Add failure rate metric to circuit breaker

### DIFF
--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/utils/MetricNames.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/utils/MetricNames.java
@@ -8,4 +8,5 @@ public class MetricNames {
     public static final String BUFFERED = "buffered";
     public static final String BUFFERED_MAX = "buffered_max";
     public static final String STATE = "state";
+    public static final String FAILURE_RATE = "failure_rate";
 }

--- a/resilience4j-metrics/src/main/java/io/github/resilience4j/metrics/CircuitBreakerMetrics.java
+++ b/resilience4j-metrics/src/main/java/io/github/resilience4j/metrics/CircuitBreakerMetrics.java
@@ -48,7 +48,7 @@ public class CircuitBreakerMetrics implements MetricSet {
         requireNonNull(circuitBreakers);
         circuitBreakers.forEach((CircuitBreaker circuitBreaker) -> {
                 String name = circuitBreaker.getName();
-            //state as an integer
+                //state as an integer
                 metricRegistry.register(name(prefix, name, STATE),
                       (Gauge<Integer>)()-> circuitBreaker.getState().getOrder());
                 metricRegistry.register(name(prefix, name, SUCCESSFUL),
@@ -61,6 +61,8 @@ public class CircuitBreakerMetrics implements MetricSet {
                     (Gauge<Integer>) () -> circuitBreaker.getMetrics().getNumberOfBufferedCalls());
                 metricRegistry.register(name(prefix, name, BUFFERED_MAX),
                     (Gauge<Integer>) () -> circuitBreaker.getMetrics().getMaxNumberOfBufferedCalls());
+                metricRegistry.register(name(prefix, name, FAILURE_RATE),
+                    (Gauge<Float>) () -> circuitBreaker.getMetrics().getFailureRate());
             }
         );
     }

--- a/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/CircuitBreakerMetricsTest.java
+++ b/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/CircuitBreakerMetricsTest.java
@@ -60,13 +60,14 @@ public class CircuitBreakerMetricsTest {
         assertThat(value).isEqualTo("Hello world");
         // Then the helloWorldService should be invoked 1 time
         BDDMockito.then(helloWorldService).should(times(1)).returnHelloWorld();
-        assertThat(metricRegistry.getMetrics()).hasSize(6);
+        assertThat(metricRegistry.getMetrics()).hasSize(7);
         assertThat(metricRegistry.getGauges().get("resilience4j.circuitbreaker.testName.state").getValue()).isEqualTo(0);
         assertThat(metricRegistry.getGauges().get("resilience4j.circuitbreaker.testName.buffered").getValue()).isEqualTo(1);
         assertThat(metricRegistry.getGauges().get("resilience4j.circuitbreaker.testName.successful").getValue()).isEqualTo(1);
         assertThat(metricRegistry.getGauges().get("resilience4j.circuitbreaker.testName.failed").getValue()).isEqualTo(0);
         assertThat(metricRegistry.getGauges().get("resilience4j.circuitbreaker.testName.not_permitted").getValue()).isEqualTo(0L);
         assertThat(metricRegistry.getGauges().get("resilience4j.circuitbreaker.testName.buffered_max").getValue()).isEqualTo(100);
+        assertThat(metricRegistry.getGauges().get("resilience4j.circuitbreaker.testName.failure_rate").getValue()).isEqualTo(-1f);
     }
 
     @Test
@@ -86,12 +87,13 @@ public class CircuitBreakerMetricsTest {
         assertThat(value).isEqualTo("Hello world");
         // Then the helloWorldService should be invoked 1 time
         BDDMockito.then(helloWorldService).should(times(1)).returnHelloWorld();
-        assertThat(metricRegistry.getMetrics()).hasSize(6);
+        assertThat(metricRegistry.getMetrics()).hasSize(7);
         assertThat(metricRegistry.getGauges().get("testPrefix.testName.state").getValue()).isEqualTo(0);
         assertThat(metricRegistry.getGauges().get("testPrefix.testName.buffered").getValue()).isEqualTo(1);
         assertThat(metricRegistry.getGauges().get("testPrefix.testName.successful").getValue()).isEqualTo(1);
         assertThat(metricRegistry.getGauges().get("testPrefix.testName.failed").getValue()).isEqualTo(0);
         assertThat(metricRegistry.getGauges().get("testPrefix.testName.not_permitted").getValue()).isEqualTo(0L);
         assertThat(metricRegistry.getGauges().get("testPrefix.testName.buffered_max").getValue()).isEqualTo(100);
+        assertThat(metricRegistry.getGauges().get("testPrefix.testName.failure_rate").getValue()).isEqualTo(-1f);
     }
 }

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetrics.java
@@ -90,6 +90,9 @@ public class TaggedCircuitBreakerMetrics extends AbstractMetrics implements Mete
         idSet.add(Gauge.builder(names.getMaxBufferedCallsMetricName(), circuitBreaker, (cb) -> cb.getMetrics().getMaxNumberOfBufferedCalls())
                 .tag(TagNames.NAME, circuitBreaker.getName())
                 .register(registry).getId());
+        idSet.add(Gauge.builder(names.getFailureRateMetricName(), circuitBreaker, (cb) -> cb.getMetrics().getFailureRate())
+                .tag(TagNames.NAME, circuitBreaker.getName())
+                .register(registry).getId());
 
         meterIdMap.put(circuitBreaker.getName(), idSet);
     }
@@ -114,6 +117,7 @@ public class TaggedCircuitBreakerMetrics extends AbstractMetrics implements Mete
         public static final String DEFAULT_CIRCUIT_BREAKER_STATE_METRIC_NAME = "resilience4j_circuitbreaker_state";
         public static final String DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS = "resilience4j_circuitbreaker_buffered_calls";
         public static final String DEFAULT_CIRCUIT_BREAKER_MAX_BUFFERED_CALLS = "resilience4j_circuitbreaker_max_buffered_calls";
+        public static final String DEFAULT_CIRCUIT_BREAKER_FAILURE_RATE = "resilience4j_circuitbreaker_failure_rate";
 
         /**
          * Returns a builder for creating custom metric names.
@@ -135,6 +139,7 @@ public class TaggedCircuitBreakerMetrics extends AbstractMetrics implements Mete
         private String stateMetricName = DEFAULT_CIRCUIT_BREAKER_STATE_METRIC_NAME;
         private String bufferedCallsMetricName = DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS;
         private String maxBufferedCallsMetricName = DEFAULT_CIRCUIT_BREAKER_MAX_BUFFERED_CALLS;
+        private String failureRateMetricName = DEFAULT_CIRCUIT_BREAKER_FAILURE_RATE;
 
         private MetricNames() {}
 
@@ -164,6 +169,13 @@ public class TaggedCircuitBreakerMetrics extends AbstractMetrics implements Mete
          */
         public String getStateMetricName() {
             return stateMetricName;
+        }
+
+        /** Returns the metric name for failure rate, defaults to {@value DEFAULT_CIRCUIT_BREAKER_FAILURE_RATE}.
+         * @return The failure rate metric name.
+         */
+        public String getFailureRateMetricName() {
+            return failureRateMetricName;
         }
 
         /** Helps building custom instance of {@link MetricNames}. */
@@ -202,6 +214,15 @@ public class TaggedCircuitBreakerMetrics extends AbstractMetrics implements Mete
              */
             public Builder maxBufferedCallsMetricName(String maxBufferedCallsMetricName) {
                 metricNames.maxBufferedCallsMetricName = requireNonNull(maxBufferedCallsMetricName);
+                return this;
+            }
+
+            /** Overrides the default metric name {@value MetricNames#DEFAULT_CIRCUIT_BREAKER_FAILURE_RATE} with a given one.
+             * @param failureRateMetricName The failure rate metric name.
+             * @return The builder.
+             */
+            public Builder failureRateMetricName(String failureRateMetricName) {
+                metricNames.failureRateMetricName = requireNonNull(failureRateMetricName);
                 return this;
             }
 

--- a/resilience4j-prometheus/src/main/java/io/github/resilience4j/prometheus/collectors/CircuitBreakerMetricsCollector.java
+++ b/resilience4j-prometheus/src/main/java/io/github/resilience4j/prometheus/collectors/CircuitBreakerMetricsCollector.java
@@ -110,6 +110,12 @@ public class CircuitBreakerMetricsCollector extends Collector {
             LabelNames.NAME
         );
 
+        GaugeMetricFamily failureRateFamily = new GaugeMetricFamily(
+                names.getFailureRateMetricName(),
+                "The failure rate",
+                LabelNames.NAME
+        );
+
         for (CircuitBreaker circuitBreaker : supplier.get()) {
             List<String> nameLabel = singletonList(circuitBreaker.getName());
 
@@ -122,9 +128,11 @@ public class CircuitBreakerMetricsCollector extends Collector {
 
             bufferedCallsFamily.addMetric(nameLabel, metrics.getNumberOfBufferedCalls());
             maxBufferedCallsFamily.addMetric(nameLabel, metrics.getMaxNumberOfBufferedCalls());
+
+            failureRateFamily.addMetric(nameLabel, metrics.getFailureRate());
         }
 
-        return asList(stateFamily, callsFamily, bufferedCallsFamily, maxBufferedCallsFamily);
+        return asList(stateFamily, callsFamily, bufferedCallsFamily, maxBufferedCallsFamily, failureRateFamily);
     }
 
     /** Defines possible configuration for metric names. */
@@ -134,6 +142,7 @@ public class CircuitBreakerMetricsCollector extends Collector {
         public static final String DEFAULT_CIRCUIT_BREAKER_STATE_METRIC_NAME = "resilience4j_circuitbreaker_state";
         public static final String DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS = "resilience4j_circuitbreaker_buffered_calls";
         public static final String DEFAULT_CIRCUIT_BREAKER_MAX_BUFFERED_CALLS = "resilience4j_circuitbreaker_max_buffered_calls";
+        public static final String DEFAULT_CIRCUIT_BREAKER_FAILURE_RATE = "resilience4j_circuitbreaker_failure_rate";
 
         /**
          * Returns a builder for creating custom metric names.
@@ -152,6 +161,7 @@ public class CircuitBreakerMetricsCollector extends Collector {
         private String stateMetricName = DEFAULT_CIRCUIT_BREAKER_STATE_METRIC_NAME;
         private String bufferedCallsMetricName = DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS;
         private String maxBufferedCallsMetricName = DEFAULT_CIRCUIT_BREAKER_MAX_BUFFERED_CALLS;
+        private String failureRateMetricName = DEFAULT_CIRCUIT_BREAKER_FAILURE_RATE;
 
         private MetricNames() {}
 
@@ -168,6 +178,11 @@ public class CircuitBreakerMetricsCollector extends Collector {
         /** Returns the metric name for max buffered calls, defaults to {@value DEFAULT_CIRCUIT_BREAKER_STATE_METRIC_NAME}. */
         public String getMaxBufferedCallsMetricName() {
             return maxBufferedCallsMetricName;
+        }
+
+        /** Returns the metric name for failure rate, defaults to {@value DEFAULT_CIRCUIT_BREAKER_FAILURE_RATE}. */
+        public String getFailureRateMetricName() {
+            return failureRateMetricName;
         }
 
         /** Returns the metric name for state, defaults to {@value DEFAULT_CIRCUIT_BREAKER_STATE_METRIC_NAME}. */
@@ -200,6 +215,12 @@ public class CircuitBreakerMetricsCollector extends Collector {
             /** Overrides the default metric name {@value MetricNames#DEFAULT_CIRCUIT_BREAKER_MAX_BUFFERED_CALLS} with a given one. */
             public Builder maxBufferedCallsMetricName(String maxBufferedCallsMetricName) {
                 metricNames.maxBufferedCallsMetricName = requireNonNull(maxBufferedCallsMetricName);
+                return this;
+            }
+
+            /** Overrides the default metric name {@value MetricNames#DEFAULT_CIRCUIT_BREAKER_FAILURE_RATE} with a given one. */
+            public Builder failureRateMetricName(String failureRateMetricName) {
+                metricNames.failureRateMetricName = requireNonNull(failureRateMetricName);
                 return this;
             }
 

--- a/resilience4j-prometheus/src/test/java/io/github/resilience4j/prometheus/collectors/CircuitBreakerMetricsCollectorTest.java
+++ b/resilience4j-prometheus/src/test/java/io/github/resilience4j/prometheus/collectors/CircuitBreakerMetricsCollectorTest.java
@@ -20,8 +20,10 @@ import io.prometheus.client.CollectorRegistry;
 import org.junit.Before;
 import org.junit.Test;
 
+
 import static io.github.resilience4j.prometheus.collectors.CircuitBreakerMetricsCollector.MetricNames.DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS;
 import static io.github.resilience4j.prometheus.collectors.CircuitBreakerMetricsCollector.MetricNames.DEFAULT_CIRCUIT_BREAKER_CALLS_METRIC_NAME;
+import static io.github.resilience4j.prometheus.collectors.CircuitBreakerMetricsCollector.MetricNames.DEFAULT_CIRCUIT_BREAKER_FAILURE_RATE;
 import static io.github.resilience4j.prometheus.collectors.CircuitBreakerMetricsCollector.MetricNames.DEFAULT_CIRCUIT_BREAKER_MAX_BUFFERED_CALLS;
 import static io.github.resilience4j.prometheus.collectors.CircuitBreakerMetricsCollector.MetricNames.DEFAULT_CIRCUIT_BREAKER_STATE_METRIC_NAME;
 import static java.util.Collections.singletonList;
@@ -111,6 +113,17 @@ public class CircuitBreakerMetricsCollectorTest {
     }
 
     @Test
+    public void failureRateReportsCorrespondingValue() {
+        Double failureRate = registry.getSampleValue(
+                DEFAULT_CIRCUIT_BREAKER_FAILURE_RATE,
+                new String[]{"name"},
+                new String[]{circuitBreaker.getName()}
+        );
+
+        assertThat(failureRate.floatValue()).isEqualTo(circuitBreaker.getMetrics().getFailureRate());
+    }
+
+    @Test
     public void customMetricNamesOverrideDefaultOnes() {
         CollectorRegistry registry = new CollectorRegistry();
 
@@ -120,6 +133,7 @@ public class CircuitBreakerMetricsCollectorTest {
                 .stateMetricName("custom_state")
                 .maxBufferedCallsMetricName("custom_max_buffered_calls")
                 .bufferedCallsMetricName("custom_buffered_calls")
+                .failureRateMetricName("custom_failure_rate")
                 .build(),
             () -> singletonList(CircuitBreaker.ofDefaults("backendA"))
         ).register(registry);

--- a/resilience4j-ratpack/src/test/groovy/io/github/resilience4j/ratpack/Resilience4jModuleSpec.groovy
+++ b/resilience4j-ratpack/src/test/groovy/io/github/resilience4j/ratpack/Resilience4jModuleSpec.groovy
@@ -627,13 +627,14 @@ class Resilience4jModuleSpec extends Specification {
         timer.count == 3
 
         and:
-        registry.gauges.size() == 14
+        registry.gauges.size() == 15
         registry.gauges.keySet() == ['resilience4j.circuitbreaker.test.state',
                                      'resilience4j.circuitbreaker.test.buffered',
                                      'resilience4j.circuitbreaker.test.buffered_max',
                                      'resilience4j.circuitbreaker.test.failed',
                                      'resilience4j.circuitbreaker.test.not_permitted',
                                      'resilience4j.circuitbreaker.test.successful',
+                                     'resilience4j.circuitbreaker.test.failure_rate',
                                      'resilience4j.ratelimiter.test.available_permissions',
                                      'resilience4j.ratelimiter.test.number_of_waiting_threads',
                                      'resilience4j.retry.test.successful_calls_without_retry',
@@ -694,6 +695,7 @@ class Resilience4jModuleSpec extends Specification {
                      'resilience4j_circuitbreaker_max_buffered_calls',
                      'resilience4j_circuitbreaker_calls',
                      'resilience4j_circuitbreaker_state',
+                     'resilience4j_circuitbreaker_failure_rate',
                      'resilience4j_ratelimiter_available_permissions',
                      'resilience4j_ratelimiter_waiting_threads'].sort()
     }


### PR DESCRIPTION
Fixes #439 

Unit tests pass but I am having issues running the snapshot with https://github.com/RobWin/resilience4j-spring-boot2-demo  

I built resilience4j using `./gradlew publishToMavenLocal` and modified the resilience4j-spring-boot2-demo to use `mavenLocal()` and `resilience4jVersion = '0.15.0-SNAPSHOT'`. Unfortunately, as soon as I run `./gradlew bootRun` I get:
```
java.lang.IllegalStateException: Error processing condition on io.github.resilience4j.springboot.common.circuitbreaker.autoconfigure.AbstractCircuitBreakerConfigurationOnMissingBean.circuitBreakerRegistry
        at org.springframework.boot.autoconfigure.condition.SpringBootCondition.matches(SpringBootCondition.java:64) ~[spring-boot-autoconfigure-2.1.3.RELEASE.jar:2.1.3.RELEASE]
...
```

This also happens when building resilience4j from the master branch. I wonder what are you using to test the snapshot :shrug:

I ended up testing the feature with my own service. For example,
http://localhost:8081/metrics/resilience4j_circuitbreaker_failure_rate returns

```
{
	"name": "resilience4j_circuitbreaker_failure_rate",
	"description": null,
	"baseUnit": null,
	"measurements": [{
		"statistic": "VALUE",
		"value": 60.0
	}],
	"availableTags": [{
		"tag": "name",
		"values": ["myservice"]
	}]
}
```

**NOTE:**
 - I didn't backport the feature to the `legacy_binder`
 - I didn't test the prometheus implementation 
