### PR TITLE
fix typo in Reactor's `Publisher are not supported by this operator`

### DIFF
--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/IllegalPublisherException.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/IllegalPublisherException.java
@@ -1,0 +1,11 @@
+package io.github.resilience4j.reactor;
+
+import org.reactivestreams.Publisher;
+
+public class IllegalPublisherException extends IllegalStateException {
+
+    public IllegalPublisherException(Publisher publisher) {
+        super("Publisher of type <" + publisher.getClass().getSimpleName()
+                + "> is not supported by this operator");
+    }
+}

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/BulkheadOperator.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/BulkheadOperator.java
@@ -17,11 +17,13 @@ package io.github.resilience4j.reactor.bulkhead.operator;
 
 import io.github.resilience4j.bulkhead.Bulkhead;
 import io.github.resilience4j.bulkhead.BulkheadFullException;
-import org.reactivestreams.Publisher;
+import io.github.resilience4j.reactor.IllegalPublisherException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.function.UnaryOperator;
+
+import org.reactivestreams.Publisher;
 
 /**
  * A Bulkhead operator which checks if a subscriber/observer can acquire a permission to subscribe to an upstream Publisher.
@@ -53,9 +55,8 @@ public class BulkheadOperator<T> implements UnaryOperator<Publisher<T>> {
             return new MonoBulkhead<>((Mono<? extends T>) publisher, bulkhead);
         } else if (publisher instanceof Flux) {
             return new FluxBulkhead<>((Flux<? extends T>) publisher, bulkhead);
+        } else {
+            throw new IllegalPublisherException(publisher);
         }
-
-        throw new IllegalStateException("Publisher of type <" + publisher.getClass().getSimpleName()
-                + "> are not supported by this operator");
     }
 }

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/circuitbreaker/operator/CircuitBreakerOperator.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/circuitbreaker/operator/CircuitBreakerOperator.java
@@ -17,11 +17,13 @@ package io.github.resilience4j.reactor.circuitbreaker.operator;
 
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
-import org.reactivestreams.Publisher;
+import io.github.resilience4j.reactor.IllegalPublisherException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.function.UnaryOperator;
+
+import org.reactivestreams.Publisher;
 
 /**
  * A CircuitBreaker operator which checks if a downstream subscriber/observer can acquire a permission to subscribe to an upstream Publisher.
@@ -54,9 +56,8 @@ public class CircuitBreakerOperator<T> implements UnaryOperator<Publisher<T>> {
             return new MonoCircuitBreaker<>((Mono<? extends T>) publisher, circuitBreaker);
         } else if (publisher instanceof Flux) {
             return new FluxCircuitBreaker<>((Flux<? extends T>) publisher, circuitBreaker);
+        } else {
+            throw new IllegalPublisherException(publisher);
         }
-
-        throw new IllegalStateException("Publisher of type <" + publisher.getClass().getSimpleName()
-                + "> are not supported by this operator");
     }
 }

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/ratelimiter/operator/RateLimiterOperator.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/ratelimiter/operator/RateLimiterOperator.java
@@ -17,11 +17,13 @@ package io.github.resilience4j.reactor.ratelimiter.operator;
 
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RequestNotPermitted;
-import org.reactivestreams.Publisher;
+import io.github.resilience4j.reactor.IllegalPublisherException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.function.UnaryOperator;
+
+import org.reactivestreams.Publisher;
 
 
 /**
@@ -54,9 +56,8 @@ public class RateLimiterOperator<T> implements UnaryOperator<Publisher<T>> {
             return new MonoRateLimiter<>((Mono<? extends T>) publisher, rateLimiter);
         } else if (publisher instanceof Flux) {
             return new FluxRateLimiter<>((Flux<? extends T>) publisher, rateLimiter);
+        } else {
+            throw new IllegalPublisherException(publisher);
         }
-
-        throw new IllegalStateException("Publisher of type <" + publisher.getClass().getSimpleName()
-                + "> are not supported by this operator");
     }
 }

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/retry/RetryOperator.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/retry/RetryOperator.java
@@ -15,13 +15,15 @@
  */
 package io.github.resilience4j.reactor.retry;
 
+import io.github.resilience4j.reactor.IllegalPublisherException;
 import io.github.resilience4j.retry.Retry;
-import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
+
+import org.reactivestreams.Publisher;
 
 /**
  * A Reactor Retry operator which wraps a reactive type in a Retry.
@@ -60,9 +62,9 @@ public class RetryOperator<T> implements UnaryOperator<Publisher<T>> {
 			return upstream.doOnNext(context::throwExceptionToForceRetryOnResult)
 					.retryWhen(errors -> errors.doOnNext(throwingConsumerWrapper(context::onError)))
 					.doOnComplete(context::onComplete);
-		}
-		throw new IllegalStateException("Publisher of type <" + publisher.getClass().getSimpleName()
-				+ "> are not supported by this operator");
+        } else {
+            throw new IllegalPublisherException(publisher);
+        }
 	}
 
 


### PR DESCRIPTION
Fix for typo in exceptions messages: `are` instead of `is`.
 `Publisher of type <X> are not supported by this operator`.