### PR TITLE
Consume the thrown exception in a Feign fallback

### DIFF
--- a/resilience4j-feign/README.adoc
+++ b/resilience4j-feign/README.adoc
@@ -91,7 +91,35 @@ In this example, the `requestFailedFallback` is called when a `FeignException` i
 All fallbacks must implement the same interface that is declared in the "target" (Resilience4jFeign.Builder#target) method, otherwise an IllegalArgumentException will be thrown.
 Multiple fallbacks can be assigned to handle the same Exception with the next fallback being called when the previous one fails.
 
+A fallback can consume a thrown Exception if needed. This can be useful if the fallback may have different behaviours depending on the Exception, or to simply log the Exception.
+Be aware that such a fallback will be instantiated for every exceptions thrown.
 
+``` java
+        public interface MyService {
+            @RequestLine("GET /greeting")
+            String greeting();
+        }
+
+        public class MyFallback implements MyService {
+            private Exception cause;
+
+            public MyFallback(Exception cause) {
+                this.cause = cause;
+            }
+
+            public String greeting() {
+                if (cause instanceOf FeignException) {
+                    return "Feign Exception";
+                } else {
+                    return "Other exception";
+                }
+            }
+        }
+
+        FeignDecorators decorators = FeignDecorators.builder()
+                                         .withFallbackFactory(MyFallback::new)
+                                         .build();
+```
 
 == License
 

--- a/resilience4j-feign/src/main/java/io/github/resilience4j/feign/DefaultFallbackHandler.java
+++ b/resilience4j-feign/src/main/java/io/github/resilience4j/feign/DefaultFallbackHandler.java
@@ -1,0 +1,54 @@
+/*
+ *
+ * Copyright 2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *
+ */
+package io.github.resilience4j.feign;
+
+import java.lang.reflect.Method;
+import java.util.function.Predicate;
+
+import io.vavr.CheckedFunction1;
+
+/**
+ * A {@link FallbackHandler} simply wrapping a fallback instance of type {@param T}.
+ *
+ * @param <T> the type of the fallback
+ */
+class DefaultFallbackHandler<T> implements FallbackHandler<T> {
+
+    private final T fallback;
+
+    DefaultFallbackHandler(T fallback) {
+        this.fallback = fallback;
+    }
+
+    @Override
+    public CheckedFunction1<Object[], Object> decorate(CheckedFunction1<Object[], Object> invocationCall,
+                                                       Method method,
+                                                       Predicate<Exception> filter) {
+        validateFallback(fallback, method);
+        Method fallbackMethod = getFallbackMethod(fallback, method);
+        return args -> {
+            try {
+                return invocationCall.apply(args);
+            } catch (Exception exception) {
+                if (filter.test(exception)) {
+                    return fallbackMethod.invoke(fallback, args);
+                }
+                throw exception;
+            }
+        };
+    }
+}

--- a/resilience4j-feign/src/main/java/io/github/resilience4j/feign/FallbackFactory.java
+++ b/resilience4j-feign/src/main/java/io/github/resilience4j/feign/FallbackFactory.java
@@ -1,0 +1,57 @@
+/*
+ *
+ * Copyright 2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *
+ */
+package io.github.resilience4j.feign;
+
+import java.lang.reflect.Method;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import io.vavr.CheckedFunction1;
+
+/**
+ * A {@link FallbackHandler} wrapping a fallback of type {@param T} whose instance will consume the exception thrown on error.
+ * A new instance of the fallback will be created for every thrown exceptions.
+ *
+ * @param <T> the type of the fallback
+ */
+class FallbackFactory<T> implements FallbackHandler<T> {
+
+    private final Function<Exception, T> fallbackSupplier;
+
+    FallbackFactory(Function<Exception, T> fallbackSupplier) {
+        this.fallbackSupplier = fallbackSupplier;
+    }
+
+    @Override
+    public CheckedFunction1<Object[], Object> decorate(CheckedFunction1<Object[], Object> invocationCall,
+                                                       Method method,
+                                                       Predicate<Exception> filter) {
+        return args -> {
+            try {
+                return invocationCall.apply(args);
+            } catch (Exception exception) {
+                if (filter.test(exception)) {
+                    T fallbackInstance = fallbackSupplier.apply(exception);
+                    validateFallback(fallbackInstance, method);
+                    Method fallbackMethod = getFallbackMethod(fallbackInstance, method);
+                    return fallbackMethod.invoke(fallbackInstance, args);
+                }
+                throw exception;
+            }
+        };
+    }
+}

--- a/resilience4j-feign/src/main/java/io/github/resilience4j/feign/FallbackHandler.java
+++ b/resilience4j-feign/src/main/java/io/github/resilience4j/feign/FallbackHandler.java
@@ -1,0 +1,52 @@
+/*
+ *
+ * Copyright 2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *
+ */
+package io.github.resilience4j.feign;
+
+import java.lang.reflect.Method;
+import java.util.function.Predicate;
+
+import io.vavr.CheckedFunction1;
+
+/**
+ * Handles a fallback of of type {@param T}.
+ *
+ * @param <T> the type of the fallback
+ */
+interface FallbackHandler<T> {
+
+    CheckedFunction1<Object[], Object> decorate(CheckedFunction1<Object[], Object> invocationCall, Method method, Predicate<Exception> filter);
+
+    default void validateFallback(T fallback, Method method) {
+        if (fallback.getClass().isAssignableFrom(method.getDeclaringClass())) {
+            throw new IllegalArgumentException("Cannot use the fallback ["
+                    + fallback.getClass() + "] for ["
+                    + method.getDeclaringClass() + "]!");
+        }
+    }
+
+    default Method getFallbackMethod(T fallbackInstance, Method method) {
+        Method fallbackMethod;
+        try {
+            fallbackMethod = fallbackInstance.getClass().getMethod(method.getName(), method.getParameterTypes());
+        } catch (NoSuchMethodException | SecurityException e) {
+            throw new IllegalArgumentException("Cannot use the fallback ["
+                    + fallbackInstance.getClass() + "] for ["
+                    + method.getDeclaringClass() + "]", e);
+        }
+        return fallbackMethod;
+    }
+}

--- a/resilience4j-feign/src/main/java/io/github/resilience4j/feign/FeignDecorators.java
+++ b/resilience4j-feign/src/main/java/io/github/resilience4j/feign/FeignDecorators.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2018
+ * Copyright 2019
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,6 +19,7 @@ package io.github.resilience4j.feign;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import feign.InvocationHandlerFactory.MethodHandler;
@@ -108,7 +109,20 @@ public class FeignDecorators implements FeignDecorator {
          * @return the builder
          */
         public Builder withFallback(Object fallback) {
-            decorators.add(new FallbackDecorator<Object>(fallback));
+            decorators.add(new FallbackDecorator<>(new DefaultFallbackHandler<>(fallback)));
+            return this;
+        }
+
+        /**
+         * Adds a fallback factory to the decorator chain. A factory can consume the exception thrown on error.
+         * Multiple fallbacks can be applied with the next fallback being called when the previous one fails.
+         *
+         * @param fallbackFactory must match the feign interface, i.e. the interface specified when calling
+         *        {@link Resilience4jFeign.Builder#target(Class, String)}.
+         * @return the builder
+         */
+        public Builder withFallbackFactory(Function<Exception, ?> fallbackFactory) {
+            decorators.add(new FallbackDecorator<>(new FallbackFactory<>(fallbackFactory)));
             return this;
         }
 
@@ -123,7 +137,22 @@ public class FeignDecorators implements FeignDecorator {
          * @return the builder
          */
         public Builder withFallback(Object fallback, Class<? extends Exception> filter) {
-            decorators.add(new FallbackDecorator<Object>(fallback, filter));
+            decorators.add(new FallbackDecorator<>(new DefaultFallbackHandler<>(fallback), filter));
+            return this;
+        }
+
+        /**
+         * Adds a fallback factory to the decorator chain. A factory can consume the exception thrown on error.
+         * Multiple fallbacks can be applied with the next fallback being called when the previous one fails.
+         *
+         * @param fallbackFactory must match the feign interface, i.e. the interface specified when calling
+         *        {@link Resilience4jFeign.Builder#target(Class, String)}.
+         * @param filter only {@link Exception}s matching the specified {@link Exception} will
+         *        trigger the fallback.
+         * @return the builder
+         */
+        public Builder withFallbackFactory(Function<Exception, ?> fallbackFactory, Class<? extends Exception> filter) {
+            decorators.add(new FallbackDecorator<>(new FallbackFactory<>(fallbackFactory), filter));
             return this;
         }
 
@@ -137,7 +166,21 @@ public class FeignDecorators implements FeignDecorator {
          * @return the builder
          */
         public Builder withFallback(Object fallback, Predicate<Exception> filter) {
-            decorators.add(new FallbackDecorator<Object>(fallback, filter));
+            decorators.add(new FallbackDecorator<>(new DefaultFallbackHandler<>(fallback), filter));
+            return this;
+        }
+
+        /**
+         * Adds a fallback to the decorator chain. A factory can consume the exception thrown on error.
+         * Multiple fallbacks can be applied with the next fallback being called when the previous one fails.
+         *
+         * @param fallbackFactory must match the feign interface, i.e. the interface specified when calling
+         *        {@link Resilience4jFeign.Builder#target(Class, String)}.
+         * @param filter the filter must return <code>true</code> for the fallback to be called.
+         * @return the builder
+         */
+        public Builder withFallbackFactory(Function<Exception, ?> fallbackFactory, Predicate<Exception> filter) {
+            decorators.add(new FallbackDecorator<>(new FallbackFactory<>(fallbackFactory), filter));
             return this;
         }
 

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignFallbackFactoryTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignFallbackFactoryTest.java
@@ -1,0 +1,167 @@
+/*
+ *
+ * Copyright 2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *
+ */
+package io.github.resilience4j.feign;
+
+import java.util.function.Function;
+
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import feign.FeignException;
+import io.github.resilience4j.feign.test.TestService;
+import io.github.resilience4j.feign.test.TestServiceFallbackWithException;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests on fallback factories.
+ */
+public class Resilience4jFeignFallbackFactoryTest {
+
+    private static final String MOCK_URL = "http://localhost:8080/";
+
+    @ClassRule
+    public static final WireMockClassRule WIRE_MOCK_RULE = new WireMockClassRule(8080);
+    @Rule
+    public WireMockClassRule instanceRule = WIRE_MOCK_RULE;
+
+    @Test
+    public void should_successfully_get_a_response() {
+        setupStub(200);
+        TestService testService = buildTestService(e -> "my fallback");
+
+        String result = testService.greeting();
+
+        assertThat(result).isEqualTo("Hello, world!");
+        verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+    }
+
+    @Test
+    public void should_lazily_fail_on_invalid_fallback() {
+        TestService testService = buildTestService(e -> "my fallback");
+
+        Throwable throwable = catchThrowable(testService::greeting);
+
+        assertThat(throwable).isNotNull()
+                .hasMessageContaining("Cannot use the fallback [class java.lang.String] for [interface io.github.resilience4j.feign.test.TestService]");
+    }
+
+    @Test
+    public void should_go_to_fallback_and_consume_exception() {
+        setupStub(400);
+        TestService testService = buildTestService(TestServiceFallbackWithException::new);
+
+        String result = testService.greeting();
+
+        assertThat(result).isEqualTo("Message from exception: status 400 reading TestService#greeting()");
+        verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+    }
+
+    @Test
+    public void should_go_to_fallback_and_consume_exception_with_exception_filter() {
+        setupStub(400);
+        TestService uselessFallback = spy(TestService.class);
+        when(uselessFallback.greeting()).thenReturn("I should not be called");
+        FeignDecorators decorators = FeignDecorators.builder()
+                .withFallbackFactory(TestServiceFallbackWithException::new, FeignException.class)
+                .withFallbackFactory(e -> uselessFallback)
+                .build();
+        TestService testService = Resilience4jFeign.builder(decorators).target(TestService.class, MOCK_URL);
+
+        String result = testService.greeting();
+
+        assertThat(result).isEqualTo("Message from exception: status 400 reading TestService#greeting()");
+        verify(uselessFallback, times(0)).greeting();
+        verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+    }
+
+    @Test
+    public void should_go_to_second_fallback_and_consume_exception_with_exception_filter() {
+        setupStub(400);
+        TestService uselessFallback = spy(TestService.class);
+        when(uselessFallback.greeting()).thenReturn("I should not be called");
+        FeignDecorators decorators = FeignDecorators.builder()
+                .withFallbackFactory(e -> uselessFallback, MyException.class)
+                .withFallbackFactory(TestServiceFallbackWithException::new)
+                .build();
+        TestService testService = Resilience4jFeign.builder(decorators).target(TestService.class, MOCK_URL);
+
+        String result = testService.greeting();
+
+        assertThat(result).isEqualTo("Message from exception: status 400 reading TestService#greeting()");
+        verify(uselessFallback, times(0)).greeting();
+        verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+    }
+
+    @Test
+    public void should_go_to_fallback_and_consume_exception_with_predicate() {
+        setupStub(400);
+        TestService uselessFallback = spy(TestService.class);
+        when(uselessFallback.greeting()).thenReturn("I should not be called");
+        FeignDecorators decorators = FeignDecorators.builder()
+                .withFallbackFactory(TestServiceFallbackWithException::new, FeignException.class::isInstance)
+                .withFallbackFactory(e -> uselessFallback)
+                .build();
+        TestService testService = Resilience4jFeign.builder(decorators).target(TestService.class, MOCK_URL);
+
+        String result = testService.greeting();
+
+        assertThat(result).isEqualTo("Message from exception: status 400 reading TestService#greeting()");
+        verify(uselessFallback, times(0)).greeting();
+        verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+    }
+
+    @Test
+    public void should_go_to_second_fallback_and_consume_exception_with_predicate() {
+        setupStub(400);
+        TestService uselessFallback = spy(TestService.class);
+        when(uselessFallback.greeting()).thenReturn("I should not be called");
+        FeignDecorators decorators = FeignDecorators.builder()
+                .withFallbackFactory(e -> uselessFallback, MyException.class::isInstance)
+                .withFallbackFactory(TestServiceFallbackWithException::new)
+                .build();
+        TestService testService = Resilience4jFeign.builder(decorators).target(TestService.class, MOCK_URL);
+
+        String result = testService.greeting();
+
+        assertThat(result).isEqualTo("Message from exception: status 400 reading TestService#greeting()");
+        verify(uselessFallback, times(0)).greeting();
+        verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+    }
+
+    private static TestService buildTestService(Function<Exception, ?> fallbackSupplier) {
+        FeignDecorators decorators = FeignDecorators.builder()
+                .withFallbackFactory(fallbackSupplier)
+                .build();
+        return Resilience4jFeign.builder(decorators).target(TestService.class, MOCK_URL);
+    }
+
+    private static void setupStub(int responseCode) {
+        stubFor(get(urlPathEqualTo("/greeting"))
+                .willReturn(aResponse()
+                        .withStatus(responseCode)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("Hello, world!")));
+    }
+
+    private static class MyException extends Exception {
+
+    }
+}

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/test/TestServiceFallbackWithException.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/test/TestServiceFallbackWithException.java
@@ -1,0 +1,18 @@
+package io.github.resilience4j.feign.test;
+
+/**
+ * A fallback consuming the thrown exception.
+ */
+public class TestServiceFallbackWithException implements TestService {
+
+    private final Exception cause;
+
+    public TestServiceFallbackWithException(Exception cause) {
+        this.cause = cause;
+    }
+
+    @Override
+    public String greeting() {
+        return "Message from exception: " + cause.getMessage();
+    }
+}


### PR DESCRIPTION
A useful feature present in Hystrix was the `FallbackFactory` which let us consume the exception thrown on error. This commit proposes to add this functionality in the Feign module by making it possible for a fallback to consume the exception.