### PR TITLE
Issue #509: Support for extending Micrometer tags

### DIFF
--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/Resilience4JBulkheadMeterBinder.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/Resilience4JBulkheadMeterBinder.java
@@ -1,0 +1,9 @@
+package io.github.resilience4j.micrometer.tagged;
+
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+/**
+ * An interface to allow extendability of the default resilience4j Bulkhead {@link MeterBinder}
+ */
+public interface Resilience4JBulkheadMeterBinder extends MeterBinder{
+}

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/Resilience4JCircuitBreakerMeterBinder.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/Resilience4JCircuitBreakerMeterBinder.java
@@ -1,0 +1,9 @@
+package io.github.resilience4j.micrometer.tagged;
+
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+/**
+ * An interface to allow extendability of the default resilience4j Circuit Breaker {@link MeterBinder}
+ */
+public interface Resilience4JCircuitBreakerMeterBinder extends MeterBinder{
+}

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/Resilience4JRateLimiterMeterBinder.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/Resilience4JRateLimiterMeterBinder.java
@@ -1,0 +1,9 @@
+package io.github.resilience4j.micrometer.tagged;
+
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+/**
+ * An interface to allow extendability of the default resilience4j Rate limiter {@link MeterBinder}
+ */
+public interface Resilience4JRateLimiterMeterBinder extends MeterBinder{
+}

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/Resilience4JRetryMeterBinder.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/Resilience4JRetryMeterBinder.java
@@ -1,0 +1,9 @@
+package io.github.resilience4j.micrometer.tagged;
+
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+/**
+ * An interface to allow extendability of the default resilience4j Retry {@link MeterBinder}
+ */
+public interface Resilience4JRetryMeterBinder extends MeterBinder {
+}

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedBulkheadMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedBulkheadMetrics.java
@@ -21,7 +21,6 @@ import io.github.resilience4j.bulkhead.BulkheadRegistry;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.binder.MeterBinder;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -31,7 +30,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * A micrometer binder that is used to register bulkhead exposed {@link Metrics metrics}.
  */
