### PR TITLE
WIP: Add tag API

### DIFF
--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/Bulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/Bulkhead.java
@@ -29,6 +29,7 @@ import io.vavr.CheckedConsumer;
 import io.vavr.CheckedFunction0;
 import io.vavr.CheckedFunction1;
 import io.vavr.CheckedRunnable;
+import io.vavr.collection.HashMap;
 import io.vavr.control.Either;
 import io.vavr.control.Try;
 
@@ -117,6 +118,13 @@ public interface Bulkhead {
      * @return the Metrics of this Bulkhead
      */
     Metrics getMetrics();
+
+    /**
+     * Returns an unmodifiable map with tags assigned to this Blukhead.
+     *
+     * @return the tags assigned to this Retry in an unmodifiable map
+     */
+    io.vavr.collection.Map<String, String> getTags();
 
     /**
      * Returns an EventPublisher which subscribes to the reactive stream of BulkheadEvent and
@@ -497,7 +505,19 @@ public interface Bulkhead {
      * @return a Bulkhead instance
      */
     static Bulkhead of(String name, BulkheadConfig config) {
-        return new SemaphoreBulkhead(name, config);
+        return of(name, config, HashMap.empty());
+    }
+
+    /**
+     * Creates a bulkhead with a custom configuration
+     *
+     * @param name the name of the bulkhead
+     * @param config a custom BulkheadConfig configuration
+     * @param tags tags added to the Bulkhead
+     * @return a Bulkhead instance
+     */
+    static Bulkhead of(String name, BulkheadConfig config, io.vavr.collection.Map<String, String> tags) {
+        return new SemaphoreBulkhead(name, config, tags);
     }
 
     /**
@@ -508,8 +528,21 @@ public interface Bulkhead {
      * @return a Bulkhead instance
      */
     static Bulkhead of(String name, Supplier<BulkheadConfig> bulkheadConfigSupplier) {
-        return new SemaphoreBulkhead(name, bulkheadConfigSupplier);
+        return of(name, bulkheadConfigSupplier, HashMap.empty());
     }
+
+    /**
+     * Creates a bulkhead with a custom configuration
+     *
+     * @param name the name of the bulkhead
+     * @param bulkheadConfigSupplier custom configuration supplier
+     * @param tags tags added to the Bulkhead
+     * @return a Bulkhead instance
+     */
+    static Bulkhead of(String name, Supplier<BulkheadConfig> bulkheadConfigSupplier, io.vavr.collection.Map<String, String> tags) {
+        return new SemaphoreBulkhead(name, bulkheadConfigSupplier, tags);
+    }
+
 
     interface Metrics {
 

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/BulkheadRegistry.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/BulkheadRegistry.java
@@ -49,6 +49,18 @@ public interface BulkheadRegistry extends Registry<Bulkhead, BulkheadConfig> {
 	Bulkhead bulkhead(String name);
 
 	/**
+	 * Returns a managed {@link Bulkhead} or creates a new one with default configuration.
+	 *
+	 * The {@code tags} passed will be appended to the tags already configured for the registry. When tags (keys) of
+	 * the two collide the tags passed with this method will override the tags of the registry.
+	 *
+	 * @param name the name of the Bulkhead
+	 * @param tags tags to add to the bulkhead
+	 * @return The {@link Bulkhead}
+	 */
+	Bulkhead bulkhead(String name, io.vavr.collection.Map<String, String> tags);
+
+	/**
 	 * Returns a managed {@link Bulkhead} or creates a new one with a custom BulkheadConfig configuration.
 	 *
 	 * @param name           the name of the Bulkhead
@@ -56,6 +68,19 @@ public interface BulkheadRegistry extends Registry<Bulkhead, BulkheadConfig> {
 	 * @return The {@link Bulkhead}
 	 */
 	Bulkhead bulkhead(String name, BulkheadConfig config);
+
+	/**
+	 * Returns a managed {@link Bulkhead} or creates a new one with a custom BulkheadConfig configuration.
+	 *
+	 * The {@code tags} passed will be appended to the tags already configured for the registry. When tags (keys) of
+	 * the two collide the tags passed with this method will override the tags of the registry.
+	 *
+	 * @param name   the name of the Bulkhead
+	 * @param config a custom Bulkhead configuration
+	 * @param tags   tags added to the bulkhead
+	 * @return The {@link Bulkhead}
+	 */
+	Bulkhead bulkhead(String name, BulkheadConfig config, io.vavr.collection.Map<String, String> tags);
 
 	/**
 	 * Returns a managed {@link Bulkhead} or creates a new one with a custom Bulkhead configuration.
@@ -69,11 +94,37 @@ public interface BulkheadRegistry extends Registry<Bulkhead, BulkheadConfig> {
 	/**
 	 * Returns a managed {@link Bulkhead} or creates a new one with a custom Bulkhead configuration.
 	 *
+	 * The {@code tags} passed will be appended to the tags already configured for the registry. When tags (keys) of
+	 * the two collide the tags passed with this method will override the tags of the registry.
+	 *
+	 * @param name                   the name of the Bulkhead
+	 * @param bulkheadConfigSupplier a custom Bulkhead configuration supplier
+	 * @param tags                   tags to add to the Bulkhead
+	 * @return The {@link Bulkhead}
+	 */
+	Bulkhead bulkhead(String name, Supplier<BulkheadConfig> bulkheadConfigSupplier, io.vavr.collection.Map<String, String> tags);
+
+	/**
+	 * Returns a managed {@link Bulkhead} or creates a new one with a custom Bulkhead configuration.
+	 *
 	 * @param name       the name of the Bulkhead
 	 * @param configName a custom Bulkhead configuration name
 	 * @return The {@link Bulkhead}
 	 */
 	Bulkhead bulkhead(String name, String configName);
+
+	/**
+	 * Returns a managed {@link Bulkhead} or creates a new one with a custom Bulkhead configuration.
+	 *
+	 * The {@code tags} passed will be appended to the tags already configured for the registry. When tags (keys) of
+	 * the two collide the tags passed with this method will override the tags of the registry.
+	 *
+	 * @param name       the name of the Bulkhead
+	 * @param configName a custom Bulkhead configuration name
+	 * @param tags       tags to add to the Bulkhead
+	 * @return The {@link Bulkhead}
+	 */
+	Bulkhead bulkhead(String name, String configName, io.vavr.collection.Map<String, String> tags);
 
 	/**
 	 * Creates a BulkheadRegistry with a custom Bulkhead configuration.
@@ -83,6 +134,19 @@ public interface BulkheadRegistry extends Registry<Bulkhead, BulkheadConfig> {
 	 */
 	static BulkheadRegistry of(BulkheadConfig bulkheadConfig) {
 		return new InMemoryBulkheadRegistry(bulkheadConfig);
+	}
+
+	/**
+	 * Creates a BulkheadRegistry with a custom Bulkhead configuration.
+	 *
+	 * Tags added to the registry will be added to every instance created by this registry.
+	 *
+	 * @param bulkheadConfig a custom Bulkhead configuration
+	 * @param tags           default tags to add to the registry
+	 * @return a BulkheadRegistry instance backed by a custom Bulkhead configuration
+	 */
+	static BulkheadRegistry of(BulkheadConfig bulkheadConfig, io.vavr.collection.Map<String, String> tags) {
+		return new InMemoryBulkheadRegistry(bulkheadConfig, tags);
 	}
 
 	/**
@@ -115,6 +179,19 @@ public interface BulkheadRegistry extends Registry<Bulkhead, BulkheadConfig> {
 	 */
 	static BulkheadRegistry of(Map<String, BulkheadConfig> configs) {
 		return new InMemoryBulkheadRegistry(configs);
+	}
+
+	/**
+	 * Creates a BulkheadRegistry with a Map of shared Bulkhead configurations.
+	 *
+	 * Tags added to the registry will be added to every instance created by this registry.
+	 *
+	 * @param configs a Map of shared Bulkhead configurations
+	 * @param tags    default tags to add to the registry
+	 * @return a RetryRegistry with a Map of shared Bulkhead configurations.
+	 */
+	static BulkheadRegistry of(Map<String, BulkheadConfig> configs, io.vavr.collection.Map<String, String> tags) {
+		return new InMemoryBulkheadRegistry(configs, tags);
 	}
 
 	/**

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkhead.java
@@ -28,6 +28,7 @@ import io.github.resilience4j.bulkhead.event.BulkheadOnCallPermittedEvent;
 import io.github.resilience4j.bulkhead.event.BulkheadOnCallRejectedEvent;
 import io.github.resilience4j.bulkhead.internal.FixedThreadPoolBulkhead;
 import io.github.resilience4j.core.EventConsumer;
+import io.vavr.collection.Map;
 
 /**
  * A Bulkhead instance is thread-safe can be used to decorate multiple requests.
@@ -93,6 +94,17 @@ public interface ThreadPoolBulkhead {
 	/**
 	 * Creates a bulkhead with a custom configuration
 	 *
+	 * @param name   the name of the bulkhead
+	 * @param config a custom BulkheadConfig configuration
+	 * @return a Bulkhead instance
+	 */
+	static ThreadPoolBulkhead of(String name, ThreadPoolBulkheadConfig config, io.vavr.collection.Map<String, String> tags) {
+		return new FixedThreadPoolBulkhead(name, config, tags);
+	}
+
+	/**
+	 * Creates a bulkhead with a custom configuration
+	 *
 	 * @param name                   the name of the bulkhead
 	 * @param bulkheadConfigSupplier custom configuration supplier
 	 * @return a Bulkhead instance
@@ -140,6 +152,13 @@ public interface ThreadPoolBulkhead {
 	 * @return the Metrics of this Bulkhead
 	 */
 	Metrics getMetrics();
+
+	/**
+	 * Returns an unmodifiable map with tags assigned to this Retry.
+	 *
+	 * @return the tags assigned to this Retry in an unmodifiable map
+	 */
+	Map<String, String> getTags();
 
 	/**
 	 * Returns an EventPublisher which subscribes to the reactive stream of BulkheadEvent and

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadRegistry.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadRegistry.java
@@ -22,6 +22,7 @@ package io.github.resilience4j.bulkhead;
 import io.github.resilience4j.bulkhead.internal.InMemoryThreadPoolBulkheadRegistry;
 import io.github.resilience4j.core.Registry;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
+import io.vavr.collection.HashMap;
 import io.vavr.collection.Seq;
 
 import java.util.List;
@@ -71,7 +72,19 @@ public interface ThreadPoolBulkheadRegistry  extends Registry<ThreadPoolBulkhead
 	 * @return a ThreadPoolBulkheadRegistry instance backed by a default ThreadPoolBulkhead configuration
 	 */
 	static ThreadPoolBulkheadRegistry ofDefaults() {
-		return new InMemoryThreadPoolBulkheadRegistry(ThreadPoolBulkheadConfig.ofDefaults());
+		return ofDefaults(HashMap.empty());
+	}
+
+	/**
+	 * Creates a ThreadPoolBulkheadRegistry with a default ThreadPoolBulkhead configuration
+	 *
+	 * Tags added to the registry will be added to every instance created by this registry.
+	 *
+	 * @param tags default tags to add to the registry
+	 * @return a ThreadPoolBulkheadRegistry instance backed by a default ThreadPoolBulkhead configuration
+	 */
+	static ThreadPoolBulkheadRegistry ofDefaults(io.vavr.collection.Map<String, String> tags) {
+		return new InMemoryThreadPoolBulkheadRegistry(ThreadPoolBulkheadConfig.ofDefaults(), tags);
 	}
 
 	/**
@@ -81,7 +94,20 @@ public interface ThreadPoolBulkheadRegistry  extends Registry<ThreadPoolBulkhead
 	 * @return a ThreadPoolBulkheadRegistry with a Map of shared ThreadPoolBulkhead configurations.
 	 */
 	static ThreadPoolBulkheadRegistry of(Map<String, ThreadPoolBulkheadConfig> configs) {
-		return new InMemoryThreadPoolBulkheadRegistry(configs);
+		return of(configs, HashMap.empty());
+	}
+
+	/**
+	 * Creates a ThreadPoolBulkheadRegistry with a Map of shared ThreadPoolBulkhead configurations.
+	 *
+	 * Tags added to the registry will be added to every instance created by this registry.
+	 *
+	 * @param configs a Map of shared Bulkhead configurations
+	 * @param tags    default tags to add to the registry
+	 * @return a ThreadPoolBulkheadRegistry with a Map of shared ThreadPoolBulkhead configurations.
+	 */
+	static ThreadPoolBulkheadRegistry of(Map<String, ThreadPoolBulkheadConfig> configs, io.vavr.collection.Map<String, String> tags) {
+		return new InMemoryThreadPoolBulkheadRegistry(configs, tags);
 	}
 
 	/**
@@ -92,7 +118,21 @@ public interface ThreadPoolBulkheadRegistry  extends Registry<ThreadPoolBulkhead
 	 * @return a ThreadPoolBulkheadRegistry with a Map of shared ThreadPoolBulkhead configurations and a ThreadPoolBulkhead registry event consumer.
 	 */
 	static ThreadPoolBulkheadRegistry of(Map<String, ThreadPoolBulkheadConfig> configs, RegistryEventConsumer<ThreadPoolBulkhead> registryEventConsumer) {
-		return new InMemoryThreadPoolBulkheadRegistry(configs, registryEventConsumer);
+		return of(configs, registryEventConsumer, HashMap.empty());
+	}
+
+	/**
+	 * Creates a ThreadPoolBulkheadRegistry with a Map of shared ThreadPoolBulkhead configurations and a ThreadPoolBulkhead registry event consumer.
+	 *
+	 * Tags added to the registry will be added to every instance created by this registry.
+	 *
+	 * @param configs a Map of shared ThreadPoolBulkhead configurations.
+	 * @param registryEventConsumer a ThreadPoolBulkhead registry event consumer.
+	 * @param tags default tags to add to the registry
+	 * @return a ThreadPoolBulkheadRegistry with a Map of shared ThreadPoolBulkhead configurations and a ThreadPoolBulkhead registry event consumer.
+	 */
+	static ThreadPoolBulkheadRegistry of(Map<String, ThreadPoolBulkheadConfig> configs, RegistryEventConsumer<ThreadPoolBulkhead> registryEventConsumer, io.vavr.collection.Map<String, String> tags) {
+		return new InMemoryThreadPoolBulkheadRegistry(configs, registryEventConsumer, tags);
 	}
 
 	/**
@@ -103,7 +143,21 @@ public interface ThreadPoolBulkheadRegistry  extends Registry<ThreadPoolBulkhead
 	 * @return a ThreadPoolBulkheadRegistry with a Map of shared ThreadPoolBulkhead configurations and a list of ThreadPoolBulkhead registry event consumers.
 	 */
 	static ThreadPoolBulkheadRegistry of(Map<String, ThreadPoolBulkheadConfig> configs, List<RegistryEventConsumer<ThreadPoolBulkhead>> registryEventConsumers) {
-		return new InMemoryThreadPoolBulkheadRegistry(configs, registryEventConsumers);
+		return of(configs, registryEventConsumers, HashMap.empty());
+	}
+
+	/**
+	 * Creates a ThreadPoolBulkheadRegistry with a Map of shared ThreadPoolBulkhead configurations and a list of ThreadPoolBulkhead registry event consumers.
+	 *
+	 * Tags added to the registry will be added to every instance created by this registry.
+	 *
+	 * @param configs a Map of shared ThreadPoolBulkhead configurations.
+	 * @param registryEventConsumers a list of ThreadPoolBulkhead registry event consumers.
+	 * @param tags Tags to add to the ThreadPoolBulkhead
+	 * @return a ThreadPoolBulkheadRegistry with a Map of shared ThreadPoolBulkhead configurations and a list of ThreadPoolBulkhead registry event consumers.
+	 */
+	static ThreadPoolBulkheadRegistry of(Map<String, ThreadPoolBulkheadConfig> configs, List<RegistryEventConsumer<ThreadPoolBulkhead>> registryEventConsumers, io.vavr.collection.Map<String, String> tags) {
+		return new InMemoryThreadPoolBulkheadRegistry(configs, registryEventConsumers, tags);
 	}
 
 	/**
@@ -122,6 +176,15 @@ public interface ThreadPoolBulkheadRegistry  extends Registry<ThreadPoolBulkhead
 	ThreadPoolBulkhead bulkhead(String name);
 
 	/**
+	 * Returns a managed {@link ThreadPoolBulkhead} or creates a new one with default configuration.
+	 *
+	 * @param name the name of the ThreadPoolBulkhead
+	 * @param tags Tags to add to the ThreadPoolBulkhead
+	 * @return The {@link ThreadPoolBulkhead}
+	 */
+	ThreadPoolBulkhead bulkhead(String name, io.vavr.collection.Map<String, String> tags);
+
+	/**
 	 * Returns a managed {@link ThreadPoolBulkhead} or creates a new one with a custom ThreadPoolBulkhead configuration.
 	 *
 	 * @param name           the name of the ThreadPoolBulkhead
@@ -129,6 +192,19 @@ public interface ThreadPoolBulkheadRegistry  extends Registry<ThreadPoolBulkhead
 	 * @return The {@link ThreadPoolBulkhead}
 	 */
 	ThreadPoolBulkhead bulkhead(String name, ThreadPoolBulkheadConfig config);
+
+	/**
+	 * Returns a managed {@link ThreadPoolBulkhead} or creates a new one with a custom ThreadPoolBulkhead configuration.
+	 *
+	 * The {@code tags} passed will be appended to the tags already configured for the registry. When tags (keys) of
+	 * the two collide the tags passed with this method will override the tags of the registry.
+	 *
+	 * @param name   the name of the ThreadPoolBulkhead
+	 * @param config a custom ThreadPoolBulkheadConfig configuration
+	 * @param tags   tags to add to the ThreadPoolBulkhead
+	 * @return The {@link ThreadPoolBulkhead}
+	 */
+	ThreadPoolBulkhead bulkhead(String name, ThreadPoolBulkheadConfig config, io.vavr.collection.Map<String, String> tags);
 
 	/**
 	 * Returns a managed {@link ThreadPoolBulkhead} or creates a new one with a custom ThreadPoolBulkhead configuration.
@@ -142,10 +218,35 @@ public interface ThreadPoolBulkheadRegistry  extends Registry<ThreadPoolBulkhead
 	/**
 	 * Returns a managed {@link ThreadPoolBulkhead} or creates a new one with a custom ThreadPoolBulkhead configuration.
 	 *
+	 * The {@code tags} passed will be appended to the tags already configured for the registry. When tags (keys) of
+	 * the two collide the tags passed with this method will override the tags of the registry.
+	 *
+	 * @param name                   the name of the ThreadPoolBulkhead
+	 * @param bulkheadConfigSupplier a custom ThreadPoolBulkhead configuration supplier
+	 * @param tags                   tags to add to the ThreadPoolBulkhead
+	 * @return The {@link ThreadPoolBulkhead}
+	 */
+	ThreadPoolBulkhead bulkhead(String name, Supplier<ThreadPoolBulkheadConfig> bulkheadConfigSupplier, io.vavr.collection.Map<String, String> tags);
+
+	/**
+	 * Returns a managed {@link ThreadPoolBulkhead} or creates a new one with a custom ThreadPoolBulkhead configuration.
+	 *
 	 * @param name       the name of the ThreadPoolBulkhead
 	 * @param configName a custom ThreadPoolBulkhead configuration name
 	 * @return The {@link ThreadPoolBulkhead}
 	 */
 	ThreadPoolBulkhead bulkhead(String name, String configName);
 
+	/**
+	 * Returns a managed {@link ThreadPoolBulkhead} or creates a new one with a custom ThreadPoolBulkhead configuration.
+	 *
+	 * The {@code tags} passed will be appended to the tags already configured for the registry. When tags (keys) of
+	 * the two collide the tags passed with this method will override the tags of the registry.
+	 *
+	 * @param name       the name of the ThreadPoolBulkhead
+	 * @param configName a custom ThreadPoolBulkhead configuration name
+	 * @param tags       tags to add to the ThreadPoolBulkhead
+	 * @return The {@link ThreadPoolBulkhead}
+	 */
+	ThreadPoolBulkhead bulkhead(String name, String configName, io.vavr.collection.Map<String, String> tags);
 }

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/InMemoryBulkheadRegistry.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/InMemoryBulkheadRegistry.java
@@ -25,6 +25,7 @@ import io.github.resilience4j.core.ConfigurationNotFoundException;
 import io.github.resilience4j.core.registry.AbstractRegistry;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
 import io.vavr.collection.Array;
+import io.vavr.collection.HashMap;
 import io.vavr.collection.Seq;
 
 import java.util.List;
@@ -45,20 +46,38 @@ public final class InMemoryBulkheadRegistry extends AbstractRegistry<Bulkhead, B
 		this(BulkheadConfig.ofDefaults());
 	}
 
+	public InMemoryBulkheadRegistry(io.vavr.collection.Map<String, String> tags) {
+		this(BulkheadConfig.ofDefaults(), tags);
+	}
+
 	public InMemoryBulkheadRegistry(Map<String, BulkheadConfig> configs) {
-		this(configs.getOrDefault(DEFAULT_CONFIG, BulkheadConfig.ofDefaults()));
+		this(configs.getOrDefault(DEFAULT_CONFIG, BulkheadConfig.ofDefaults()), HashMap.empty());
+	}
+
+	public InMemoryBulkheadRegistry(Map<String, BulkheadConfig> configs, io.vavr.collection.Map<String, String> tags) {
+		this(configs.getOrDefault(DEFAULT_CONFIG, BulkheadConfig.ofDefaults()), tags);
 		this.configurations.putAll(configs);
 	}
 
 	public InMemoryBulkheadRegistry(
 			Map<String, BulkheadConfig> configs, RegistryEventConsumer<Bulkhead> registryEventConsumer) {
-		this(configs.getOrDefault(DEFAULT_CONFIG, BulkheadConfig.ofDefaults()), registryEventConsumer);
+		this(configs, registryEventConsumer, HashMap.empty());
+	}
+
+	public InMemoryBulkheadRegistry(
+			Map<String, BulkheadConfig> configs, RegistryEventConsumer<Bulkhead> registryEventConsumer, io.vavr.collection.Map<String, String> tags) {
+		this(configs.getOrDefault(DEFAULT_CONFIG, BulkheadConfig.ofDefaults()), registryEventConsumer, tags);
 		this.configurations.putAll(configs);
 	}
 
 	public InMemoryBulkheadRegistry(
 			Map<String, BulkheadConfig> configs, List<RegistryEventConsumer<Bulkhead>> registryEventConsumers) {
-		this(configs.getOrDefault(DEFAULT_CONFIG, BulkheadConfig.ofDefaults()), registryEventConsumers);
+		this(configs, registryEventConsumers, HashMap.empty());
+	}
+
+	public InMemoryBulkheadRegistry(
+			Map<String, BulkheadConfig> configs, List<RegistryEventConsumer<Bulkhead>> registryEventConsumers, io.vavr.collection.Map<String, String> tags) {
+		this(configs.getOrDefault(DEFAULT_CONFIG, BulkheadConfig.ofDefaults()), registryEventConsumers, tags);
 		this.configurations.putAll(configs);
 	}
 
@@ -71,12 +90,24 @@ public final class InMemoryBulkheadRegistry extends AbstractRegistry<Bulkhead, B
 		super(defaultConfig);
 	}
 
