### PR TITLE
Refactoring of fallback method support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -141,6 +141,7 @@ https://resilience4j.readme.io/docs/bulkhead[documentation]
 |"Degrade gracefully",
 "A bird in the hand is worth two in the bush"
 |<<circuitbreaker-retry-fallback,Try::recover>>,
+https://resilience4j.readme.io/docs/getting-started-3#section-annotations[Spring],
 link:resilience4j-feign/README.adoc[Feign]
 
 |===


### PR DESCRIPTION
For future, simpler maintenance:
* a few private methods extracted
* `RECOVERY_METHODS_CACHE` moved  up and `computeIfAbsent` applied
* `MethodMeta` used also as an argument/DTO
* nested IF statements in `filter` flatted
* complex FOR (140 chars width!) refactored to WHILE

Now, core `extractMethods` logic is more transparent:
```
        ReflectionUtils.doWithMethods(methodMeta.targetClass,
                method -> merge(method, methods),
                method -> filter(method, methodMeta)
        );
```
@Romeh 