-public class TaggedBulkheadMetrics extends AbstractMetrics implements MeterBinder {
+public class TaggedBulkheadMetrics extends AbstractMetrics implements Resilience4JBulkheadMeterBinder {
 
     /**
      * Creates a new binder that uses given {@code registry} as source of bulkheads.

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetrics.java
@@ -19,7 +19,6 @@ import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker.Metrics;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.micrometer.core.instrument.*;
-import io.micrometer.core.instrument.binder.MeterBinder;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -29,7 +28,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * A micrometer binder that is used to register circuit breaker exposed {@link Metrics metrics}.
  */
-public class TaggedCircuitBreakerMetrics extends AbstractMetrics implements MeterBinder {
+public class TaggedCircuitBreakerMetrics extends AbstractMetrics implements Resilience4JCircuitBreakerMeterBinder {
 
     private static final String KIND_STATE = "state";
     private static final String KIND_FAILED = "failed";

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedRateLimiterMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedRateLimiterMetrics.java
@@ -21,7 +21,6 @@ import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.binder.MeterBinder;
 
 import java.util.HashSet;
 import java.util.Objects;
@@ -32,7 +31,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * A micrometer binder that is used to register retry exposed {@link Metrics metrics}.
  */
-public class TaggedRateLimiterMetrics extends AbstractMetrics implements MeterBinder {
+public class TaggedRateLimiterMetrics extends AbstractMetrics implements Resilience4JRateLimiterMeterBinder {
 
     /**
      * Creates a new binder that uses given {@code registry} as source of retries.

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedRetryMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedRetryMetrics.java
@@ -20,7 +20,6 @@ import io.github.resilience4j.retry.RetryRegistry;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.binder.MeterBinder;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -31,7 +30,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * A micrometer binder that is used to register retry exposed {@link Metrics metrics}.
  */
-public class TaggedRetryMetrics extends AbstractMetrics implements MeterBinder {
+public class TaggedRetryMetrics extends AbstractMetrics implements Resilience4JRetryMeterBinder {
 
     /**
      * Creates a new binder that uses given {@code registry} as source of retries.

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/bulkhead/autoconfigure/BulkheadMetricsAutoConfiguration.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/bulkhead/autoconfigure/BulkheadMetricsAutoConfiguration.java
@@ -16,6 +16,7 @@
 package io.github.resilience4j.bulkhead.autoconfigure;
 
 import io.github.resilience4j.bulkhead.BulkheadRegistry;
+import io.github.resilience4j.micrometer.tagged.Resilience4JBulkheadMeterBinder;
 import io.github.resilience4j.micrometer.tagged.TaggedBulkheadMetrics;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -38,7 +39,7 @@ public class BulkheadMetricsAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public TaggedBulkheadMetrics registerBulkheadMetrics(BulkheadRegistry bulkheadRegistry) {
+    public Resilience4JBulkheadMeterBinder registerBulkheadMetrics(BulkheadRegistry bulkheadRegistry) {
         return TaggedBulkheadMetrics.ofBulkheadRegistry(bulkheadRegistry);
     }
 }

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/circuitbreaker/autoconfigure/CircuitBreakerMetricsAutoConfiguration.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/circuitbreaker/autoconfigure/CircuitBreakerMetricsAutoConfiguration.java
@@ -16,6 +16,7 @@
 package io.github.resilience4j.circuitbreaker.autoconfigure;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.micrometer.tagged.Resilience4JCircuitBreakerMeterBinder;
 import io.github.resilience4j.micrometer.tagged.TaggedCircuitBreakerMetrics;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -37,7 +38,7 @@ public class CircuitBreakerMetricsAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public TaggedCircuitBreakerMetrics registerCircuitBreakerMetrics(CircuitBreakerRegistry circuitBreakerRegistry) {
+    public Resilience4JCircuitBreakerMeterBinder registerCircuitBreakerMetrics(CircuitBreakerRegistry circuitBreakerRegistry) {
         return TaggedCircuitBreakerMetrics.ofCircuitBreakerRegistry(circuitBreakerRegistry);
     }
 }

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/ratelimiter/autoconfigure/RateLimiterMetricsAutoConfiguration.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/ratelimiter/autoconfigure/RateLimiterMetricsAutoConfiguration.java
@@ -16,6 +16,7 @@
 package io.github.resilience4j.ratelimiter.autoconfigure;
 
 import io.github.resilience4j.circuitbreaker.autoconfigure.CircuitBreakerAutoConfiguration;
+import io.github.resilience4j.micrometer.tagged.Resilience4JRateLimiterMeterBinder;
 import io.github.resilience4j.micrometer.tagged.TaggedRateLimiterMetrics;
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
@@ -38,7 +39,7 @@ public class RateLimiterMetricsAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public TaggedRateLimiterMetrics registerRateLimiterMetrics(RateLimiterRegistry rateLimiterRegistry) {
+    public Resilience4JRateLimiterMeterBinder registerRateLimiterMetrics(RateLimiterRegistry rateLimiterRegistry) {
         return TaggedRateLimiterMetrics.ofRateLimiterRegistry(rateLimiterRegistry);
     }
 }

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/retry/autoconfigure/RetryMetricsAutoConfiguration.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/retry/autoconfigure/RetryMetricsAutoConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.github.resilience4j.retry.autoconfigure;
 
+import io.github.resilience4j.micrometer.tagged.Resilience4JRetryMeterBinder;
 import io.github.resilience4j.micrometer.tagged.TaggedRetryMetrics;
 import io.github.resilience4j.retry.RetryRegistry;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
@@ -38,7 +39,7 @@ public class RetryMetricsAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public TaggedRetryMetrics registerRetryMetrics(RetryRegistry retryRegistry) {
+	public Resilience4JRetryMeterBinder registerRetryMetrics(RetryRegistry retryRegistry) {
 		return TaggedRetryMetrics.ofRetryRegistry(retryRegistry);
 	}
 }


### PR DESCRIPTION
For extending the tags provided by resilience4j, the classes that implement
MeterBinder for the respective concern(Retry, CircuitBreaker, RateLimiter
and Bulkhead) need to be extendable. With this commit, they all now implement
respective interfaces and these interfaces are set as the return type for
the respective spring boot auto configuration.