### PR TITLE
Add Registry.find() method and test

### DIFF
--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/Registry.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/Registry.java
@@ -39,6 +39,13 @@ public interface Registry<E, C> {
 	void addConfiguration(String configName, C configuration);
 
 	/**
+	 * Find a named entry in the Registry
+	 *
+	 * @param name    the  name
+	 */
+	Optional<E> find(String name);
+
+	/**
 	 * Remove an entry from the Registry
 	 *
 	 * @param name    the  name

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/registry/AbstractRegistry.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/registry/AbstractRegistry.java
@@ -59,6 +59,11 @@ public class AbstractRegistry<E, C> implements Registry<E, C> {
 	}
 
 	@Override
+	public Optional<E> find(String name){
+		return Optional.ofNullable(entryMap.get(name));
+	}
+
+	@Override
 	public Optional<E> remove(String name){
 		Optional<E> removedEntry = Optional.ofNullable(entryMap.remove(name));
 		removedEntry.ifPresent(entry -> eventProcessor.processEvent(new EntryRemovedEvent<>(entry)));

--- a/resilience4j-core/src/test/java/io/github/resilience4j/core/registry/AbstractRegistryTest.java
+++ b/resilience4j-core/src/test/java/io/github/resilience4j/core/registry/AbstractRegistryTest.java
@@ -76,6 +76,16 @@ public class AbstractRegistryTest {
 
 	}
 
+	@Test
+	public void shouldOnlyFindRegisteredObjects() {
+		TestRegistry testRegistry = new TestRegistry();
+
+		assertThat(testRegistry.find("test")).isEmpty();
+		testRegistry.entryMap.put("test", "value");
+		assertThat(testRegistry.find("test")).contains("value");
+	}
+
+
 	class TestRegistry extends AbstractRegistry<String, String> {
 
 		public TestRegistry() {


### PR DESCRIPTION
### About
Add find() method that will only return an existing object in a Registry but will not create a new one.

Addresses #476.

### Notes
I added a test, miniscule as it is. Let me know if I forgot anything or you want changes; my Java's a little rusty.