### PR TITLE
Update javadocs for resilience4j-bulkhead Bulkhead.java

### DIFF
--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/Bulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/Bulkhead.java
@@ -64,7 +64,7 @@ public interface Bulkhead {
      * Attempts to obtain a permission to execute a call.
      * @deprecated Use {@link Bulkhead#tryAcquirePermission()} ()}. instead.
      *
-     * @return {@code true} if a permission was acquired and {@code true} otherwise
+     * @return {@code true} if a permission was acquired and {@code false} otherwise
      */
     @Deprecated
     boolean isCallPermitted();
@@ -72,7 +72,7 @@ public interface Bulkhead {
     /**
      * Acquires a permission to execute a call, only if one is available at the time of invocation.
      *
-     * @return {@code true} if a permission was acquired and {@code true} otherwise
+     * @return {@code true} if a permission was acquired and {@code false} otherwise
      */
     boolean tryAcquirePermission();
 


### PR DESCRIPTION
A very simple Javadoc update. I found the same line in `resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreaker.java` as well. Let me know if that needs to be updated as well.