### PR TITLE
https://github.com/resilience4j/resilience4j/issues/544

### DIFF
--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachine.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachine.java
@@ -167,6 +167,7 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
             publishCircuitErrorEvent(name, durationInNanos, throwable);
             stateReference.get().onError(throwable);
         } else {
+            releasePermission();
             publishCircuitIgnoredErrorEvent(name, durationInNanos, throwable);
         }
     }


### PR DESCRIPTION
1. release this permission when ignored exception thrown, so we won't count this exception into the ring buffer during HALF_OPEN state.
2. revert the change in ratpack project, to avoid release permission twice