### PR TITLE
Issue #773: Add `configurationName` to `@RateLimiter`

### DIFF
--- a/resilience4j-annotations/src/main/java/io/github/resilience4j/ratelimiter/annotation/RateLimiter.java
+++ b/resilience4j-annotations/src/main/java/io/github/resilience4j/ratelimiter/annotation/RateLimiter.java
@@ -36,6 +36,13 @@ public @interface RateLimiter {
     String name();
 
     /**
+     * Name of the configuration
+     *
+     * @return the name of the configuration
+     */
+    String configurationName() default "";
+
+    /**
      * fallbackMethod method name.
      *
      * @return fallbackMethod method name.

--- a/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/internal/InMemoryRateLimiterRegistry.java
+++ b/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/internal/InMemoryRateLimiterRegistry.java
@@ -199,7 +199,13 @@ public class InMemoryRateLimiterRegistry extends
     @Override
     public RateLimiter rateLimiter(String name, String configName,
         io.vavr.collection.Map<String, String> tags) {
-        return computeIfAbsent(name, () -> RateLimiter.of(name, getConfiguration(configName)
-            .orElseThrow(() -> new ConfigurationNotFoundException(configName)), getAllTags(tags)));
+        RateLimiterConfig rateLimiterConfig = getConfiguration(configName)
+            .orElseThrow(() -> new ConfigurationNotFoundException(configName));
+        RateLimiter rateLimiter = computeIfAbsent(name, () -> RateLimiter.of(name, rateLimiterConfig, getAllTags(tags)));
+        if(rateLimiter.getRateLimiterConfig() != rateLimiterConfig) {
+           throw new IllegalStateException("Rate limiter '" + name + "' was already initialized with configurationName" +
+               " different that '" + configName +"'");
+        }
+        return rateLimiter;
     }
 }

--- a/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/ratelimiter/RateLimiterMethodInterceptor.java
+++ b/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/ratelimiter/RateLimiterMethodInterceptor.java
@@ -17,6 +17,7 @@
 package io.github.resilience4j.ratpack.ratelimiter;
 
 import com.google.inject.Inject;
+import io.github.resilience4j.core.StringUtils;
 import io.github.resilience4j.core.lang.Nullable;
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
 import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
@@ -85,8 +86,13 @@ public class RateLimiterMethodInterceptor extends AbstractMethodInterceptor {
         if (registry == null) {
             registry = RateLimiterRegistry.ofDefaults();
         }
-        io.github.resilience4j.ratelimiter.RateLimiter rateLimiter = registry
-            .rateLimiter(annotation.name());
+        String configurationName = annotation.configurationName();
+        io.github.resilience4j.ratelimiter.RateLimiter rateLimiter;
+        if(StringUtils.isNotEmpty(configurationName)) {
+            rateLimiter = registry.rateLimiter(annotation.name(), configurationName);
+        } else {
+            rateLimiter = registry.rateLimiter(annotation.name());
+        }
         Class<?> returnType = invocation.getMethod().getReturnType();
         if (Promise.class.isAssignableFrom(returnType)) {
             Promise<?> result = (Promise<?>) proceed(invocation);

--- a/resilience4j-spring-boot/src/test/java/io/github/resilience4j/service/test/DummyService.java
+++ b/resilience4j-spring-boot/src/test/java/io/github/resilience4j/service/test/DummyService.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 public interface DummyService {
 
     String BACKEND = "backendA";
+    String BACKEND_C = "backendC";
 
     void doSomething(boolean throwException) throws IOException;
 }

--- a/resilience4j-spring-boot/src/test/java/io/github/resilience4j/service/test/RateLimiterWithConfigDummyServiceImpl.java
+++ b/resilience4j-spring-boot/src/test/java/io/github/resilience4j/service/test/RateLimiterWithConfigDummyServiceImpl.java
@@ -1,0 +1,19 @@
+package io.github.resilience4j.service.test;
+
+
+import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@RateLimiter(name = DummyService.BACKEND_C, configurationName = "testConfig")
+@Component(value = "rateLimiterWithConfigDummyService")
+public class RateLimiterWithConfigDummyServiceImpl implements DummyService {
+
+    @Override
+    public void doSomething(boolean throwBackendTrouble) throws IOException {
+        if (throwBackendTrouble) {
+            throw new IOException("Test Message");
+        }
+    }
+}

--- a/resilience4j-spring-boot/src/test/resources/application.yaml
+++ b/resilience4j-spring-boot/src/test/resources/application.yaml
@@ -17,6 +17,7 @@ resilience4j.retry:
       - java.io.IOException
       ignoreExceptions:
       - io.github.resilience4j.circuitbreaker.IgnoredException
+
 resilience4j.circuitbreaker:
   circuitBreakerAspectOrder: 400
   configs:
@@ -66,6 +67,11 @@ resilience4j.circuitbreaker:
       baseConfig: default
 
 resilience4j.ratelimiter:
+  configs:
+    testConfig:
+      limitForPeriod: 2
+      limitRefreshPeriod: 2000ms
+      timeoutDuration: 2s
   rateLimiterAspectOrder: 401
   limiters:
     backendA:

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/ratelimiter/configure/RateLimiterAspect.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/ratelimiter/configure/RateLimiterAspect.java
@@ -106,8 +106,9 @@ public class RateLimiterAspect implements Ordered {
             return proceedingJoinPoint.proceed();
         }
         String name = rateLimiterAnnotation.name();
+        String configurationName = rateLimiterAnnotation.configurationName();
         io.github.resilience4j.ratelimiter.RateLimiter rateLimiter = getOrCreateRateLimiter(
-            methodName, name);
+            methodName, name, configurationName);
         Class<?> returnType = method.getReturnType();
 
         if (StringUtils.isEmpty(rateLimiterAnnotation.fallbackMethod())) {
@@ -138,9 +139,13 @@ public class RateLimiterAspect implements Ordered {
     }
 
     private io.github.resilience4j.ratelimiter.RateLimiter getOrCreateRateLimiter(String methodName,
-        String name) {
-        io.github.resilience4j.ratelimiter.RateLimiter rateLimiter = rateLimiterRegistry
-            .rateLimiter(name);
+        String name, String configurationName) {
+        io.github.resilience4j.ratelimiter.RateLimiter rateLimiter;
+        if (StringUtils.isEmpty(configurationName)) {
+            rateLimiter = rateLimiterRegistry.rateLimiter(name);
+        } else {
+            rateLimiter = rateLimiterRegistry.rateLimiter(name, configurationName);
+        }
 
         if (logger.isDebugEnabled()) {
             RateLimiterConfig rateLimiterConfig = rateLimiter.getRateLimiterConfig();


### PR DESCRIPTION
Just the implementation - without tests.

I tried to find proper place to test this but then I noticed something in  `RateLimiterRegistry` API (and `InMemoryRateLimiterRegistry` implementation):

https://github.com/resilience4j/resilience4j/blob/4cce868397ff6bc046a1bb70892d5b652671b6c7/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/internal/InMemoryRateLimiterRegistry.java#L200-L204 

1st call:  `rateLimiterRegistry.rateLimiter("name", "configName1")` will cache limiter instance created and configured with `configName1`.
2nd call: `rateLimiterRegistry.rateLimiter("name", "configName2")` will silently ignore `"configName2"` and just return limiter configured with `"configName1"`.

I am not sure how the cache is implemented but it may get really ugly in multi-threaded scenario where order of calls to registry is different on each application run.

With `configurationName` parameter added to `@RateLimiter` it will be easy to introduce subtle bugs in client applications.

Maybe it would be good idea to check it like this (from top of my head):

```java
        RateLimiterConfig rateLimiterConfig = getConfiguration(configName)
            .orElseThrow(() -> new ConfigurationNotFoundException(configName));
        RateLimiter rateLimiter = computeIfAbsent(name, () -> RateLimiter.of(name, rateLimiterConfig, getAllTags(tags)));
        if(rateLimiter.getRateLimiterConfig() != rateLimiterConfig) {
            // throw or log warning?
        }
        return rateLimiter;
```
