### PR TITLE
Disable stack traces for exceptions from ratelimiter and bulkhead

### DIFF
--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/Bulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/Bulkhead.java
@@ -38,7 +38,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import static io.github.resilience4j.bulkhead.BulkheadFullException.getCallNotPermittedException;
+import static io.github.resilience4j.bulkhead.BulkheadFullException.getBulkheadFullException;
 
 /**
  *  A Bulkhead instance is thread-safe can be used to decorate multiple requests.
@@ -231,7 +231,7 @@ public interface Bulkhead {
             final CompletableFuture<T> promise = new CompletableFuture<>();
 
             if (!bulkhead.tryAcquirePermission()) {
-                promise.completeExceptionally(getCallNotPermittedException(bulkhead));
+                promise.completeExceptionally(BulkheadFullException.getBulkheadFullException(bulkhead));
             }
             else {
                 try {
@@ -339,7 +339,7 @@ public interface Bulkhead {
                     bulkhead.onComplete();
                 }
             }else{
-                return Try.failure(getCallNotPermittedException(bulkhead));
+                return Try.failure(BulkheadFullException.getBulkheadFullException(bulkhead));
             }
         };
     }
@@ -364,7 +364,7 @@ public interface Bulkhead {
                     bulkhead.onComplete();
                 }
             }else{
-                return Either.left(getCallNotPermittedException(bulkhead));
+                return Either.left(BulkheadFullException.getBulkheadFullException(bulkhead));
             }
         };
     }

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/Bulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/Bulkhead.java
@@ -38,6 +38,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static io.github.resilience4j.bulkhead.BulkheadFullException.getCallNotPermittedException;
+
 /**
  *  A Bulkhead instance is thread-safe can be used to decorate multiple requests.
  *
@@ -229,7 +231,7 @@ public interface Bulkhead {
             final CompletableFuture<T> promise = new CompletableFuture<>();
 
             if (!bulkhead.tryAcquirePermission()) {
-                promise.completeExceptionally(new BulkheadFullException(bulkhead));
+                promise.completeExceptionally(getCallNotPermittedException(bulkhead));
             }
             else {
                 try {
@@ -337,7 +339,7 @@ public interface Bulkhead {
                     bulkhead.onComplete();
                 }
             }else{
-                return Try.failure(new BulkheadFullException(bulkhead));
+                return Try.failure(getCallNotPermittedException(bulkhead));
             }
         };
     }
@@ -362,7 +364,7 @@ public interface Bulkhead {
                     bulkhead.onComplete();
                 }
             }else{
-                return Either.left(new BulkheadFullException(bulkhead));
+                return Either.left(getCallNotPermittedException(bulkhead));
             }
         };
     }

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/BulkheadConfig.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/BulkheadConfig.java
@@ -27,9 +27,11 @@ public class BulkheadConfig {
 
 	public static final int DEFAULT_MAX_CONCURRENT_CALLS = 25;
 	public static final Duration DEFAULT_MAX_WAIT_DURATION = Duration.ofSeconds(0);
+	public static final boolean DEFAULT_WRITABLE_STACK_TRACE_ENABLED = true;
 
 	private int maxConcurrentCalls = DEFAULT_MAX_CONCURRENT_CALLS;
 	private Duration maxWaitDuration= DEFAULT_MAX_WAIT_DURATION;
+	private boolean writableStackTraceEnabled = DEFAULT_WRITABLE_STACK_TRACE_ENABLED;
 
 	private BulkheadConfig() {
 	}
@@ -67,6 +69,10 @@ public class BulkheadConfig {
 
 	public Duration getMaxWaitDuration() {
 		return maxWaitDuration;
+	}
+
+	public boolean isWritableStackTraceEnabled() {
+		return writableStackTraceEnabled;
 	}
 
 	public static class Builder {
@@ -109,6 +115,19 @@ public class BulkheadConfig {
 				throw new IllegalArgumentException("maxWaitDuration must be a positive integer value >= 0");
 			}
 			config.maxWaitDuration = maxWaitDuration;
+			return this;
+		}
+
+		/**
+		 * Enables writable stack traces. When set to false, {@link Exception#getStackTrace()} returns a zero length array.
+		 * This may be used to reduce log spam when the circuit breaker is open as the cause of the exceptions is already
+		 * known (the circuit breaker is short-circuiting calls).
+		 *
+		 * @param writableStackTraceEnabled flag to control if stack trace is writable
+		 * @return the BulkheadConfig.Builder
+		 */
+		public Builder writableStackTraceEnabled(boolean writableStackTraceEnabled) {
+			config.writableStackTraceEnabled = writableStackTraceEnabled;
 			return this;
 		}
 

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/BulkheadFullException.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/BulkheadFullException.java
@@ -24,22 +24,32 @@ package io.github.resilience4j.bulkhead;
 public class BulkheadFullException extends RuntimeException {
 
     /**
-     * The constructor with a message.
+     * Static method to construct a {@link BulkheadFullException} with a Bulkhead.
      *
      * @param bulkhead the Bulkhead.
      */
-    public BulkheadFullException(Bulkhead bulkhead) {
-        super(String.format("Bulkhead '%s' is full and does not permit further calls", bulkhead.getName()));
+    public static BulkheadFullException getCallNotPermittedException(Bulkhead bulkhead) {
+        boolean writableStackTraceEnabled = bulkhead.getBulkheadConfig().isWritableStackTraceEnabled();
+
+        String message = String.format("Bulkhead '%s' is full and does not permit further calls", bulkhead.getName());
+
+        return new BulkheadFullException(message, writableStackTraceEnabled);
     }
 
     /**
-     * The constructor with a message.
+     * Static method to construct a {@link BulkheadFullException} with a ThreadPoolBulkhead.
      *
      * @param bulkhead the Bulkhead.
      */
-    public BulkheadFullException(ThreadPoolBulkhead bulkhead) {
-        super(String.format("Bulkhead '%s' is full and does not permit further calls", bulkhead.getName()));
+    public static BulkheadFullException getCallNotPermittedException(ThreadPoolBulkhead bulkhead) {
+        boolean writableStackTraceEnabled = bulkhead.getBulkheadConfig().isWritableStackTraceEnabled();
+
+        String message = String.format("Bulkhead '%s' is full and does not permit further calls", bulkhead.getName());
+
+        return new BulkheadFullException(message, writableStackTraceEnabled);
+    }
+
+    private BulkheadFullException(String message, boolean writableStackTrace) {
+        super(message, null, false, writableStackTrace);
     }
 }
-
-

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/BulkheadFullException.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/BulkheadFullException.java
@@ -28,7 +28,7 @@ public class BulkheadFullException extends RuntimeException {
      *
      * @param bulkhead the Bulkhead.
      */
-    public static BulkheadFullException getCallNotPermittedException(Bulkhead bulkhead) {
+    public static BulkheadFullException getBulkheadFullException(Bulkhead bulkhead) {
         boolean writableStackTraceEnabled = bulkhead.getBulkheadConfig().isWritableStackTraceEnabled();
 
         String message = String.format("Bulkhead '%s' is full and does not permit further calls", bulkhead.getName());
@@ -41,7 +41,7 @@ public class BulkheadFullException extends RuntimeException {
      *
      * @param bulkhead the Bulkhead.
      */
-    public static BulkheadFullException getCallNotPermittedException(ThreadPoolBulkhead bulkhead) {
+    public static BulkheadFullException getBulkheadFullException(ThreadPoolBulkhead bulkhead) {
         boolean writableStackTraceEnabled = bulkhead.getBulkheadConfig().isWritableStackTraceEnabled();
 
         String message = String.format("Bulkhead '%s' is full and does not permit further calls", bulkhead.getName());

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfig.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfig.java
@@ -29,11 +29,13 @@ public class ThreadPoolBulkheadConfig {
 	public static final Duration DEFAULT_KEEP_ALIVE_DURATION = Duration.ofMillis(20);
 	public static final int DEFAULT_CORE_THREAD_POOL_SIZE = Runtime.getRuntime().availableProcessors() > 1 ? Runtime.getRuntime().availableProcessors() - 1 : 1;
 	public static final int DEFAULT_MAX_THREAD_POOL_SIZE = Runtime.getRuntime().availableProcessors();
+	public static final boolean DEFAULT_WRITABLE_STACK_TRACE_ENABLED = true;
 
 	private int maxThreadPoolSize = DEFAULT_MAX_THREAD_POOL_SIZE;
 	private int coreThreadPoolSize = DEFAULT_CORE_THREAD_POOL_SIZE;
 	private int queueCapacity = DEFAULT_QUEUE_CAPACITY;
 	private Duration keepAliveDuration = DEFAULT_KEEP_ALIVE_DURATION;
+	private boolean writableStackTraceEnabled = DEFAULT_WRITABLE_STACK_TRACE_ENABLED;
 
 	private ThreadPoolBulkheadConfig() {
 	}
@@ -79,6 +81,10 @@ public class ThreadPoolBulkheadConfig {
 
 	public int getCoreThreadPoolSize() {
 		return coreThreadPoolSize;
+	}
+
+	public boolean isWritableStackTraceEnabled() {
+		return writableStackTraceEnabled;
 	}
 
 	public static class Builder {
@@ -149,6 +155,19 @@ public class ThreadPoolBulkheadConfig {
 				throw new IllegalArgumentException("keepAliveDuration must be a positive integer value >= 0");
 			}
 			config.keepAliveDuration = keepAliveDuration;
+			return this;
+		}
+
+		/**
+		 * Enables writable stack traces. When set to false, {@link Exception#getStackTrace()} returns a zero length array.
+		 * This may be used to reduce log spam when the circuit breaker is open as the cause of the exceptions is already
+		 * known (the circuit breaker is short-circuiting calls).
+		 *
+		 * @param writableStackTraceEnabled flag to control if stack trace is writable
+		 * @return the BulkheadConfig.Builder
+		 */
+		public Builder writableStackTraceEnabled(boolean writableStackTraceEnabled) {
+			config.writableStackTraceEnabled = writableStackTraceEnabled;
 			return this;
 		}
 

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/FixedThreadPoolBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/FixedThreadPoolBulkhead.java
@@ -19,7 +19,6 @@
 package io.github.resilience4j.bulkhead.internal;
 
 
-import io.github.resilience4j.bulkhead.BulkheadFullException;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkheadConfig;
 import io.github.resilience4j.bulkhead.event.BulkheadEvent;
@@ -33,7 +32,7 @@ import io.github.resilience4j.core.lang.Nullable;
 import java.util.concurrent.*;
 import java.util.function.Supplier;
 
-import static io.github.resilience4j.bulkhead.BulkheadFullException.getCallNotPermittedException;
+import static io.github.resilience4j.bulkhead.BulkheadFullException.getBulkheadFullException;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -118,7 +117,7 @@ public class FixedThreadPoolBulkhead implements ThreadPoolBulkhead {
 			});
 		} catch (RejectedExecutionException rejected) {
 			publishBulkheadEvent(() -> new BulkheadOnCallRejectedEvent(name));
-			throw getCallNotPermittedException(this);
+			throw getBulkheadFullException(this);
 		}
 		return promise;
 	}
@@ -139,7 +138,7 @@ public class FixedThreadPoolBulkhead implements ThreadPoolBulkhead {
 			}, executorService).whenComplete((voidResult, throwable) -> publishBulkheadEvent(() -> new BulkheadOnCallFinishedEvent(name)));
 		} catch (RejectedExecutionException rejected) {
 			publishBulkheadEvent(() -> new BulkheadOnCallRejectedEvent(name));
-			throw getCallNotPermittedException(this);
+			throw getBulkheadFullException(this);
 		}
 	}
 

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/FixedThreadPoolBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/FixedThreadPoolBulkhead.java
@@ -33,6 +33,7 @@ import io.github.resilience4j.core.lang.Nullable;
 import java.util.concurrent.*;
 import java.util.function.Supplier;
 
+import static io.github.resilience4j.bulkhead.BulkheadFullException.getCallNotPermittedException;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -117,7 +118,7 @@ public class FixedThreadPoolBulkhead implements ThreadPoolBulkhead {
 			});
 		} catch (RejectedExecutionException rejected) {
 			publishBulkheadEvent(() -> new BulkheadOnCallRejectedEvent(name));
-			throw new BulkheadFullException(this);
+			throw getCallNotPermittedException(this);
 		}
 		return promise;
 	}
@@ -138,7 +139,7 @@ public class FixedThreadPoolBulkhead implements ThreadPoolBulkhead {
 			}, executorService).whenComplete((voidResult, throwable) -> publishBulkheadEvent(() -> new BulkheadOnCallFinishedEvent(name)));
 		} catch (RejectedExecutionException rejected) {
 			publishBulkheadEvent(() -> new BulkheadOnCallRejectedEvent(name));
-			throw new BulkheadFullException(this);
+			throw getCallNotPermittedException(this);
 		}
 	}
 

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkhead.java
@@ -34,6 +34,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import static io.github.resilience4j.bulkhead.BulkheadFullException.getCallNotPermittedException;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -116,7 +117,7 @@ public class SemaphoreBulkhead implements Bulkhead {
     @Override
     public void acquirePermission() {
         if(!tryAcquirePermission()) {
-            throw new BulkheadFullException(this);
+            throw getCallNotPermittedException(this);
         }
     }
 

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkhead.java
@@ -34,7 +34,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
-import static io.github.resilience4j.bulkhead.BulkheadFullException.getCallNotPermittedException;
+import static io.github.resilience4j.bulkhead.BulkheadFullException.getBulkheadFullException;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -117,7 +117,7 @@ public class SemaphoreBulkhead implements Bulkhead {
     @Override
     public void acquirePermission() {
         if(!tryAcquirePermission()) {
-            throw getCallNotPermittedException(this);
+            throw BulkheadFullException.getBulkheadFullException(this);
         }
     }
 

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/BulkheadConfigTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/BulkheadConfigTest.java
@@ -47,6 +47,24 @@ public class BulkheadConfigTest {
 	}
 
     @Test
+    public void testBuildCustomWithWritableStackTraceDisabled() {
+
+        // given
+        int maxConcurrent = 66;
+
+        // when
+        BulkheadConfig config = BulkheadConfig.custom()
+                .maxConcurrentCalls(maxConcurrent)
+                .writableStackTraceEnabled(false)
+                .build();
+
+        // then
+        assertThat(config).isNotNull();
+        assertThat(config.getMaxConcurrentCalls()).isEqualTo(maxConcurrent);
+        assertThat(config.isWritableStackTraceEnabled()).isFalse();
+    }
+
+    @Test
     public void testBuildCustom() {
 
         // given

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/BulkheadTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/BulkheadTest.java
@@ -41,8 +41,7 @@ import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.*;
 
 public class BulkheadTest {
 
@@ -663,7 +662,7 @@ public class BulkheadTest {
     @Test
     public void shouldDecorateTrySupplierAndReturnWithBulkheadFullException() {
         // Given
-        Bulkhead bulkhead = Mockito.mock(Bulkhead.class);
+        Bulkhead bulkhead = Mockito.mock(Bulkhead.class, RETURNS_DEEP_STUBS);
         BDDMockito.given(bulkhead.tryAcquirePermission()).willReturn(false);
 
         // When
@@ -678,7 +677,7 @@ public class BulkheadTest {
     @Test
     public void shouldDecorateEitherSupplierAndReturnWithBulkheadFullException() {
         // Given
-        Bulkhead bulkhead = Mockito.mock(Bulkhead.class);
+        Bulkhead bulkhead = Mockito.mock(Bulkhead.class, RETURNS_DEEP_STUBS);
         BDDMockito.given(bulkhead.tryAcquirePermission()).willReturn(false);
 
         // When

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkheadTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkheadTest.java
@@ -32,6 +32,7 @@ import java.util.function.Supplier;
 
 import static com.jayway.awaitility.Awaitility.await;
 import static io.github.resilience4j.bulkhead.BulkheadConfig.DEFAULT_MAX_CONCURRENT_CALLS;
+import static io.github.resilience4j.bulkhead.BulkheadConfig.DEFAULT_WRITABLE_STACK_TRACE_ENABLED;
 import static io.github.resilience4j.bulkhead.event.BulkheadEvent.Type.*;
 import static java.lang.Thread.State.*;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -115,6 +116,7 @@ public class SemaphoreBulkheadTest {
 		assertThat(bulkhead).isNotNull();
 		assertThat(bulkhead.getBulkheadConfig()).isNotNull();
 		assertThat(bulkhead.getBulkheadConfig().getMaxConcurrentCalls()).isEqualTo(DEFAULT_MAX_CONCURRENT_CALLS);
+		assertThat(bulkhead.getBulkheadConfig().isWritableStackTraceEnabled()).isEqualTo(DEFAULT_WRITABLE_STACK_TRACE_ENABLED);
 	}
 
 	@Test

--- a/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/bulkhead/configuration/ThreadPoolBulkheadConfigurationProperties.java
+++ b/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/bulkhead/configuration/ThreadPoolBulkheadConfigurationProperties.java
@@ -89,6 +89,9 @@ public class ThreadPoolBulkheadConfigurationProperties {
 		if (properties.getKeepAliveDuration() != null) {
 			builder.keepAliveDuration(properties.getKeepAliveDuration());
 		}
+		if (properties.getWritableStackTraceEnabled() != null) {
+			builder.writableStackTraceEnabled(properties.getWritableStackTraceEnabled());
+		}
 
 		return builder.build();
 	}
@@ -105,6 +108,9 @@ public class ThreadPoolBulkheadConfigurationProperties {
 
 		@Nullable
 		private String baseConfig;
+
+		@Nullable
+		private Boolean writableStackTraceEnabled;
 
 		private int maxThreadPoolSize;
 		private int coreThreadPoolSize;
@@ -153,6 +159,15 @@ public class ThreadPoolBulkheadConfigurationProperties {
 		}
 
 		public InstanceProperties setEventConsumerBufferSize(Integer eventConsumerBufferSize) {
+			this.eventConsumerBufferSize = eventConsumerBufferSize;
+			return this;
+		}
+
+		public Boolean getWritableStackTraceEnabled() {
+			return writableStackTraceEnabled;
+		}
+
+		public InstanceProperties setWritableStackTraceEnabled(Integer eventConsumerBufferSize) {
 			this.eventConsumerBufferSize = eventConsumerBufferSize;
 			return this;
 		}

--- a/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationProperties.java
+++ b/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationProperties.java
@@ -78,8 +78,8 @@ public class CircuitBreakerConfigurationProperties {
 			builder.failureRateThreshold(properties.getFailureRateThreshold());
 		}
 
-		if (properties.writableStackTraceEnabled() != null) {
-			builder.writableStackTraceEnabled(properties.writableStackTraceEnabled());
+		if (properties.getWritableStackTraceEnabled() != null) {
+			builder.writableStackTraceEnabled(properties.getWritableStackTraceEnabled());
 		}
 
 		if (properties.getSlowCallRateThreshold() != null) {
@@ -346,7 +346,7 @@ public class CircuitBreakerConfigurationProperties {
 		 *
 		 * @return writableStackTraceEnabled if we should enable writable stack traces or not.
 		 */
-		public Boolean writableStackTraceEnabled() {
+		public Boolean getWritableStackTraceEnabled() {
 			return this.writableStackTraceEnabled;
 		}
 
@@ -355,7 +355,7 @@ public class CircuitBreakerConfigurationProperties {
 		 *
 		 * @param writableStackTraceEnabled The flag to enable writable stack traces.
 		 */
-		public InstanceProperties writableStackTraceEnabled(Boolean writableStackTraceEnabled) {
+		public InstanceProperties setWritableStackTraceEnabled(Boolean writableStackTraceEnabled) {
 			this.writableStackTraceEnabled = writableStackTraceEnabled;
 			return this;
 		}

--- a/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/ratelimiter/configuration/RateLimiterConfigurationProperties.java
+++ b/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/ratelimiter/configuration/RateLimiterConfigurationProperties.java
@@ -77,6 +77,10 @@ public class RateLimiterConfigurationProperties {
 			builder.timeoutDuration(instanceProperties.getTimeoutDuration());
 		}
 
+		if (instanceProperties.getWritableStackTraceEnabled() != null) {
+			builder.writableStackTraceEnabled(instanceProperties.getWritableStackTraceEnabled());
+		}
+
 		return builder.build();
 	}
 
@@ -123,6 +127,8 @@ public class RateLimiterConfigurationProperties {
 		@Min(1)
 		@Nullable
 		private Integer eventConsumerBufferSize;
+		@Nullable
+		private Boolean writableStackTraceEnabled;
 		@Nullable
 		private String baseConfig;
 
@@ -197,6 +203,25 @@ public class RateLimiterConfigurationProperties {
 		 */
 		public InstanceProperties setTimeoutDuration(Duration timeout) {
 			this.timeoutDuration = timeout;
+			return this;
+		}
+
+		/**
+		 * Returns if we should enable writable stack traces or not.
+		 *
+		 * @return writableStackTraceEnabled if we should enable writable stack traces or not.
+		 */
+		public Boolean getWritableStackTraceEnabled() {
+			return this.writableStackTraceEnabled;
+		}
+
+		/**
+		 * Sets if we should enable writable stack traces or not.
+		 *
+		 * @param writableStackTraceEnabled The flag to enable writable stack traces.
+		 */
+		public InstanceProperties setWritableStackTraceEnabled(Boolean writableStackTraceEnabled) {
+			this.writableStackTraceEnabled = writableStackTraceEnabled;
 			return this;
 		}
 

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationPropertiesTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationPropertiesTest.java
@@ -45,7 +45,7 @@ public class CircuitBreakerConfigurationPropertiesTest {
 		instanceProperties1.setSlowCallRateThreshold(50f);
 		instanceProperties1.setPermittedNumberOfCallsInHalfOpenState(100);
 		instanceProperties1.setAutomaticTransitionFromOpenToHalfOpenEnabled(true);
-		instanceProperties1.writableStackTraceEnabled(false);
+		instanceProperties1.setWritableStackTraceEnabled(false);
 		//noinspection unchecked
 		instanceProperties1.setIgnoreExceptions(new Class[]{IllegalStateException.class});
 		//noinspection unchecked

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/ratelimiter/configuration/RateLimiterConfigurationPropertiesTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/ratelimiter/configuration/RateLimiterConfigurationPropertiesTest.java
@@ -33,6 +33,7 @@ public class RateLimiterConfigurationPropertiesTest {
 		//Given
 		io.github.resilience4j.common.ratelimiter.configuration.RateLimiterConfigurationProperties.InstanceProperties instanceProperties1 = new io.github.resilience4j.common.ratelimiter.configuration.RateLimiterConfigurationProperties.InstanceProperties();
 		instanceProperties1.setLimitForPeriod(2);
+		instanceProperties1.setWritableStackTraceEnabled(false);
 		instanceProperties1.setSubscribeForEvents(true);
 		instanceProperties1.setEventConsumerBufferSize(100);
 		instanceProperties1.setLimitRefreshPeriod(Duration.ofMillis(100));
@@ -41,6 +42,7 @@ public class RateLimiterConfigurationPropertiesTest {
 		io.github.resilience4j.common.ratelimiter.configuration.RateLimiterConfigurationProperties.InstanceProperties instanceProperties2 = new io.github.resilience4j.common.ratelimiter.configuration.RateLimiterConfigurationProperties.InstanceProperties();
 		instanceProperties2.setLimitForPeriod(4);
 		instanceProperties2.setSubscribeForEvents(true);
+		instanceProperties2.setWritableStackTraceEnabled(true);
 
 		RateLimiterConfigurationProperties rateLimiterConfigurationProperties = new RateLimiterConfigurationProperties();
 		rateLimiterConfigurationProperties.getInstances().put("backend1", instanceProperties1);
@@ -53,10 +55,12 @@ public class RateLimiterConfigurationPropertiesTest {
 		RateLimiterConfig rateLimiter = rateLimiterConfigurationProperties.createRateLimiterConfig("backend1");
 		assertThat(rateLimiter).isNotNull();
 		assertThat(rateLimiter.getLimitForPeriod()).isEqualTo(2);
+		assertThat(rateLimiter.isWritableStackTraceEnabled()).isFalse();
 
 		RateLimiterConfig rateLimiter2 = rateLimiterConfigurationProperties.createRateLimiterConfig("backend2");
 		assertThat(rateLimiter2).isNotNull();
 		assertThat(rateLimiter2.getLimitForPeriod()).isEqualTo(4);
+		assertThat(rateLimiter2.isWritableStackTraceEnabled()).isTrue();
 
 
 	}
@@ -68,6 +72,7 @@ public class RateLimiterConfigurationPropertiesTest {
 		defaultProperties.setLimitForPeriod(3);
 		defaultProperties.setLimitRefreshPeriod(Duration.ofNanos(5000000));
 		defaultProperties.setSubscribeForEvents(true);
+		defaultProperties.setWritableStackTraceEnabled(false);
 
 		io.github.resilience4j.common.ratelimiter.configuration.RateLimiterConfigurationProperties.InstanceProperties sharedProperties = new io.github.resilience4j.common.ratelimiter.configuration.RateLimiterConfigurationProperties.InstanceProperties();
 		sharedProperties.setLimitForPeriod(2);
@@ -78,11 +83,13 @@ public class RateLimiterConfigurationPropertiesTest {
 		backendWithDefaultConfig.setBaseConfig("default");
 		backendWithDefaultConfig.setLimitForPeriod(200);
 		backendWithDefaultConfig.setSubscribeForEvents(true);
+		backendWithDefaultConfig.setWritableStackTraceEnabled(true);
 
 		io.github.resilience4j.common.ratelimiter.configuration.RateLimiterConfigurationProperties.InstanceProperties backendWithSharedConfig = new io.github.resilience4j.common.ratelimiter.configuration.RateLimiterConfigurationProperties.InstanceProperties();
 		backendWithSharedConfig.setBaseConfig("sharedConfig");
 		backendWithSharedConfig.setLimitForPeriod(300);
 		backendWithSharedConfig.setSubscribeForEvents(true);
+		backendWithSharedConfig.setWritableStackTraceEnabled(true);
 
 		RateLimiterConfigurationProperties rateLimiterConfigurationProperties = new RateLimiterConfigurationProperties();
 		rateLimiterConfigurationProperties.getConfigs().put("default", defaultProperties);
@@ -100,17 +107,20 @@ public class RateLimiterConfigurationPropertiesTest {
 		assertThat(rateLimiter1).isNotNull();
 		assertThat(rateLimiter1.getLimitForPeriod()).isEqualTo(200);
 		assertThat(rateLimiter1.getLimitRefreshPeriod()).isEqualTo(Duration.ofMillis(5));
+		assertThat(rateLimiter1.isWritableStackTraceEnabled()).isTrue();
 
 		// Should get shared config and override LimitForPeriod
 		RateLimiterConfig rateLimiter2 = rateLimiterConfigurationProperties.createRateLimiterConfig("backendWithSharedConfig");
 		assertThat(rateLimiter2).isNotNull();
 		assertThat(rateLimiter2.getLimitForPeriod()).isEqualTo(300);
 		assertThat(rateLimiter2.getLimitRefreshPeriod()).isEqualTo(Duration.ofMillis(6));
+		assertThat(rateLimiter2.isWritableStackTraceEnabled()).isTrue();
 
 		// Unknown backend should get default config of Registry
 		RateLimiterConfig rerateLimiter3 = rateLimiterConfigurationProperties.createRateLimiterConfig("unknownBackend");
 		assertThat(rerateLimiter3).isNotNull();
 		assertThat(rerateLimiter3.getLimitForPeriod()).isEqualTo(50);
+		assertThat(rerateLimiter3.isWritableStackTraceEnabled()).isTrue();
 
 
 	}

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/ratelimiter/RateLimiter.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/ratelimiter/RateLimiter.kt
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit
  */
 suspend fun <T> RateLimiter.executeSuspendFunction(block: suspend () -> T): T {
     val waitTimeNs = reservePermission()
-    if (waitTimeNs < 0) throw RequestNotPermitted(this)
+    if (waitTimeNs < 0) throw RequestNotPermitted.getRequestNotPermitted(this)
     delay(TimeUnit.NANOSECONDS.toMillis(waitTimeNs))
     return block()
 }

--- a/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/RateLimiter.java
+++ b/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/RateLimiter.java
@@ -37,6 +37,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static io.github.resilience4j.ratelimiter.RequestNotPermitted.getRequestNotPermitted;
+
 /**
  * A RateLimiter instance is thread-safe can be used to decorate multiple requests.
  * <p>
@@ -284,7 +286,7 @@ public interface RateLimiter {
 			throw new IllegalStateException("Thread was interrupted during permission wait");
 		}
 		if (!permission) {
-			throw new RequestNotPermitted(rateLimiter);
+			throw getRequestNotPermitted(rateLimiter);
 		}
 	}
 

--- a/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/RateLimiterConfig.java
+++ b/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/RateLimiterConfig.java
@@ -26,15 +26,18 @@ public class RateLimiterConfig {
     private static final String TIMEOUT_DURATION_MUST_NOT_BE_NULL = "TimeoutDuration must not be null";
     private static final String LIMIT_REFRESH_PERIOD_MUST_NOT_BE_NULL = "LimitRefreshPeriod must not be null";
     private static final Duration ACCEPTABLE_REFRESH_PERIOD = Duration.ofNanos(1L);
+    private static final boolean DEFAULT_WRITABLE_STACK_TRACE_ENABLED = true;
 
     private final Duration timeoutDuration;
     private final Duration limitRefreshPeriod;
     private final int limitForPeriod;
+    private final boolean writableStackTraceEnabled;
 
-    private RateLimiterConfig(Duration timeoutDuration, Duration limitRefreshPeriod, int limitForPeriod) {
+    private RateLimiterConfig(Duration timeoutDuration, Duration limitRefreshPeriod, int limitForPeriod, boolean writableStackTraceEnabled) {
         this.timeoutDuration = timeoutDuration;
         this.limitRefreshPeriod = limitRefreshPeriod;
         this.limitForPeriod = limitForPeriod;
+        this.writableStackTraceEnabled = writableStackTraceEnabled;
     }
 
     /**
@@ -77,11 +80,16 @@ public class RateLimiterConfig {
         return limitForPeriod;
     }
 
+    public boolean isWritableStackTraceEnabled() {
+        return writableStackTraceEnabled;
+    }
+
     @Override public String toString() {
         return "RateLimiterConfig{" +
             "timeoutDuration=" + timeoutDuration +
             ", limitRefreshPeriod=" + limitRefreshPeriod +
             ", limitForPeriod=" + limitForPeriod +
+            ", writableStackTraceEnabled=" + writableStackTraceEnabled +
             '}';
     }
 
@@ -89,6 +97,7 @@ public class RateLimiterConfig {
         private Duration timeoutDuration =  Duration.ofSeconds(5);
         private Duration limitRefreshPeriod = Duration.ofNanos(500);
         private int limitForPeriod = 50;
+        private boolean writableStackTraceEnabled = DEFAULT_WRITABLE_STACK_TRACE_ENABLED;
 
         public Builder() {
         }
@@ -97,6 +106,7 @@ public class RateLimiterConfig {
             this.timeoutDuration = prototype.timeoutDuration;
             this.limitRefreshPeriod = prototype.limitRefreshPeriod;
             this.limitForPeriod = prototype.limitForPeriod;
+            this.writableStackTraceEnabled = prototype.writableStackTraceEnabled;
         }
 
         /**
@@ -105,7 +115,20 @@ public class RateLimiterConfig {
          * @return the RateLimiterConfig
          */
         public RateLimiterConfig build() {
-            return new RateLimiterConfig(timeoutDuration, limitRefreshPeriod, limitForPeriod);
+            return new RateLimiterConfig(timeoutDuration, limitRefreshPeriod, limitForPeriod, writableStackTraceEnabled);
+        }
+
+        /**
+         * Enables writable stack traces. When set to false, {@link Exception#getStackTrace()} returns a zero length array.
+         * This may be used to reduce log spam when the circuit breaker is open as the cause of the exceptions is already
+         * known (the circuit breaker is short-circuiting calls).
+         *
+         * @param writableStackTraceEnabled flag to control if stack trace is writable
+         * @return the BulkheadConfig.Builder
+         */
+        public Builder writableStackTraceEnabled(boolean writableStackTraceEnabled) {
+            this.writableStackTraceEnabled = writableStackTraceEnabled;
+            return this;
         }
 
         /**

--- a/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/RequestNotPermitted.java
+++ b/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/RequestNotPermitted.java
@@ -25,20 +25,11 @@ package io.github.resilience4j.ratelimiter;
 public class RequestNotPermitted extends RuntimeException {
 
     /**
-     * The constructor with a RateLimiter.
+     * Static method to construct a {@link RequestNotPermitted} with a RateLimiter.
      *
      * @param rateLimiter the RateLimiter.
      */
-    public RequestNotPermitted(RateLimiter rateLimiter) {
-        super(String.format("RateLimiter '%s' does not permit further calls", rateLimiter.getName()));
-    }
-
-    /**
-     * Static method to construct a {@link RequestNotPermitted} with a ThreadPoolBulkhead.
-     *
-     * @param rateLimiter the RateLimiter.
-     */
-    public static RequestNotPermitted getCallNotPermittedException(RateLimiter rateLimiter) {
+    public static RequestNotPermitted getRequestNotPermitted(RateLimiter rateLimiter) {
         boolean writableStackTraceEnabled = rateLimiter.getRateLimiterConfig().isWritableStackTraceEnabled();
 
         String message = String.format("RateLimiter '%s' does not permit further calls", rateLimiter.getName());

--- a/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/RequestNotPermitted.java
+++ b/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/RequestNotPermitted.java
@@ -32,4 +32,21 @@ public class RequestNotPermitted extends RuntimeException {
     public RequestNotPermitted(RateLimiter rateLimiter) {
         super(String.format("RateLimiter '%s' does not permit further calls", rateLimiter.getName()));
     }
+
+    /**
+     * Static method to construct a {@link RequestNotPermitted} with a ThreadPoolBulkhead.
+     *
+     * @param rateLimiter the RateLimiter.
+     */
+    public static RequestNotPermitted getCallNotPermittedException(RateLimiter rateLimiter) {
+        boolean writableStackTraceEnabled = rateLimiter.getRateLimiterConfig().isWritableStackTraceEnabled();
+
+        String message = String.format("RateLimiter '%s' does not permit further calls", rateLimiter.getName());
+
+        return new RequestNotPermitted(message, writableStackTraceEnabled);
+    }
+
+    private RequestNotPermitted(String message, boolean writableStackTrace) {
+        super(message, null, false, writableStackTrace);
+    }
 }

--- a/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/bulkhead/BulkheadMethodInterceptor.java
+++ b/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/bulkhead/BulkheadMethodInterceptor.java
@@ -34,6 +34,8 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+import static io.github.resilience4j.bulkhead.BulkheadFullException.getCallNotPermittedException;
+
 /**
  * A {@link MethodInterceptor} to handle all methods annotated with {@link Bulkhead}. It will
  *  handle methods that return a {@link Promise}, {@link reactor.core.publisher.Flux}, {@link reactor.core.publisher.Mono}, {@link java.util.concurrent.CompletionStage}, or value.
@@ -119,7 +121,7 @@ public class BulkheadMethodInterceptor extends AbstractMethodInterceptor {
                     });
                 }
             } else {
-                Throwable t = new BulkheadFullException(bulkhead);
+                Throwable t = getCallNotPermittedException(bulkhead);
                 completeFailedFuture(t, fallbackMethod, promise);
             }
             return promise;

--- a/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/bulkhead/BulkheadMethodInterceptor.java
+++ b/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/bulkhead/BulkheadMethodInterceptor.java
@@ -34,7 +34,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
-import static io.github.resilience4j.bulkhead.BulkheadFullException.getCallNotPermittedException;
+import static io.github.resilience4j.bulkhead.BulkheadFullException.getBulkheadFullException;
 
 /**
  * A {@link MethodInterceptor} to handle all methods annotated with {@link Bulkhead}. It will
@@ -121,7 +121,7 @@ public class BulkheadMethodInterceptor extends AbstractMethodInterceptor {
                     });
                 }
             } else {
-                Throwable t = getCallNotPermittedException(bulkhead);
+                Throwable t = BulkheadFullException.getBulkheadFullException(bulkhead);
                 completeFailedFuture(t, fallbackMethod, promise);
             }
             return promise;

--- a/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/bulkhead/BulkheadTransformer.java
+++ b/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/bulkhead/BulkheadTransformer.java
@@ -22,6 +22,8 @@ import ratpack.exec.Downstream;
 import ratpack.exec.Upstream;
 import ratpack.func.Function;
 
+import static io.github.resilience4j.bulkhead.BulkheadFullException.getCallNotPermittedException;
+
 
 public class BulkheadTransformer<T> extends AbstractTransformer<T> {
 
@@ -81,7 +83,7 @@ public class BulkheadTransformer<T> extends AbstractTransformer<T> {
                     }
                 });
             } else {
-                Throwable t = new BulkheadFullException(bulkhead);
+                Throwable t = getCallNotPermittedException(bulkhead);
                 handleRecovery(down, t);
             }
         };

--- a/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/bulkhead/BulkheadTransformer.java
+++ b/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/bulkhead/BulkheadTransformer.java
@@ -22,7 +22,7 @@ import ratpack.exec.Downstream;
 import ratpack.exec.Upstream;
 import ratpack.func.Function;
 
-import static io.github.resilience4j.bulkhead.BulkheadFullException.getCallNotPermittedException;
+import static io.github.resilience4j.bulkhead.BulkheadFullException.getBulkheadFullException;
 
 
 public class BulkheadTransformer<T> extends AbstractTransformer<T> {
@@ -83,7 +83,7 @@ public class BulkheadTransformer<T> extends AbstractTransformer<T> {
                     }
                 });
             } else {
-                Throwable t = getCallNotPermittedException(bulkhead);
+                Throwable t = BulkheadFullException.getBulkheadFullException(bulkhead);
                 handleRecovery(down, t);
             }
         };

--- a/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/ratelimiter/RateLimiterHandler.java
+++ b/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/ratelimiter/RateLimiterHandler.java
@@ -22,6 +22,8 @@ import io.github.resilience4j.ratelimiter.RequestNotPermitted;
 import ratpack.handling.Context;
 import ratpack.handling.Handler;
 
+import static io.github.resilience4j.ratelimiter.RequestNotPermitted.getRequestNotPermitted;
+
 public class RateLimiterHandler implements Handler {
 
     private final RateLimiter rateLimiter;
@@ -41,7 +43,7 @@ public class RateLimiterHandler implements Handler {
             throw new IllegalStateException("Thread was interrupted during permission wait");
         }
         if (!permission) {
-            Throwable t = new RequestNotPermitted(rateLimiter);
+            Throwable t = getRequestNotPermitted(rateLimiter);
             ctx.error(t);
         } else {
             ctx.next();

--- a/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/ratelimiter/RateLimiterMethodInterceptor.java
+++ b/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/ratelimiter/RateLimiterMethodInterceptor.java
@@ -35,6 +35,8 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+import static io.github.resilience4j.ratelimiter.RequestNotPermitted.getRequestNotPermitted;
+
 /**
  * A {@link MethodInterceptor} to handle all methods annotated with {@link RateLimiter}. It will
  * handle methods that return a {@link Promise}, {@link reactor.core.publisher.Flux}, {@link reactor.core.publisher.Mono}, {@link java.util.concurrent.CompletionStage}, or value.
@@ -109,7 +111,7 @@ public class RateLimiterMethodInterceptor extends AbstractMethodInterceptor {
                 return proceed(invocation);
             } else {
                 final CompletableFuture promise = new CompletableFuture<>();
-                Throwable t = new RequestNotPermitted(rateLimiter);
+                Throwable t = getRequestNotPermitted(rateLimiter);
                 completeFailedFuture(t, fallbackMethod, promise);
                 return promise;
             }

--- a/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/ratelimiter/RateLimiterTransformer.java
+++ b/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/ratelimiter/RateLimiterTransformer.java
@@ -22,6 +22,8 @@ import ratpack.exec.Downstream;
 import ratpack.exec.Upstream;
 import ratpack.func.Function;
 
+import static io.github.resilience4j.ratelimiter.RequestNotPermitted.getRequestNotPermitted;
+
 public class RateLimiterTransformer<T> extends AbstractTransformer<T> {
 
     private final RateLimiter rateLimiter;
@@ -61,7 +63,7 @@ public class RateLimiterTransformer<T> extends AbstractTransformer<T> {
                 throw new IllegalStateException("Thread was interrupted during permission wait");
             }
             if (!permission) {
-                Throwable t = new RequestNotPermitted(rateLimiter);
+                Throwable t = getRequestNotPermitted(rateLimiter);
                 if (recoverer != null) {
                     down.success(recoverer.apply(t));
                 } else {

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/FluxBulkhead.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/FluxBulkhead.java
@@ -22,7 +22,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxOperator;
 import reactor.core.publisher.Operators;
 
-import static io.github.resilience4j.bulkhead.BulkheadFullException.getCallNotPermittedException;
+import static io.github.resilience4j.bulkhead.BulkheadFullException.getBulkheadFullException;
 
 class FluxBulkhead<T> extends FluxOperator<T, T> {
 
@@ -38,7 +38,7 @@ class FluxBulkhead<T> extends FluxOperator<T, T> {
         if(bulkhead.tryAcquirePermission()){
             source.subscribe(new BulkheadSubscriber<>(bulkhead, actual, false));
         }else{
-            Operators.error(actual, getCallNotPermittedException(bulkhead));
+            Operators.error(actual, BulkheadFullException.getBulkheadFullException(bulkhead));
         }
     }
 

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/FluxBulkhead.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/FluxBulkhead.java
@@ -22,6 +22,8 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxOperator;
 import reactor.core.publisher.Operators;
 
+import static io.github.resilience4j.bulkhead.BulkheadFullException.getCallNotPermittedException;
+
 class FluxBulkhead<T> extends FluxOperator<T, T> {
 
     private final Bulkhead bulkhead;
@@ -36,7 +38,7 @@ class FluxBulkhead<T> extends FluxOperator<T, T> {
         if(bulkhead.tryAcquirePermission()){
             source.subscribe(new BulkheadSubscriber<>(bulkhead, actual, false));
         }else{
-            Operators.error(actual, new BulkheadFullException(bulkhead));
+            Operators.error(actual, getCallNotPermittedException(bulkhead));
         }
     }
 

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/MonoBulkhead.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/MonoBulkhead.java
@@ -22,7 +22,7 @@ import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoOperator;
 import reactor.core.publisher.Operators;
 
-import static io.github.resilience4j.bulkhead.BulkheadFullException.getCallNotPermittedException;
+import static io.github.resilience4j.bulkhead.BulkheadFullException.getBulkheadFullException;
 
 class MonoBulkhead<T> extends MonoOperator<T, T> {
     private final Bulkhead bulkhead;
@@ -37,7 +37,7 @@ class MonoBulkhead<T> extends MonoOperator<T, T> {
         if(bulkhead.tryAcquirePermission()){
             source.subscribe(new BulkheadSubscriber<>(bulkhead, actual, true));
         }else{
-            Operators.error(actual, getCallNotPermittedException(bulkhead));
+            Operators.error(actual, BulkheadFullException.getBulkheadFullException(bulkhead));
         }
     }
 }

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/MonoBulkhead.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/MonoBulkhead.java
@@ -22,6 +22,8 @@ import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoOperator;
 import reactor.core.publisher.Operators;
 
+import static io.github.resilience4j.bulkhead.BulkheadFullException.getCallNotPermittedException;
+
 class MonoBulkhead<T> extends MonoOperator<T, T> {
     private final Bulkhead bulkhead;
 
@@ -35,7 +37,7 @@ class MonoBulkhead<T> extends MonoOperator<T, T> {
         if(bulkhead.tryAcquirePermission()){
             source.subscribe(new BulkheadSubscriber<>(bulkhead, actual, true));
         }else{
-            Operators.error(actual, new BulkheadFullException(bulkhead));
+            Operators.error(actual, getCallNotPermittedException(bulkhead));
         }
     }
 }

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/ratelimiter/operator/FluxRateLimiter.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/ratelimiter/operator/FluxRateLimiter.java
@@ -25,6 +25,8 @@ import reactor.core.publisher.Operators;
 
 import java.time.Duration;
 
+import static io.github.resilience4j.ratelimiter.RequestNotPermitted.getRequestNotPermitted;
+
 class FluxRateLimiter<T> extends FluxOperator<T, T> {
 
     private final RateLimiter rateLimiter;
@@ -45,7 +47,7 @@ class FluxRateLimiter<T> extends FluxOperator<T, T> {
                 source.subscribe(new RateLimiterSubscriber<>(actual));
             }
         }else{
-            Operators.error(actual, new RequestNotPermitted(rateLimiter));
+            Operators.error(actual, getRequestNotPermitted(rateLimiter));
         }
     }
 

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/ratelimiter/operator/MonoRateLimiter.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/ratelimiter/operator/MonoRateLimiter.java
@@ -24,6 +24,8 @@ import reactor.core.publisher.Operators;
 
 import java.time.Duration;
 
+import static io.github.resilience4j.ratelimiter.RequestNotPermitted.getRequestNotPermitted;
+
 class MonoRateLimiter<T> extends MonoOperator<T, T> {
     private final RateLimiter rateLimiter;
 
@@ -43,7 +45,7 @@ class MonoRateLimiter<T> extends MonoOperator<T, T> {
                 source.subscribe(new RateLimiterSubscriber<>(actual));
             }
         }else{
-            Operators.error(actual, new RequestNotPermitted(rateLimiter));
+            Operators.error(actual, getRequestNotPermitted(rateLimiter));
         }
     }
 }

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/FluxBulkheadTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/FluxBulkheadTest.java
@@ -38,7 +38,7 @@ public class FluxBulkheadTest {
 
     @Before
     public void setUp(){
-        bulkhead = Mockito.mock(Bulkhead.class);
+        bulkhead = Mockito.mock(Bulkhead.class, RETURNS_DEEP_STUBS);
     }
 
     @Test

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/MonoBulkheadTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/MonoBulkheadTest.java
@@ -35,7 +35,7 @@ public class MonoBulkheadTest {
 
     @Before
     public void setUp(){
-        bulkhead = Mockito.mock(Bulkhead.class);
+        bulkhead = Mockito.mock(Bulkhead.class, RETURNS_DEEP_STUBS);
     }
 
     @Test

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/ratelimiter/operator/FluxRateLimiterTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/ratelimiter/operator/FluxRateLimiterTest.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.time.Duration;
 
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 
 public class FluxRateLimiterTest {
 
@@ -34,7 +35,7 @@ public class FluxRateLimiterTest {
 
     @Before
     public void setUp(){
-        rateLimiter = Mockito.mock(RateLimiter.class);
+        rateLimiter = Mockito.mock(RateLimiter.class, RETURNS_DEEP_STUBS);
     }
 
     @Test

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/ratelimiter/operator/MonoRateLimiterTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/ratelimiter/operator/MonoRateLimiterTest.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.time.Duration;
 
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 
 public class MonoRateLimiterTest {
 
@@ -34,7 +35,7 @@ public class MonoRateLimiterTest {
 
     @Before
     public void setUp(){
-        rateLimiter = Mockito.mock(RateLimiter.class);
+        rateLimiter = Mockito.mock(RateLimiter.class, RETURNS_DEEP_STUBS);
     }
 
     @Test

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/CompletableBulkhead.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/CompletableBulkhead.java
@@ -22,7 +22,7 @@ import io.reactivex.Completable;
 import io.reactivex.CompletableObserver;
 import io.reactivex.internal.disposables.EmptyDisposable;
 
-import static io.github.resilience4j.bulkhead.BulkheadFullException.getCallNotPermittedException;
+import static io.github.resilience4j.bulkhead.BulkheadFullException.getBulkheadFullException;
 
 class CompletableBulkhead extends Completable {
 
@@ -40,7 +40,7 @@ class CompletableBulkhead extends Completable {
             upstream.subscribe(new BulkheadCompletableObserver(downstream));
         }else{
             downstream.onSubscribe(EmptyDisposable.INSTANCE);
-            downstream.onError(getCallNotPermittedException(bulkhead));
+            downstream.onError(BulkheadFullException.getBulkheadFullException(bulkhead));
         }
     }
 

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/CompletableBulkhead.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/CompletableBulkhead.java
@@ -22,6 +22,8 @@ import io.reactivex.Completable;
 import io.reactivex.CompletableObserver;
 import io.reactivex.internal.disposables.EmptyDisposable;
 
+import static io.github.resilience4j.bulkhead.BulkheadFullException.getCallNotPermittedException;
+
 class CompletableBulkhead extends Completable {
 
     private final Completable upstream;
@@ -38,7 +40,7 @@ class CompletableBulkhead extends Completable {
             upstream.subscribe(new BulkheadCompletableObserver(downstream));
         }else{
             downstream.onSubscribe(EmptyDisposable.INSTANCE);
-            downstream.onError(new BulkheadFullException(bulkhead));
+            downstream.onError(getCallNotPermittedException(bulkhead));
         }
     }
 

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/FlowableBulkhead.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/FlowableBulkhead.java
@@ -25,6 +25,7 @@ import org.reactivestreams.Subscriber;
 
 import java.util.Objects;
 
+import static io.github.resilience4j.bulkhead.BulkheadFullException.getCallNotPermittedException;
 import static java.util.Objects.requireNonNull;
 
 class FlowableBulkhead<T> extends Flowable<T> {
@@ -43,7 +44,7 @@ class FlowableBulkhead<T> extends Flowable<T> {
             upstream.subscribe(new BulkheadSubscriber(downstream));
         }else{
             downstream.onSubscribe(EmptySubscription.INSTANCE);
-            downstream.onError(new BulkheadFullException(bulkhead));
+            downstream.onError(getCallNotPermittedException(bulkhead));
         }
     }
 

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/FlowableBulkhead.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/FlowableBulkhead.java
@@ -25,7 +25,7 @@ import org.reactivestreams.Subscriber;
 
 import java.util.Objects;
 
-import static io.github.resilience4j.bulkhead.BulkheadFullException.getCallNotPermittedException;
+import static io.github.resilience4j.bulkhead.BulkheadFullException.getBulkheadFullException;
 import static java.util.Objects.requireNonNull;
 
 class FlowableBulkhead<T> extends Flowable<T> {
@@ -44,7 +44,7 @@ class FlowableBulkhead<T> extends Flowable<T> {
             upstream.subscribe(new BulkheadSubscriber(downstream));
         }else{
             downstream.onSubscribe(EmptySubscription.INSTANCE);
-            downstream.onError(getCallNotPermittedException(bulkhead));
+            downstream.onError(BulkheadFullException.getBulkheadFullException(bulkhead));
         }
     }
 

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/MaybeBulkhead.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/MaybeBulkhead.java
@@ -22,7 +22,7 @@ import io.reactivex.Maybe;
 import io.reactivex.MaybeObserver;
 import io.reactivex.internal.disposables.EmptyDisposable;
 
-import static io.github.resilience4j.bulkhead.BulkheadFullException.getCallNotPermittedException;
+import static io.github.resilience4j.bulkhead.BulkheadFullException.getBulkheadFullException;
 
 class MaybeBulkhead<T> extends Maybe<T> {
 
@@ -40,7 +40,7 @@ class MaybeBulkhead<T> extends Maybe<T> {
             upstream.subscribe(new BulkheadMaybeObserver(downstream));
         }else{
             downstream.onSubscribe(EmptyDisposable.INSTANCE);
-            downstream.onError(getCallNotPermittedException(bulkhead));
+            downstream.onError(BulkheadFullException.getBulkheadFullException(bulkhead));
         }
     }
 

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/MaybeBulkhead.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/MaybeBulkhead.java
@@ -22,6 +22,8 @@ import io.reactivex.Maybe;
 import io.reactivex.MaybeObserver;
 import io.reactivex.internal.disposables.EmptyDisposable;
 
+import static io.github.resilience4j.bulkhead.BulkheadFullException.getCallNotPermittedException;
+
 class MaybeBulkhead<T> extends Maybe<T> {
 
     private final Maybe<T> upstream;
@@ -38,7 +40,7 @@ class MaybeBulkhead<T> extends Maybe<T> {
             upstream.subscribe(new BulkheadMaybeObserver(downstream));
         }else{
             downstream.onSubscribe(EmptyDisposable.INSTANCE);
-            downstream.onError(new BulkheadFullException(bulkhead));
+            downstream.onError(getCallNotPermittedException(bulkhead));
         }
     }
 

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/ObserverBulkhead.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/ObserverBulkhead.java
@@ -22,6 +22,8 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.internal.disposables.EmptyDisposable;
 
+import static io.github.resilience4j.bulkhead.BulkheadFullException.getCallNotPermittedException;
+
 class ObserverBulkhead<T> extends Observable<T> {
 
     private final Observable<T> upstream;
@@ -38,7 +40,7 @@ class ObserverBulkhead<T> extends Observable<T> {
             upstream.subscribe(new BulkheadObserver(downstream));
         }else{
             downstream.onSubscribe(EmptyDisposable.INSTANCE);
-            downstream.onError(new BulkheadFullException(bulkhead));
+            downstream.onError(getCallNotPermittedException(bulkhead));
         }
     }
     class BulkheadObserver extends AbstractObserver<T> {

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/ObserverBulkhead.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/ObserverBulkhead.java
@@ -22,7 +22,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.internal.disposables.EmptyDisposable;
 
-import static io.github.resilience4j.bulkhead.BulkheadFullException.getCallNotPermittedException;
+import static io.github.resilience4j.bulkhead.BulkheadFullException.getBulkheadFullException;
 
 class ObserverBulkhead<T> extends Observable<T> {
 
@@ -40,7 +40,7 @@ class ObserverBulkhead<T> extends Observable<T> {
             upstream.subscribe(new BulkheadObserver(downstream));
         }else{
             downstream.onSubscribe(EmptyDisposable.INSTANCE);
-            downstream.onError(getCallNotPermittedException(bulkhead));
+            downstream.onError(BulkheadFullException.getBulkheadFullException(bulkhead));
         }
     }
     class BulkheadObserver extends AbstractObserver<T> {

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/SingleBulkhead.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/SingleBulkhead.java
@@ -22,6 +22,8 @@ import io.reactivex.Single;
 import io.reactivex.SingleObserver;
 import io.reactivex.internal.disposables.EmptyDisposable;
 
+import static io.github.resilience4j.bulkhead.BulkheadFullException.getCallNotPermittedException;
+
 class SingleBulkhead<T> extends Single<T> {
 
     private final Bulkhead bulkhead;
@@ -38,7 +40,7 @@ class SingleBulkhead<T> extends Single<T> {
             upstream.subscribe(new BulkheadSingleObserver(downstream));
         }else{
             downstream.onSubscribe(EmptyDisposable.INSTANCE);
-            downstream.onError(new BulkheadFullException(bulkhead));
+            downstream.onError(getCallNotPermittedException(bulkhead));
         }
     }
 

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/SingleBulkhead.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/SingleBulkhead.java
@@ -22,7 +22,7 @@ import io.reactivex.Single;
 import io.reactivex.SingleObserver;
 import io.reactivex.internal.disposables.EmptyDisposable;
 
-import static io.github.resilience4j.bulkhead.BulkheadFullException.getCallNotPermittedException;
+import static io.github.resilience4j.bulkhead.BulkheadFullException.getBulkheadFullException;
 
 class SingleBulkhead<T> extends Single<T> {
 
@@ -40,7 +40,7 @@ class SingleBulkhead<T> extends Single<T> {
             upstream.subscribe(new BulkheadSingleObserver(downstream));
         }else{
             downstream.onSubscribe(EmptyDisposable.INSTANCE);
-            downstream.onError(getCallNotPermittedException(bulkhead));
+            downstream.onError(BulkheadFullException.getBulkheadFullException(bulkhead));
         }
     }
 

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/ratelimiter/operator/CompletableRateLimiter.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/ratelimiter/operator/CompletableRateLimiter.java
@@ -24,6 +24,8 @@ import io.reactivex.internal.disposables.EmptyDisposable;
 
 import java.util.concurrent.TimeUnit;
 
+import static io.github.resilience4j.ratelimiter.RequestNotPermitted.getRequestNotPermitted;
+
 class CompletableRateLimiter extends Completable {
 
     private final Completable upstream;
@@ -46,7 +48,7 @@ class CompletableRateLimiter extends Completable {
             }
         }else{
             downstream.onSubscribe(EmptyDisposable.INSTANCE);
-            downstream.onError(new RequestNotPermitted(rateLimiter));
+            downstream.onError(getRequestNotPermitted(rateLimiter));
         }
     }
 

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/ratelimiter/operator/FlowableRateLimiter.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/ratelimiter/operator/FlowableRateLimiter.java
@@ -27,6 +27,7 @@ import org.reactivestreams.Subscriber;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
+import static io.github.resilience4j.ratelimiter.RequestNotPermitted.getRequestNotPermitted;
 import static java.util.Objects.requireNonNull;
 
 class FlowableRateLimiter<T> extends Flowable<T> {
@@ -51,7 +52,7 @@ class FlowableRateLimiter<T> extends Flowable<T> {
             }
         }else{
             downstream.onSubscribe(EmptySubscription.INSTANCE);
-            downstream.onError(new RequestNotPermitted(rateLimiter));
+            downstream.onError(getRequestNotPermitted(rateLimiter));
         }
     }
 

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/ratelimiter/operator/MaybeRateLimiter.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/ratelimiter/operator/MaybeRateLimiter.java
@@ -25,6 +25,8 @@ import io.reactivex.internal.disposables.EmptyDisposable;
 
 import java.util.concurrent.TimeUnit;
 
+import static io.github.resilience4j.ratelimiter.RequestNotPermitted.getRequestNotPermitted;
+
 class MaybeRateLimiter<T> extends Maybe<T> {
 
     private final Maybe<T> upstream;
@@ -47,7 +49,7 @@ class MaybeRateLimiter<T> extends Maybe<T> {
             }
         }else{
             downstream.onSubscribe(EmptyDisposable.INSTANCE);
-            downstream.onError(new RequestNotPermitted(rateLimiter));
+            downstream.onError(getRequestNotPermitted(rateLimiter));
         }
     }
 

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/ratelimiter/operator/ObserverRateLimiter.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/ratelimiter/operator/ObserverRateLimiter.java
@@ -25,6 +25,8 @@ import io.reactivex.internal.disposables.EmptyDisposable;
 
 import java.util.concurrent.TimeUnit;
 
+import static io.github.resilience4j.ratelimiter.RequestNotPermitted.getRequestNotPermitted;
+
 class ObserverRateLimiter<T> extends Observable<T> {
 
     private final Observable<T> upstream;
@@ -47,7 +49,7 @@ class ObserverRateLimiter<T> extends Observable<T> {
             }
         }else{
             downstream.onSubscribe(EmptyDisposable.INSTANCE);
-            downstream.onError(new RequestNotPermitted(rateLimiter));
+            downstream.onError(getRequestNotPermitted(rateLimiter));
         }
     }
 

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/ratelimiter/operator/SingleRateLimiter.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/ratelimiter/operator/SingleRateLimiter.java
@@ -25,6 +25,8 @@ import io.reactivex.internal.disposables.EmptyDisposable;
 
 import java.util.concurrent.TimeUnit;
 
+import static io.github.resilience4j.ratelimiter.RequestNotPermitted.getRequestNotPermitted;
+
 class SingleRateLimiter<T> extends Single<T> {
 
     private final RateLimiter rateLimiter;
@@ -47,7 +49,7 @@ class SingleRateLimiter<T> extends Single<T> {
             }
         }else{
             downstream.onSubscribe(EmptyDisposable.INSTANCE);
-            downstream.onError(new RequestNotPermitted(rateLimiter));
+            downstream.onError(getRequestNotPermitted(rateLimiter));
         }
     }
 

--- a/resilience4j-rxjava2/src/test/java/io/github/resilience4j/bulkhead/operator/CompletableBulkheadTest.java
+++ b/resilience4j-rxjava2/src/test/java/io/github/resilience4j/bulkhead/operator/CompletableBulkheadTest.java
@@ -21,7 +21,7 @@ public class CompletableBulkheadTest {
 
     @Before
     public void setUp(){
-        bulkhead = Mockito.mock(Bulkhead.class);
+        bulkhead = Mockito.mock(Bulkhead.class, RETURNS_DEEP_STUBS);
     }
 
     @Test

--- a/resilience4j-rxjava2/src/test/java/io/github/resilience4j/bulkhead/operator/FlowableBulkheadTest.java
+++ b/resilience4j-rxjava2/src/test/java/io/github/resilience4j/bulkhead/operator/FlowableBulkheadTest.java
@@ -21,7 +21,7 @@ public class FlowableBulkheadTest {
 
     @Before
     public void setUp(){
-        bulkhead = Mockito.mock(Bulkhead.class);
+        bulkhead = Mockito.mock(Bulkhead.class, RETURNS_DEEP_STUBS);
     }
 
     @Test

--- a/resilience4j-rxjava2/src/test/java/io/github/resilience4j/bulkhead/operator/MaybeBulkheadTest.java
+++ b/resilience4j-rxjava2/src/test/java/io/github/resilience4j/bulkhead/operator/MaybeBulkheadTest.java
@@ -23,7 +23,7 @@ public class MaybeBulkheadTest {
 
     @Before
     public void setUp(){
-        bulkhead = Mockito.mock(Bulkhead.class);
+        bulkhead = Mockito.mock(Bulkhead.class, RETURNS_DEEP_STUBS);
     }
 
     @Test

--- a/resilience4j-rxjava2/src/test/java/io/github/resilience4j/bulkhead/operator/ObserverBulkheadTest.java
+++ b/resilience4j-rxjava2/src/test/java/io/github/resilience4j/bulkhead/operator/ObserverBulkheadTest.java
@@ -21,7 +21,7 @@ public class ObserverBulkheadTest {
 
     @Before
     public void setUp(){
-        bulkhead = Mockito.mock(Bulkhead.class);
+        bulkhead = Mockito.mock(Bulkhead.class, RETURNS_DEEP_STUBS);
     }
 
     @Test

--- a/resilience4j-rxjava2/src/test/java/io/github/resilience4j/bulkhead/operator/SingleBulkheadTest.java
+++ b/resilience4j-rxjava2/src/test/java/io/github/resilience4j/bulkhead/operator/SingleBulkheadTest.java
@@ -24,7 +24,7 @@ public class SingleBulkheadTest {
 
     @Before
     public void setUp(){
-        bulkhead = Mockito.mock(Bulkhead.class);
+        bulkhead = Mockito.mock(Bulkhead.class, RETURNS_DEEP_STUBS);
     }
 
     @Test

--- a/resilience4j-rxjava2/src/test/java/io/github/resilience4j/ratelimiter/operator/CompletableRateLimiterTest.java
+++ b/resilience4j-rxjava2/src/test/java/io/github/resilience4j/ratelimiter/operator/CompletableRateLimiterTest.java
@@ -12,6 +12,7 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 
 /**
  * Unit test for {@link CompletableRateLimiter}.
@@ -22,7 +23,7 @@ public class CompletableRateLimiterTest {
 
     @Before
     public void setUp(){
-        rateLimiter = Mockito.mock(RateLimiter.class);
+        rateLimiter = Mockito.mock(RateLimiter.class, RETURNS_DEEP_STUBS);
     }
 
     @Test

--- a/resilience4j-rxjava2/src/test/java/io/github/resilience4j/ratelimiter/operator/FlowableRateLimiterTest.java
+++ b/resilience4j-rxjava2/src/test/java/io/github/resilience4j/ratelimiter/operator/FlowableRateLimiterTest.java
@@ -12,6 +12,7 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 
 /**
  * Unit test for {@link FlowableRateLimiter}.
@@ -22,7 +23,7 @@ public class FlowableRateLimiterTest {
 
     @Before
     public void setUp(){
-        rateLimiter = Mockito.mock(RateLimiter.class);
+        rateLimiter = Mockito.mock(RateLimiter.class, RETURNS_DEEP_STUBS);
     }
 
     @Test

--- a/resilience4j-rxjava2/src/test/java/io/github/resilience4j/ratelimiter/operator/MaybeRateLimiterTest.java
+++ b/resilience4j-rxjava2/src/test/java/io/github/resilience4j/ratelimiter/operator/MaybeRateLimiterTest.java
@@ -12,6 +12,7 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 
 /**
  * Unit test for {@link MaybeRateLimiter}.
@@ -22,7 +23,7 @@ public class MaybeRateLimiterTest {
 
     @Before
     public void setUp(){
-        rateLimiter = Mockito.mock(RateLimiter.class);
+        rateLimiter = Mockito.mock(RateLimiter.class, RETURNS_DEEP_STUBS);
     }
 
     @Test

--- a/resilience4j-rxjava2/src/test/java/io/github/resilience4j/ratelimiter/operator/ObserverRateLimiterTest.java
+++ b/resilience4j-rxjava2/src/test/java/io/github/resilience4j/ratelimiter/operator/ObserverRateLimiterTest.java
@@ -12,6 +12,7 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 
 /**
  * Unit test for {@link ObserverRateLimiter}.
@@ -22,7 +23,7 @@ public class ObserverRateLimiterTest {
 
     @Before
     public void setUp(){
-        rateLimiter = Mockito.mock(RateLimiter.class);
+        rateLimiter = Mockito.mock(RateLimiter.class, RETURNS_DEEP_STUBS);
     }
 
     @Test

--- a/resilience4j-rxjava2/src/test/java/io/github/resilience4j/ratelimiter/operator/SingleRateLimiterTest.java
+++ b/resilience4j-rxjava2/src/test/java/io/github/resilience4j/ratelimiter/operator/SingleRateLimiterTest.java
@@ -12,6 +12,7 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 
 /**
  * Unit test for {@link SingleRateLimiter}.
@@ -22,7 +23,7 @@ public class SingleRateLimiterTest {
 
     @Before
     public void setUp(){
-        rateLimiter = Mockito.mock(RateLimiter.class);
+        rateLimiter = Mockito.mock(RateLimiter.class, RETURNS_DEEP_STUBS);
     }
 
     @Test


### PR DESCRIPTION
Related with #618.

Similar approach as the one used for the circuit breaker.

I'm not sure about what documentation/examples I need to update.