### PR TITLE
Fix typo in core_guides/timelimiter

### DIFF
--- a/resilience4j-documentation/src/docs/asciidoc/core_guides/timelimiter.adoc
+++ b/resilience4j-documentation/src/docs/asciidoc/core_guides/timelimiter.adoc
@@ -41,7 +41,7 @@ Integer result = timeLimiter.executeFutureSupplier(futureSupplier);
 Callable restrictedCall = TimeLimiter
     .decorateFutureSupplier(timeLimiter, futureSupplier);
 
-Try.of(restrictedCall.call)
+Try.of(restrictedCall::call)
     .onFailure(throwable -> LOG.info("A timeout possibly occurred."));
 ----
 


### PR DESCRIPTION
Fix sample code typo in core_guides/timelimiter.adoc.
Use Try.of() with method reference like another sample code.