### PR TITLE
chores: replaced Java6Assertions to Assertions

### DIFF
--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/BulkheadConfigTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/BulkheadConfigTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 
 import java.time.Duration;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class BulkheadConfigTest {
 

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfigTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfigTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 
 import java.time.Duration;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ThreadPoolBulkheadConfigTest {
 

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfigTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfigTest.java
@@ -26,7 +26,7 @@ import java.util.function.Predicate;
 
 import static io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.*;
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class CircuitBreakerConfigTest {
 

--- a/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/InMemoryRateLimiterRegistryTest.java
+++ b/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/InMemoryRateLimiterRegistryTest.java
@@ -30,7 +30,7 @@ import java.time.Duration;
 import java.util.function.Supplier;
 
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 public class InMemoryRateLimiterRegistryTest {

--- a/resilience4j-spring/src/test/java/io/github/resilience4j/fallback/FallbackMethodParentTest.java
+++ b/resilience4j-spring/src/test/java/io/github/resilience4j/fallback/FallbackMethodParentTest.java
@@ -21,7 +21,7 @@ import java.lang.reflect.Method;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Java6Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * https://github.com/resilience4j/resilience4j/issues/653

--- a/resilience4j-spring/src/test/java/io/github/resilience4j/fallback/FallbackMethodTest.java
+++ b/resilience4j-spring/src/test/java/io/github/resilience4j/fallback/FallbackMethodTest.java
@@ -16,7 +16,7 @@
 package io.github.resilience4j.fallback;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Java6Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.lang.reflect.Method;
 


### PR DESCRIPTION
replaced `org.assertj.core.api.Java6Assertions` to `org.assertj.core.api.Assertions` because `Java6Assertions` is deprecated in 3.13.0

https://github.com/joel-costigliola/assertj-core/commit/27d43740ab2b8c718b0bf6606f0483b06c58e8b6
