### PR TITLE
fix fallback method support when using FeignClient (#653)

### DIFF
--- a/resilience4j-spring/src/main/java/io/github/resilience4j/fallback/FallbackMethod.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/fallback/FallbackMethod.java
@@ -176,10 +176,13 @@ public class FallbackMethod {
 
         ReflectionUtils.doWithMethods(targetClass, method -> {
             Class<?>[] recoveryParams = method.getParameterTypes();
-            if (methods.get(recoveryParams[recoveryParams.length - 1]) != null) {
-                throw new IllegalStateException("You have more that one fallback method that cover the same exception type " + recoveryParams[recoveryParams.length - 1].getName());
+            Class<?> exception = recoveryParams[recoveryParams.length - 1];
+            Method similar = methods.get(exception);
+            if (similar == null || Arrays.equals(similar.getParameterTypes(), method.getParameterTypes())) {
+                methods.put(exception, method);
+            } else {
+                throw new IllegalStateException("You have more that one fallback method that cover the same exception type " + exception.getName());
             }
-            methods.put(recoveryParams[recoveryParams.length - 1], method);
         }, method -> {
             if (method.getParameterCount() == 1) {
                 if (!method.getName().equals(fallbackMethodName) || !originalReturnType.isAssignableFrom(method.getReturnType())) {

--- a/resilience4j-spring/src/test/java/io/github/resilience4j/fallback/FallbackMethodParentTest.java
+++ b/resilience4j-spring/src/test/java/io/github/resilience4j/fallback/FallbackMethodParentTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2019 authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.fallback;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Java6Assertions.assertThatThrownBy;
+
+/**
+ * https://github.com/resilience4j/resilience4j/issues/653
+ */
+@SuppressWarnings("unused")
+public class FallbackMethodParentTest {
+
+    interface ProxyInterface {
+
+        default String fallbackInterface(String parameter, IllegalArgumentException exception) {
+            return "interface-recovered";
+        }
+
+        default String fallbackOnlyInterface(String parameter, IllegalArgumentException exception) {
+            return "only-interface-recovered";
+        }
+
+    }
+
+    class Proxy extends FallbackMethodParentTest implements ProxyInterface {
+
+        @Override
+        public String fallbackParent(String parameter, IllegalStateException exception) {
+            return "proxy-recovered";
+        }
+
+        @Override
+        public String fallbackInterface(String parameter, IllegalArgumentException exception) {
+            return "proxy-recovered";
+        }
+
+        public String ambiguousFallback(IOException exception) {
+            return "only-exception";
+        }
+    }
+
+    public String testMethod(String parameter) {
+        return "test";
+    }
+
+    public String fallbackParent(String parameter, IllegalStateException exception) {
+        return "recovered";
+    }
+
+    public String ambiguousFallback(String parameter, IOException exception) {
+        return "not-only-exception";
+    }
+
+    @Test
+    public void recoverIgnoringParentMethod() throws Throwable {
+        Proxy target = new Proxy();
+        Method testMethod = target.getClass().getMethod("testMethod", String.class);
+
+        FallbackMethod recoveryMethod = FallbackMethod.create("fallbackParent", testMethod, new Object[]{"test"}, target);
+
+        assertThat(recoveryMethod.fallback(new IllegalStateException("err"))).isEqualTo("proxy-recovered");
+    }
+
+    @Test
+    public void recoverIgnoringInterfaceMethod() throws Throwable {
+        Proxy target = new Proxy();
+        Method testMethod = target.getClass().getMethod("testMethod", String.class);
+
+        FallbackMethod recoveryMethod = FallbackMethod.create("fallbackInterface", testMethod, new Object[]{"test"}, target);
+
+        assertThat(recoveryMethod.fallback(new IllegalArgumentException("err"))).isEqualTo("proxy-recovered");
+    }
+
+    @Test
+    public void recoverNotIgnoringInterfaceMethod() throws Throwable {
+        Proxy target = new Proxy();
+        Method testMethod = target.getClass().getMethod("testMethod", String.class);
+
+        FallbackMethod recoveryMethod = FallbackMethod.create("fallbackOnlyInterface", testMethod, new Object[]{"test"}, target);
+
+        assertThat(recoveryMethod.fallback(new IllegalArgumentException("err"))).isEqualTo("only-interface-recovered");
+    }
+
+    @Test
+    public void dontRecoverAmbiguousMethod() throws Throwable {
+        Proxy target = new Proxy();
+        Method testMethod = target.getClass().getMethod("testMethod", String.class);
+
+        assertThatThrownBy(() -> FallbackMethod.create("ambiguousFallback", testMethod, new Object[]{"test"}, target))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("You have more that one fallback method that cover the same exception type " + IOException.class.getName());
+    }
+}

--- a/resilience4j-spring/src/test/java/io/github/resilience4j/fallback/FallbackMethodTest.java
+++ b/resilience4j-spring/src/test/java/io/github/resilience4j/fallback/FallbackMethodTest.java
@@ -22,7 +22,7 @@ import java.lang.reflect.Method;
 
 import org.junit.Test;
 
-@SuppressWarnings({"WeakerAccess", "unused"})
+@SuppressWarnings("unused")
 public class FallbackMethodTest {
     @Test
     public void recoverRuntimeExceptionTest() throws Throwable {
@@ -94,7 +94,7 @@ public class FallbackMethodTest {
     }
 
     public String testMethod(String parameter) {
-        return null;
+        return "test";
     }
 
     public String fallbackMethod(String parameter, RuntimeException exception) {


### PR DESCRIPTION
Here we have Feign interface and Spring Proxy hierarchy. For `ReflectionUtils` the same method occurs twice what was the problem.
```
	public static void doWithMethods(Class<?> clazz, MethodCallback mc, @Nullable MethodFilter mf) {
		// Keep backing up the inheritance hierarchy.		
		// (...)
		if (clazz.getSuperclass() != null) {
			doWithMethods(clazz.getSuperclass(), mc, mf);
		}
		else if (clazz.isInterface()) {
			for (Class<?> superIfc : clazz.getInterfaces()) {
				doWithMethods(superIfc, mc, mf);
			}
		}
```
@Romeh 