### PR TITLE
Let a fallback from a fallback factory throw an exception (Feign)

### DIFF
--- a/resilience4j-feign/src/main/java/io/github/resilience4j/feign/FallbackFactory.java
+++ b/resilience4j-feign/src/main/java/io/github/resilience4j/feign/FallbackFactory.java
@@ -16,6 +16,7 @@
  */
 package io.github.resilience4j.feign;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -48,7 +49,12 @@ class FallbackFactory<T> implements FallbackHandler<T> {
                     T fallbackInstance = fallbackSupplier.apply(exception);
                     validateFallback(fallbackInstance, method);
                     Method fallbackMethod = getFallbackMethod(fallbackInstance, method);
-                    return fallbackMethod.invoke(fallbackInstance, args);
+                    try {
+                        return fallbackMethod.invoke(fallbackInstance, args);
+                    } catch (InvocationTargetException e) {
+                        // Rethrow the exception thrown in the fallback wrapped by InvocationTargetException
+                        throw e.getCause();
+                    }
                 }
                 throw exception;
             }

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/test/TestServiceFallbackThrowingException.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/test/TestServiceFallbackThrowingException.java
@@ -1,0 +1,12 @@
+package io.github.resilience4j.feign.test;
+
+/**
+ * A fallback throwing an exception.
+ */
+public class TestServiceFallbackThrowingException implements TestService {
+
+    @Override
+    public String greeting() {
+        throw new RuntimeException("Exception in greeting fallback");
+    }
+}


### PR DESCRIPTION
A fallback factory consumes the exception thrown on error. This exception might be re-thrown after some processing in the fallback, or transformed if necessary. This PR lets this exception be re-thrown if thrown during the reflective method invocation.