### PR TITLE
Don't prevent using other call adapters in CircuitBreakerCallAdapter (fixes #431)

### DIFF
--- a/libraries.gradle
+++ b/libraries.gradle
@@ -88,11 +88,12 @@ ext {
             retrofit: "com.squareup.retrofit2:retrofit:${retrofitVersion}",
             retrofit_test: "com.squareup.retrofit2:converter-scalars:${retrofitVersion}",
             retrofit_wiremock: "com.github.tomakehurst:wiremock:${wiremockVersion}",
-            
+            retrofit_rxjava: "com.squareup.retrofit2:adapter-rxjava2:2.3.0",
+
             // Feign addon
             feign: "io.github.openfeign:feign-core:${feignVersion}",
             feign_wiremock: "com.github.tomakehurst:wiremock:${wiremockVersion}",
-            
+
             // Metrics addon
             metrics: "io.dropwizard.metrics:metrics-core:${metricsVersion}",
 

--- a/resilience4j-retrofit/build.gradle
+++ b/resilience4j-retrofit/build.gradle
@@ -5,5 +5,6 @@ dependencies {
     testCompile ( libraries.retrofit_test )
     testCompile ( libraries.retrofit_wiremock )
     testCompile ( libraries.retrofit )
+    testCompile ( libraries.retrofit_rxjava )
 }
 ext.moduleName='io.github.resilience4j.retrofit'

--- a/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/CircuitBreakerCallAdapter.java
+++ b/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/CircuitBreakerCallAdapter.java
@@ -25,7 +25,6 @@ import retrofit2.Response;
 import retrofit2.Retrofit;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.function.Predicate;
 
@@ -63,30 +62,20 @@ public final class CircuitBreakerCallAdapter extends CallAdapter.Factory {
     }
 
     @Override
-    public CallAdapter<?,?> get(Type returnType, Annotation[] annotations, Retrofit retrofit) {
-        if (getRawType(returnType) != Call.class) {
-            return null;
-        }
+    public CallAdapter<?, ?> get(Type returnType, Annotation[] annotations, Retrofit retrofit) {
+        @SuppressWarnings("unchecked")
+        CallAdapter<Object, Object> nextAdapter = (CallAdapter<Object, Object>) retrofit.nextCallAdapter(this, returnType, annotations);
 
-        final Type responseType = getCallResponseType(returnType);
-        return new CallAdapter<Object, Call<?>>() {
+        return new CallAdapter<Object, Object>() {
             @Override
             public Type responseType() {
-                return responseType;
+                return nextAdapter.responseType();
             }
 
             @Override
-            public Call<Object> adapt(Call<Object> call) {
-                return RetrofitCircuitBreaker.decorateCall(circuitBreaker, call, successResponse);
+            public Object adapt(Call<Object> call) {
+                return nextAdapter.adapt(RetrofitCircuitBreaker.decorateCall(circuitBreaker, call, successResponse));
             }
         };
     }
-
-    private static Type getCallResponseType(Type returnType) {
-        if (!(returnType instanceof ParameterizedType)) {
-            throw new IllegalArgumentException("Call return type must be parameterized as Call<Foo> or Call<? extends Foo>");
-        }
-        return getParameterUpperBound(0, (ParameterizedType) returnType);
-    }
-
 }

--- a/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/RetrofitCircuitBreaker.java
+++ b/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/RetrofitCircuitBreaker.java
@@ -49,59 +49,75 @@ public interface RetrofitCircuitBreaker {
      * @return Original Call decorated with CircuitBreaker
      */
     static <T> Call<T> decorateCall(final CircuitBreaker circuitBreaker, final Call<T> call, final Predicate<Response> responseSuccess) {
-        return new DecoratedCall<T>(call) {
+        return new CircuitBreakingCall<>(call, circuitBreaker, responseSuccess);
+    }
 
-            @Override
-            public void enqueue(final Callback<T> callback) {
-                try {
-                    circuitBreaker.acquirePermission();
-                } catch (CallNotPermittedException cb) {
-                    callback.onFailure(call, cb);
-                    return;
-                }
+    class CircuitBreakingCall<T> extends DecoratedCall<T> {
+        private final Call<T> call;
+        private final CircuitBreaker circuitBreaker;
+        private final Predicate<Response> responseSuccess;
 
-                final StopWatch stopWatch = StopWatch.start();
-                call.enqueue(new Callback<T>() {
-                    @Override
-                    public void onResponse(final Call<T> call, final Response<T> response) {
-                        if (responseSuccess.test(response)) {
-                            circuitBreaker.onSuccess(stopWatch.stop().toNanos());
-                        } else {
-                            final Throwable throwable = new Throwable("Response error: HTTP " + response.code() + " - " + response.message());
-                            circuitBreaker.onError(stopWatch.stop().toNanos(), throwable);
-                        }
-                        callback.onResponse(call, response);
-                    }
+        public CircuitBreakingCall(Call<T> call, CircuitBreaker circuitBreaker, Predicate<Response> responseSuccess) {
+            super(call);
+            this.call = call;
+            this.circuitBreaker = circuitBreaker;
+            this.responseSuccess = responseSuccess;
+        }
 
-                    @Override
-                    public void onFailure(final Call<T> call, final Throwable t) {
-                        circuitBreaker.onError(stopWatch.stop().toNanos(), t);
-                        callback.onFailure(call, t);
-                    }
-                });
+        @Override
+        public void enqueue(final Callback<T> callback) {
+            try {
+                circuitBreaker.acquirePermission();
+            } catch (CallNotPermittedException cb) {
+                callback.onFailure(call, cb);
+                return;
             }
 
-            @Override
-            public Response<T> execute() throws IOException {
-                circuitBreaker.acquirePermission();
-                final StopWatch stopWatch = StopWatch.start();
-                try {
-                    final Response<T> response = call.execute();
-
+            final StopWatch stopWatch = StopWatch.start();
+            call.enqueue(new Callback<T>() {
+                @Override
+                public void onResponse(final Call<T> call, final Response<T> response) {
                     if (responseSuccess.test(response)) {
                         circuitBreaker.onSuccess(stopWatch.stop().toNanos());
                     } else {
                         final Throwable throwable = new Throwable("Response error: HTTP " + response.code() + " - " + response.message());
                         circuitBreaker.onError(stopWatch.stop().toNanos(), throwable);
                     }
-
-                    return response;
-                } catch (Exception exception) {
-                    circuitBreaker.onError(stopWatch.stop().toNanos(), exception);
-                    throw exception;
+                    callback.onResponse(call, response);
                 }
-            }
-        };
-    }
 
+                @Override
+                public void onFailure(final Call<T> call, final Throwable t) {
+                    circuitBreaker.onError(stopWatch.stop().toNanos(), t);
+                    callback.onFailure(call, t);
+                }
+            });
+        }
+
+        @Override
+        public Response<T> execute() throws IOException {
+            circuitBreaker.acquirePermission();
+            final StopWatch stopWatch = StopWatch.start();
+            try {
+                final Response<T> response = call.execute();
+
+                if (responseSuccess.test(response)) {
+                    circuitBreaker.onSuccess(stopWatch.stop().toNanos());
+                } else {
+                    final Throwable throwable = new Throwable("Response error: HTTP " + response.code() + " - " + response.message());
+                    circuitBreaker.onError(stopWatch.stop().toNanos(), throwable);
+                }
+
+                return response;
+            } catch (Exception exception) {
+                circuitBreaker.onError(stopWatch.stop().toNanos(), exception);
+                throw exception;
+            }
+        }
+
+        @Override
+        public Call<T> clone() {
+            return new CircuitBreakingCall<>(call.clone(), circuitBreaker, responseSuccess);
+        }
+    }
 }

--- a/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/RetrofitRateLimiter.java
+++ b/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/RetrofitRateLimiter.java
@@ -53,42 +53,57 @@ public interface RetrofitRateLimiter {
      * @return Original Call decorated with CircuitBreaker
      */
     static <T> Call<T> decorateCall(final RateLimiter rateLimiter, final Call<T> call) {
-        return new DecoratedCall<T>(call) {
-            @Override
-            public void enqueue(final Callback<T> callback) {
-                try {
-                    RateLimiter.waitForPermission(rateLimiter);
-                } catch (RequestNotPermitted | IllegalStateException e) {
-                    callback.onResponse(call, tooManyRequestsError());
-                    return;
-                }
-
-                call.enqueue(callback);
-            }
-
-            @Override
-            public Response<T> execute() throws IOException {
-                CheckedFunction0<Response<T>> restrictedSupplier = RateLimiter.decorateCheckedSupplier(rateLimiter, call::execute);
-                final Try<Response<T>> response = Try.of(restrictedSupplier);
-                return response.isSuccess() ? response.get() : handleFailure(response);
-            }
-
-            private Response<T> handleFailure(Try<Response<T>> response) throws IOException {
-                try {
-                    throw response.getCause();
-                } catch (RequestNotPermitted | IllegalStateException e) {
-                    return tooManyRequestsError();
-                } catch (IOException ioe) {
-                    throw ioe;
-                } catch (Throwable t) {
-                    throw new RuntimeException("Exception executing call", t);
-                }
-            }
-
-            private Response<T> tooManyRequestsError() {
-                return Response.error(429, ResponseBody.create(MediaType.parse("text/plain"), "Too many requests for the client"));
-            }
-        };
+        return new RateLimitingCall<>(call, rateLimiter);
     }
 
+    class RateLimitingCall<T> extends DecoratedCall<T> {
+        private final Call<T> call;
+        private final RateLimiter rateLimiter;
+
+        public RateLimitingCall(Call<T> call, RateLimiter rateLimiter) {
+            super(call);
+            this.call = call;
+            this.rateLimiter = rateLimiter;
+        }
+
+        @Override
+        public void enqueue(final Callback<T> callback) {
+            try {
+                RateLimiter.waitForPermission(rateLimiter);
+            } catch (RequestNotPermitted | IllegalStateException e) {
+                callback.onResponse(call, tooManyRequestsError());
+                return;
+            }
+
+            call.enqueue(callback);
+        }
+
+        @Override
+        public Response<T> execute() throws IOException {
+            CheckedFunction0<Response<T>> restrictedSupplier = RateLimiter.decorateCheckedSupplier(rateLimiter, call::execute);
+            final Try<Response<T>> response = Try.of(restrictedSupplier);
+            return response.isSuccess() ? response.get() : handleFailure(response);
+        }
+
+        private Response<T> handleFailure(Try<Response<T>> response) throws IOException {
+            try {
+                throw response.getCause();
+            } catch (RequestNotPermitted | IllegalStateException e) {
+                return tooManyRequestsError();
+            } catch (IOException ioe) {
+                throw ioe;
+            } catch (Throwable t) {
+                throw new RuntimeException("Exception executing call", t);
+            }
+        }
+
+        private Response<T> tooManyRequestsError() {
+            return Response.error(429, ResponseBody.create(MediaType.parse("text/plain"), "Too many requests for the client"));
+        }
+
+        @Override
+        public Call<T> clone() {
+            return new RateLimitingCall<>(call.clone(), rateLimiter);
+        }
+    }
 }

--- a/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/internal/DecoratedCall.java
+++ b/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/internal/DecoratedCall.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  *
  * @param <T> Call parameter type
  */
-public class DecoratedCall<T> implements Call<T> {
+public abstract class DecoratedCall<T> implements Call<T> {
 
     private final Call<T> call;
 
@@ -65,9 +65,7 @@ public class DecoratedCall<T> implements Call<T> {
     }
 
     @Override
-    public Call<T> clone() {
-        return new DecoratedCall<>(call.clone());
-    }
+    public abstract Call<T> clone();
 
     @Override
     public Request request() {

--- a/resilience4j-retrofit/src/test/java/io/github/resilience4j/retrofit/RetrofitService.java
+++ b/resilience4j-retrofit/src/test/java/io/github/resilience4j/retrofit/RetrofitService.java
@@ -18,6 +18,7 @@
  */
 package io.github.resilience4j.retrofit;
 
+import io.reactivex.Single;
 import retrofit2.Call;
 import retrofit2.http.GET;
 
@@ -26,4 +27,6 @@ public interface RetrofitService {
     @GET("greeting")
     Call<String> greeting();
 
+    @GET("delegated")
+    Single<String> delegated();
 }

--- a/resilience4j-retrofit/src/test/java/io/github/resilience4j/retrofit/internal/DecoratedCallTest.java
+++ b/resilience4j-retrofit/src/test/java/io/github/resilience4j/retrofit/internal/DecoratedCallTest.java
@@ -16,7 +16,12 @@ import static org.mockito.Mockito.mock;
 public class DecoratedCallTest {
 
     private final Call<String> call = mock(StringCall.class);
-    private final Call<String> decorated = new DecoratedCall<>(call);
+    private final Call<String> decorated = new DecoratedCall<String>(call) {
+        @Override
+        public Call<String> clone() {
+            throw new UnsupportedOperationException();
+        }
+    };
 
     @Test
     public void passThroughCallsToDecoratedObject() throws IOException {
@@ -32,31 +37,11 @@ public class DecoratedCallTest {
         decorated.isCanceled();
         Mockito.verify(call).isCanceled();
 
-        decorated.clone();
-        Mockito.verify(call).clone();
-
         decorated.request();
         Mockito.verify(call).request();
 
         decorated.execute();
         Mockito.verify(call).execute();
-    }
-
-    @Test
-    public void cloneShouldReturnDecoratedCall() {
-        Call<String> clonedTarget = mock(StringCall.class);
-        Mockito.when(call.clone()).thenReturn(clonedTarget);
-
-        Call<String> clonedDecorator = decorated.clone();
-        Mockito.verify(call).clone();
-        assertThat(clonedDecorator).isInstanceOf(DecoratedCall.class);
-
-        decorated.request();
-        Mockito.verify(call).request();
-        Mockito.verifyNoMoreInteractions(call);
-
-        clonedDecorator.request();
-        Mockito.verify(clonedTarget).request();
     }
 
     private interface StringCall extends Call<String> {


### PR DESCRIPTION
The `CircuitBreakerCallAdapter` doesn't need to actually adapt the call, it just needs to delegate to whatever call adapter *should* be handling a certain return type.

This fixes #431 with one caveat: The `CircuitBreakerCallAdapter` needs to be added to retrofit before any other adapters.