### PR TITLE
Determine whether Circuit Breaker permits calls

### DIFF
--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/utils/CircuitBreakerUtil.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/utils/CircuitBreakerUtil.java
@@ -1,0 +1,20 @@
+package io.github.resilience4j.circuitbreaker.utils;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker.State;
+
+import static io.github.resilience4j.circuitbreaker.CircuitBreaker.State.*;
+
+public final class CircuitBreakerUtil {
+
+    /**
+     * Indicates whether Circuit Breaker allows any calls or not.
+     *
+     * @param circuitBreaker to test
+     * @return call is permitted
+     */
+    public static boolean isCallPermitted(CircuitBreaker circuitBreaker) {
+        State state = circuitBreaker.getState();
+        return state == CLOSED || state == HALF_OPEN || state == DISABLED;
+    }
+}

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/utils/CircuitBreakerUtilIIsCallPermittedTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/utils/CircuitBreakerUtilIIsCallPermittedTest.java
@@ -1,0 +1,56 @@
+package io.github.resilience4j.circuitbreaker.utils;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker.State;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Collection;
+
+import static io.github.resilience4j.circuitbreaker.utils.CircuitBreakerUtil.isCallPermitted;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(Parameterized.class)
+public class CircuitBreakerUtilIIsCallPermittedTest {
+
+    private static final boolean CALL_NOT_PERMITTED = false;
+    private static final boolean CALL_PERMITTED = true;
+
+    @Parameter
+    public State state;
+
+    @Parameter(1)
+    public boolean expectedPermission;
+
+    @Test
+    public void shouldIndicateCallPermittedForGivenStatus() {
+        CircuitBreaker circuitBreaker = givenCircuitBreakerAtState(state);
+
+        boolean isPermitted = isCallPermitted(circuitBreaker);
+
+        assertThat(isPermitted).isEqualTo(expectedPermission);
+    }
+
+    @Parameters(name = "isCallPermitted should be {1} for circuit breaker state {0}")
+    public static Collection<Object[]> cases() {
+        return asList(new Object[][] {
+                { State.DISABLED, CALL_PERMITTED },
+                { State.CLOSED, CALL_PERMITTED },
+                { State.OPEN, CALL_NOT_PERMITTED },
+                { State.FORCED_OPEN, CALL_NOT_PERMITTED },
+                { State.HALF_OPEN, CALL_PERMITTED },
+        });
+    }
+
+    private static CircuitBreaker givenCircuitBreakerAtState(State state) {
+        CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
+        when(circuitBreaker.getState()).thenReturn(state);
+        return circuitBreaker;
+    }
+}

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/utils/CircuitBreakerUtilIsCallPermittedTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/utils/CircuitBreakerUtilIsCallPermittedTest.java
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(Parameterized.class)
-public class CircuitBreakerUtilIIsCallPermittedTest {
+public class CircuitBreakerUtilIsCallPermittedTest {
 
     private static final boolean CALL_NOT_PERMITTED = false;
     private static final boolean CALL_PERMITTED = true;

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/utils/CircuitBreakerUtilTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/utils/CircuitBreakerUtilTest.java
@@ -1,0 +1,19 @@
+package io.github.resilience4j.circuitbreaker.utils;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker.State;
+import org.junit.Test;
+
+import static io.github.resilience4j.circuitbreaker.CircuitBreaker.State.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CircuitBreakerUtilTest {
+
+    @Test
+    public void shouldConsiderAllKnownStatusesUsingIsCallPermitted() {
+        assertThat(State.values())
+                .describedAs("List of statuses changed." +
+                        "Please consider updating CircuitBreakerUtil#isCallPermitted to handle" +
+                        "new status properly.")
+                .containsOnly(DISABLED, CLOSED, OPEN, FORCED_OPEN, HALF_OPEN);
+    }
+}


### PR DESCRIPTION
Currently the only way to determine whether Circuit Breaker permits calls is to invoke `acquirePermission` or `tryAcquirePermission`.

However, `tryAcquirePermission` have some side effects. Especially in HALF-OPEN state where counters are decremented - they might be decremented twice when check is performed and then call invoked.

This PR introduces `CircuitBreakerUtil.isCallPermitted()` method to determine status of Circuit Breaker without side effects.

Use case: Client side round-robin over instances behind Circuit Breaker not picking up not operative services to not loose retires.