+	public InMemoryBulkheadRegistry(BulkheadConfig defaultConfig, io.vavr.collection.Map<String, String> tags) {
+		super(defaultConfig, tags);
+	}
+
 	public InMemoryBulkheadRegistry(BulkheadConfig defaultConfig, List<RegistryEventConsumer<Bulkhead>> registryEventConsumers) {
 		super(defaultConfig, registryEventConsumers);
 	}
 
+	public InMemoryBulkheadRegistry(BulkheadConfig defaultConfig, List<RegistryEventConsumer<Bulkhead>> registryEventConsumers, io.vavr.collection.Map<String, String> tags) {
+		super(defaultConfig, registryEventConsumers, tags);
+	}
+
 	public InMemoryBulkheadRegistry(BulkheadConfig defaultConfig, RegistryEventConsumer<Bulkhead> registryEventConsumer) {
 		super(defaultConfig, registryEventConsumer);
+	}
+
+	public InMemoryBulkheadRegistry(BulkheadConfig defaultConfig, RegistryEventConsumer<Bulkhead> registryEventConsumer, io.vavr.collection.Map<String, String> tags) {
+		super(defaultConfig, registryEventConsumer, tags);
 	}
 
 	/**
@@ -92,7 +123,15 @@ public final class InMemoryBulkheadRegistry extends AbstractRegistry<Bulkhead, B
 	 */
 	@Override
 	public Bulkhead bulkhead(String name) {
-		return bulkhead(name, getDefaultConfig());
+		return bulkhead(name, HashMap.empty());
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Bulkhead bulkhead(String name, io.vavr.collection.Map<String, String> tags) {
+		return bulkhead(name, getDefaultConfig(), getAllTags(tags));
 	}
 
 	/**
@@ -100,7 +139,15 @@ public final class InMemoryBulkheadRegistry extends AbstractRegistry<Bulkhead, B
 	 */
 	@Override
 	public Bulkhead bulkhead(String name, BulkheadConfig config) {
-		return computeIfAbsent(name, () -> Bulkhead.of(name, Objects.requireNonNull(config, CONFIG_MUST_NOT_BE_NULL)));
+		return bulkhead(name, config, HashMap.empty());
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Bulkhead bulkhead(String name, BulkheadConfig config, io.vavr.collection.Map<String, String> tags) {
+		return computeIfAbsent(name, () -> Bulkhead.of(name, Objects.requireNonNull(config, CONFIG_MUST_NOT_BE_NULL), getAllTags(tags)));
 	}
 
 	/**
@@ -108,7 +155,15 @@ public final class InMemoryBulkheadRegistry extends AbstractRegistry<Bulkhead, B
 	 */
 	@Override
 	public Bulkhead bulkhead(String name, Supplier<BulkheadConfig> bulkheadConfigSupplier) {
-		return computeIfAbsent(name, () -> Bulkhead.of(name, Objects.requireNonNull(Objects.requireNonNull(bulkheadConfigSupplier, SUPPLIER_MUST_NOT_BE_NULL).get(), CONFIG_MUST_NOT_BE_NULL)));
+		return bulkhead(name, bulkheadConfigSupplier, HashMap.empty());
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Bulkhead bulkhead(String name, Supplier<BulkheadConfig> bulkheadConfigSupplier, io.vavr.collection.Map<String, String> tags) {
+		return computeIfAbsent(name, () -> Bulkhead.of(name, Objects.requireNonNull(Objects.requireNonNull(bulkheadConfigSupplier, SUPPLIER_MUST_NOT_BE_NULL).get(), CONFIG_MUST_NOT_BE_NULL), getAllTags(tags)));
 	}
 
 	/**
@@ -116,7 +171,15 @@ public final class InMemoryBulkheadRegistry extends AbstractRegistry<Bulkhead, B
 	 */
 	@Override
 	public Bulkhead bulkhead(String name, String configName) {
+		return bulkhead(name, configName, HashMap.empty());
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Bulkhead bulkhead(String name, String configName, io.vavr.collection.Map<String, String> tags) {
 		return computeIfAbsent(name, () -> Bulkhead.of(name, getConfiguration(configName)
-				.orElseThrow(() -> new ConfigurationNotFoundException(configName))));
+				.orElseThrow(() -> new ConfigurationNotFoundException(configName)), getAllTags(tags)));
 	}
 }

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/InMemoryThreadPoolBulkheadRegistry.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/InMemoryThreadPoolBulkheadRegistry.java
@@ -25,6 +25,7 @@ import io.github.resilience4j.core.ConfigurationNotFoundException;
 import io.github.resilience4j.core.registry.AbstractRegistry;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
 import io.vavr.collection.Array;
+import io.vavr.collection.HashMap;
 import io.vavr.collection.Seq;
 
 import java.util.List;
@@ -42,23 +43,41 @@ public final class InMemoryThreadPoolBulkheadRegistry extends AbstractRegistry<T
 	 * The constructor with default default.
 	 */
 	public InMemoryThreadPoolBulkheadRegistry() {
-		this(ThreadPoolBulkheadConfig.ofDefaults());
+		this(HashMap.empty());
+	}
+
+	public InMemoryThreadPoolBulkheadRegistry(io.vavr.collection.Map<String, String> tags) {
+		this(ThreadPoolBulkheadConfig.ofDefaults(), tags);
 	}
 
 	public InMemoryThreadPoolBulkheadRegistry(Map<String, ThreadPoolBulkheadConfig> configs) {
-		this(configs.getOrDefault(DEFAULT_CONFIG, ThreadPoolBulkheadConfig.ofDefaults()));
+		this(configs, HashMap.empty());
+	}
+
+	public InMemoryThreadPoolBulkheadRegistry(Map<String, ThreadPoolBulkheadConfig> configs, io.vavr.collection.Map<String, String> tags) {
+		this(configs.getOrDefault(DEFAULT_CONFIG, ThreadPoolBulkheadConfig.ofDefaults()), tags);
 		this.configurations.putAll(configs);
 	}
 
 	public InMemoryThreadPoolBulkheadRegistry(
 			Map<String, ThreadPoolBulkheadConfig> configs, RegistryEventConsumer<ThreadPoolBulkhead> registryEventConsumer) {
-		this(configs.getOrDefault(DEFAULT_CONFIG, ThreadPoolBulkheadConfig.ofDefaults()), registryEventConsumer);
+		this(configs, registryEventConsumer, HashMap.empty());
+	}
+
+	public InMemoryThreadPoolBulkheadRegistry(
+			Map<String, ThreadPoolBulkheadConfig> configs, RegistryEventConsumer<ThreadPoolBulkhead> registryEventConsumer, io.vavr.collection.Map<String, String> tags) {
+		this(configs.getOrDefault(DEFAULT_CONFIG, ThreadPoolBulkheadConfig.ofDefaults()), registryEventConsumer, tags);
 		this.configurations.putAll(configs);
 	}
 
 	public InMemoryThreadPoolBulkheadRegistry(
 			Map<String, ThreadPoolBulkheadConfig> configs, List<RegistryEventConsumer<ThreadPoolBulkhead>> registryEventConsumers) {
-		this(configs.getOrDefault(DEFAULT_CONFIG, ThreadPoolBulkheadConfig.ofDefaults()), registryEventConsumers);
+		this(configs, registryEventConsumers, HashMap.empty());
+	}
+
+	public InMemoryThreadPoolBulkheadRegistry(
+			Map<String, ThreadPoolBulkheadConfig> configs, List<RegistryEventConsumer<ThreadPoolBulkhead>> registryEventConsumers, io.vavr.collection.Map<String, String> tags) {
+		this(configs.getOrDefault(DEFAULT_CONFIG, ThreadPoolBulkheadConfig.ofDefaults()), registryEventConsumers, tags);
 		this.configurations.putAll(configs);
 	}
 
@@ -71,14 +90,28 @@ public final class InMemoryThreadPoolBulkheadRegistry extends AbstractRegistry<T
 		super(defaultConfig);
 	}
 
