### PR TITLE
Issue #581: Some RxJava2 or Reactor operators like ZipObserver are ca…

### DIFF
--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/FluxCircuitBreakerTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/FluxCircuitBreakerTest.java
@@ -155,4 +155,21 @@ public class FluxCircuitBreakerTest {
         verify(circuitBreaker, never()).onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
         verify(circuitBreaker, never()).onSuccess(anyLong(), any(TimeUnit.class));
     }
+
+    @Test
+    public void shouldInvokeOnSuccessOnCancelWhenEventWasEmitted() {
+        given(circuitBreaker.tryAcquirePermission()).willReturn(true);
+
+        StepVerifier.create(
+                Flux.just("Event1", "Event2", "Event3")
+                        .compose(CircuitBreakerOperator.of(circuitBreaker)))
+                .expectSubscription()
+                .thenRequest(1)
+                .thenCancel()
+                .verify();
+
+        verify(circuitBreaker, never()).releasePermission();
+        verify(circuitBreaker, never()).onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
+        verify(circuitBreaker, times(1)).onSuccess(anyLong(), any(TimeUnit.class));
+    }
 }

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/AbstractObserver.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/AbstractObserver.java
@@ -2,11 +2,14 @@ package io.github.resilience4j;
 
 import io.reactivex.Observer;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import static java.util.Objects.requireNonNull;
 
 public abstract class AbstractObserver<T> extends AbstractDisposable implements Observer<T> {
 
     private final Observer<? super T> downstreamObserver;
+    protected final AtomicBoolean eventWasEmitted = new AtomicBoolean(false);
 
     public AbstractObserver(Observer<? super T> downstreamObserver) {
         this.downstreamObserver = requireNonNull(downstreamObserver);
@@ -19,7 +22,10 @@ public abstract class AbstractObserver<T> extends AbstractDisposable implements 
 
     @Override
     public void onNext(T item) {
-        whenNotDisposed(() -> downstreamObserver.onNext(item));
+        whenNotDisposed(() -> {
+            eventWasEmitted.set(true);
+            downstreamObserver.onNext(item);
+        });
     }
 
     @Override

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/AbstractSubscriber.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/AbstractSubscriber.java
@@ -20,6 +20,7 @@ import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static io.reactivex.internal.subscriptions.SubscriptionHelper.CANCELLED;
@@ -29,6 +30,7 @@ public abstract class AbstractSubscriber<T> implements Subscriber<T>, Subscripti
 
     protected final Subscriber<? super T> downstreamSubscriber;
     private final AtomicReference<Subscription> subscription = new AtomicReference<>();
+    protected final AtomicBoolean eventWasEmitted = new AtomicBoolean(false);
 
     protected AbstractSubscriber(Subscriber<? super T> downstreamSubscriber) {
         this.downstreamSubscriber = requireNonNull(downstreamSubscriber);
@@ -44,6 +46,7 @@ public abstract class AbstractSubscriber<T> implements Subscriber<T>, Subscripti
     @Override
     public void onNext(T value) {
         if(!isDisposed()){
+            eventWasEmitted.set(true);
             downstreamSubscriber.onNext(value);
         }
 

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/FlowableCircuitBreaker.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/FlowableCircuitBreaker.java
@@ -69,7 +69,11 @@ class FlowableCircuitBreaker<T> extends Flowable<T> {
 
         @Override
         public void hookOnCancel() {
-            circuitBreaker.releasePermission();
+            if(eventWasEmitted.get()){
+                circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+            }else{
+                circuitBreaker.releasePermission();
+            }
         }
     }
 

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/ObserverCircuitBreaker.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/ObserverCircuitBreaker.java
@@ -64,7 +64,11 @@ class ObserverCircuitBreaker<T> extends Observable<T> {
 
         @Override
         protected void hookOnCancel() {
-            circuitBreaker.releasePermission();
+            if(eventWasEmitted.get()){
+                circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+            }else{
+                circuitBreaker.releasePermission();
+            }
         }
     }
 

--- a/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/ObserverCircuitBreakerTest.java
+++ b/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/ObserverCircuitBreakerTest.java
@@ -1,7 +1,6 @@
 package io.github.resilience4j.circuitbreaker.operator;
 
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
-import io.reactivex.Flowable;
 import io.reactivex.Observable;
 import org.junit.Test;
 

--- a/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/ObserverCircuitBreakerTest.java
+++ b/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/ObserverCircuitBreakerTest.java
@@ -1,6 +1,7 @@
 package io.github.resilience4j.circuitbreaker.operator;
 
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.reactivex.Flowable;
 import io.reactivex.Observable;
 import org.junit.Test;
 


### PR DESCRIPTION
…ncelling (disposing) a second Observable when the first observable is complete. This is because an operator like zip must combine two events. It makes no sense to consume further events of the second observable when the first is completed. Unfortunately the cancellation is bad for the CircuitBreakerOperator, since no success is recorded even if an emit was emitted successfully. Solution: The CircuitBreaker operator and BulkHead operator could track if an event has been emitted successfully (onNext). And when dispose/cancel is invoked, the operator either invokes onSuccess/onComplete or releasePermission.