### PR TITLE
Support auto complete config in spring boot

### DIFF
--- a/resilience4j-spring-boot-common/build.gradle
+++ b/resilience4j-spring-boot-common/build.gradle
@@ -2,9 +2,9 @@ dependencies {
     compile project(':resilience4j-spring')
     
     compileOnly(libraries.spring_boot2_aop)
-    compileOnly(libraries.spring_boot2_config_processor)
-    compileOnly(libraries.spring_boot2_autoconfigure_processor)
     compileOnly(libraries.spring_boot2_actuator)
+    annotationProcessor(libraries.spring_boot2_config_processor)
+    annotationProcessor(libraries.spring_boot2_autoconfigure_processor)
     
     testCompile project(':resilience4j-reactor')
     testCompile project(':resilience4j-rxjava2')

--- a/resilience4j-spring-boot/build.gradle
+++ b/resilience4j-spring-boot/build.gradle
@@ -12,8 +12,8 @@ dependencies {
     compileOnly(libraries.metrics)
     compileOnly(libraries.micrometer_spring_legacy)
     compileOnly(libraries.hibernate_validator)
-    compileOnly(libraries.spring_boot_config_processor)
-    compileOnly(libraries.spring_boot_autoconfigure_processor)
+    annotationProcessor(libraries.spring_boot_config_processor)
+    annotationProcessor(libraries.spring_boot_autoconfigure_processor)
     
     testCompile(libraries.spring_boot_test)
     testCompile(libraries.spring_boot_aop)

--- a/resilience4j-spring-boot2/build.gradle
+++ b/resilience4j-spring-boot2/build.gradle
@@ -5,8 +5,8 @@ dependencies {
     compileOnly(libraries.spring_boot2_aop)
     compileOnly(libraries.spring_boot2_actuator)
     compileOnly(libraries.hibernate_validator)
-    compileOnly(libraries.spring_boot2_config_processor)
-    compileOnly(libraries.spring_boot2_autoconfigure_processor)
+    annotationProcessor(libraries.spring_boot2_config_processor)
+    annotationProcessor(libraries.spring_boot2_autoconfigure_processor)
 
     testCompile(libraries.spring_boot2_test)
     testCompile(libraries.spring_boot2_aop)


### PR DESCRIPTION
Issue #540 

Please refer https://docs.spring.io/spring-boot/docs/current/reference/html/configuration-metadata.html
> With Gradle 4.5 and earlier, the dependency should be declared in the compileOnly configuration, as shown in the following example:
> ```
> dependencies {
> 	compileOnly "org.springframework.boot:spring-boot-configuration-processor"
> }
> ```
> With Gradle 4.6 and later, the dependency should be declared in the annotationProcessor configuration, as shown in the following example:
> ```
> dependencies {
> 	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
> }
> ```

Because resilience4j gradle version is `5.3.1`, we have to use `annotationProcessor` not `compileOnly`
https://github.com/resilience4j/resilience4j/blob/b84a70a95fff1cd60d30c878d8deaafd710d535f/gradle/wrapper/gradle-wrapper.properties#L6

![image](https://user-images.githubusercontent.com/19386038/63040143-cb676680-beff-11e9-9c63-bc9132fa7786.png)
I tested this in local, it works well.