+	public InMemoryThreadPoolBulkheadRegistry(ThreadPoolBulkheadConfig defaultConfig, io.vavr.collection.Map<String, String> tags ) {
+		super(defaultConfig, tags);
+	}
+
 	public InMemoryThreadPoolBulkheadRegistry(
 			ThreadPoolBulkheadConfig defaultConfig, RegistryEventConsumer<ThreadPoolBulkhead> registryEventConsumer) {
 		super(defaultConfig, registryEventConsumer);
 	}
 
 	public InMemoryThreadPoolBulkheadRegistry(
+			ThreadPoolBulkheadConfig defaultConfig, RegistryEventConsumer<ThreadPoolBulkhead> registryEventConsumer, io.vavr.collection.Map<String, String> tags) {
+		super(defaultConfig, registryEventConsumer, tags);
+	}
+
+	public InMemoryThreadPoolBulkheadRegistry(
 			ThreadPoolBulkheadConfig defaultConfig, List<RegistryEventConsumer<ThreadPoolBulkhead>> registryEventConsumers) {
 		super(defaultConfig, registryEventConsumers);
+	}
+
+	public InMemoryThreadPoolBulkheadRegistry(
+			ThreadPoolBulkheadConfig defaultConfig, List<RegistryEventConsumer<ThreadPoolBulkhead>> registryEventConsumers, io.vavr.collection.Map<String, String> tags) {
+		super(defaultConfig, registryEventConsumers, tags);
 	}
 
 	/**
@@ -94,7 +127,15 @@ public final class InMemoryThreadPoolBulkheadRegistry extends AbstractRegistry<T
 	 */
 	@Override
 	public ThreadPoolBulkhead bulkhead(String name) {
-		return bulkhead(name, getDefaultConfig());
+		return bulkhead(name, HashMap.empty());
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public ThreadPoolBulkhead bulkhead(String name, io.vavr.collection.Map<String, String> tags) {
+		return bulkhead(name, getDefaultConfig(), tags);
 	}
 
 	/**
@@ -102,7 +143,15 @@ public final class InMemoryThreadPoolBulkheadRegistry extends AbstractRegistry<T
 	 */
 	@Override
 	public ThreadPoolBulkhead bulkhead(String name, ThreadPoolBulkheadConfig config) {
-		return computeIfAbsent(name, () -> ThreadPoolBulkhead.of(name, Objects.requireNonNull(config, CONFIG_MUST_NOT_BE_NULL)));
+		return bulkhead(name, config, HashMap.empty());
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public ThreadPoolBulkhead bulkhead(String name, ThreadPoolBulkheadConfig config, io.vavr.collection.Map<String, String> tags) {
+		return computeIfAbsent(name, () -> ThreadPoolBulkhead.of(name, Objects.requireNonNull(config, CONFIG_MUST_NOT_BE_NULL), getAllTags(tags)));
 	}
 
 	/**
@@ -110,7 +159,15 @@ public final class InMemoryThreadPoolBulkheadRegistry extends AbstractRegistry<T
 	 */
 	@Override
 	public ThreadPoolBulkhead bulkhead(String name, Supplier<ThreadPoolBulkheadConfig> bulkheadConfigSupplier) {
-		return computeIfAbsent(name, () -> ThreadPoolBulkhead.of(name, Objects.requireNonNull(Objects.requireNonNull(bulkheadConfigSupplier, SUPPLIER_MUST_NOT_BE_NULL).get(), CONFIG_MUST_NOT_BE_NULL)));
+		return bulkhead(name, bulkheadConfigSupplier, HashMap.empty());
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public ThreadPoolBulkhead bulkhead(String name, Supplier<ThreadPoolBulkheadConfig> bulkheadConfigSupplier, io.vavr.collection.Map<String, String> tags) {
+		return computeIfAbsent(name, () -> ThreadPoolBulkhead.of(name, Objects.requireNonNull(Objects.requireNonNull(bulkheadConfigSupplier, SUPPLIER_MUST_NOT_BE_NULL).get(), CONFIG_MUST_NOT_BE_NULL), getAllTags(tags)));
 	}
 
 	/**
@@ -118,7 +175,15 @@ public final class InMemoryThreadPoolBulkheadRegistry extends AbstractRegistry<T
 	 */
 	@Override
 	public ThreadPoolBulkhead bulkhead(String name, String configName) {
+		return bulkhead(name, configName, HashMap.empty());
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public ThreadPoolBulkhead bulkhead(String name, String configName, io.vavr.collection.Map<String, String> tags) {
 		return computeIfAbsent(name, () -> ThreadPoolBulkhead.of(name, getConfiguration(configName)
-				.orElseThrow(() -> new ConfigurationNotFoundException(configName))));
+				.orElseThrow(() -> new ConfigurationNotFoundException(configName)), getAllTags(tags)));
 	}
 }

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadRegistryTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadRegistryTest.java
@@ -84,6 +84,56 @@ public class ThreadPoolBulkheadRegistryTest {
 	}
 
 	@Test
+	public void noTagsByDefault() {
+		ThreadPoolBulkhead bulkhead = registry.bulkhead("testName");
+		assertThat(bulkhead.getTags()).hasSize(0);
+	}
+
+//	@Test
+//	public void tagsOfRegistryAddedToInstance() {
+//		ThreadPoolBulkhead retryConfig = ThreadPoolBulkhead.ofDefaults();
+//		Map<String, RetryConfig> retryConfigs = Collections.singletonMap("default", retryConfig);
+//		io.vavr.collection.Map<String, String> retryTags = io.vavr.collection.HashMap.of("key1","value1", "key2", "value2");
+//		RetryRegistry retryRegistry = RetryRegistry.of(retryConfigs, retryTags);
+//		Retry retry = retryRegistry.retry("testName");
+//
+//		Assertions.assertThat(retry.getTags()).containsOnlyElementsOf(retryTags);
+//	}
+
+	@Test
+	public void tagsAddedToInstance() {
+		io.vavr.collection.Map<String, String> bulkheadTags = io.vavr.collection.HashMap.of("key1","value1", "key2", "value2");
+		ThreadPoolBulkhead bulkhead = registry.bulkhead("testName", bulkheadTags);
+
+		assertThat(bulkhead.getTags()).containsOnlyElementsOf(bulkheadTags);
+	}
+
+	@Test
+	public void tagsOfRetriesShouldNotBeMixed() {
+		ThreadPoolBulkheadConfig config = ThreadPoolBulkheadConfig.ofDefaults();
+		io.vavr.collection.Map<String, String> bulkheadTags = io.vavr.collection.HashMap.of("key1","value1", "key2", "value2");
+		ThreadPoolBulkhead bulkhead = registry.bulkhead("testName", config, bulkheadTags);
+		io.vavr.collection.Map<String, String> bulkheadTags2 = io.vavr.collection.HashMap.of("key3","value3", "key4", "value4");
+		ThreadPoolBulkhead bulkhead2 = registry.bulkhead("otherTestName", config, bulkheadTags2);
+
+		assertThat(bulkhead.getTags()).containsOnlyElementsOf(bulkheadTags);
+		assertThat(bulkhead2.getTags()).containsOnlyElementsOf(bulkheadTags2);
+	}
+
+	@Test
+	public void tagsOfInstanceTagsShouldOverrideRegistryTags() {
+		ThreadPoolBulkheadConfig bulkheadConfig = ThreadPoolBulkheadConfig.ofDefaults();
+		Map<String, ThreadPoolBulkheadConfig> bulkheadConfigs = Collections.singletonMap("default", bulkheadConfig);
+		io.vavr.collection.Map<String, String> registryTags = io.vavr.collection.HashMap.of("key1","value1", "key2", "value2");
+		io.vavr.collection.Map<String, String> instanceTags = io.vavr.collection.HashMap.of("key1","value3", "key4", "value4");
+		ThreadPoolBulkheadRegistry bulkheadRegistry = ThreadPoolBulkheadRegistry.of(bulkheadConfigs, registryTags);
+		ThreadPoolBulkhead bulkhead = bulkheadRegistry.bulkhead("testName", bulkheadConfig, instanceTags);
+
+		io.vavr.collection.Map<String, String> expectedTags = io.vavr.collection.HashMap.of("key1","value3", "key2", "value2", "key4", "value4");
+		assertThat(bulkhead.getTags()).containsOnlyElementsOf(expectedTags);
+	}
+
+	@Test
 	public void testCreateWithConfigurationMap() {
 		Map<String, ThreadPoolBulkheadConfig> configs = new HashMap<>();
 		configs.put("default", ThreadPoolBulkheadConfig.ofDefaults());

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreaker.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreaker.java
@@ -186,6 +186,13 @@ public interface CircuitBreaker {
     Metrics getMetrics();
 
     /**
+     * Returns an unmodifiable map with tags assigned to this Retry.
+     *
+     * @return the tags assigned to this Retry in an unmodifiable map
+     */
+    io.vavr.collection.Map<String, String> getTags();
+
+    /**
      * Returns an EventPublisher which can be used to register event consumers.
      *
      * @return an EventPublisher
@@ -950,6 +957,22 @@ public interface CircuitBreaker {
     /**
      * Creates a CircuitBreaker with a custom CircuitBreaker configuration.
      *
+     * The {@code tags} passed will be appended to the tags already configured for the registry. When tags (keys) of
+     * the two collide the tags passed with this method will override the tags of the registry.
+     *
+     * @param name the name of the CircuitBreaker
+     * @param circuitBreakerConfig a custom CircuitBreaker configuration
+     * @param tags tags added to the Retry
+     *
+     * @return a CircuitBreaker with a custom CircuitBreaker configuration.
+     */
+    static CircuitBreaker of(String name, CircuitBreakerConfig circuitBreakerConfig, io.vavr.collection.Map<String, String> tags){
+        return new CircuitBreakerStateMachine(name, circuitBreakerConfig, tags);
+    }
+
+    /**
+     * Creates a CircuitBreaker with a custom CircuitBreaker configuration.
+     *
      * @param name      the name of the CircuitBreaker
      * @param circuitBreakerConfigSupplier a supplier of a custom CircuitBreaker configuration
      *
@@ -957,5 +980,21 @@ public interface CircuitBreaker {
      */
     static CircuitBreaker of(String name, Supplier<CircuitBreakerConfig> circuitBreakerConfigSupplier){
         return new CircuitBreakerStateMachine(name, circuitBreakerConfigSupplier);
+    }
+
+    /**
+     * Creates a CircuitBreaker with a custom CircuitBreaker configuration.
+     *
+     * The {@code tags} passed will be appended to the tags already configured for the registry. When tags (keys) of
+     * the two collide the tags passed with this method will override the tags of the registry.
+     *
+     * @param name      the name of the CircuitBreaker
+     * @param circuitBreakerConfigSupplier a supplier of a custom CircuitBreaker configuration
+     * @param tags tags added to the CircuitBreaker
+     *
+     * @return a CircuitBreaker with a custom CircuitBreaker configuration.
+     */
+    static CircuitBreaker of(String name, Supplier<CircuitBreakerConfig> circuitBreakerConfigSupplier, io.vavr.collection.Map<String, String> tags){
+        return new CircuitBreakerStateMachine(name, circuitBreakerConfigSupplier, tags);
     }
 }

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerRegistry.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerRegistry.java
@@ -22,6 +22,7 @@ package io.github.resilience4j.circuitbreaker;
 import io.github.resilience4j.circuitbreaker.internal.InMemoryCircuitBreakerRegistry;
 import io.github.resilience4j.core.Registry;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
+import io.vavr.collection.HashMap;
 import io.vavr.collection.Seq;
 
 import java.util.List;
@@ -48,6 +49,18 @@ public interface CircuitBreakerRegistry extends Registry<CircuitBreaker, Circuit
 	CircuitBreaker circuitBreaker(String name);
 
 	/**
+	 * Returns a managed {@link CircuitBreaker} or creates a new one with the default CircuitBreaker configuration.
+	 *
+	 * The {@code tags} passed will be appended to the tags already configured for the registry. When tags (keys) of
+	 * the two collide the tags passed with this method will override the tags of the registry.
+	 *
+	 * @param name the name of the CircuitBreaker
+	 * @param tags tags added to the CircuitBreaker
+	 * @return The {@link CircuitBreaker}
+	 */
+	CircuitBreaker circuitBreaker(String name, io.vavr.collection.Map<String, String> tags);
+
+	/**
 	 * Returns a managed {@link CircuitBreaker} or creates a new one with a custom CircuitBreaker configuration.
 	 *
 	 * @param name                 the name of the CircuitBreaker
@@ -56,6 +69,18 @@ public interface CircuitBreakerRegistry extends Registry<CircuitBreaker, Circuit
 	 */
 	CircuitBreaker circuitBreaker(String name, CircuitBreakerConfig config);
 
+	/**
+	 * Returns a managed {@link CircuitBreaker} or creates a new one with a custom CircuitBreaker configuration.
+	 *
+	 * The {@code tags} passed will be appended to the tags already configured for the registry. When tags (keys) of
+	 * the two collide the tags passed with this method will override the tags of the registry.
+	 *
+	 * @param name                 the name of the CircuitBreaker
+	 * @param config a custom CircuitBreaker configuration
+	 * @param tags tags added to the CircuitBreaker
+	 * @return The {@link CircuitBreaker}
+	 */
+	CircuitBreaker circuitBreaker(String name, CircuitBreakerConfig config, io.vavr.collection.Map<String, String> tags);
 
 	/**
 	 * Returns a managed {@link CircuitBreaker} or creates a new one with a custom CircuitBreaker configuration.
@@ -69,11 +94,37 @@ public interface CircuitBreakerRegistry extends Registry<CircuitBreaker, Circuit
 	/**
 	 * Returns a managed {@link CircuitBreaker} or creates a new one with a custom CircuitBreaker configuration.
 	 *
+	 * The {@code tags} passed will be appended to the tags already configured for the registry. When tags (keys) of
+	 * the two collide the tags passed with this method will override the tags of the registry.
+	 *
+	 * @param name       the name of the CircuitBreaker
+	 * @param configName a custom CircuitBreaker configuration name
+	 * @param tags tags added to the CircuitBreaker
+	 * @return The {@link CircuitBreaker}
+	 */
+	CircuitBreaker circuitBreaker(String name, String configName, io.vavr.collection.Map<String, String> tags);
+
+	/**
+	 * Returns a managed {@link CircuitBreaker} or creates a new one with a custom CircuitBreaker configuration.
+	 *
 	 * @param name                         the name of the CircuitBreaker
 	 * @param circuitBreakerConfigSupplier a supplier of a custom CircuitBreaker configuration
 	 * @return The {@link CircuitBreaker}
 	 */
 	CircuitBreaker circuitBreaker(String name, Supplier<CircuitBreakerConfig> circuitBreakerConfigSupplier);
+
+	/**
+	 * Returns a managed {@link CircuitBreaker} or creates a new one with a custom CircuitBreaker configuration.
+	 *
+	 * The {@code tags} passed will be appended to the tags already configured for the registry. When tags (keys) of
+	 * the two collide the tags passed with this method will override the tags of the registry.
+	 *
+	 * @param name                         the name of the CircuitBreaker
+	 * @param circuitBreakerConfigSupplier a supplier of a custom CircuitBreaker configuration
+	 * @param tags                         tags added to the CircuitBreaker
+	 * @return The {@link CircuitBreaker}
+	 */
+	CircuitBreaker circuitBreaker(String name, Supplier<CircuitBreakerConfig> circuitBreakerConfigSupplier, io.vavr.collection.Map<String, String> tags);
 
 	/**
 	 * Creates a CircuitBreakerRegistry with a custom default CircuitBreaker configuration.
@@ -114,7 +165,20 @@ public interface CircuitBreakerRegistry extends Registry<CircuitBreaker, Circuit
 	 * @return a CircuitBreakerRegistry with a Map of shared CircuitBreaker configurations.
 	 */
 	static CircuitBreakerRegistry of(Map<String, CircuitBreakerConfig> configs) {
-		return new InMemoryCircuitBreakerRegistry(configs);
+		return of(configs, HashMap.empty());
+	}
+
+	/**
+	 * Creates a CircuitBreakerRegistry with a Map of shared CircuitBreaker configurations.
+	 *
+	 * Tags added to the registry will be added to every instance created by this registry.
+	 *
+	 * @param configs a Map of shared CircuitBreaker configurations
+	 * @param tags default tags to add to the registry
+	 * @return a CircuitBreakerRegistry with a Map of shared CircuitBreaker configurations.
+	 */
+	static CircuitBreakerRegistry of(Map<String, CircuitBreakerConfig> configs, io.vavr.collection.Map<String, String> tags) {
+		return new InMemoryCircuitBreakerRegistry(configs, tags);
 	}
 
 	/**

--- a/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/RateLimiter.java
+++ b/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/RateLimiter.java
@@ -27,6 +27,8 @@ import io.github.resilience4j.ratelimiter.internal.AtomicRateLimiter;
 import io.vavr.CheckedFunction0;
 import io.vavr.CheckedFunction1;
 import io.vavr.CheckedRunnable;
+import io.vavr.collection.HashMap;
+import io.vavr.collection.Map;
 import io.vavr.control.Either;
 import io.vavr.control.Try;
 
@@ -54,7 +56,19 @@ public interface RateLimiter {
 	 * @return The {@link RateLimiter}
 	 */
 	static RateLimiter of(String name, RateLimiterConfig rateLimiterConfig) {
-		return new AtomicRateLimiter(name, rateLimiterConfig);
+		return of(name, rateLimiterConfig, HashMap.empty());
+	}
+
+	/**
+	 * Creates a RateLimiter with a custom RateLimiter configuration.
+	 *
+	 * @param name              the name of the RateLimiter
+	 * @param rateLimiterConfig a custom RateLimiter configuration
+	 * @param tags              tags to assign to the RateLimiter
+	 * @return The {@link RateLimiter}
+	 */
+	static RateLimiter of(String name, RateLimiterConfig rateLimiterConfig, Map<String, String> tags) {
+		return new AtomicRateLimiter(name, rateLimiterConfig, tags);
 	}
 
 	/**
@@ -65,7 +79,19 @@ public interface RateLimiter {
 	 * @return The {@link RateLimiter}
 	 */
 	static RateLimiter of(String name, Supplier<RateLimiterConfig> rateLimiterConfigSupplier) {
-		return new AtomicRateLimiter(name, rateLimiterConfigSupplier.get());
+		return of(name, rateLimiterConfigSupplier.get(), HashMap.empty());
+	}
+
+	/**
+	 * Creates a RateLimiter with a custom RateLimiterConfig configuration.
+	 *
+	 * @param name                      the name of the RateLimiter
+	 * @param rateLimiterConfigSupplier a supplier of a custom RateLimiterConfig configuration
+	 * @param tags                      tags to assign to the RateLimiter
+	 * @return The {@link RateLimiter}
+	 */
+	static RateLimiter of(String name, Supplier<RateLimiterConfig> rateLimiterConfigSupplier, Map<String, String> tags) {
+		return new AtomicRateLimiter(name, rateLimiterConfigSupplier.get(), tags);
 	}
 
 	/**
@@ -370,6 +396,13 @@ public interface RateLimiter {
 	 * @return the RateLimiterConfig of this RateLimiter
 	 */
 	RateLimiterConfig getRateLimiterConfig();
+
+	/**
+	 * Returns an unmodifiable map with tags assigned to this RateLimiter.
+	 *
+	 * @return the tags assigned to this Retry in an unmodifiable map
+	 */
+	Map<String, String> getTags();
 
 	/**
 	 * Get the Metrics of this RateLimiter.

--- a/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/RateLimiterRegistry.java
+++ b/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/RateLimiterRegistry.java
@@ -48,6 +48,18 @@ public interface RateLimiterRegistry extends Registry<RateLimiter, RateLimiterCo
     RateLimiter rateLimiter(String name);
 
     /**
+     * Returns a managed {@link RateLimiter} or creates a new one with the default RateLimiter configuration.
+     *
+     * The {@code tags} passed will be appended to the tags already configured for the registry. When tags (keys) of
+     * the two collide the tags passed with this method will override the tags of the registry.
+     *
+     * @param name the name of the RateLimiter
+     * @param tags tags added to the RateLimiter
+     * @return The {@link RateLimiter}
+     */
+    RateLimiter rateLimiter(String name, io.vavr.collection.Map<String, String> tags);
+
+    /**
      * Returns a managed {@link RateLimiter} or creates a new one with a custom RateLimiter configuration.
      *
      * @param name              the name of the RateLimiter
@@ -55,6 +67,19 @@ public interface RateLimiterRegistry extends Registry<RateLimiter, RateLimiterCo
      * @return The {@link RateLimiter}
      */
     RateLimiter rateLimiter(String name, RateLimiterConfig rateLimiterConfig);
+
+    /**
+     * Returns a managed {@link RateLimiter} or creates a new one with a custom RateLimiter configuration.
+     *
+     * The {@code tags} passed will be appended to the tags already configured for the registry. When tags (keys) of
+     * the two collide the tags passed with this method will override the tags of the registry.
+     *
+     * @param name              the name of the RateLimiter
+     * @param rateLimiterConfig a custom RateLimiter configuration
+     * @param tags              tags added to the RateLimiter
+     * @return The {@link RateLimiter}
+     */
+    RateLimiter rateLimiter(String name, RateLimiterConfig rateLimiterConfig, io.vavr.collection.Map<String, String> tags);
 
     /**
      * Returns a managed {@link RateLimiterConfig} or creates a new one with a custom RateLimiterConfig configuration.
@@ -66,6 +91,19 @@ public interface RateLimiterRegistry extends Registry<RateLimiter, RateLimiterCo
     RateLimiter rateLimiter(String name, Supplier<RateLimiterConfig> rateLimiterConfigSupplier);
 
     /**
+     * Returns a managed {@link RateLimiterConfig} or creates a new one with a custom RateLimiterConfig configuration.
+     *
+     * The {@code tags} passed will be appended to the tags already configured for the registry. When tags (keys) of
+     * the two collide the tags passed with this method will override the tags of the registry.
+     *
+     * @param name                      the name of the RateLimiterConfig
+     * @param rateLimiterConfigSupplier a supplier of a custom RateLimiterConfig configuration
+     * @param tags                      tags added to the RateLimiter
+     * @return The {@link RateLimiterConfig}
+     */
+    RateLimiter rateLimiter(String name, Supplier<RateLimiterConfig> rateLimiterConfigSupplier, io.vavr.collection.Map<String, String> tags);
+
+    /**
      * Returns a managed {@link RateLimiter} or creates a new one with a custom RateLimiter configuration.
      *
      * @param name       the name of the RateLimiter
@@ -73,6 +111,15 @@ public interface RateLimiterRegistry extends Registry<RateLimiter, RateLimiterCo
      * @return The {@link RateLimiter}
      */
     RateLimiter rateLimiter(String name, String configName);
+
+    /**
+     * Returns a managed {@link RateLimiter} or creates a new one with a custom RateLimiter configuration.
+     *
+     * @param name       the name of the RateLimiter
+     * @param configName a custom RateLimiter configuration name
+     * @return The {@link RateLimiter}
+     */
+    RateLimiter rateLimiter(String name, String configName, io.vavr.collection.Map<String, String> tags);
 
     /**
      * Creates a RateLimiterRegistry with a custom RateLimiter configuration.
@@ -123,6 +170,19 @@ public interface RateLimiterRegistry extends Registry<RateLimiter, RateLimiterCo
      */
     static RateLimiterRegistry of(Map<String, RateLimiterConfig> configs) {
         return new InMemoryRateLimiterRegistry(configs);
+    }
+
+    /**
+     * Creates a ThreadPoolBulkheadRegistry with a Map of shared RateLimiter configurations.
+     *
+     * Tags added to the registry will be added to every instance created by this registry.
+     *
+     * @param configs a Map of shared RateLimiter configurations
+     * @param tags default tags to add to the registry
+     * @return a ThreadPoolBulkheadRegistry with a Map of shared RateLimiter configurations.
+     */
+    static RateLimiterRegistry of(Map<String, RateLimiterConfig> configs, io.vavr.collection.Map<String, String> tags) {
+        return new InMemoryRateLimiterRegistry(configs, tags);
     }
 
     /**

--- a/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/internal/AtomicRateLimiter.java
+++ b/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/internal/AtomicRateLimiter.java
@@ -22,6 +22,8 @@ import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
 import io.github.resilience4j.ratelimiter.event.RateLimiterOnFailureEvent;
 import io.github.resilience4j.ratelimiter.event.RateLimiterOnSuccessEvent;
+import io.vavr.collection.HashMap;
+import io.vavr.collection.Map;
 
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -49,10 +51,16 @@ public class AtomicRateLimiter implements RateLimiter {
     private final String name;
     private final AtomicInteger waitingThreads;
     private final AtomicReference<State> state;
+    private final Map<String, String> tags;
     private final RateLimiterEventProcessor eventProcessor;
 
     public AtomicRateLimiter(String name, RateLimiterConfig rateLimiterConfig) {
+        this(name, rateLimiterConfig, HashMap.empty());
+    }
+
+    public AtomicRateLimiter(String name, RateLimiterConfig rateLimiterConfig, Map<String, String> tags) {
         this.name = name;
+        this.tags = tags;
 
         waitingThreads = new AtomicInteger(0);
         state = new AtomicReference<>(new State(
@@ -312,6 +320,14 @@ public class AtomicRateLimiter implements RateLimiter {
     @Override
     public RateLimiterConfig getRateLimiterConfig() {
         return state.get().config;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<String, String> getTags() {
+        return tags;
     }
 
     /**

--- a/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/SemaphoreBasedRateLimiterImplTest.java
+++ b/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/SemaphoreBasedRateLimiterImplTest.java
@@ -261,13 +261,13 @@ public class SemaphoreBasedRateLimiterImplTest extends RateLimitersImplementatio
     public void constructionWithNullName() throws Exception {
         exception.expect(NullPointerException.class);
         exception.expectMessage(NAME_MUST_NOT_BE_NULL);
-        new SemaphoreBasedRateLimiter(null, config, null);
+        new SemaphoreBasedRateLimiter(null, config, (ScheduledExecutorService) null);
     }
 
     @Test
     public void constructionWithNullConfig() throws Exception {
         exception.expect(NullPointerException.class);
         exception.expectMessage(CONFIG_MUST_NOT_BE_NULL);
-        new SemaphoreBasedRateLimiter("test", null, null);
+        new SemaphoreBasedRateLimiter("test", null, (ScheduledExecutorService) null);
     }
 }

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/Retry.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/Retry.java
@@ -24,6 +24,8 @@ import io.github.resilience4j.retry.internal.RetryImpl;
 import io.vavr.CheckedFunction0;
 import io.vavr.CheckedFunction1;
 import io.vavr.CheckedRunnable;
+import io.vavr.collection.HashMap;
+import io.vavr.collection.Map;
 import io.vavr.control.Either;
 import io.vavr.control.Try;
 
@@ -45,7 +47,19 @@ public interface Retry {
 	 * @return a Retry with a custom Retry configuration.
 	 */
 	static Retry of(String name, RetryConfig retryConfig) {
-		return new RetryImpl(name, retryConfig);
+		return of(name, retryConfig, HashMap.empty());
+	}
+
+	/**
+	 * Creates a Retry with a custom Retry configuration.
+	 *
+	 * @param name        the ID of the Retry
+	 * @param retryConfig a custom Retry configuration
+	 * @param tags        tags to assign to the Retry
+	 * @return a Retry with a custom Retry configuration.
+	 */
+	static Retry of(String name, RetryConfig retryConfig, Map<String, String> tags) {
+		return new RetryImpl(name, retryConfig, tags);
 	}
 
 	/**
@@ -56,7 +70,19 @@ public interface Retry {
 	 * @return a Retry with a custom Retry configuration.
 	 */
 	static Retry of(String name, Supplier<RetryConfig> retryConfigSupplier) {
-		return new RetryImpl(name, retryConfigSupplier.get());
+		return of(name, retryConfigSupplier.get(), HashMap.empty());
+	}
+
+	/**
+	 * Creates a Retry with a custom Retry configuration.
+	 *
+	 * @param name                the ID of the Retry
+	 * @param retryConfigSupplier a supplier of a custom Retry configuration
+	 * @param tags                tags to assign to the Retry
+	 * @return a Retry with a custom Retry configuration.
+	 */
+	static Retry of(String name, Supplier<RetryConfig> retryConfigSupplier, Map<String, String> tags) {
+		return new RetryImpl(name, retryConfigSupplier.get(), tags);
 	}
 
 	/**
@@ -66,7 +92,7 @@ public interface Retry {
 	 * @return a Retry with default configuration
 	 */
 	static Retry ofDefaults(String name) {
-		return new RetryImpl(name, RetryConfig.ofDefaults());
+		return of(name, RetryConfig.ofDefaults(), HashMap.empty());
 	}
 
 	/**
@@ -349,6 +375,13 @@ public interface Retry {
 	 * @return the RetryConfig of this Retry
 	 */
 	RetryConfig getRetryConfig();
+
+	/**
+	 * Returns an unmodifiable map with tags assigned to this Retry.
+	 *
+	 * @return the tags assigned to this Retry in an unmodifiable map
+	 */
+	Map<String, String> getTags();
 
 	/**
 	 * Returns an EventPublisher can be used to register event consumers.

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/RetryRegistry.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/RetryRegistry.java
@@ -19,6 +19,7 @@ package io.github.resilience4j.retry;
 import io.github.resilience4j.core.Registry;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
 import io.github.resilience4j.retry.internal.InMemoryRetryRegistry;
+import io.vavr.collection.HashMap;
 import io.vavr.collection.Seq;
 
 import java.util.List;
@@ -46,6 +47,18 @@ public interface RetryRegistry extends Registry<Retry, RetryConfig> {
 	Retry retry(String name);
 
 	/**
+	 * Returns a managed {@link Retry} or creates a new one with the default Retry configuration.
+	 *
+	 * The {@code tags} passed will be appended to the tags already configured for the registry. When tags (keys) of
+	 * the two collide the tags passed with this method will override the tags of the registry.
+	 *
+	 * @param name the name of the Retry
+	 * @param tags   tags added to the Retry
+	 * @return The {@link Retry}
+	 */
+	Retry retry(String name, io.vavr.collection.Map<String, String> tags);
+
+	/**
 	 * Returns a managed {@link Retry} or creates a new one with a custom Retry configuration.
 	 *
 	 * @param name        the name of the Retry
@@ -53,6 +66,19 @@ public interface RetryRegistry extends Registry<Retry, RetryConfig> {
 	 * @return The {@link Retry}
 	 */
 	Retry retry(String name, RetryConfig config);
+
+	/**
+	 * Returns a managed {@link Retry} or creates a new one with a custom Retry configuration.
+	 *
+	 * The {@code tags} passed will be appended to the tags already configured for the registry. When tags (keys) of
+	 * the two collide the tags passed with this method will override the tags of the registry.
+	 *
+	 * @param name   the name of the Retry
+	 * @param config a custom Retry configuration
+	 * @param tags   tags added to the Retry
+	 * @return The {@link Retry}
+	 */
+	Retry retry(String name, RetryConfig config, io.vavr.collection.Map<String, String> tags);
 
 	/**
 	 * Returns a managed {@link Retry} or creates a new one with a custom Retry configuration.
@@ -66,12 +92,37 @@ public interface RetryRegistry extends Registry<Retry, RetryConfig> {
 	/**
 	 * Returns a managed {@link Retry} or creates a new one with a custom Retry configuration.
 	 *
+	 * The {@code tags} passed will be appended to the tags already configured for the registry. When tags (keys) of
+	 * the two collide the tags passed with this method will override the tags of the registry.
+	 *
+	 * @param name                the name of the Retry
+	 * @param retryConfigSupplier a supplier of a custom Retry configuration
+	 * @param tags       tags added to the Retry
+	 * @return The {@link Retry}
+	 */
+	Retry retry(String name, Supplier<RetryConfig> retryConfigSupplier, io.vavr.collection.Map<String, String> tags);
+
+	/**
+	 * Returns a managed {@link Retry} or creates a new one with a custom Retry configuration.
+	 *
 	 * @param name       the name of the Retry
 	 * @param configName a custom Retry configuration name
 	 * @return The {@link Retry}
 	 */
 	Retry retry(String name, String configName);
 
+	/**
+	 * Returns a managed {@link Retry} or creates a new one with a custom Retry configuration.
+	 *
+	 * The {@code tags} passed will be appended to the tags already configured for the registry. When tags (keys) of
+	 * the two collide the tags passed with this method will override the tags of the registry.
+	 *
+	 * @param name       the name of the Retry
+	 * @param configName a custom Retry configuration name
+	 * @param tags       tags added to the Retry
+	 * @return The {@link Retry}
+	 */
+	Retry retry(String name, String configName, io.vavr.collection.Map<String, String> tags);
 
 	/**
 	 * Creates a RetryRegistry with a custom default Retry configuration.
@@ -121,7 +172,20 @@ public interface RetryRegistry extends Registry<Retry, RetryConfig> {
 	 * @return a RetryRegistry with a Map of shared Retry configurations.
 	 */
 	static RetryRegistry of(Map<String, RetryConfig> configs) {
-		return new InMemoryRetryRegistry(configs);
+		return of(configs, HashMap.empty());
+	}
+
+	/**
+	 * Creates a RetryRegistry with a Map of shared Retry configurations.
+	 *
+	 * Tags added to the registry will be added to every instance created by this registry.
+	 *
+	 * @param configs a Map of shared Retry configurations
+	 * @param tags default tags to add to the registry
+	 * @return a RetryRegistry with a Map of shared Retry configurations.
+	 */
+	static RetryRegistry of(Map<String, RetryConfig> configs, io.vavr.collection.Map<String, String> tags) {
+		return new InMemoryRetryRegistry(configs, tags);
 	}
 
 	/**

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/internal/RetryImpl.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/internal/RetryImpl.java
@@ -26,6 +26,8 @@ import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.retry.event.*;
 import io.vavr.CheckedConsumer;
+import io.vavr.collection.HashMap;
+import io.vavr.collection.Map;
 import io.vavr.control.Option;
 import io.vavr.control.Try;
 
@@ -47,6 +49,7 @@ public class RetryImpl<T> implements Retry {
 	private final Predicate<T> resultPredicate;
     private final String name;
     private final RetryConfig config;
+    private final Map<String, String> tags;
 
     private final int maxAttempts;
     private final Function<Integer, Long> intervalFunction;
@@ -57,8 +60,13 @@ public class RetryImpl<T> implements Retry {
     private final LongAdder failedWithoutRetryCounter;
 
 	public RetryImpl(String name, RetryConfig config) {
+		this(name, config, HashMap.empty());
+	}
+
+	public RetryImpl(String name, RetryConfig config, Map<String, String> tags) {
 		this.name = name;
 		this.config = config;
+		this.tags = tags;
 		this.maxAttempts = config.getMaxAttempts();
 		this.intervalFunction = config.getIntervalFunction();
 		this.exceptionPredicate = config.getExceptionPredicate();
@@ -94,6 +102,10 @@ public class RetryImpl<T> implements Retry {
 	@Override
 	public RetryConfig getRetryConfig() {
 		return config;
+	}
+
+	public Map<String, String> getTags() {
+		return tags;
 	}
 
 	private void publishRetryEvent(Supplier<RetryEvent> event) {


### PR DESCRIPTION
Adds a tag API which can be used to add tags to various metric collecting backends like Prometheus, micrometer, etc.

Based upon discussion in issue #509.