### PR TITLE
Fix non deterministic test

### DIFF
--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedThreadPoolBulkheadMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedThreadPoolBulkheadMetricsTest.java
@@ -94,7 +94,7 @@ public class TaggedThreadPoolBulkheadMetricsTest {
         assertThat(successful.get().value()).isEqualTo(bulkhead.getMetrics().getMaximumThreadPoolSize());
 
         ThreadPoolBulkhead newBulkhead = ThreadPoolBulkhead.of(bulkhead.getName(), ThreadPoolBulkheadConfig.custom()
-                .maxThreadPoolSize(10).build());
+                .maxThreadPoolSize(ThreadPoolBulkheadConfig.DEFAULT_MAX_THREAD_POOL_SIZE + 1).build());
 
         bulkheadRegistry.replace(bulkhead.getName(), newBulkhead);
 


### PR DESCRIPTION
Depending on the number of cpus, the default core threadpool size can be less than 10 which causes the test to fail.

The default is calculated in ThreadPoolBulkheadConfig:
`DEFAULT_CORE_THREAD_POOL_SIZE = Runtime.getRuntime().availableProcessors() > 1 ? Runtime.getRuntime().availableProcessors() - 1 : 1;`

If this is less than 10, the test fails with the error :

> maxThreadPoolSize must be a greater than or equals to coreThreadPoolSize