### PR TITLE
Release permission on cancellation of retrofit calls

### DIFF
--- a/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/RetrofitCircuitBreaker.java
+++ b/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/RetrofitCircuitBreaker.java
@@ -89,7 +89,11 @@ public interface RetrofitCircuitBreaker {
 
                 @Override
                 public void onFailure(final Call<T> call, final Throwable t) {
-                    circuitBreaker.onError(System.nanoTime() - start, TimeUnit.NANOSECONDS, t);
+                    if(call.isCanceled()){
+                        circuitBreaker.releasePermission();
+                    }else{
+                        circuitBreaker.onError(System.nanoTime() - start, TimeUnit.NANOSECONDS, t);
+                    }
                     callback.onFailure(call, t);
                 }
             });
@@ -111,7 +115,11 @@ public interface RetrofitCircuitBreaker {
 
                 return response;
             } catch (Exception exception) {
-                circuitBreaker.onError(stopWatch.stop().toNanos(), TimeUnit.NANOSECONDS, exception);
+                if(call.isCanceled()){
+                    circuitBreaker.releasePermission();
+                } else {
+                    circuitBreaker.onError(stopWatch.stop().toNanos(), TimeUnit.NANOSECONDS, exception);
+                }
                 throw exception;
             }
         }

--- a/resilience4j-retrofit/src/test/java/io/github/resilience4j/retrofit/EnqueueDecorator.java
+++ b/resilience4j-retrofit/src/test/java/io/github/resilience4j/retrofit/EnqueueDecorator.java
@@ -33,4 +33,11 @@ public class EnqueueDecorator {
         }
         return responseReference.get();
     }
+
+    public static void performCatchingEnqueue(Call<?> call){
+        try{
+            enqueue(call);
+        } catch (Throwable ignored) {
+        }
+    }
 }


### PR DESCRIPTION
This PR checks updates the implementation of `CircuitBreakerCall` to check for cancellation before reporting an error the provided circuit breaker.

If the call has failed due to explicit cancellation (usually someone invoking `call.cancel()`) then the acquired permission will be released.

Initial testing shows that `call.isCancelled()` will not return true when cancellation occurs via pre configured timeout, so this change should be backwards compatible.