### PR TITLE
[Feedback wanted] Disable stack traces for CallNotPermittedExceptions

### DIFF
--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CallNotPermittedException.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CallNotPermittedException.java
@@ -25,13 +25,23 @@ package io.github.resilience4j.circuitbreaker;
 public class CallNotPermittedException extends RuntimeException {
 
     /**
-     * The constructor with a CircuitBreaker.
+     * Static method to construct a {@link CallNotPermittedException} with a CircuitBreaker.
      *
      * @param circuitBreaker the CircuitBreaker.
      */
-    public CallNotPermittedException(CircuitBreaker circuitBreaker) {
-        super(String.format("CircuitBreaker '%s' is %s and does not permit further calls", circuitBreaker.getName(), circuitBreaker.getState()));
+    public static CallNotPermittedException getCallNotPermittedException(CircuitBreaker circuitBreaker) {
+        boolean disableStackTraces = circuitBreaker.getCircuitBreakerConfig().isDisableStackTraces();
+
+        String message = String.format("CircuitBreaker '%s' is %s and does not permit further calls", circuitBreaker.getName(), circuitBreaker.getState());
+
+        if (disableStackTraces) {
+            return new CallNotPermittedException(message, false);
+        } else {
+            return new CallNotPermittedException(message, true);
+        }
+    }
+
+    private CallNotPermittedException(String message, boolean writableStackTrace) {
+        super(message, null, false, writableStackTrace);
     }
 }
-
-

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CallNotPermittedException.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CallNotPermittedException.java
@@ -30,15 +30,11 @@ public class CallNotPermittedException extends RuntimeException {
      * @param circuitBreaker the CircuitBreaker.
      */
     public static CallNotPermittedException getCallNotPermittedException(CircuitBreaker circuitBreaker) {
-        boolean disableStackTraces = circuitBreaker.getCircuitBreakerConfig().isDisableStackTraces();
+        boolean writableStackTraceEnabled = circuitBreaker.getCircuitBreakerConfig().isWritableStackTraceEnabled();
 
         String message = String.format("CircuitBreaker '%s' is %s and does not permit further calls", circuitBreaker.getName(), circuitBreaker.getState());
 
-        if (disableStackTraces) {
-            return new CallNotPermittedException(message, false);
-        } else {
-            return new CallNotPermittedException(message, true);
-        }
+        return new CallNotPermittedException(message, writableStackTraceEnabled);
     }
 
     private CallNotPermittedException(String message, boolean writableStackTrace) {

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreaker.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreaker.java
@@ -36,6 +36,8 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static io.github.resilience4j.circuitbreaker.CallNotPermittedException.getCallNotPermittedException;
+
 /**
  * A CircuitBreaker instance is thread-safe can be used to decorate multiple requests.
  *
@@ -616,8 +618,7 @@ public interface CircuitBreaker {
             final CompletableFuture<T> promise = new CompletableFuture<>();
 
             if (!circuitBreaker.tryAcquirePermission()) {
-                promise.completeExceptionally(
-                        new CallNotPermittedException(circuitBreaker));
+                promise.completeExceptionally(getCallNotPermittedException(circuitBreaker));
 
             } else {
                 final long start = System.nanoTime();
@@ -748,7 +749,7 @@ public interface CircuitBreaker {
                 }
                 return Either.narrow(result);
             }else{
-                return Either.left(new CallNotPermittedException(circuitBreaker));
+                return Either.left(getCallNotPermittedException(circuitBreaker));
             }
         };
     }
@@ -775,7 +776,7 @@ public interface CircuitBreaker {
                     return result;
                 }
             }else{
-                return Try.failure(new CallNotPermittedException(circuitBreaker));
+                return Try.failure(getCallNotPermittedException(circuitBreaker));
             }
         };
     }

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfig.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfig.java
@@ -40,6 +40,7 @@ public class CircuitBreakerConfig {
     private static final Predicate<Throwable> DEFAULT_RECORD_EXCEPTION_PREDICATE = throwable -> true;
     private static final Predicate<Throwable> DEFAULT_IGNORE_EXCEPTION_PREDICATE = throwable -> false;
     public static final SlidingWindowType DEFAULT_SLIDING_WINDOW_TYPE = SlidingWindowType.COUNT_BASED;
+    public static final boolean DEFAULT_DISABLE_STACK_TRACES = false;
 
     // The default exception predicate counts all exceptions as failures.
     private Predicate<Throwable> recordExceptionPredicate = DEFAULT_RECORD_EXCEPTION_PREDICATE;
@@ -56,6 +57,7 @@ public class CircuitBreakerConfig {
     private int slidingWindowSize = DEFAULT_SLIDING_WINDOW_SIZE;
     private SlidingWindowType slidingWindowType = DEFAULT_SLIDING_WINDOW_TYPE;
     private int minimumNumberOfCalls = DEFAULT_MINIMUM_NUMBER_OF_CALLS;
+    private boolean disableStackTraces = DEFAULT_DISABLE_STACK_TRACES;
     private Duration waitDurationInOpenState = Duration.ofSeconds(DEFAULT_WAIT_DURATION_IN_OPEN_STATE);
     private boolean automaticTransitionFromOpenToHalfOpenEnabled = false;
     private float slowCallRateThreshold = DEFAULT_SLOW_CALL_RATE_THRESHOLD;
@@ -120,6 +122,10 @@ public class CircuitBreakerConfig {
         return minimumNumberOfCalls;
     }
 
+    public boolean isDisableStackTraces() {
+        return disableStackTraces;
+    }
+
     public int getPermittedNumberOfCallsInHalfOpenState() {
         return permittedNumberOfCallsInHalfOpenState;
     }
@@ -152,6 +158,7 @@ public class CircuitBreakerConfig {
 
         private float failureRateThreshold = DEFAULT_FAILURE_RATE_THRESHOLD;
         private int minimumNumberOfCalls = DEFAULT_MINIMUM_NUMBER_OF_CALLS;
+        private boolean disableStackTraces = DEFAULT_DISABLE_STACK_TRACES;
         private int permittedNumberOfCallsInHalfOpenState = DEFAULT_PERMITTED_CALLS_IN_HALF_OPEN_STATE;
         private int slidingWindowSize = DEFAULT_SLIDING_WINDOW_SIZE;
         private Duration waitDurationInOpenState = Duration.ofSeconds(DEFAULT_SLOW_CALL_DURATION_THRESHOLD);
@@ -174,6 +181,7 @@ public class CircuitBreakerConfig {
             this.automaticTransitionFromOpenToHalfOpenEnabled = baseConfig.automaticTransitionFromOpenToHalfOpenEnabled;
             this.slowCallRateThreshold = baseConfig.slowCallRateThreshold;
             this.slowCallDurationThreshold = baseConfig.slowCallDurationThreshold;
+            this.disableStackTraces = baseConfig.disableStackTraces;
         }
 
         public Builder() {
@@ -213,6 +221,17 @@ public class CircuitBreakerConfig {
                 throw new IllegalArgumentException("slowCallRateThreshold must be between 1 and 100");
             }
             this.slowCallRateThreshold = slowCallRateThreshold;
+            return this;
+        }
+
+        /**
+         * Disables writable stack traces. When set to false {@link Exception#getStackTrace()} returns a zero length array.
+         * This may be used to reduce log spam when the circuit breaker is open as the cause of the exceptions is already known (the circuit breaker is short-circuiting calls).
+         *
+         * @return the CircuitBreakerConfig.Builder
+         */
+        public Builder disableStackTraces(boolean disableStackTraces) {
+            this.disableStackTraces = disableStackTraces;
             return this;
         }
 
@@ -505,6 +524,7 @@ public class CircuitBreakerConfig {
             config.recordExceptions = recordExceptions;
             config.ignoreExceptions = ignoreExceptions;
             config.automaticTransitionFromOpenToHalfOpenEnabled = automaticTransitionFromOpenToHalfOpenEnabled;
+            config.disableStackTraces = disableStackTraces;
             config.recordExceptionPredicate = createRecordExceptionPredicate();
             config.ignoreExceptionPredicate = createIgnoreFailurePredicate();
             return config;

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfig.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfig.java
@@ -225,7 +225,7 @@ public class CircuitBreakerConfig {
         }
 
         /**
-         * Disables writable stack traces. When set to false {@link Exception#getStackTrace()} returns a zero length array.
+         * Disables writable stack traces. When set to true, {@link Exception#getStackTrace()} returns a zero length array.
          * This may be used to reduce log spam when the circuit breaker is open as the cause of the exceptions is already known (the circuit breaker is short-circuiting calls).
          *
          * @return the CircuitBreakerConfig.Builder

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfig.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfig.java
@@ -40,7 +40,7 @@ public class CircuitBreakerConfig {
     private static final Predicate<Throwable> DEFAULT_RECORD_EXCEPTION_PREDICATE = throwable -> true;
     private static final Predicate<Throwable> DEFAULT_IGNORE_EXCEPTION_PREDICATE = throwable -> false;
     public static final SlidingWindowType DEFAULT_SLIDING_WINDOW_TYPE = SlidingWindowType.COUNT_BASED;
-    public static final boolean DEFAULT_DISABLE_STACK_TRACES = false;
+    public static final boolean DEFAULT_WRITABLE_STACK_TRACE_ENABLED = true;
 
     // The default exception predicate counts all exceptions as failures.
     private Predicate<Throwable> recordExceptionPredicate = DEFAULT_RECORD_EXCEPTION_PREDICATE;
@@ -57,7 +57,7 @@ public class CircuitBreakerConfig {
     private int slidingWindowSize = DEFAULT_SLIDING_WINDOW_SIZE;
     private SlidingWindowType slidingWindowType = DEFAULT_SLIDING_WINDOW_TYPE;
     private int minimumNumberOfCalls = DEFAULT_MINIMUM_NUMBER_OF_CALLS;
-    private boolean disableStackTraces = DEFAULT_DISABLE_STACK_TRACES;
+    private boolean writableStackTraceEnabled = DEFAULT_WRITABLE_STACK_TRACE_ENABLED;
     private Duration waitDurationInOpenState = Duration.ofSeconds(DEFAULT_WAIT_DURATION_IN_OPEN_STATE);
     private boolean automaticTransitionFromOpenToHalfOpenEnabled = false;
     private float slowCallRateThreshold = DEFAULT_SLOW_CALL_RATE_THRESHOLD;
@@ -122,8 +122,8 @@ public class CircuitBreakerConfig {
         return minimumNumberOfCalls;
     }
 
-    public boolean isDisableStackTraces() {
-        return disableStackTraces;
+    public boolean isWritableStackTraceEnabled() {
+        return writableStackTraceEnabled;
     }
 
     public int getPermittedNumberOfCallsInHalfOpenState() {
@@ -158,7 +158,7 @@ public class CircuitBreakerConfig {
 
         private float failureRateThreshold = DEFAULT_FAILURE_RATE_THRESHOLD;
         private int minimumNumberOfCalls = DEFAULT_MINIMUM_NUMBER_OF_CALLS;
-        private boolean disableStackTraces = DEFAULT_DISABLE_STACK_TRACES;
+        private boolean writableStackTraceEnabled = DEFAULT_WRITABLE_STACK_TRACE_ENABLED;
         private int permittedNumberOfCallsInHalfOpenState = DEFAULT_PERMITTED_CALLS_IN_HALF_OPEN_STATE;
         private int slidingWindowSize = DEFAULT_SLIDING_WINDOW_SIZE;
         private Duration waitDurationInOpenState = Duration.ofSeconds(DEFAULT_SLOW_CALL_DURATION_THRESHOLD);
@@ -181,7 +181,7 @@ public class CircuitBreakerConfig {
             this.automaticTransitionFromOpenToHalfOpenEnabled = baseConfig.automaticTransitionFromOpenToHalfOpenEnabled;
             this.slowCallRateThreshold = baseConfig.slowCallRateThreshold;
             this.slowCallDurationThreshold = baseConfig.slowCallDurationThreshold;
-            this.disableStackTraces = baseConfig.disableStackTraces;
+            this.writableStackTraceEnabled = baseConfig.writableStackTraceEnabled;
         }
 
         public Builder() {
@@ -225,13 +225,13 @@ public class CircuitBreakerConfig {
         }
 
         /**
-         * Disables writable stack traces. When set to true, {@link Exception#getStackTrace()} returns a zero length array.
+         * Enables writable stack traces. When set to false, {@link Exception#getStackTrace()} returns a zero length array.
          * This may be used to reduce log spam when the circuit breaker is open as the cause of the exceptions is already known (the circuit breaker is short-circuiting calls).
          *
          * @return the CircuitBreakerConfig.Builder
          */
-        public Builder disableStackTraces(boolean disableStackTraces) {
-            this.disableStackTraces = disableStackTraces;
+        public Builder writableStackTraceEnabled(boolean writableStackTraceEnabled) {
+            this.writableStackTraceEnabled = writableStackTraceEnabled;
             return this;
         }
 
@@ -524,7 +524,7 @@ public class CircuitBreakerConfig {
             config.recordExceptions = recordExceptions;
             config.ignoreExceptions = ignoreExceptions;
             config.automaticTransitionFromOpenToHalfOpenEnabled = automaticTransitionFromOpenToHalfOpenEnabled;
-            config.disableStackTraces = disableStackTraces;
+            config.writableStackTraceEnabled = writableStackTraceEnabled;
             config.recordExceptionPredicate = createRecordExceptionPredicate();
             config.ignoreExceptionPredicate = createIgnoreFailurePredicate();
             return config;

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachine.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachine.java
@@ -40,6 +40,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
+import static io.github.resilience4j.circuitbreaker.CallNotPermittedException.getCallNotPermittedException;
 import static io.github.resilience4j.circuitbreaker.CircuitBreaker.State.*;
 import static io.github.resilience4j.circuitbreaker.internal.CircuitBreakerMetrics.Result;
 import static io.github.resilience4j.circuitbreaker.internal.CircuitBreakerMetrics.Result.ABOVE_THRESHOLDS;
@@ -485,7 +486,7 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
         @Override
         public void acquirePermission() {
             if(!tryAcquirePermission()){
-                throw new CallNotPermittedException(CircuitBreakerStateMachine.this);
+                throw getCallNotPermittedException(CircuitBreakerStateMachine.this);
             }
         }
 
@@ -611,7 +612,7 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
         @Override
         public void acquirePermission() {
             circuitBreakerMetrics.onCallNotPermitted();
-            throw new CallNotPermittedException(CircuitBreakerStateMachine.this);
+            throw getCallNotPermittedException(CircuitBreakerStateMachine.this);
         }
 
         @Override
@@ -680,7 +681,7 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
         @Override
         public void acquirePermission() {
             if(!tryAcquirePermission()){
-                throw new CallNotPermittedException(CircuitBreakerStateMachine.this);
+                throw getCallNotPermittedException(CircuitBreakerStateMachine.this);
             }
         }
 

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CallNotPermittedExceptionTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CallNotPermittedExceptionTest.java
@@ -2,6 +2,7 @@ package io.github.resilience4j.circuitbreaker;
 
 import org.junit.Test;
 
+import static io.github.resilience4j.circuitbreaker.CallNotPermittedException.getCallNotPermittedException;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CallNotPermittedExceptionTest {
@@ -10,13 +11,13 @@ public class CallNotPermittedExceptionTest {
     public void shouldReturnCorrectMessageWhenStateIsOpen(){
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
         circuitBreaker.transitionToOpenState();
-        assertThat(new CallNotPermittedException(circuitBreaker).getMessage()).isEqualTo("CircuitBreaker 'testName' is OPEN and does not permit further calls");
+        assertThat(getCallNotPermittedException(circuitBreaker).getMessage()).isEqualTo("CircuitBreaker 'testName' is OPEN and does not permit further calls");
     }
 
     @Test
     public void shouldReturnCorrectMessageWhenStateIsForcedOpen(){
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
         circuitBreaker.transitionToForcedOpenState();
-        assertThat(new CallNotPermittedException(circuitBreaker).getMessage()).isEqualTo("CircuitBreaker 'testName' is FORCED_OPEN and does not permit further calls");
+        assertThat(getCallNotPermittedException(circuitBreaker).getMessage()).isEqualTo("CircuitBreaker 'testName' is FORCED_OPEN and does not permit further calls");
     }
 }

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfigTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfigTest.java
@@ -113,7 +113,7 @@ public class CircuitBreakerConfigTest {
         then(circuitBreakerConfig.getRecordExceptionPredicate()).isNotNull();
         then(circuitBreakerConfig.getSlowCallRateThreshold()).isEqualTo(DEFAULT_SLOW_CALL_RATE_THRESHOLD);
         then(circuitBreakerConfig.getSlowCallDurationThreshold().getSeconds()).isEqualTo(DEFAULT_SLOW_CALL_DURATION_THRESHOLD);
-        then(circuitBreakerConfig.isDisableStackTraces()).isEqualTo(DEFAULT_DISABLE_STACK_TRACES);
+        then(circuitBreakerConfig.isWritableStackTraceEnabled()).isEqualTo(DEFAULT_WRITABLE_STACK_TRACE_ENABLED);
     }
 
     @Test
@@ -141,9 +141,9 @@ public class CircuitBreakerConfigTest {
     }
 
     @Test
-    public void shouldSetDisablingOfStackTraces() {
-        CircuitBreakerConfig circuitBreakerConfig = custom().disableStackTraces(true).build();
-        then(circuitBreakerConfig.isDisableStackTraces()).isEqualTo(true);
+    public void shouldSetWritableStackTraces() {
+        CircuitBreakerConfig circuitBreakerConfig = custom().writableStackTraceEnabled(false).build();
+        then(circuitBreakerConfig.isWritableStackTraceEnabled()).isEqualTo(false);
     }
 
     @Test
@@ -327,7 +327,7 @@ public class CircuitBreakerConfigTest {
                 .waitDurationInOpenState(Duration.ofSeconds(100))
                 .slidingWindowSize(1000)
                 .permittedNumberOfCallsInHalfOpenState(100)
-                .disableStackTraces(true)
+                .writableStackTraceEnabled(false)
                 .automaticTransitionFromOpenToHalfOpenEnabled(true)
                 .failureRateThreshold(20f).build();
 
@@ -336,7 +336,7 @@ public class CircuitBreakerConfigTest {
                 .build();
 
         then(extendedConfig.getFailureRateThreshold()).isEqualTo(20f);
-        then(extendedConfig.isDisableStackTraces()).isEqualTo(true);
+        then(extendedConfig.isWritableStackTraceEnabled()).isEqualTo(false);
         then(extendedConfig.getWaitDurationInOpenState()).isEqualTo(Duration.ofSeconds(20));
         then(extendedConfig.getSlidingWindowSize()).isEqualTo(1000);
         then(extendedConfig.getPermittedNumberOfCallsInHalfOpenState()).isEqualTo(100);

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfigTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfigTest.java
@@ -113,6 +113,7 @@ public class CircuitBreakerConfigTest {
         then(circuitBreakerConfig.getRecordExceptionPredicate()).isNotNull();
         then(circuitBreakerConfig.getSlowCallRateThreshold()).isEqualTo(DEFAULT_SLOW_CALL_RATE_THRESHOLD);
         then(circuitBreakerConfig.getSlowCallDurationThreshold().getSeconds()).isEqualTo(DEFAULT_SLOW_CALL_DURATION_THRESHOLD);
+        then(circuitBreakerConfig.isDisableStackTraces()).isEqualTo(DEFAULT_DISABLE_STACK_TRACES);
     }
 
     @Test
@@ -137,6 +138,12 @@ public class CircuitBreakerConfigTest {
     public void shouldSetLowFailureRateThreshold() {
         CircuitBreakerConfig circuitBreakerConfig = custom().failureRateThreshold(0.001f).build();
         then(circuitBreakerConfig.getFailureRateThreshold()).isEqualTo(0.001f);
+    }
+
+    @Test
+    public void shouldSetDisablingOfStackTraces() {
+        CircuitBreakerConfig circuitBreakerConfig = custom().disableStackTraces(true).build();
+        then(circuitBreakerConfig.isDisableStackTraces()).isEqualTo(true);
     }
 
     @Test
@@ -320,6 +327,7 @@ public class CircuitBreakerConfigTest {
                 .waitDurationInOpenState(Duration.ofSeconds(100))
                 .slidingWindowSize(1000)
                 .permittedNumberOfCallsInHalfOpenState(100)
+                .disableStackTraces(true)
                 .automaticTransitionFromOpenToHalfOpenEnabled(true)
                 .failureRateThreshold(20f).build();
 
@@ -328,6 +336,7 @@ public class CircuitBreakerConfigTest {
                 .build();
 
         then(extendedConfig.getFailureRateThreshold()).isEqualTo(20f);
+        then(extendedConfig.isDisableStackTraces()).isEqualTo(true);
         then(extendedConfig.getWaitDurationInOpenState()).isEqualTo(Duration.ofSeconds(20));
         then(extendedConfig.getSlidingWindowSize()).isEqualTo(1000);
         then(extendedConfig.getPermittedNumberOfCallsInHalfOpenState()).isEqualTo(100);

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerOpenExceptionTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerOpenExceptionTest.java
@@ -2,6 +2,7 @@ package io.github.resilience4j.circuitbreaker;
 
 import org.junit.Test;
 
+import static io.github.resilience4j.circuitbreaker.CallNotPermittedException.getCallNotPermittedException;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CircuitBreakerOpenExceptionTest {
@@ -10,13 +11,13 @@ public class CircuitBreakerOpenExceptionTest {
     public void shouldReturnCorrectMessageWhenStateIsOpen(){
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
         circuitBreaker.transitionToOpenState();
-        assertThat(new CallNotPermittedException(circuitBreaker).getMessage()).isEqualTo("CircuitBreaker 'testName' is OPEN and does not permit further calls");
+        assertThat(getCallNotPermittedException(circuitBreaker).getMessage()).isEqualTo("CircuitBreaker 'testName' is OPEN and does not permit further calls");
     }
 
     @Test
     public void shouldReturnCorrectMessageWhenStateIsForcedOpen(){
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
         circuitBreaker.transitionToForcedOpenState();
-        assertThat(new CallNotPermittedException(circuitBreaker).getMessage()).isEqualTo("CircuitBreaker 'testName' is FORCED_OPEN and does not permit further calls");
+        assertThat(getCallNotPermittedException(circuitBreaker).getMessage()).isEqualTo("CircuitBreaker 'testName' is FORCED_OPEN and does not permit further calls");
     }
 }

--- a/resilience4j-documentation/src/docs/asciidoc/addon_guides/springboot2.adoc
+++ b/resilience4j-documentation/src/docs/asciidoc/addon_guides/springboot2.adoc
@@ -451,7 +451,7 @@ For example
 resilience4j.circuitbreaker:
     configs:
         default:
-            disableStackTraces: true
+            writableStackTraceEnabled: false
             ringBufferSizeInClosedState: 100
             ringBufferSizeInHalfOpenState: 10
             waitInterval: 10000

--- a/resilience4j-documentation/src/docs/asciidoc/addon_guides/springboot2.adoc
+++ b/resilience4j-documentation/src/docs/asciidoc/addon_guides/springboot2.adoc
@@ -451,6 +451,7 @@ For example
 resilience4j.circuitbreaker:
     configs:
         default:
+            disableStackTraces: true
             ringBufferSizeInClosedState: 100
             ringBufferSizeInHalfOpenState: 10
             waitInterval: 10000

--- a/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationProperties.java
+++ b/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationProperties.java
@@ -78,8 +78,8 @@ public class CircuitBreakerConfigurationProperties {
 			builder.failureRateThreshold(properties.getFailureRateThreshold());
 		}
 
-		if (properties.getDisableStackTraces() != null) {
-			builder.disableStackTraces(properties.getDisableStackTraces());
+		if (properties.writableStackTraceEnabled() != null) {
+			builder.writableStackTraceEnabled(properties.writableStackTraceEnabled());
 		}
 
 		if (properties.getSlowCallRateThreshold() != null) {
@@ -216,7 +216,7 @@ public class CircuitBreakerConfigurationProperties {
 		private Boolean automaticTransitionFromOpenToHalfOpenEnabled;
 
 		@Nullable
-		private Boolean disableStackTraces;
+		private Boolean writableStackTraceEnabled;
 
 		@Min(1)
 		@Nullable
@@ -342,21 +342,21 @@ public class CircuitBreakerConfigurationProperties {
 		}
 
 		/**
-		 * Returns if we should disable stack traces or not.
+		 * Returns if we should enable writable stack traces or not.
 		 *
-		 * @return disableStackTraces if we should disable stack traces or not.
+		 * @return writableStackTraceEnabled if we should enable writable stack traces or not.
 		 */
-		public Boolean getDisableStackTraces() {
-			return this.disableStackTraces;
+		public Boolean writableStackTraceEnabled() {
+			return this.writableStackTraceEnabled;
 		}
 
 		/**
-		 * Sets if we should disable stack traces or not.
+		 * Sets if we should enable writable stack traces or not.
 		 *
-		 * @param disableStackTraces The flag to disable stack traces.
+		 * @param writableStackTraceEnabled The flag to enable writable stack traces.
 		 */
-		public InstanceProperties setDisableStackTraces(Boolean disableStackTraces) {
-			this.disableStackTraces = disableStackTraces;
+		public InstanceProperties writableStackTraceEnabled(Boolean writableStackTraceEnabled) {
+			this.writableStackTraceEnabled = writableStackTraceEnabled;
 			return this;
 		}
 

--- a/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationProperties.java
+++ b/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationProperties.java
@@ -78,6 +78,10 @@ public class CircuitBreakerConfigurationProperties {
 			builder.failureRateThreshold(properties.getFailureRateThreshold());
 		}
 
+		if (properties.getDisableStackTraces() != null) {
+			builder.disableStackTraces(properties.getDisableStackTraces());
+		}
+
 		if (properties.getSlowCallRateThreshold() != null) {
 			builder.slowCallRateThreshold(properties.getSlowCallRateThreshold());
 		}
@@ -211,6 +215,9 @@ public class CircuitBreakerConfigurationProperties {
 		@Nullable
 		private Boolean automaticTransitionFromOpenToHalfOpenEnabled;
 
+		@Nullable
+		private Boolean disableStackTraces;
+
 		@Min(1)
 		@Nullable
 		private Integer eventConsumerBufferSize;
@@ -331,6 +338,25 @@ public class CircuitBreakerConfigurationProperties {
 		 */
 		public InstanceProperties setAutomaticTransitionFromOpenToHalfOpenEnabled(Boolean automaticTransitionFromOpenToHalfOpenEnabled) {
 			this.automaticTransitionFromOpenToHalfOpenEnabled = automaticTransitionFromOpenToHalfOpenEnabled;
+			return this;
+		}
+
+		/**
+		 * Returns if we should disable stack traces or not.
+		 *
+		 * @return disableStackTraces if we should disable stack traces or not.
+		 */
+		public Boolean getDisableStackTraces() {
+			return this.disableStackTraces;
+		}
+
+		/**
+		 * Sets if we should disable stack traces or not.
+		 *
+		 * @param disableStackTraces The flag to disable stack traces.
+		 */
+		public InstanceProperties setDisableStackTraces(Boolean disableStackTraces) {
+			this.disableStackTraces = disableStackTraces;
 			return this;
 		}
 

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationPropertiesTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationPropertiesTest.java
@@ -45,7 +45,7 @@ public class CircuitBreakerConfigurationPropertiesTest {
 		instanceProperties1.setSlowCallRateThreshold(50f);
 		instanceProperties1.setPermittedNumberOfCallsInHalfOpenState(100);
 		instanceProperties1.setAutomaticTransitionFromOpenToHalfOpenEnabled(true);
-		instanceProperties1.setDisableStackTraces(true);
+		instanceProperties1.writableStackTraceEnabled(false);
 		//noinspection unchecked
 		instanceProperties1.setIgnoreExceptions(new Class[]{IllegalStateException.class});
 		//noinspection unchecked
@@ -76,7 +76,7 @@ public class CircuitBreakerConfigurationPropertiesTest {
 		assertThat(circuitBreaker1.getSlowCallRateThreshold()).isEqualTo(50f);
 		assertThat(circuitBreaker1.getWaitDurationInOpenState().toMillis()).isEqualTo(100);
 		assertThat(circuitBreaker1.isAutomaticTransitionFromOpenToHalfOpenEnabled()).isTrue();
-		assertThat(circuitBreaker1.isDisableStackTraces()).isTrue();
+		assertThat(circuitBreaker1.isWritableStackTraceEnabled()).isFalse();
 
 		final CircuitBreakerConfigurationProperties.InstanceProperties backend1 = circuitBreakerConfigurationProperties.getBackendProperties("backend1");
 		assertThat(circuitBreakerConfigurationProperties.findCircuitBreakerProperties("backend1")).isNotEmpty();

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationPropertiesTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationPropertiesTest.java
@@ -45,6 +45,7 @@ public class CircuitBreakerConfigurationPropertiesTest {
 		instanceProperties1.setSlowCallRateThreshold(50f);
 		instanceProperties1.setPermittedNumberOfCallsInHalfOpenState(100);
 		instanceProperties1.setAutomaticTransitionFromOpenToHalfOpenEnabled(true);
+		instanceProperties1.setDisableStackTraces(true);
 		//noinspection unchecked
 		instanceProperties1.setIgnoreExceptions(new Class[]{IllegalStateException.class});
 		//noinspection unchecked
@@ -75,6 +76,7 @@ public class CircuitBreakerConfigurationPropertiesTest {
 		assertThat(circuitBreaker1.getSlowCallRateThreshold()).isEqualTo(50f);
 		assertThat(circuitBreaker1.getWaitDurationInOpenState().toMillis()).isEqualTo(100);
 		assertThat(circuitBreaker1.isAutomaticTransitionFromOpenToHalfOpenEnabled()).isTrue();
+		assertThat(circuitBreaker1.isDisableStackTraces()).isTrue();
 
 		final CircuitBreakerConfigurationProperties.InstanceProperties backend1 = circuitBreakerConfigurationProperties.getBackendProperties("backend1");
 		assertThat(circuitBreakerConfigurationProperties.findCircuitBreakerProperties("backend1")).isNotEmpty();

--- a/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/circuitbreaker/CircuitBreakerMethodInterceptor.java
+++ b/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/circuitbreaker/CircuitBreakerMethodInterceptor.java
@@ -35,6 +35,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
+import static io.github.resilience4j.circuitbreaker.CallNotPermittedException.getCallNotPermittedException;
+
 /**
  * A {@link MethodInterceptor} to handle all methods annotated with {@link CircuitBreaker}. It will
  * handle methods that return a {@link Promise}, {@link reactor.core.publisher.Flux}, {@link reactor.core.publisher.Mono}, {@link java.util.concurrent.CompletionStage}, or value.
@@ -124,7 +126,7 @@ public class CircuitBreakerMethodInterceptor extends AbstractMethodInterceptor {
                     });
                 }
             } else {
-                Throwable t = new CallNotPermittedException(breaker);
+                Throwable t = getCallNotPermittedException(breaker);
                 completeFailedFuture(t, fallbackMethod, promise);
             }
             return promise;

--- a/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/circuitbreaker/CircuitBreakerTransformer.java
+++ b/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/circuitbreaker/CircuitBreakerTransformer.java
@@ -24,6 +24,8 @@ import ratpack.func.Function;
 
 import java.util.concurrent.TimeUnit;
 
+import static io.github.resilience4j.circuitbreaker.CallNotPermittedException.getCallNotPermittedException;
+
 public class CircuitBreakerTransformer<T> extends AbstractTransformer<T> {
     private CircuitBreaker circuitBreaker;
 
@@ -84,7 +86,7 @@ public class CircuitBreakerTransformer<T> extends AbstractTransformer<T> {
                     }
                 });
             } else {
-                Throwable t = new CallNotPermittedException(circuitBreaker);
+                Throwable t = getCallNotPermittedException(circuitBreaker);
                 handleRecovery(down, t);
             }
         };

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/circuitbreaker/operator/FluxCircuitBreaker.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/circuitbreaker/operator/FluxCircuitBreaker.java
@@ -22,6 +22,8 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxOperator;
 import reactor.core.publisher.Operators;
 
+import static io.github.resilience4j.circuitbreaker.CallNotPermittedException.getCallNotPermittedException;
+
 class FluxCircuitBreaker<T> extends FluxOperator<T, T> {
 
     private CircuitBreaker circuitBreaker;
@@ -36,7 +38,7 @@ class FluxCircuitBreaker<T> extends FluxOperator<T, T> {
         if(circuitBreaker.tryAcquirePermission()){
             source.subscribe(new CircuitBreakerSubscriber<>(circuitBreaker, actual, false));
         }else{
-            Operators.error(actual, new CallNotPermittedException(circuitBreaker));
+            Operators.error(actual, getCallNotPermittedException(circuitBreaker));
         }
     }
 

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/circuitbreaker/operator/MonoCircuitBreaker.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/circuitbreaker/operator/MonoCircuitBreaker.java
@@ -22,6 +22,8 @@ import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoOperator;
 import reactor.core.publisher.Operators;
 
+import static io.github.resilience4j.circuitbreaker.CallNotPermittedException.getCallNotPermittedException;
+
 class MonoCircuitBreaker<T> extends MonoOperator<T, T> {
 
     private CircuitBreaker circuitBreaker;
@@ -36,7 +38,7 @@ class MonoCircuitBreaker<T> extends MonoOperator<T, T> {
         if(circuitBreaker.tryAcquirePermission()){
             source.subscribe(new CircuitBreakerSubscriber<>(circuitBreaker, actual, true));
         }else{
-            Operators.error(actual, new CallNotPermittedException(circuitBreaker));
+            Operators.error(actual, getCallNotPermittedException(circuitBreaker));
         }
     }
 }

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/FluxCircuitBreakerTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/FluxCircuitBreakerTest.java
@@ -37,7 +37,7 @@ public class FluxCircuitBreakerTest {
 
     @Before
     public void setUp(){
-        circuitBreaker = Mockito.mock(CircuitBreaker.class);
+        circuitBreaker = Mockito.mock(CircuitBreaker.class, RETURNS_DEEP_STUBS);
     }
 
     @Test

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/MonoCircuitBreakerTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/MonoCircuitBreakerTest.java
@@ -43,7 +43,7 @@ public class MonoCircuitBreakerTest  {
 
     @Before
     public void setUp(){
-        circuitBreaker = Mockito.mock(CircuitBreaker.class);
+        circuitBreaker = Mockito.mock(CircuitBreaker.class, RETURNS_DEEP_STUBS);
         helloWorldService = Mockito.mock(HelloWorldService.class);
     }
 

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/CompletableCircuitBreaker.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/CompletableCircuitBreaker.java
@@ -24,6 +24,8 @@ import io.reactivex.internal.disposables.EmptyDisposable;
 
 import java.util.concurrent.TimeUnit;
 
+import static io.github.resilience4j.circuitbreaker.CallNotPermittedException.getCallNotPermittedException;
+
 class CompletableCircuitBreaker extends Completable {
 
     private final Completable upstream;
@@ -40,7 +42,7 @@ class CompletableCircuitBreaker extends Completable {
             upstream.subscribe(new CircuitBreakerCompletableObserver(downstream));
         }else{
             downstream.onSubscribe(EmptyDisposable.INSTANCE);
-            downstream.onError(new CallNotPermittedException(circuitBreaker));
+            downstream.onError(getCallNotPermittedException(circuitBreaker));
         }
     }
 

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/FlowableCircuitBreaker.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/FlowableCircuitBreaker.java
@@ -26,6 +26,7 @@ import org.reactivestreams.Subscriber;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
+import static io.github.resilience4j.circuitbreaker.CallNotPermittedException.getCallNotPermittedException;
 import static java.util.Objects.requireNonNull;
 
 class FlowableCircuitBreaker<T> extends Flowable<T> {
@@ -44,7 +45,7 @@ class FlowableCircuitBreaker<T> extends Flowable<T> {
             upstream.subscribe(new CircuitBreakerSubscriber(downstream));
         }else{
             downstream.onSubscribe(EmptySubscription.INSTANCE);
-            downstream.onError(new CallNotPermittedException(circuitBreaker));
+            downstream.onError(getCallNotPermittedException(circuitBreaker));
         }
     }
 

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/MaybeCircuitBreaker.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/MaybeCircuitBreaker.java
@@ -24,6 +24,8 @@ import io.reactivex.internal.disposables.EmptyDisposable;
 
 import java.util.concurrent.TimeUnit;
 
+import static io.github.resilience4j.circuitbreaker.CallNotPermittedException.getCallNotPermittedException;
+
 class MaybeCircuitBreaker<T> extends Maybe<T> {
 
     private final Maybe<T> upstream;
@@ -40,7 +42,7 @@ class MaybeCircuitBreaker<T> extends Maybe<T> {
             upstream.subscribe(new CircuitBreakerMaybeObserver(downstream));
         }else{
             downstream.onSubscribe(EmptyDisposable.INSTANCE);
-            downstream.onError(new CallNotPermittedException(circuitBreaker));
+            downstream.onError(getCallNotPermittedException(circuitBreaker));
         }
     }
 

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/ObserverCircuitBreaker.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/ObserverCircuitBreaker.java
@@ -24,6 +24,8 @@ import io.reactivex.internal.disposables.EmptyDisposable;
 
 import java.util.concurrent.TimeUnit;
 
+import static io.github.resilience4j.circuitbreaker.CallNotPermittedException.getCallNotPermittedException;
+
 class ObserverCircuitBreaker<T> extends Observable<T> {
 
     private final Observable<T> upstream;
@@ -40,7 +42,7 @@ class ObserverCircuitBreaker<T> extends Observable<T> {
             upstream.subscribe(new CircuitBreakerObserver(downstream));
         }else{
             downstream.onSubscribe(EmptyDisposable.INSTANCE);
-            downstream.onError(new CallNotPermittedException(circuitBreaker));
+            downstream.onError(getCallNotPermittedException(circuitBreaker));
         }
     }
     class CircuitBreakerObserver extends AbstractObserver<T> {

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/SingleCircuitBreaker.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/SingleCircuitBreaker.java
@@ -24,6 +24,8 @@ import io.reactivex.internal.disposables.EmptyDisposable;
 
 import java.util.concurrent.TimeUnit;
 
+import static io.github.resilience4j.circuitbreaker.CallNotPermittedException.getCallNotPermittedException;
+
 class SingleCircuitBreaker<T> extends Single<T> {
 
     private final CircuitBreaker circuitBreaker;
@@ -40,7 +42,7 @@ class SingleCircuitBreaker<T> extends Single<T> {
             upstream.subscribe(new CircuitBreakerSingleObserver(downstream));
         }else{
             downstream.onSubscribe(EmptyDisposable.INSTANCE);
-            downstream.onError(new CallNotPermittedException(circuitBreaker));
+            downstream.onError(getCallNotPermittedException(circuitBreaker));
         }
     }
 

--- a/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/BaseCircuitBreakerTest.java
+++ b/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/BaseCircuitBreakerTest.java
@@ -15,7 +15,7 @@ abstract class BaseCircuitBreakerTest {
 
     @Before
     public void setUp(){
-        circuitBreaker = Mockito.mock(CircuitBreaker.class);
+        circuitBreaker = Mockito.mock(CircuitBreaker.class, Mockito.RETURNS_DEEP_STUBS);
         helloWorldService = Mockito.mock(HelloWorldService.class);
     }
 }

--- a/resilience4j-vertx/src/main/java/io/github/resilience4j/circuitbreaker/VertxCircuitBreaker.java
+++ b/resilience4j-vertx/src/main/java/io/github/resilience4j/circuitbreaker/VertxCircuitBreaker.java
@@ -23,6 +23,8 @@ import io.vertx.core.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import static io.github.resilience4j.circuitbreaker.CallNotPermittedException.getCallNotPermittedException;
+
 /**
  * CircuitBreaker decorators for Vert.x
  */
@@ -53,7 +55,7 @@ public interface VertxCircuitBreaker {
             final Future<T> future = Future.future();
 
             if (!circuitBreaker.tryAcquirePermission()) {
-                future.fail(new CallNotPermittedException(circuitBreaker));
+                future.fail(getCallNotPermittedException(circuitBreaker));
 
             } else {
                 long start = System.nanoTime();


### PR DESCRIPTION
Fixes #618.

Created a static method that constructs a regular CallNotPermitedException or a similar one but  without a stack trace,