### PR TITLE
Issue #607: The CircuitBreakerHealthIndicator and RateLimiterHealthIn…

### DIFF
--- a/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationProperties.java
+++ b/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationProperties.java
@@ -41,7 +41,11 @@ public class CircuitBreakerConfigurationProperties {
 	private Map<String, InstanceProperties> configs = new HashMap<>();
 
 	public Optional<InstanceProperties> findCircuitBreakerProperties(String name) {
-		return Optional.ofNullable(instances.get(name));
+		InstanceProperties instanceProperties = instances.get(name);
+		if(instanceProperties == null){
+			instanceProperties = configs.get("default");
+		}
+		return Optional.ofNullable(instanceProperties);
 	}
 
 	public CircuitBreakerConfig createCircuitBreakerConfig(InstanceProperties instanceProperties) {

--- a/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/ratelimiter/configuration/RateLimiterConfigurationProperties.java
+++ b/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/ratelimiter/configuration/RateLimiterConfigurationProperties.java
@@ -33,7 +33,11 @@ public class RateLimiterConfigurationProperties {
 	private Map<String, InstanceProperties> configs = new HashMap<>();
 
 	public Optional<InstanceProperties> findRateLimiterProperties(String name) {
-		return Optional.ofNullable(instances.get(name));
+		InstanceProperties instanceProperties = instances.get(name);
+		if(instanceProperties == null){
+			instanceProperties = configs.get("default");
+		}
+		return Optional.ofNullable(instanceProperties);
 	}
 
 	public RateLimiterConfig createRateLimiterConfig(@Nullable InstanceProperties instanceProperties) {

--- a/resilience4j-spring-boot-common/src/main/java/io/github/resilience4j/circuitbreaker/monitoring/health/CircuitBreakersHealthIndicator.java
+++ b/resilience4j-spring-boot-common/src/main/java/io/github/resilience4j/circuitbreaker/monitoring/health/CircuitBreakersHealthIndicator.java
@@ -65,8 +65,8 @@ public class CircuitBreakersHealthIndicator implements HealthIndicator {
 
     private boolean isRegisterHealthIndicator(CircuitBreaker circuitBreaker) {
         return circuitBreakerProperties.findCircuitBreakerProperties(circuitBreaker.getName())
-                .map(io.github.resilience4j.common.circuitbreaker.configuration.CircuitBreakerConfigurationProperties.InstanceProperties::getRegisterHealthIndicator)
-                .orElse(true);
+                .map(CircuitBreakerConfigurationProperties.InstanceProperties::getRegisterHealthIndicator)
+                .orElse(false);
     }
 
     private static Health mapBackendMonitorState(CircuitBreaker circuitBreaker) {

--- a/resilience4j-spring-boot-common/src/main/java/io/github/resilience4j/ratelimiter/monitoring/health/RateLimitersHealthIndicator.java
+++ b/resilience4j-spring-boot-common/src/main/java/io/github/resilience4j/ratelimiter/monitoring/health/RateLimitersHealthIndicator.java
@@ -52,8 +52,8 @@ public class RateLimitersHealthIndicator implements HealthIndicator {
 
     private boolean isRegisterHealthIndicator(RateLimiter rateLimiter) {
         return rateLimiterProperties.findRateLimiterProperties(rateLimiter.getName())
-                .map(io.github.resilience4j.common.ratelimiter.configuration.RateLimiterConfigurationProperties.InstanceProperties::getRegisterHealthIndicator)
-                .orElse(true);
+                .map(RateLimiterConfigurationProperties.InstanceProperties::getRegisterHealthIndicator)
+                .orElse(false);
     }
 
     private Health mapRateLimiterHealth(RateLimiter rateLimiter) {

--- a/resilience4j-spring-boot-common/src/test/java/io/github/resilience4j/circuitbreaker/monitoring/health/CircuitBreakersHealthIndicatorTest.java
+++ b/resilience4j-spring-boot-common/src/test/java/io/github/resilience4j/circuitbreaker/monitoring/health/CircuitBreakersHealthIndicatorTest.java
@@ -33,8 +33,8 @@ public class CircuitBreakersHealthIndicatorTest {
         CircuitBreakerRegistry registry = mock(CircuitBreakerRegistry.class);
         CircuitBreaker.Metrics metrics = mock(CircuitBreaker.Metrics.class);
         CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
-        io.github.resilience4j.common.circuitbreaker.configuration.CircuitBreakerConfigurationProperties.InstanceProperties instanceProperties =
-                mock(io.github.resilience4j.common.circuitbreaker.configuration.CircuitBreakerConfigurationProperties.InstanceProperties.class);
+        CircuitBreakerConfigurationProperties.InstanceProperties instanceProperties =
+                mock(CircuitBreakerConfigurationProperties.InstanceProperties.class);
         CircuitBreakerConfigurationProperties circuitBreakerProperties = mock(CircuitBreakerConfigurationProperties.class);
         HealthAggregator healthAggregator = new OrderedHealthAggregator();
         CircuitBreakersHealthIndicator healthIndicator =
@@ -86,8 +86,8 @@ public class CircuitBreakersHealthIndicatorTest {
         expectedStateToCircuitBreaker.put(OPEN, openCircuitBreaker);
         expectedStateToCircuitBreaker.put(HALF_OPEN, halfOpenCircuitBreaker);
         expectedStateToCircuitBreaker.put(CLOSED, closeCircuitBreaker);
-        io.github.resilience4j.common.circuitbreaker.configuration.CircuitBreakerConfigurationProperties.InstanceProperties instanceProperties =
-                mock(io.github.resilience4j.common.circuitbreaker.configuration.CircuitBreakerConfigurationProperties.InstanceProperties.class);
+        CircuitBreakerConfigurationProperties.InstanceProperties instanceProperties =
+                mock(CircuitBreakerConfigurationProperties.InstanceProperties.class);
         CircuitBreakerConfigurationProperties circuitBreakerProperties = mock(CircuitBreakerConfigurationProperties.class);
 
         // given
@@ -126,7 +126,7 @@ public class CircuitBreakersHealthIndicatorTest {
         when(circuitBreaker.getState()).thenReturn(givenState);
         when(circuitBreaker.getCircuitBreakerConfig()).thenReturn(config);
         when(circuitBreaker.getMetrics()).thenReturn(metrics);
-        when(circuitBreakerProperties.findCircuitBreakerProperties("test")).thenReturn(Optional.of(instanceProperties));
+        when(circuitBreakerProperties.findCircuitBreakerProperties(givenState.name())).thenReturn(Optional.of(instanceProperties));
         when(instanceProperties.getRegisterHealthIndicator()).thenReturn(true);
     }
 

--- a/resilience4j-spring-boot2/src/test/resources/application.yaml
+++ b/resilience4j-spring-boot2/src/test/resources/application.yaml
@@ -39,6 +39,7 @@ resilience4j.circuitbreaker:
       registerHealthIndicator: true
   backends:
     backendA:
+      registerHealthIndicator: true
       slidingWindowSize: 6
       permittedNumberOfCallsInHalfOpenState: 2
       waitDurationInOpenState: 5s


### PR DESCRIPTION
…dicator should be disabled by default. Otherwise the application health status is DOWN when a CircuitBreaker is open which is not what users want.