### PR TITLE
Tests speedup - flaky waitingThreadIsInterrupted fixup (#617)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ classes
 .settings
 */bin
 *.orig
+.attach_pid*

--- a/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/AtomicRateLimiterTest.java
+++ b/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/AtomicRateLimiterTest.java
@@ -42,7 +42,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 public class AtomicRateLimiterTest {
 
     private static final String LIMITER_NAME = "test";
-    private static final long CYCLE_IN_NANOS = 50_000_000L;
+    private static final long CYCLE_IN_NANOS = 500_000_000L;
     private static final long POLL_INTERVAL_IN_NANOS = 2_000_000L;
     private static final int PERMISSIONS_RER_CYCLE = 1;
     private AtomicRateLimiter rateLimiter;


### PR DESCRIPTION
I restored an old value before `Tests speedup` change.
I can't reproduce error locally but it occurs on pipeline:
```
io.github.resilience4j.ratelimiter.internal.AtomicRateLimiterTest > waitingThreadIsInterrupted FAILED
    org.junit.ComparisonFailure at AtomicRateLimiterTest.java:376
```
https://dev.azure.com/resilience4j/resilience4j/_build/results?buildId=81 