### PR TITLE
Issue #568: Changed the logic in the CircuitBreaker how to handle exceptions.

### DIFF
--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachine.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachine.java
@@ -37,7 +37,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
@@ -155,23 +154,28 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
     public void onError(long duration, TimeUnit durationUnit, Throwable throwable) {
         // Handle the case if the completable future throw CompletionException wrapping the original exception
         // where original exception is the the one to retry not the CompletionException.
-        Predicate<Throwable> recordFailurePredicate = circuitBreakerConfig.getRecordFailurePredicate();
         if (throwable instanceof CompletionException) {
             Throwable cause = throwable.getCause();
-            handleThrowable(duration, durationUnit, recordFailurePredicate, cause);
+            handleThrowable(duration, durationUnit, cause);
         }else{
-            handleThrowable(duration, durationUnit, recordFailurePredicate, throwable);
+            handleThrowable(duration, durationUnit, throwable);
         }
     }
 
-    private void handleThrowable(long duration, TimeUnit durationUnit, Predicate<Throwable> recordFailurePredicate, Throwable throwable) {
-        if (recordFailurePredicate.test(throwable)) {
-            LOG.debug("CircuitBreaker '{}' recorded a failure:", name, throwable);
-            publishCircuitErrorEvent(name, duration, durationUnit, throwable);
-            stateReference.get().onError(duration, durationUnit, throwable);
-        } else {
+    private void handleThrowable(long duration, TimeUnit durationUnit, Throwable throwable) {
+        if(circuitBreakerConfig.getIgnoreExceptionPredicate().test(throwable)){
+            LOG.debug("CircuitBreaker '{}' ignored an exception:", name, throwable);
             releasePermission();
             publishCircuitIgnoredErrorEvent(name, duration,durationUnit, throwable);
+        }
+        else if(circuitBreakerConfig.getRecordExceptionPredicate().test(throwable)){
+            LOG.debug("CircuitBreaker '{}' recorded an exception as failure:", name, throwable);
+            publishCircuitErrorEvent(name, duration, durationUnit, throwable);
+            stateReference.get().onError(duration, durationUnit, throwable);
+        }else{
+            LOG.debug("CircuitBreaker '{}' recorded an exception as success:", name, throwable);
+            publishSuccessEvent(duration, durationUnit);
+            stateReference.get().onSuccess(duration, durationUnit);
         }
     }
 

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerEventPublisherTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerEventPublisherTest.java
@@ -23,12 +23,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 
-import javax.xml.ws.WebServiceException;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
-import static io.vavr.API.*;
-import static io.vavr.Predicates.instanceOf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
@@ -96,7 +93,7 @@ public class CircuitBreakerEventPublisherTest {
     @Test
     public void shouldConsumeOnStateTransitionEvent() {
         circuitBreaker = CircuitBreaker.of("test", CircuitBreakerConfig.custom()
-                .ringBufferSizeInClosedState(1).build());
+                .slidingWindowSize(1).build());
 
         circuitBreaker.getEventPublisher()
                 .onStateTransition(this::logEventType);
@@ -110,7 +107,7 @@ public class CircuitBreakerEventPublisherTest {
     @Test
     public void shouldConsumeCallNotPermittedEvent() {
         circuitBreaker = CircuitBreaker.of("test", CircuitBreakerConfig.custom()
-                .ringBufferSizeInClosedState(1).build());
+                .slidingWindowSize(1).build());
 
         circuitBreaker.getEventPublisher()
                 .onCallNotPermitted(this::logEventType);
@@ -126,7 +123,7 @@ public class CircuitBreakerEventPublisherTest {
     public void shouldNotProduceEventsInDisabledState() {
         //Given
         circuitBreaker = CircuitBreaker.of("test", CircuitBreakerConfig.custom()
-                .ringBufferSizeInClosedState(1).build());
+                .slidingWindowSize(1).build());
 
         circuitBreaker.getEventPublisher()
                 .onEvent(this::logEventType);
@@ -155,9 +152,7 @@ public class CircuitBreakerEventPublisherTest {
     @Test
     public void shouldConsumeIgnoredErrorEvent() {
         CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
-                .recordFailure(throwable -> Match(throwable).of(
-                        Case($(instanceOf(WebServiceException.class)), true),
-                        Case($(), false)))
+                .ignoreExceptions(IOException.class)
                 .build();
 
         circuitBreaker = CircuitBreaker.of("test", circuitBreakerConfig);

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerTest.java
@@ -39,8 +39,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import static io.vavr.API.*;
-import static io.vavr.Predicates.instanceOf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -515,8 +513,8 @@ public class CircuitBreakerTest {
         // Given
         // Create a custom configuration for a CircuitBreaker
         CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
-                .ringBufferSizeInClosedState(2)
-                .ringBufferSizeInHalfOpenState(2)
+                .slidingWindowSize(2)
+                .permittedNumberOfCallsInHalfOpenState(2)
                 .failureRateThreshold(50)
                 .waitDurationInOpenState(Duration.ofMillis(1000))
                 .build();
@@ -569,12 +567,10 @@ public class CircuitBreakerTest {
         // tag::shouldNotRecordIOExceptionAsAFailure[]
         // Given
         CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
-                .ringBufferSizeInClosedState(2)
-                .ringBufferSizeInHalfOpenState(2)
+                .slidingWindowSize(2)
+                .permittedNumberOfCallsInHalfOpenState(2)
                 .waitDurationInOpenState(Duration.ofMillis(1000))
-                .recordFailure(throwable -> Match(throwable).of(
-                        Case($(instanceOf(WebServiceException.class)), true),
-                        Case($(), false)))
+                .ignoreExceptions(IOException.class)
                 .build();
         CircuitBreaker circuitBreaker = CircuitBreaker.of("testName", circuitBreakerConfig);
 
@@ -646,7 +642,7 @@ public class CircuitBreakerTest {
         // tag::shouldThrowCircuitBreakerOpenException[]
         // Given
         CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
-                .ringBufferSizeInClosedState(2)
+                .slidingWindowSize(2)
                 .waitDurationInOpenState(Duration.ofMillis(1000))
                 .build();
         CircuitBreaker circuitBreaker = CircuitBreaker.of("testName", circuitBreakerConfig);

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerExceptionHandlingTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerExceptionHandlingTest.java
@@ -1,0 +1,99 @@
+package io.github.resilience4j.circuitbreaker.internal;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import static io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.custom;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CircuitBreakerExceptionHandlingTest {
+
+    private static class BusinessException extends Exception {
+
+        public BusinessException(String message) {
+            super(message);
+        }
+    }
+
+    @Test
+    public void shouldRecordRuntimeExceptionAsFailureAndBusinessExceptionAsSuccess() {
+        CircuitBreaker circuitBreaker = new CircuitBreakerStateMachine("testName", custom()
+                .slidingWindowSize(5)
+                .recordException(ex -> !(ex instanceof BusinessException))
+                .build());
+
+        assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
+        circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new RuntimeException());
+
+        // Call 2 is a failure
+        assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
+        circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new BusinessException("test"));
+
+        assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls()).isEqualTo(1);
+        assertThat(circuitBreaker.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(1);
+        assertThat(circuitBreaker.getMetrics().getNumberOfBufferedCalls()).isEqualTo(2);
+    }
+
+    @Test
+    public void shouldRecordIOExceptionAsFailureAndBusinessExceptionAsSuccess() {
+        CircuitBreaker circuitBreaker = new CircuitBreakerStateMachine("testName", custom()
+                .slidingWindowSize(5)
+                .recordExceptions(IOException.class)
+                .build());
+
+        assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
+        circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new IOException());
+
+        // Call 2 is a failure
+        assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
+        circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new BusinessException("test"));
+
+        assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls()).isEqualTo(1);
+        assertThat(circuitBreaker.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(1);
+        assertThat(circuitBreaker.getMetrics().getNumberOfBufferedCalls()).isEqualTo(2);
+    }
+
+    @Test
+    public void shouldRecordBusinessExceptionAsFailure() {
+        CircuitBreaker circuitBreaker = new CircuitBreakerStateMachine("testName", custom()
+                .slidingWindowSize(5)
+                .recordException(ex -> "record".equals(ex.getMessage()))
+                .build());
+
+        assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
+        circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new BusinessException("record"));
+
+        // Call 2 is a failure
+        assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
+        circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new BusinessException("bla"));
+
+        assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls()).isEqualTo(1);
+        assertThat(circuitBreaker.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(1);
+        assertThat(circuitBreaker.getMetrics().getNumberOfBufferedCalls()).isEqualTo(2);
+    }
+
+    @Test
+    public void shouldIgnoreNumberFormatException() {
+        CircuitBreaker circuitBreaker = new CircuitBreakerStateMachine("testName", custom()
+                .failureRateThreshold(50)
+                .slidingWindowSize(5)
+                .waitDurationInOpenState(Duration.ofSeconds(5))
+                .ignoreExceptions(NumberFormatException.class)
+                .build());
+
+        assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
+        circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new RuntimeException());
+
+        // Call 2 is a failure
+        assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
+        circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new NumberFormatException());
+
+        assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls()).isEqualTo(1);
+        assertThat(circuitBreaker.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(0);
+        assertThat(circuitBreaker.getMetrics().getNumberOfBufferedCalls()).isEqualTo(1);
+    }
+}

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachineTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachineTest.java
@@ -49,7 +49,7 @@ public class CircuitBreakerStateMachineTest {
                 .slowCallRateThreshold(50)
                 .slidingWindow(5, 5, SlidingWindow.COUNT_BASED)
                 .waitDurationInOpenState(Duration.ofSeconds(5))
-                .recordFailure(error -> !(error instanceof NumberFormatException))
+                .ignoreExceptions(NumberFormatException.class)
                 .build(), mockClock);
     }
 

--- a/resilience4j-consumer/src/test/java/io/github/resilience4j/consumer/CircularEventConsumerTest.java
+++ b/resilience4j-consumer/src/test/java/io/github/resilience4j/consumer/CircularEventConsumerTest.java
@@ -21,7 +21,6 @@ package io.github.resilience4j.consumer;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.github.resilience4j.circuitbreaker.event.CircuitBreakerEvent;
-import io.vavr.API;
 import org.junit.Test;
 
 import javax.xml.ws.WebServiceException;
@@ -29,9 +28,6 @@ import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 import static io.github.resilience4j.circuitbreaker.event.CircuitBreakerEvent.Type;
-import static io.vavr.API.$;
-import static io.vavr.API.Case;
-import static io.vavr.Predicates.instanceOf;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CircularEventConsumerTest {
@@ -68,10 +64,8 @@ public class CircularEventConsumerTest {
     public void shouldBufferAllEvents() {
         // Given
         CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
-                .ringBufferSizeInClosedState(3)
-                .recordFailure(throwable -> API.Match(throwable).of(
-                        Case($(instanceOf(WebServiceException.class)), true),
-                        Case($(), false)))
+                .slidingWindowSize(3)
+                .ignoreExceptions(IOException.class)
                 .build();
         CircuitBreaker circuitBreaker = CircuitBreaker.of("testName", circuitBreakerConfig);
         CircularEventConsumer<CircuitBreakerEvent> ringBuffer = new CircularEventConsumer<>(10);

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/predicate/PredicateCreator.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/predicate/PredicateCreator.java
@@ -9,12 +9,12 @@ public class PredicateCreator {
     private PredicateCreator() {}
 
     @SafeVarargs
-    public static Optional<Predicate<Throwable>> createRecordExceptionsPredicate(Class<? extends Throwable> ...recordExceptions) {
+    public static Optional<Predicate<Throwable>> createExceptionsPredicate(Class<? extends Throwable> ...recordExceptions) {
         return exceptionPredicate(recordExceptions);
     }
 
     @SafeVarargs
-    public static Optional<Predicate<Throwable>> createIgnoreExceptionsPredicate(Class<? extends Throwable> ...ignoreExceptions) {
+    public static Optional<Predicate<Throwable>> createNegatedExceptionsPredicate(Class<? extends Throwable> ...ignoreExceptions) {
         return exceptionPredicate(ignoreExceptions)
                 .map(Predicate::negate);
     }

--- a/resilience4j-core/src/test/java/io/github/resilience4j/core/predicate/PredicateCreatorTest.java
+++ b/resilience4j-core/src/test/java/io/github/resilience4j/core/predicate/PredicateCreatorTest.java
@@ -12,7 +12,7 @@ public class PredicateCreatorTest {
 
     @Test
     public void buildRecordExceptionsPredicate() {
-        Optional<Predicate<Throwable>> optionalPredicate = PredicateCreator.createRecordExceptionsPredicate(RuntimeException.class);
+        Optional<Predicate<Throwable>> optionalPredicate = PredicateCreator.createExceptionsPredicate(RuntimeException.class, IOException.class);
 
         then(optionalPredicate).isNotEmpty();
         Predicate<Throwable> predicate = optionalPredicate.get();
@@ -20,13 +20,13 @@ public class PredicateCreatorTest {
         then(predicate.test(new IllegalArgumentException())).isEqualTo(true);
         then(predicate.test(new Throwable())).isEqualTo(false);
         then(predicate.test(new Exception())).isEqualTo(false);
-        then(predicate.test(new IOException())).isEqualTo(false);
+        then(predicate.test(new IOException())).isEqualTo(true);
 
     }
 
     @Test
     public void buildIgnoreExceptionsPredicate() {
-        Optional<Predicate<Throwable>> optionalPredicate = PredicateCreator.createIgnoreExceptionsPredicate(RuntimeException.class);
+        Optional<Predicate<Throwable>> optionalPredicate = PredicateCreator.createNegatedExceptionsPredicate(RuntimeException.class, BusinessException.class);
 
         then(optionalPredicate).isNotEmpty();
         Predicate<Throwable> predicate = optionalPredicate.get();
@@ -35,5 +35,9 @@ public class PredicateCreatorTest {
         then(predicate.test(new Throwable())).isEqualTo(true);
         then(predicate.test(new Exception())).isEqualTo(true);
         then(predicate.test(new IOException())).isEqualTo(true);
+        then(predicate.test(new BusinessException())).isEqualTo(false);
+    }
+
+    private class BusinessException extends Exception {
     }
 }

--- a/resilience4j-ratpack/src/test/groovy/io/github/resilience4j/ratpack/Resilience4jModuleSpec.groovy
+++ b/resilience4j-ratpack/src/test/groovy/io/github/resilience4j/ratpack/Resilience4jModuleSpec.groovy
@@ -98,7 +98,7 @@ class Resilience4jModuleSpec extends Specification {
             assert waitDurationInOpenState == Duration.ofMillis(5000)
             assert failureRateThreshold == 60
             assert automaticTransitionFromOpenToHalfOpenEnabled
-            assert recordFailurePredicate.test(new Exception())
+            assert recordExceptionPredicate.test(new Exception())
             it
         }
     }
@@ -169,8 +169,8 @@ class Resilience4jModuleSpec extends Specification {
             assert waitDurationInOpenState == Duration.ofMillis(1000)
             assert failureRateThreshold == 60
             assert automaticTransitionFromOpenToHalfOpenEnabled
-            assert recordFailurePredicate.test(new DummyException1("test"))
-            assert recordFailurePredicate.test(new DummyException2("test"))
+            assert recordExceptionPredicate.test(new DummyException1("test"))
+            assert recordExceptionPredicate.test(new DummyException2("test"))
             it
         }
         def test2 = circuitBreakerRegistry.circuitBreaker('test2')
@@ -181,8 +181,8 @@ class Resilience4jModuleSpec extends Specification {
             assert waitDurationInOpenState == Duration.ofMillis(5000)
             assert failureRateThreshold == 60
             assert automaticTransitionFromOpenToHalfOpenEnabled
-            assert recordFailurePredicate.test(new DummyException1("test"))
-            assert !recordFailurePredicate.test(new DummyException2("test"))
+            assert recordExceptionPredicate.test(new DummyException1("test"))
+            assert !recordExceptionPredicate.test(new DummyException2("test"))
             it
         }
         // test default
@@ -195,8 +195,8 @@ class Resilience4jModuleSpec extends Specification {
             assert waitDurationInOpenState == Duration.ofMillis(1000)
             assert failureRateThreshold == 60
             assert automaticTransitionFromOpenToHalfOpenEnabled
-            assert recordFailurePredicate.test(new DummyException1("test"))
-            assert recordFailurePredicate.test(new DummyException2("test"))
+            assert recordExceptionPredicate.test(new DummyException1("test"))
+            assert recordExceptionPredicate.test(new DummyException2("test"))
             it
         }
     }

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/RetryConfig.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/RetryConfig.java
@@ -19,12 +19,12 @@
 package io.github.resilience4j.retry;
 
 
+import io.github.resilience4j.core.lang.Nullable;
+import io.github.resilience4j.core.predicate.PredicateCreator;
+
 import java.time.Duration;
 import java.util.function.Function;
 import java.util.function.Predicate;
-
-import io.github.resilience4j.core.lang.Nullable;
-import io.github.resilience4j.core.predicate.PredicateCreator;
 
 public class RetryConfig {
 
@@ -250,12 +250,12 @@ public class RetryConfig {
 
 		private Predicate<Throwable> createExceptionPredicate() {
 			return createRetryOnExceptionPredicate()
-					.and(PredicateCreator.createIgnoreExceptionsPredicate(ignoreExceptions)
+					.and(PredicateCreator.createNegatedExceptionsPredicate(ignoreExceptions)
 							.orElse(DEFAULT_RECORD_FAILURE_PREDICATE));
 		}
 
 		private Predicate<Throwable> createRetryOnExceptionPredicate() {
-			return PredicateCreator.createRecordExceptionsPredicate(retryExceptions)
+			return PredicateCreator.createExceptionsPredicate(retryExceptions)
 					.map(predicate -> retryOnExceptionPredicate != null ? predicate.or(retryOnExceptionPredicate) : predicate)
 					.orElseGet(() -> retryOnExceptionPredicate != null ? retryOnExceptionPredicate : DEFAULT_RECORD_FAILURE_PREDICATE);
 		}

--- a/resilience4j-spring-boot/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerAutoConfigurationTest.java
+++ b/resilience4j-spring-boot/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerAutoConfigurationTest.java
@@ -103,8 +103,8 @@ public class CircuitBreakerAutoConfigurationTest {
 		ResponseEntity<CircuitBreakerEventsEndpointResponse> circuitBreakerEventList = restTemplate.getForEntity("/circuitbreaker/events", CircuitBreakerEventsEndpointResponse.class);
 		assertThat(circuitBreakerEventList.getBody().getCircuitBreakerEvents()).hasSize(2);
 
-		assertThat(circuitBreaker.getCircuitBreakerConfig().getRecordFailurePredicate().test(new RecordedException())).isTrue();
-		assertThat(circuitBreaker.getCircuitBreakerConfig().getRecordFailurePredicate().test(new IgnoredException())).isFalse();
+		assertThat(circuitBreaker.getCircuitBreakerConfig().getRecordExceptionPredicate().test(new RecordedException())).isTrue();
+		assertThat(circuitBreaker.getCircuitBreakerConfig().getIgnoreExceptionPredicate().test(new IgnoredException())).isTrue();
 
 		// expect no health indicator for backendB, as it is disabled via properties
 		ResponseEntity<String> healthResponse = restTemplate.getForEntity("/health", String.class);
@@ -115,7 +115,7 @@ public class CircuitBreakerAutoConfigurationTest {
 
 		// Verify that an exception for which setRecordFailurePredicate returns false and it is not included in
 		// setRecordExceptions evaluates to false.
-		assertThat(circuitBreaker.getCircuitBreakerConfig().getRecordFailurePredicate().test(new Exception())).isFalse();
+		assertThat(circuitBreaker.getCircuitBreakerConfig().getRecordExceptionPredicate().test(new Exception())).isFalse();
 
 		assertThat(circuitBreakerAspect.getOrder()).isEqualTo(400);
 

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerAutoConfigurationTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerAutoConfigurationTest.java
@@ -75,7 +75,7 @@ public class CircuitBreakerAutoConfigurationTest {
 		try {
 			dummyService.doSomething(true);
 		} catch (IOException ex) {
-			// Do nothing. The IOException is recorded by the CircuitBreaker as part of the setRecordFailurePredicate as a failure.
+			// Do nothing. The IOException is recorded by the CircuitBreaker as part of the recordFailurePredicate as a failure.
 		}
 		// The invocation is recorded by the CircuitBreaker as a success.
 		dummyService.doSomething(false);
@@ -116,12 +116,12 @@ public class CircuitBreakerAutoConfigurationTest {
 		assertThat(healthResponse.getBody().getDetails().get("backendSharedBCircuitBreaker")).isNotNull();
 		assertThat(healthResponse.getBody().getDetails().get("dynamicBackend")).isNull();
 
-		assertThat(circuitBreaker.getCircuitBreakerConfig().getRecordFailurePredicate().test(new RecordedException())).isTrue();
-		assertThat(circuitBreaker.getCircuitBreakerConfig().getRecordFailurePredicate().test(new IgnoredException())).isFalse();
+		assertThat(circuitBreaker.getCircuitBreakerConfig().getRecordExceptionPredicate().test(new RecordedException())).isTrue();
+		assertThat(circuitBreaker.getCircuitBreakerConfig().getIgnoreExceptionPredicate().test(new IgnoredException())).isTrue();
 
 		// Verify that an exception for which setRecordFailurePredicate returns false and it is not included in
 		// setRecordExceptions evaluates to false.
-		assertThat(circuitBreaker.getCircuitBreakerConfig().getRecordFailurePredicate().test(new Exception())).isFalse();
+		assertThat(circuitBreaker.getCircuitBreakerConfig().getRecordExceptionPredicate().test(new Exception())).isFalse();
 
 		assertThat(circuitBreakerAspect.getOrder()).isEqualTo(400);
 


### PR DESCRIPTION
Changed the logic in the CircuitBreaker how to handle exceptions so that it is also possible to count exceptions as a success.
The list of ignored exceptions has always precedence. If an exception is ignored it neither counts as a success nor failure.
If the list of recorded exceptions only contains some exceptions, all others count as a success, unless they are part of the list of ignored exceptions.