### PR TITLE
Kotlin Coroutines flow support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
+kotlin.code.style=official
 systemProp.file.encoding=UTF-8
 systemProp.sun.jnu.encoding=UTF-8

--- a/libraries.gradle
+++ b/libraries.gradle
@@ -30,7 +30,7 @@ ext {
     hibernateValidatorVersion = '6.0.16.Final'
     wiremockVersion = '2.22.0'
     validationApiVersion = '2.0.1.Final'
-    kotlinCoroutinesVersion = '1.2.0'
+    kotlinCoroutinesVersion = '1.3.2'
     springBootOpenFeignVersion= '2.1.2.RELEASE'
 
     libraries = [

--- a/resilience4j-kotlin/build.gradle
+++ b/resilience4j-kotlin/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.3.31'
+    id 'org.jetbrains.kotlin.jvm' version '1.3.50'
 }
 
 dependencies {
@@ -19,12 +19,22 @@ dependencies {
     testImplementation(project(':resilience4j-timelimiter'))
 }
 
+def experimentalFlags = [
+    "-Xuse-experimental=kotlin.Experimental"
+]
+
 compileKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions{
+        jvmTarget = "1.8"
+        freeCompilerArgs += experimentalFlags
+    }
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions{
+        jvmTarget = "1.8"
+        freeCompilerArgs += experimentalFlags
+    }
 }
 
 ext.moduleName='io.github.resilience4j.kotlin'

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/Cancellation.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/Cancellation.kt
@@ -1,0 +1,13 @@
+package io.github.resilience4j.kotlin
+
+import kotlinx.coroutines.Job
+import java.util.concurrent.CancellationException
+import kotlin.coroutines.CoroutineContext
+
+internal fun isCancellation(error: Throwable?, coroutineContext: CoroutineContext): Boolean {
+
+    // If job is missing then there is no cancellation
+    val job = coroutineContext[Job] ?: return false
+
+    return job.isCancelled || (error != null && error is CancellationException)
+}

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/Cancellation.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/Cancellation.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.Job
 import java.util.concurrent.CancellationException
 import kotlin.coroutines.CoroutineContext
 
-internal fun isCancellation(error: Throwable?, coroutineContext: CoroutineContext): Boolean {
+internal fun isCancellation(coroutineContext: CoroutineContext, error: Throwable? = null): Boolean {
 
     // If job is missing then there is no cancellation
     val job = coroutineContext[Job] ?: return false

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/Cancellation.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/Cancellation.kt
@@ -1,3 +1,21 @@
+/*
+ *
+ *  Copyright 2019 authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
 package io.github.resilience4j.kotlin
 
 import kotlinx.coroutines.Job

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/bulkhead/Bulkhead.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/bulkhead/Bulkhead.kt
@@ -21,6 +21,8 @@ package io.github.resilience4j.kotlin.bulkhead
 import io.github.resilience4j.bulkhead.Bulkhead
 import io.github.resilience4j.bulkhead.BulkheadConfig
 import io.github.resilience4j.kotlin.isCancellation
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlin.coroutines.coroutineContext
 
 /**
@@ -29,19 +31,17 @@ import kotlin.coroutines.coroutineContext
  * If [BulkheadConfig.maxWaitTime] is non-zero, *blocks* until the max wait time is reached or permission is obtained.
  * For this reason, it is not recommended to use this extension function with Bulkheads with non-zero max wait times.
  */
-suspend fun <T> Bulkhead.executeSuspendFunction(block: suspend () -> T): T {
-    acquirePermission()
-    return try {
-        block().also { onComplete() }
-    } catch (e: Throwable){
-        if(isCancellation(e, coroutineContext)){
+suspend fun <T> Bulkhead.executeSuspendFunction(block: suspend () -> T): T =
+    try {
+        acquirePermissionSuspend()
+        block()
+    } finally {
+        if(isCancellation(coroutineContext)){
             releasePermission()
         }else{
             onComplete()
         }
-        throw e
     }
-}
 
 /**
  * Decorates the given suspend function [block] and returns it.
@@ -51,4 +51,20 @@ suspend fun <T> Bulkhead.executeSuspendFunction(block: suspend () -> T): T {
  */
 fun <T> Bulkhead.decorateSuspendFunction(block: suspend () -> T): suspend () -> T = {
     executeSuspendFunction(block)
+}
+
+/**
+ * Try to immediately acquire permission from the bulkhead when it is not expected to block.
+ *
+ * If a wait duration is configured on the bulkhead, then attempt to acquire permission within
+ * the confines of a dispatcher specialized for blocking calls.
+ *
+ */
+internal suspend fun Bulkhead.acquirePermissionSuspend(){
+    // Fast path. Avoid dispatch context switch.
+    if(bulkheadConfig.maxWaitDuration.isZero){
+        acquirePermission()
+    }else{
+        withContext(Dispatchers.IO){ acquirePermission() }
+    }
 }

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/bulkhead/FlowBulkhead.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/bulkhead/FlowBulkhead.kt
@@ -15,7 +15,7 @@ fun <T> Flow<T>.bulkhead(bulkhead: Bulkhead): Flow<T> =
         bulkhead.acquirePermission()
 
         val source = this@bulkhead.onCompletion { e ->
-            if(isCancellation(e, coroutineContext)){
+            if(isCancellation(coroutineContext, e)){
                 bulkhead.releasePermission()
             }else{
                 bulkhead.onComplete()

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/bulkhead/FlowBulkhead.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/bulkhead/FlowBulkhead.kt
@@ -1,0 +1,26 @@
+package io.github.resilience4j.kotlin.bulkhead
+
+import io.github.resilience4j.bulkhead.Bulkhead
+import io.github.resilience4j.kotlin.isCancellation
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onCompletion
+import kotlin.coroutines.coroutineContext
+
+@UseExperimental(ExperimentalCoroutinesApi::class)
+fun <T> Flow<T>.bulkhead(bulkhead: Bulkhead): Flow<T> =
+    flow {
+        bulkhead.acquirePermission()
+
+        val source = this@bulkhead.onCompletion { e ->
+            if(isCancellation(e, coroutineContext)){
+                bulkhead.releasePermission()
+            }else{
+                bulkhead.onComplete()
+            }
+        }
+
+        emitAll(source)
+    }

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/bulkhead/FlowBulkhead.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/bulkhead/FlowBulkhead.kt
@@ -12,7 +12,7 @@ import kotlin.coroutines.coroutineContext
 @UseExperimental(ExperimentalCoroutinesApi::class)
 fun <T> Flow<T>.bulkhead(bulkhead: Bulkhead): Flow<T> =
     flow {
-        bulkhead.acquirePermission()
+        bulkhead.acquirePermissionSuspend()
 
         val source = this@bulkhead.onCompletion { e ->
             if(isCancellation(coroutineContext, e)){
@@ -21,6 +21,5 @@ fun <T> Flow<T>.bulkhead(bulkhead: Bulkhead): Flow<T> =
                 bulkhead.onComplete()
             }
         }
-
         emitAll(source)
     }

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/bulkhead/FlowBulkhead.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/bulkhead/FlowBulkhead.kt
@@ -1,3 +1,21 @@
+/*
+ *
+ *  Copyright 2019 authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
 package io.github.resilience4j.kotlin.bulkhead
 
 import io.github.resilience4j.bulkhead.Bulkhead

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/CircuitBreaker.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/CircuitBreaker.kt
@@ -35,7 +35,7 @@ suspend fun <T> CircuitBreaker.executeSuspendFunction(block: suspend () -> T): T
         onSuccess(durationInNanos, TimeUnit.NANOSECONDS)
         return result
     } catch (exception: Throwable) {
-        if(isCancellation(exception, coroutineContext)){
+        if(isCancellation(coroutineContext, exception)){
             releasePermission()
         }else{
             val durationInNanos = System.nanoTime() - start

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/CircuitBreaker.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/CircuitBreaker.kt
@@ -19,7 +19,9 @@
 package io.github.resilience4j.kotlin.circuitbreaker
 
 import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.kotlin.isCancellation
 import java.util.concurrent.TimeUnit
+import kotlin.coroutines.coroutineContext
 
 /**
  * Decorates and executes the given suspend function [block].
@@ -32,9 +34,13 @@ suspend fun <T> CircuitBreaker.executeSuspendFunction(block: suspend () -> T): T
         val durationInNanos = System.nanoTime() - start
         onSuccess(durationInNanos, TimeUnit.NANOSECONDS)
         return result
-    } catch (exception: Exception) {
-        val durationInNanos = System.nanoTime() - start
-        onError(durationInNanos, TimeUnit.NANOSECONDS, exception)
+    } catch (exception: Throwable) {
+        if(isCancellation(exception, coroutineContext)){
+            releasePermission()
+        }else{
+            val durationInNanos = System.nanoTime() - start
+            onError(durationInNanos, TimeUnit.NANOSECONDS, exception)
+        }
         throw exception
     }
 }
@@ -43,5 +49,5 @@ suspend fun <T> CircuitBreaker.executeSuspendFunction(block: suspend () -> T): T
  * Decorates the given *suspend* function [block] and returns it.
  */
 fun <T> CircuitBreaker.decorateSuspendFunction(block: suspend () -> T): suspend () -> T = {
-    executeSuspendFunction { block() }
+    executeSuspendFunction(block)
 }

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/FlowCircuitBreaker.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/FlowCircuitBreaker.kt
@@ -53,7 +53,7 @@ fun <T> Flow<T>.circuitBreaker(circuitBreaker: CircuitBreaker): Flow<T> =
         val start = System.nanoTime()
         val source = this@circuitBreaker.onCompletion { e ->
             when {
-                isCancellation(e, coroutineContext) -> circuitBreaker
+                isCancellation(coroutineContext, e) -> circuitBreaker
                     .releasePermission()
 
                 e == null -> circuitBreaker

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/FlowCircuitBreaker.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/FlowCircuitBreaker.kt
@@ -1,0 +1,96 @@
+/*
+ *
+ *  Copyright 2019 authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.kotlin.circuitbreaker
+
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onCompletion
+import java.util.concurrent.CancellationException
+import java.util.concurrent.TimeUnit
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.coroutineContext
+
+/**
+ * Wraps the given flows collection with a permission check on the supplied [circuitBreaker].
+ *
+ * The events are published to the circuit breaker via the `onCompletion` operator chained to the given flow.
+ *
+ * When the circuit breaker is OPEN, flow collection throws a [CallNotPermittedException]
+ * ```
+ * flowOf("a", "b", "c")
+ *     .circuitBreaker(circuitBreaker)
+ *     .collect { println(it) } // Throws CallNotPermittedException
+ * ```
+ *
+ * Coroutine cancellation (_normal_ and _exceptional_) doe not record any events on the circuit breaker
+ * and the acquired permission is released.
+ *
+ */
+@UseExperimental(ExperimentalCoroutinesApi::class)
+fun <T> Flow<T>.circuitBreaker(circuitBreaker: CircuitBreaker): Flow<T> =
+    flow {
+        if(circuitBreaker.tryAcquirePermission()) {
+
+            val start = System.nanoTime()
+            val source = this@circuitBreaker.onCompletion { e ->
+                when {
+                    isCancellation(e, coroutineContext) -> circuitBreaker
+                        .releasePermission()
+
+                    e == null -> circuitBreaker
+                        .onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS)
+
+                    else -> circuitBreaker
+                        .onError(System.nanoTime() - start, TimeUnit.NANOSECONDS, e)
+                }
+            }
+
+            emitAll(source)
+        }else{
+            throw CallNotPermittedException.createCallNotPermittedException(circuitBreaker)
+        }
+    }
+
+
+private fun isCancellation(error: Throwable? = null, coroutineContext: CoroutineContext): Boolean {
+
+    // Check if job missing or not cancelled or supplied
+    // exception is a cancellation.
+    val job = coroutineContext[Job]
+    if (job == null || !job.isCancelled) return false
+    if(error != null && error is CancellationException) return true
+
+    // If the job is in a transient state it could potentially be
+    // already cancelled. In this case `job.isCancelled` would still
+    // return false.
+    //
+    // To check for transient cancellation we need to use `job.ensureActive()`
+    return try{
+        job.ensureActive()
+        false
+    }catch (e: Throwable){
+        e is CancellationException
+    }
+}

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/FlowCircuitBreaker.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/FlowCircuitBreaker.kt
@@ -70,24 +70,3 @@ fun <T> Flow<T>.circuitBreaker(circuitBreaker: CircuitBreaker): Flow<T> =
         emitAll(source)
     }
 
-
-private fun isCancellation(error: Throwable? = null, coroutineContext: CoroutineContext): Boolean {
-
-    // Check if job missing or not cancelled or supplied
-    // exception is a cancellation.
-    val job = coroutineContext[Job]
-    if (job == null || !job.isCancelled) return false
-    if(error != null && error is CancellationException) return true
-
-    // If the job is in a transient state it could potentially be
-    // already cancelled. In this case `job.isCancelled` would still
-    // return false.
-    //
-    // To check for transient cancellation we need to use `job.ensureActive()`
-    return try{
-        job.ensureActive()
-        false
-    }catch (e: Throwable){
-        e is CancellationException
-    }
-}

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/FlowCircuitBreaker.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/FlowCircuitBreaker.kt
@@ -20,16 +20,13 @@ package io.github.resilience4j.kotlin.circuitbreaker
 
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException
 import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.kotlin.isCancellation
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onCompletion
-import java.util.concurrent.CancellationException
 import java.util.concurrent.TimeUnit
-import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.coroutineContext
 
 /**
@@ -44,7 +41,7 @@ import kotlin.coroutines.coroutineContext
  *     .collect { println(it) } // Throws CallNotPermittedException
  * ```
  *
- * Coroutine cancellation (_normal_ and _exceptional_) doe not record any events on the circuit breaker
+ * Coroutine cancellation (_normal_ and _exceptional_) do not record any events on the circuit breaker
  * and the acquired permission is released.
  *
  */

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/ratelimiter/FlowRateLimiter.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/ratelimiter/FlowRateLimiter.kt
@@ -1,0 +1,25 @@
+package io.github.resilience4j.kotlin.ratelimiter
+
+import io.github.resilience4j.ratelimiter.RateLimiter
+import io.github.resilience4j.ratelimiter.RequestNotPermitted
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onStart
+import java.util.concurrent.TimeUnit
+
+
+@UseExperimental(ExperimentalCoroutinesApi::class)
+fun <T> Flow<T>.rateLimiter(rateLimiter: RateLimiter): Flow<T> =
+    flow {
+        val waitTimeNs = rateLimiter.reservePermission()
+        if (waitTimeNs < 0) throw RequestNotPermitted.createRequestNotPermitted(rateLimiter)
+
+        val source = this@rateLimiter.onStart {
+            delay(TimeUnit.NANOSECONDS.toMillis(waitTimeNs))
+        }
+
+        emitAll(source)
+    }

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/ratelimiter/FlowRateLimiter.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/ratelimiter/FlowRateLimiter.kt
@@ -31,13 +31,4 @@ import java.util.concurrent.TimeUnit
 
 @UseExperimental(ExperimentalCoroutinesApi::class)
 fun <T> Flow<T>.rateLimiter(rateLimiter: RateLimiter): Flow<T> =
-    flow {
-        val waitTimeNs = rateLimiter.reservePermission()
-        if (waitTimeNs < 0) throw RequestNotPermitted.createRequestNotPermitted(rateLimiter)
-
-        val source = this@rateLimiter.onStart {
-            delay(TimeUnit.NANOSECONDS.toMillis(waitTimeNs))
-        }
-
-        emitAll(source)
-    }
+    onStart { rateLimiter.awaitPermission() }

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/ratelimiter/FlowRateLimiter.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/ratelimiter/FlowRateLimiter.kt
@@ -1,3 +1,21 @@
+/*
+ *
+ *  Copyright 2019 authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
 package io.github.resilience4j.kotlin.ratelimiter
 
 import io.github.resilience4j.ratelimiter.RateLimiter

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/retry/FlowRetry.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/retry/FlowRetry.kt
@@ -1,3 +1,21 @@
+/*
+ *
+ *  Copyright 2019 authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
 package io.github.resilience4j.kotlin.retry
 
 import io.github.resilience4j.retry.Retry

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/retry/FlowRetry.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/retry/FlowRetry.kt
@@ -31,7 +31,7 @@ fun <T> Flow<T>.retry(retry: Retry): Flow<T> {
 
     return onEach {
         val delayMs = retryContext.onResult(it)
-        if (delayMs > 0) {
+        if (delayMs >= 0) {
             delay(delayMs)
             throw RetryDueToResultException()
         }
@@ -43,7 +43,7 @@ fun <T> Flow<T>.retry(retry: Retry): Flow<T> {
             shouldRetry = true
         } else {
             val delayMs = retryContext.onError(e)
-            if(delayMs > 0) {
+            if(delayMs >= 0) {
                 delay(delayMs)
                 shouldRetry = true
             }

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/retry/FlowRetry.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/retry/FlowRetry.kt
@@ -1,0 +1,43 @@
+package io.github.resilience4j.kotlin.retry
+
+import io.github.resilience4j.retry.Retry
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.*
+
+
+@UseExperimental(ExperimentalCoroutinesApi::class)
+fun <T> Flow<T>.retry(retry: Retry): Flow<T> {
+
+    val retryContext = retry.asyncContext<T>()
+
+    return onEach {
+        val delayMs = retryContext.onResult(it)
+        if (delayMs > 0) {
+            delay(delayMs)
+            throw RetryDueToResultException()
+        }
+    }.retryWhen { e,  _ ->
+
+        var shouldRetry = false
+
+        if(e is RetryDueToResultException) {
+            shouldRetry = true
+        } else {
+            val delayMs = retryContext.onError(e)
+            if(delayMs > 0) {
+                delay(delayMs)
+                shouldRetry = true
+            }
+        }
+
+        shouldRetry
+
+    }.onCompletion { e ->
+        if(e == null)
+            retryContext.onSuccess()
+    }
+
+}
+
+private class RetryDueToResultException : RuntimeException("Retry due to retryOnResult predicate")

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/timelimiter/FlowTimeLimiter.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/timelimiter/FlowTimeLimiter.kt
@@ -21,16 +21,18 @@ package io.github.resilience4j.kotlin.timelimiter
 import io.github.resilience4j.timelimiter.TimeLimiter
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emitAll
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.collect
 
 
 @UseExperimental(ExperimentalCoroutinesApi::class)
 fun <T> Flow<T>.timeLimiter(timeLimiter: TimeLimiter): Flow<T> {
     val source = this
-    return flow {
+    return channelFlow {
         timeLimiter.executeSuspendFunction {
-            emitAll(source)
+            source.collect {
+                send(it)
+            }
         }
     }
 }

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/timelimiter/FlowTimeLimiter.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/timelimiter/FlowTimeLimiter.kt
@@ -1,0 +1,18 @@
+package io.github.resilience4j.kotlin.timelimiter
+
+import io.github.resilience4j.timelimiter.TimeLimiter
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+
+
+@UseExperimental(ExperimentalCoroutinesApi::class)
+fun <T> Flow<T>.timeLimiter(timeLimiter: TimeLimiter): Flow<T> {
+    val source = this
+    return flow {
+        timeLimiter.executeSuspendFunction {
+            emitAll(source)
+        }
+    }
+}

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/timelimiter/FlowTimeLimiter.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/timelimiter/FlowTimeLimiter.kt
@@ -1,3 +1,21 @@
+/*
+ *
+ *  Copyright 2019 authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
 package io.github.resilience4j.kotlin.timelimiter
 
 import io.github.resilience4j.timelimiter.TimeLimiter

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/timelimiter/TimeLimiter.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/timelimiter/TimeLimiter.kt
@@ -37,9 +37,9 @@ import kotlinx.coroutines.withTimeout
  *    even if the `cancelRunningFuture` is set to `false`.
  */
 suspend fun <T> TimeLimiter.executeSuspendFunction(block: suspend () -> T): T =
-        withTimeout(timeLimiterConfig.timeoutDuration.toMillis()) {
-            block()
-        }
+    withTimeout(timeLimiterConfig.timeoutDuration.toMillis()) {
+        block()
+    }
 
 /**
  * Decorates the given suspend function [block] and returns it.

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/bulkhead/FlowBulkheadTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/bulkhead/FlowBulkheadTest.kt
@@ -1,0 +1,255 @@
+/*
+ *
+ *  Copyright 2019: authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.kotlin.bulkhead
+
+import io.github.resilience4j.bulkhead.Bulkhead
+import io.github.resilience4j.bulkhead.BulkheadConfig
+import io.github.resilience4j.bulkhead.BulkheadFullException
+import io.github.resilience4j.kotlin.HelloWorldService
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.flow.toList
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import java.time.Duration
+import java.util.concurrent.Phaser
+
+class FlowBulkheadTest {
+
+    private var permittedEvents = 0
+    private var rejectedEvents = 0
+    private var finishedEvents = 0
+
+    private fun Bulkhead.registerEventListener(): Bulkhead {
+        eventPublisher.apply {
+            onCallPermitted { permittedEvents++ }
+            onCallRejected { rejectedEvents++ }
+            onCallFinished { finishedEvents++ }
+        }
+        return this
+    }
+
+    @Test
+    fun `should execute successful function`() {
+        runBlocking {
+            val bulkhead = Bulkhead.ofDefaults("testName").registerEventListener()
+            val resultList = mutableListOf<Int>()
+
+            //When
+            flow {
+                repeat(3){
+                    emit(it)
+                }
+            }
+                .bulkhead(bulkhead)
+                .toList(resultList)
+
+
+            //Then
+            repeat(3){
+                assertThat(resultList[it]).isEqualTo(it)
+            }
+            assertThat(permittedEvents).isEqualTo(1)
+            assertThat(rejectedEvents).isEqualTo(0)
+            assertThat(finishedEvents).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun `should not execute function when full`() {
+        runBlocking {
+            val bulkhead = Bulkhead.of("testName") {
+                BulkheadConfig.custom()
+                    .maxConcurrentCalls(1)
+                    .maxWaitDuration(Duration.ZERO)
+                    .build()
+            }.registerEventListener()
+
+            val resultList = mutableListOf<Int>()
+
+            //When
+
+
+            val sync = Channel<Int>(Channel.RENDEZVOUS)
+            val testFlow = flow {
+                emit(sync.receive())
+                emit(sync.receive())
+            }.bulkhead(bulkhead)
+
+            val firstCall = launch {
+                testFlow.toList(resultList)
+            }
+
+            // wait until our first coroutine is inside the bulkhead
+            sync.send(1)
+
+            assertThat(permittedEvents).isEqualTo(1)
+            assertThat(rejectedEvents).isEqualTo(0)
+            assertThat(finishedEvents).isEqualTo(0)
+            assertThat(resultList.size).isEqualTo(1)
+            assertThat(resultList[0]).isEqualTo(1)
+
+            val helloWorldService = HelloWorldService()
+
+            //When
+            try {
+                flow { emit(helloWorldService.returnHelloWorld()) }
+                    .bulkhead(bulkhead)
+                    .single()
+
+                Assertions.failBecauseExceptionWasNotThrown<Nothing>(BulkheadFullException::class.java)
+            } catch (e: BulkheadFullException) {
+                // nothing - proceed
+            }
+
+            assertThat(permittedEvents).isEqualTo(1)
+            assertThat(rejectedEvents).isEqualTo(1)
+            assertThat(finishedEvents).isEqualTo(0)
+
+            // allow our first call to complete, and then wait for it
+            sync.send(2)
+            firstCall.join()
+
+            //Then
+            assertThat(permittedEvents).isEqualTo(1)
+            assertThat(rejectedEvents).isEqualTo(1)
+            assertThat(finishedEvents).isEqualTo(1)
+            assertThat(resultList.size).isEqualTo(2)
+            assertThat(resultList[1]).isEqualTo(2)
+            // Then the helloWorldService should not be invoked
+            assertThat(helloWorldService.invocationCounter).isEqualTo(0)
+        }
+    }
+
+    @Test
+    fun `should execute unsuccessful function`() {
+        runBlocking {
+            val bulkhead = Bulkhead.ofDefaults("testName").registerEventListener()
+            val resultList = mutableListOf<Int>()
+
+            //When
+            try {
+                flow {
+                    repeat(3){
+                        emit(it)
+                    }
+                    error("failed")
+                }
+                    .bulkhead(bulkhead)
+                    .toList(resultList)
+
+                Assertions.failBecauseExceptionWasNotThrown<Nothing>(IllegalStateException::class.java)
+            } catch (e: IllegalStateException) {
+                // nothing - proceed
+            }
+
+            //Then
+            repeat(3){
+                assertThat(resultList[it]).isEqualTo(it)
+            }
+            assertThat(permittedEvents).isEqualTo(1)
+            assertThat(rejectedEvents).isEqualTo(0)
+            assertThat(finishedEvents).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun `should not record call finished when cancelled normally`() {
+        runBlocking {
+
+            val phaser = Phaser(1)
+            var flowCompleted = false
+            val bulkhead = Bulkhead.of("testName") {
+                BulkheadConfig.custom()
+                    .maxConcurrentCalls(1)
+                    .maxWaitDuration(Duration.ZERO)
+                    .build()
+            }.registerEventListener()
+
+            //When
+            val job = launch(start = CoroutineStart.ATOMIC) {
+                flow {
+                    phaser.arrive()
+                    delay(5000L)
+                    emit(1)
+                    flowCompleted = true
+                }
+                    .bulkhead(bulkhead)
+                    .first()
+            }
+
+            phaser.awaitAdvance(1)
+            job.cancelAndJoin()
+
+            //Then
+            assertThat(job.isCompleted).isTrue()
+            assertThat(job.isCancelled).isTrue()
+            assertThat(flowCompleted).isFalse()
+            assertThat(permittedEvents).isEqualTo(1)
+            assertThat(rejectedEvents).isEqualTo(0)
+            assertThat(finishedEvents).isEqualTo(0)
+        }
+    }
+
+    @Test
+    fun `should not record call finished when cancelled exceptionally`() {
+        runBlocking(Dispatchers.Default) {
+
+            val phaser = Phaser(1)
+            val parentJob = Job()
+            var flowCompleted = false
+            val bulkhead = Bulkhead.of("testName") {
+                BulkheadConfig.custom()
+                    .maxConcurrentCalls(1)
+                    .maxWaitDuration(Duration.ZERO)
+                    .build()
+            }.registerEventListener()
+
+            //When
+            val job = launch(parentJob) {
+                launch(start = CoroutineStart.ATOMIC) {
+                    flow {
+                        phaser.arrive()
+                        delay(5000L)
+                        emit(1)
+                        flowCompleted = true
+                    }
+                        .bulkhead(bulkhead)
+                        .first()
+                }
+                error("exceptional cancellation")
+            }
+
+            phaser.awaitAdvance(1)
+            parentJob.runCatching { join() }
+
+            //Then
+            assertThat(job.isCompleted).isTrue()
+            assertThat(job.isCancelled).isTrue()
+            assertThat(flowCompleted).isFalse()
+            assertThat(permittedEvents).isEqualTo(1)
+            assertThat(rejectedEvents).isEqualTo(0)
+            assertThat(finishedEvents).isEqualTo(0)
+        }
+    }
+}

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/circuitbreaker/FlowCircuitBreakerTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/circuitbreaker/FlowCircuitBreakerTest.kt
@@ -1,0 +1,202 @@
+/*
+ *
+ *  Copyright 2019 authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.kotlin.circuitbreaker
+
+
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.toList
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import java.lang.IllegalStateException
+import java.util.concurrent.Phaser
+
+class FlowCircuitBreakerTest {
+
+    @Test
+    fun `should collect successfully`() {
+        runBlocking {
+            val circuitBreaker = CircuitBreaker.ofDefaults("testName")
+            val metrics = circuitBreaker.metrics
+            assertThat(metrics.numberOfBufferedCalls).isEqualTo(0)
+            val resultList = mutableListOf<Int>()
+
+            //When
+            flow {
+                repeat(3){
+                    emit(it)
+                }
+            }
+                .circuitBreaker(circuitBreaker)
+                .toList(resultList)
+
+            //Then
+            repeat(3){
+                assertThat(resultList[it]).isEqualTo(it)
+            }
+            assertThat(metrics.numberOfBufferedCalls).isEqualTo(1)
+            assertThat(metrics.numberOfFailedCalls).isEqualTo(0)
+            assertThat(metrics.numberOfSuccessfulCalls).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun `should not collect when open`() {
+        runBlocking {
+
+            val circuitBreaker = CircuitBreaker.ofDefaults("testName")
+            circuitBreaker.transitionToOpenState()
+            val metrics = circuitBreaker.metrics
+            assertThat(metrics.numberOfBufferedCalls).isEqualTo(0)
+
+            //When
+            val resultList = mutableListOf<Int>()
+            try {
+                flow {
+                    Assertions.failBecauseExceptionWasNotThrown<Nothing>(CallNotPermittedException::class.java)
+                    repeat(3){
+                        emit(it)
+                    }
+                }
+                    .circuitBreaker(circuitBreaker)
+                    .toList(resultList)
+            } catch (e: CallNotPermittedException) {
+                // nothing - proceed
+            }
+
+            //Then
+            assertThat(metrics.numberOfBufferedCalls).isEqualTo(0)
+            assertThat(metrics.numberOfFailedCalls).isEqualTo(0)
+            assertThat(metrics.numberOfSuccessfulCalls).isEqualTo(0)
+            assertThat(metrics.numberOfNotPermittedCalls).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun `should record failed flows`() {
+        runBlocking {
+            val resultList = mutableListOf<Int>()
+            val circuitBreaker = CircuitBreaker.ofDefaults("testName")
+            val metrics = circuitBreaker.metrics
+            assertThat(metrics.numberOfBufferedCalls).isEqualTo(0)
+
+            //When
+            try {
+                flow {
+                    repeat(6){
+                        if(it == 4) error("failed")
+                        emit(it)
+                    }
+                }
+                    .circuitBreaker(circuitBreaker)
+                    .toList(resultList)
+
+                Assertions.failBecauseExceptionWasNotThrown<Nothing>(IllegalStateException::class.java)
+            } catch (e: IllegalStateException) {
+                // nothing - proceed
+            }
+
+            //Then
+            assertThat(metrics.numberOfBufferedCalls).isEqualTo(1)
+            assertThat(metrics.numberOfFailedCalls).isEqualTo(1)
+            assertThat(metrics.numberOfSuccessfulCalls).isEqualTo(0)
+            assertThat(metrics.numberOfNotPermittedCalls).isEqualTo(0)
+        }
+    }
+
+    @Test
+    fun `should not record failed call when cancelled normally`() {
+        runBlocking {
+
+            val phaser = Phaser(1)
+            var flowCompleted = false
+            val circuitBreaker = CircuitBreaker.ofDefaults("testName")
+            val metrics = circuitBreaker.metrics
+            assertThat(metrics.numberOfBufferedCalls).isEqualTo(0)
+
+            //When
+            val job = launch(start = CoroutineStart.ATOMIC) {
+                flow {
+                    phaser.arrive()
+                    delay(5000L)
+                    emit(1)
+                    flowCompleted = true
+                }
+                    .circuitBreaker(circuitBreaker)
+                    .first()
+            }
+
+            phaser.awaitAdvance(1)
+            job.cancelAndJoin()
+
+            //Then
+            assertThat(job.isCompleted).isTrue()
+            assertThat(job.isCancelled).isTrue()
+            assertThat(flowCompleted).isFalse()
+            assertThat(metrics.numberOfBufferedCalls).isEqualTo(0)
+            assertThat(metrics.numberOfFailedCalls).isEqualTo(0)
+            assertThat(metrics.numberOfSuccessfulCalls).isEqualTo(0)
+            assertThat(metrics.numberOfNotPermittedCalls).isEqualTo(0)
+        }
+    }
+
+    @Test
+    fun `should not record failed call when cancelled exceptionally`() {
+        runBlocking(Dispatchers.Default) {
+
+            val phaser = Phaser(1)
+            var flowCompleted = false
+            val parentJob = Job()
+            val circuitBreaker = CircuitBreaker.ofDefaults("testName")
+            val metrics = circuitBreaker.metrics
+            assertThat(metrics.numberOfBufferedCalls).isEqualTo(0)
+
+            //When
+            val job = launch(parentJob) {
+                launch(start = CoroutineStart.ATOMIC) {
+                    flow {
+                        phaser.arrive()
+                        delay(5000L)
+                        emit(1)
+                        flowCompleted = true
+                    }
+                        .circuitBreaker(circuitBreaker)
+                        .first()
+                }
+                error("exceptional cancellation")
+            }
+
+            phaser.awaitAdvance(1)
+            parentJob.runCatching { join() }
+
+            //Then
+            assertThat(job.isCompleted).isTrue()
+            assertThat(job.isCancelled).isTrue()
+            assertThat(flowCompleted).isFalse()
+            assertThat(metrics.numberOfBufferedCalls).isEqualTo(0)
+            assertThat(metrics.numberOfFailedCalls).isEqualTo(0)
+            assertThat(metrics.numberOfSuccessfulCalls).isEqualTo(0)
+            assertThat(metrics.numberOfNotPermittedCalls).isEqualTo(0)
+        }
+    }
+}

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/ratelimiter/FlowRateLimiterTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/ratelimiter/FlowRateLimiterTest.kt
@@ -1,0 +1,120 @@
+/*
+ *
+ *  Copyright 2019: authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.kotlin.ratelimiter
+
+import io.github.resilience4j.kotlin.HelloWorldService
+import io.github.resilience4j.kotlin.bulkhead.bulkhead
+import io.github.resilience4j.ratelimiter.RateLimiter
+import io.github.resilience4j.ratelimiter.RateLimiterConfig
+import io.github.resilience4j.ratelimiter.RequestNotPermitted
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions
+import org.junit.Test
+import java.lang.IllegalStateException
+import java.time.Duration
+
+class FlowRateLimiterTest {
+
+    private fun noWaitConfig() = RateLimiterConfig
+        .custom()
+        .limitRefreshPeriod(Duration.ofSeconds(10))
+        .limitForPeriod(10)
+        .timeoutDuration(Duration.ZERO)
+        .build()
+
+    @Test
+    fun `should execute successful function`() {
+        runBlocking {
+            val rateLimiter = RateLimiter.of("testName", noWaitConfig())
+            val metrics = rateLimiter.metrics
+            val helloWorldService = HelloWorldService()
+
+            //When
+            val testFlow = flow {
+                emit(helloWorldService.returnHelloWorld())
+            }.rateLimiter(rateLimiter)
+
+            //Then
+            Assertions.assertThat(testFlow.single()).isEqualTo("Hello world")
+            Assertions.assertThat(metrics.availablePermissions).isEqualTo(9)
+            Assertions.assertThat(metrics.numberOfWaitingThreads).isEqualTo(0)
+            // Then the helloWorldService should be invoked 1 time
+            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun `should execute unsuccessful function`() {
+        runBlocking {
+            val rateLimiter = RateLimiter.of("testName", noWaitConfig())
+            val metrics = rateLimiter.metrics
+            val helloWorldService = HelloWorldService()
+
+            //When
+            try {
+                flow { emit(helloWorldService.throwException()) }
+                    .rateLimiter(rateLimiter)
+                    .single()
+
+                Assertions.failBecauseExceptionWasNotThrown<Nothing>(IllegalStateException::class.java)
+            } catch (e: IllegalStateException) {
+                // nothing - proceed
+            }
+
+            //Then
+            Assertions.assertThat(metrics.availablePermissions).isEqualTo(9)
+            Assertions.assertThat(metrics.numberOfWaitingThreads).isEqualTo(0)
+            // Then the helloWorldService should be invoked 1 time
+            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun `should not execute function when rate limit reached and no waiting is allowed`() {
+        runBlocking {
+            val rateLimiter = RateLimiter.of("testName", noWaitConfig())
+            val metrics = rateLimiter.metrics
+            val helloWorldService = HelloWorldService()
+
+            for (i in 0 until 10) {
+                flow { emit(helloWorldService.returnHelloWorld()) }
+                    .rateLimiter(rateLimiter)
+                    .single()
+            }
+
+            //When
+            try {
+                flow { emit(helloWorldService.returnHelloWorld()) }
+                    .rateLimiter(rateLimiter)
+                    .single()
+                Assertions.failBecauseExceptionWasNotThrown<Nothing>(RequestNotPermitted::class.java)
+            } catch (e: RequestNotPermitted) {
+                // nothing - proceed
+            }
+
+            //Then
+            Assertions.assertThat(metrics.availablePermissions).isEqualTo(0)
+            Assertions.assertThat(metrics.numberOfWaitingThreads).isEqualTo(0)
+            // Then the helloWorldService should not be invoked after the initial 10 times to use up the permits
+            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(10)
+        }
+    }
+}

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/retry/FlowRetryTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/retry/FlowRetryTest.kt
@@ -1,0 +1,167 @@
+/*
+ *
+ *  Copyright 2019: Brad Newman
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.kotlin.retry
+
+import io.github.resilience4j.kotlin.HelloWorldService
+import io.github.resilience4j.kotlin.bulkhead.bulkhead
+import io.github.resilience4j.retry.Retry
+import io.github.resilience4j.retry.RetryConfig
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions
+import org.junit.Test
+import java.lang.IllegalStateException
+import java.time.Duration
+
+class FlowRetryTest {
+    @Test
+    fun `should execute successful function`() {
+        runBlocking {
+            val retry = Retry.ofDefaults("testName")
+            val metrics = retry.metrics
+            val helloWorldService = HelloWorldService()
+            val resultList = mutableListOf<String>()
+
+            //When
+            flow {
+                repeat(3){
+                    emit(helloWorldService.returnHelloWorld()+it)
+                }
+            }
+                .retry(retry)
+                .toList(resultList)
+
+
+            //Then
+            repeat(3){
+                Assertions.assertThat(resultList[it]).isEqualTo("Hello world$it")
+            }
+            Assertions.assertThat(resultList.size).isEqualTo(3)
+            Assertions.assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isEqualTo(1)
+            Assertions.assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isEqualTo(0)
+            Assertions.assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isEqualTo(0)
+            Assertions.assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isEqualTo(0)
+            // Then the helloWorldService should be invoked 1 time
+            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(3)
+        }
+    }
+
+    @Test
+    fun `should execute function with retries`() {
+        runBlocking {
+            val retry = Retry.of("testName") {
+                RetryConfig.custom<Any?>().waitDuration(Duration.ofMillis(10)).build()
+            }
+            val metrics = retry.metrics
+            val helloWorldService = HelloWorldService()
+            val resultList = mutableListOf<String>()
+
+            //When
+            flow {
+                repeat(3){
+                    when (helloWorldService.invocationCounter) {
+                        0 -> helloWorldService.throwException()
+                        else -> emit(helloWorldService.returnHelloWorld()+it)
+                    }
+                }
+            }
+                .retry(retry)
+                .toList(resultList)
+
+
+            //Then
+            repeat(3){
+                Assertions.assertThat(resultList[it]).isEqualTo("Hello world$it")
+            }
+            Assertions.assertThat(resultList.size).isEqualTo(3)
+            Assertions.assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isEqualTo(0)
+            Assertions.assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isEqualTo(1)
+            Assertions.assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isEqualTo(0)
+            Assertions.assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isEqualTo(0)
+            // Then the helloWorldService should be invoked twice
+            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(4)
+        }
+    }
+
+    @Test
+    fun `should execute function with retry of result`() {
+        runBlocking {
+            val helloWorldService = HelloWorldService()
+            val resultList = mutableListOf<String>()
+            val retry = Retry.of("testName") {
+                RetryConfig.custom<Any?>()
+                    .waitDuration(Duration.ofMillis(10))
+                    .retryOnResult { helloWorldService.invocationCounter < 2 }
+                    .build()
+            }
+            val metrics = retry.metrics
+
+            //When
+            flow { emit(helloWorldService.returnHelloWorld()) }
+                .retry(retry)
+                .toList(resultList)
+
+            //Then
+            Assertions.assertThat(resultList.size).isEqualTo(1)
+            Assertions.assertThat(resultList[0]).isEqualTo("Hello world")
+            Assertions.assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isEqualTo(0)
+            Assertions.assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isEqualTo(1)
+            Assertions.assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isEqualTo(0)
+            Assertions.assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isEqualTo(0)
+            // Then the helloWorldService should be invoked twice
+            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(2)
+        }
+    }
+
+    @Test
+    fun `should execute function with repeated failures`() {
+        runBlocking {
+            val retry = Retry.of("testName") {
+                RetryConfig.custom<Any?>().waitDuration(Duration.ofMillis(10)).build()
+            }
+            val metrics = retry.metrics
+            val helloWorldService = HelloWorldService()
+            val resultList = mutableListOf<String>()
+
+            //When
+            try {
+                retry.executeSuspendFunction {
+                    helloWorldService.throwException()
+                }
+                //When
+                flow<String> { helloWorldService.throwException() }
+                    .retry(retry)
+                    .toList(resultList)
+                Assertions.failBecauseExceptionWasNotThrown<Nothing>(IllegalStateException::class.java)
+            } catch (e: IllegalStateException) {
+                // nothing - proceed
+            }
+
+            //Then
+            Assertions.assertThat(resultList).isEmpty()
+            Assertions.assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isEqualTo(0)
+            Assertions.assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isEqualTo(0)
+            Assertions.assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isEqualTo(0)
+            Assertions.assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isEqualTo(1)
+            // Then the helloWorldService should be invoked the maximum number of times
+            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(retry.retryConfig.maxAttempts)
+        }
+    }
+}

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/timelimiter/FlowTimeLimiterTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/timelimiter/FlowTimeLimiterTest.kt
@@ -1,0 +1,110 @@
+/*
+ *
+ *  Copyright 2019: authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.kotlin.timelimiter
+
+import io.github.resilience4j.kotlin.HelloWorldService
+import io.github.resilience4j.timelimiter.TimeLimiter
+import io.github.resilience4j.timelimiter.TimeLimiterConfig
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions
+import org.junit.Test
+import java.lang.IllegalStateException
+import java.time.Duration
+
+class FlowTimeLimiterTest {
+
+    @Test
+    fun `should execute successful function`() {
+        runBlocking {
+            val timelimiter = TimeLimiter.ofDefaults()
+            val helloWorldService = HelloWorldService()
+            val resultList = mutableListOf<String>()
+
+            //When
+            flow {
+                repeat(3) {
+                    emit(helloWorldService.returnHelloWorld()+it)
+                }
+            }
+                .timeLimiter(timelimiter)
+                .toList(resultList)
+
+            //Then
+            repeat(3){
+                Assertions.assertThat(resultList[it]).isEqualTo("Hello world$it")
+            }
+            Assertions.assertThat(resultList.size).isEqualTo(3)
+            // Then the helloWorldService should be invoked 1 time
+            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(3)
+        }
+    }
+
+    @Test
+    fun `should execute unsuccessful function`() {
+        runBlocking {
+            val timelimiter = TimeLimiter.ofDefaults()
+            val helloWorldService = HelloWorldService()
+            val resultList = mutableListOf<String>()
+
+            //When
+            try {
+                flow<String> { helloWorldService.throwException() }
+                    .timeLimiter(timelimiter)
+                    .toList(resultList)
+
+                Assertions.failBecauseExceptionWasNotThrown<Nothing>(IllegalStateException::class.java)
+            } catch (e: IllegalStateException) {
+                // nothing - proceed
+            }
+
+            //Then
+            Assertions.assertThat(resultList.size).isEqualTo(0)
+            // Then the helloWorldService should be invoked 1 time
+            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun `should cancel operation that times out`() {
+        runBlocking {
+            val timelimiter = TimeLimiter.of(TimeLimiterConfig.custom().timeoutDuration(Duration.ofMillis(10)).build())
+
+            val helloWorldService = HelloWorldService()
+            val resultList = mutableListOf<String>()
+
+            //When
+            try {
+                flow<String> { helloWorldService.wait() }
+                    .timeLimiter(timelimiter)
+                    .toList(resultList)
+                Assertions.failBecauseExceptionWasNotThrown<Nothing>(CancellationException::class.java)
+            } catch (e: CancellationException) {
+                // nothing - proceed
+            }
+
+            //Then
+            Assertions.assertThat(resultList.size).isEqualTo(0)
+            // Then the helloWorldService should be invoked 1 time
+            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(1)
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces support for a circuit breaker operator for cold streams in kotlin coroutines. 

Based on feedback from this PR I can continue implement equivalent operators for the remaining resilience primitives (retry, bulkhead,...) if desired.

Now that the core Flow API has reached a stable [release](https://github.com/Kotlin/kotlinx.coroutines/releases/tag/1.3.0), it should be safe to implement these operators without worrying about breaking compatibility in future releases.