### PR TITLE
Issue #806 Provide aggregated retry.calls

### DIFF
--- a/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/retry/monitoring/endpoint/RetryEventDTOBuilder.java
+++ b/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/retry/monitoring/endpoint/RetryEventDTOBuilder.java
@@ -15,6 +15,7 @@
  */
 package io.github.resilience4j.common.retry.monitoring.endpoint;
 
+import io.github.resilience4j.core.lang.Nullable;
 import io.github.resilience4j.retry.event.RetryEvent;
 
 /**
@@ -35,8 +36,10 @@ class RetryEventDTOBuilder {
         this.creationTime = creationTime;
     }
 
-    RetryEventDTOBuilder throwable(Throwable throwable) {
-        this.errorMessage = throwable.toString();
+    RetryEventDTOBuilder throwable(@Nullable Throwable throwable) {
+        if (throwable != null) {
+            this.errorMessage = throwable.toString();
+        }
         return this;
     }
 

--- a/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/retry/monitoring/endpoint/RetryEventDTOFactory.java
+++ b/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/retry/monitoring/endpoint/RetryEventDTOFactory.java
@@ -33,11 +33,17 @@ public class RetryEventDTOFactory {
                     .throwable(onErrorEvent.getLastThrowable())
                     .numberOfAttempts(onErrorEvent.getNumberOfRetryAttempts())
                     .build();
-            case SUCCESS:
+            case SUCCESS_WITH_RETRY:
                 RetryOnSuccessEvent onSuccessEvent = (RetryOnSuccessEvent) event;
                 return newRetryEventDTOBuilder(onSuccessEvent)
                     .numberOfAttempts(onSuccessEvent.getNumberOfRetryAttempts())
                     .throwable(onSuccessEvent.getLastThrowable())
+                    .build();
+            case SUCCESS_WITHOUT_RETRY:
+                SuccessWithoutErrorEvent successWithoutErrorEvent = (SuccessWithoutErrorEvent) event;
+                return newRetryEventDTOBuilder(successWithoutErrorEvent)
+                    .numberOfAttempts(successWithoutErrorEvent.getNumberOfRetryAttempts())
+                    .throwable(successWithoutErrorEvent.getLastThrowable())
                     .build();
             case RETRY:
                 RetryOnRetryEvent onStateTransitionEvent = (RetryOnRetryEvent) event;

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/retry/monitoring/endpoint/RetryEventDTOFactoryTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/retry/monitoring/endpoint/RetryEventDTOFactoryTest.java
@@ -20,7 +20,7 @@ public class RetryEventDTOFactoryTest {
 
         assertThat(retryEventDTO.getRetryName()).isEqualTo("name");
         assertThat(retryEventDTO.getNumberOfAttempts()).isEqualTo(1);
-        assertThat(retryEventDTO.getType()).isEqualTo(RetryEvent.Type.SUCCESS);
+        assertThat(retryEventDTO.getType()).isEqualTo(RetryEvent.Type.SUCCESS_WITH_RETRY);
         assertThat(retryEventDTO.getErrorMessage()).isEqualTo("java.io.IOException: Error Message");
         assertThat(retryEventDTO.getCreationTime()).isNotNull();
     }

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRetryMetricsPublisherTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRetryMetricsPublisherTest.java
@@ -19,6 +19,7 @@ package io.github.resilience4j.micrometer.tagged;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.retry.RetryRegistry;
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -31,6 +32,7 @@ import java.util.stream.Collectors;
 
 import static io.github.resilience4j.micrometer.tagged.AbstractRetryMetrics.MetricNames.DEFAULT_RETRY_CALLS;
 import static io.github.resilience4j.micrometer.tagged.AbstractRetryMetrics.MetricNames.DEFAULT_RETRY_CALLS_AGGREGATED;
+import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findCounterByKindAndNameTags;
 import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findGaugeByKindAndNameTags;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -121,17 +123,13 @@ public class TaggedRetryMetricsPublisherTest {
 
     @Test
     public void successfulWithoutRetryCallsGaugeReportsAggregatedValue() {
-        // when
-        Collection<Gauge> gauges = meterRegistry.get(DEFAULT_RETRY_CALLS_AGGREGATED).gauges();
+        Collection<Counter> counters = meterRegistry.get(DEFAULT_RETRY_CALLS_AGGREGATED).counters();
 
-        // then
-        Optional<Gauge> successfulWithoutRetry = findGaugeByKindAndNameTags(gauges,
+        Optional<Counter> successfulWithoutRetry = findCounterByKindAndNameTags(counters,
             "successful_without_retry", retry.getName());
         assertThat(successfulWithoutRetry).isPresent();
-        assertThat(successfulWithoutRetry.get().value())
+        assertThat(successfulWithoutRetry.get().count())
             .isEqualTo(retry.getMetrics().getNumberOfSuccessfulCallsWithoutRetryAttempt());
-        assertThat(successfulWithoutRetry.get().value())
-            .isEqualTo(0);
     }
 
     @Test

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRetryMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRetryMetricsTest.java
@@ -58,11 +58,11 @@ public class TaggedRetryMetricsTest {
         Retry newRetry = retryRegistry.retry("backendB");
 
         assertThat(taggedRetryMetrics.meterIdMap).containsKeys("backendA", "backendB");
-        assertThat(taggedRetryMetrics.meterIdMap.get("backendA")).hasSize(4);
-        assertThat(taggedRetryMetrics.meterIdMap.get("backendB")).hasSize(4);
+        assertThat(taggedRetryMetrics.meterIdMap.get("backendA")).hasSize(8);
+        assertThat(taggedRetryMetrics.meterIdMap.get("backendB")).hasSize(8);
 
         List<Meter> meters = meterRegistry.getMeters();
-        assertThat(meters).hasSize(8);
+        assertThat(meters).hasSize(16);
 
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_RETRY_CALLS).gauges();
 
@@ -77,10 +77,10 @@ public class TaggedRetryMetricsTest {
     public void shouldAddCustomTags() {
         retryRegistry.retry("backendF", io.vavr.collection.HashMap.of("key1", "value1"));
         assertThat(taggedRetryMetrics.meterIdMap).containsKeys("backendA", "backendF");
-        assertThat(taggedRetryMetrics.meterIdMap.get("backendA")).hasSize(4);
-        assertThat(taggedRetryMetrics.meterIdMap.get("backendF")).hasSize(4);
+        assertThat(taggedRetryMetrics.meterIdMap.get("backendA")).hasSize(8);
+        assertThat(taggedRetryMetrics.meterIdMap.get("backendF")).hasSize(8);
         List<Meter> meters = meterRegistry.getMeters();
-        assertThat(meters).hasSize(8);
+        assertThat(meters).hasSize(16);
         assertThat(meterRegistry.get(DEFAULT_RETRY_CALLS).tag("key1", "value1")).isNotNull();
 
     }
@@ -88,7 +88,7 @@ public class TaggedRetryMetricsTest {
     @Test
     public void shouldRemovedMetricsForRemovedRetry() {
         List<Meter> meters = meterRegistry.getMeters();
-        assertThat(meters).hasSize(4);
+        assertThat(meters).hasSize(8);
 
         assertThat(taggedRetryMetrics.meterIdMap).containsKeys("backendA");
         retryRegistry.remove("backendA");
@@ -172,6 +172,7 @@ public class TaggedRetryMetricsTest {
         TaggedRetryMetrics.ofRetryRegistry(
             TaggedRetryMetrics.MetricNames.custom()
                 .callsMetricName("custom_calls")
+                .callsAggregatedMetricName("custom_calls_aggregated")
                 .build(),
             retryRegistry
         ).bindTo(meterRegistry);
@@ -182,6 +183,8 @@ public class TaggedRetryMetricsTest {
             .map(Meter.Id::getName)
             .collect(Collectors.toSet());
 
-        assertThat(metricNames).hasSameElementsAs(Collections.singletonList("custom_calls"));
+        assertThat(metricNames).hasSameElementsAs(Arrays.asList(
+            "custom_calls", "custom_calls_aggregated"
+        ));
     }
 }

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/Retry.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/Retry.java
@@ -622,6 +622,8 @@ public interface Retry {
 
         EventPublisher onSuccess(EventConsumer<RetryOnSuccessEvent> eventConsumer);
 
+        EventPublisher onSuccessWithoutError(EventConsumer<SuccessWithoutErrorEvent> eventConsumer);
+
         EventPublisher onError(EventConsumer<RetryOnErrorEvent> eventConsumer);
 
         EventPublisher onIgnoredError(EventConsumer<RetryOnIgnoredErrorEvent> eventConsumer);

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/event/RetryEvent.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/event/RetryEvent.java
@@ -73,9 +73,13 @@ public interface RetryEvent {
          */
         ERROR,
         /**
-         * A RetryEvent which informs that a call has been successful
+         * A RetryEvent which informs that a call has been successful with RETRY
          */
-        SUCCESS,
+        SUCCESS_WITH_RETRY,
+        /**
+         * A RetryEvent which informs that a call has been successful without RETRY
+         */
+        SUCCESS_WITHOUT_RETRY,
         /**
          * A RetryEvent which informs that an error has been ignored
          */

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/event/RetryOnSuccessEvent.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/event/RetryOnSuccessEvent.java
@@ -32,7 +32,7 @@ public class RetryOnSuccessEvent extends AbstractRetryEvent {
 
     @Override
     public Type getEventType() {
-        return Type.SUCCESS;
+        return Type.SUCCESS_WITH_RETRY;
     }
 
     @Override

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/event/SuccessWithoutErrorEvent.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/event/SuccessWithoutErrorEvent.java
@@ -1,0 +1,21 @@
+package io.github.resilience4j.retry.event;
+
+public class SuccessWithoutErrorEvent extends AbstractRetryEvent  {
+
+    public SuccessWithoutErrorEvent(String name) {
+        super(name, 0, null);
+    }
+
+    @Override
+    public Type getEventType() {
+        return Type.SUCCESS_WITHOUT_RETRY;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+            "%s: Retry '%s' recorded a successful without retry attempt. Number of retry attempts: '0', Last exception was: 'null'.",
+            getCreationTime(),
+            getName());
+    }
+}

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/internal/RetryImpl.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/internal/RetryImpl.java
@@ -164,6 +164,7 @@ public class RetryImpl<T> implements Retry {
                             "max retries is reached out for the result predicate check")));
                 } else {
                     succeededWithoutRetryCounter.increment();
+                    publishRetryEvent(() -> new SuccessWithoutErrorEvent(getName()));
                 }
             }
         }
@@ -273,7 +274,8 @@ public class RetryImpl<T> implements Retry {
                             "max retries is reached out for the result predicate check")));
                 } else {
                     succeededWithoutRetryCounter.increment();
-
+                    publishRetryEvent(
+                        () -> new SuccessWithoutErrorEvent(name));
                 }
             }
         }
@@ -371,6 +373,14 @@ public class RetryImpl<T> implements Retry {
         @Override
         public EventPublisher onSuccess(EventConsumer<RetryOnSuccessEvent> onSuccessEventConsumer) {
             registerConsumer(RetryOnSuccessEvent.class.getSimpleName(), onSuccessEventConsumer);
+            return this;
+        }
+
+        @Override
+        public EventPublisher onSuccessWithoutError(
+            EventConsumer<SuccessWithoutErrorEvent> onSuccessWithoutErrorEventConsumer) {
+            registerConsumer(SuccessWithoutErrorEvent.class.getSimpleName(),
+                onSuccessWithoutErrorEventConsumer);
             return this;
         }
 

--- a/resilience4j-retry/src/test/java/io/github/resilience4j/retry/RetryEventPublisherTest.java
+++ b/resilience4j-retry/src/test/java/io/github/resilience4j/retry/RetryEventPublisherTest.java
@@ -65,7 +65,20 @@ public class RetryEventPublisherTest {
         retry.executeSupplier(helloWorldService::returnHelloWorld);
 
         then(helloWorldService).should(times(2)).returnHelloWorld();
-        then(logger).should(times(1)).info("SUCCESS");
+        then(logger).should(times(1)).info("SUCCESS_WITH_RETRY");
+    }
+
+    @Test
+    public void shouldConsumeOnSuccessWithoutErrorEvent() {
+        given(helloWorldService.returnHelloWorld())
+            .willReturn("Hello world");
+        retry.getEventPublisher().onSuccessWithoutError(
+            event -> logger.info(event.getEventType().toString()));
+
+        retry.executeSupplier(helloWorldService::returnHelloWorld);
+
+        then(helloWorldService).should(times(1)).returnHelloWorld();
+        then(logger).should(times(1)).info("SUCCESS_WITHOUT_RETRY");
     }
 
     @Test

--- a/resilience4j-retry/src/test/java/io/github/resilience4j/retry/event/RetryEventTest.java
+++ b/resilience4j-retry/src/test/java/io/github/resilience4j/retry/event/RetryEventTest.java
@@ -54,10 +54,21 @@ public class RetryEventTest {
             new IOException("Bla"));
         assertThat(retryOnSuccessEvent.getName()).isEqualTo("test");
         assertThat(retryOnSuccessEvent.getNumberOfRetryAttempts()).isEqualTo(2);
-        assertThat(retryOnSuccessEvent.getEventType()).isEqualTo(Type.SUCCESS);
+        assertThat(retryOnSuccessEvent.getEventType()).isEqualTo(Type.SUCCESS_WITH_RETRY);
         assertThat(retryOnSuccessEvent.getLastThrowable()).isInstanceOf(IOException.class);
         assertThat(retryOnSuccessEvent.toString()).contains(
             "Retry 'test' recorded a successful retry attempt. Number of retry attempts: '2', Last exception was: 'java.io.IOException: Bla'.");
+    }
+
+    @Test
+    public void testSuccessWithoutErrorEvent() {
+        SuccessWithoutErrorEvent successWithoutErrorEvent = new SuccessWithoutErrorEvent("test");
+        assertThat(successWithoutErrorEvent.getName()).isEqualTo("test");
+        assertThat(successWithoutErrorEvent.getNumberOfRetryAttempts()).isEqualTo(0);
+        assertThat(successWithoutErrorEvent.getEventType()).isEqualTo(Type.SUCCESS_WITHOUT_RETRY);
+        assertThat(successWithoutErrorEvent.getLastThrowable()).isEqualTo(null);
+        assertThat(successWithoutErrorEvent.toString()).contains(
+            "Retry 'test' recorded a successful without retry attempt. Number of retry attempts: '0', Last exception was: 'null'.");
     }
 
     @Test

--- a/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/EventPublisherTest.java
+++ b/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/EventPublisherTest.java
@@ -86,7 +86,7 @@ public class EventPublisherTest {
         assertThat(result.isSuccess()).isTrue();
         assertThat(sleptTime).isEqualTo(RetryConfig.DEFAULT_WAIT_DURATION);
         testSubscriber.assertValueCount(2)
-            .assertValues(RetryEvent.Type.RETRY, RetryEvent.Type.SUCCESS);
+            .assertValues(RetryEvent.Type.RETRY, RetryEvent.Type.SUCCESS_WITH_RETRY);
     }
 
     @Test

--- a/resilience4j-spring-boot/src/test/java/io/github/resilience4j/retry/AsyncRetryAutoConfigurationTest.java
+++ b/resilience4j-spring-boot/src/test/java/io/github/resilience4j/retry/AsyncRetryAutoConfigurationTest.java
@@ -101,7 +101,7 @@ public class AsyncRetryAutoConfigurationTest {
         // expect retry-event actuator endpoint recorded both events
         ResponseEntity<RetryEventsEndpointResponse> retryBackendEventList = restTemplate
             .getForEntity("/retries/events/" + RETRY_BACKEND_B, RetryEventsEndpointResponse.class);
-        assertThat(retryBackendEventList.getBody().getRetryEvents()).hasSize(3);
+        assertThat(retryBackendEventList.getBody().getRetryEvents()).hasSize(4);
 
         assertThat(retry.getRetryConfig().getExceptionPredicate().test(new IOException())).isTrue();
         assertThat(retry.getRetryConfig().getExceptionPredicate().test(new IgnoredException()))

--- a/resilience4j-spring-boot/src/test/java/io/github/resilience4j/retry/RetryAutoConfigurationTest.java
+++ b/resilience4j-spring-boot/src/test/java/io/github/resilience4j/retry/RetryAutoConfigurationTest.java
@@ -94,7 +94,7 @@ public class RetryAutoConfigurationTest {
         // expect retry-event actuator endpoint recorded both events
         ResponseEntity<RetryEventsEndpointResponse> retryEventListA = restTemplate
             .getForEntity("/retries/events/" + RETRY_BACKEND_A, RetryEventsEndpointResponse.class);
-        assertThat(retryEventListA.getBody().getRetryEvents()).hasSize(3);
+        assertThat(retryEventListA.getBody().getRetryEvents()).hasSize(4);
 
         assertThat(retry.getRetryConfig().getExceptionPredicate().test(new IOException())).isTrue();
         assertThat(retry.getRetryConfig().getExceptionPredicate().test(new IgnoredException()))

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/retry/RetryAutoConfigurationAsyncTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/retry/RetryAutoConfigurationAsyncTest.java
@@ -106,11 +106,11 @@ public class RetryAutoConfigurationAsyncTest {
         // expect retry-event actuator endpoint recorded both events
         RetryEventsEndpointResponse retryEventList = retryEvents("/actuator/retryevents");
         assertThat(retryEventList.getRetryEvents())
-            .hasSize(retryEventListBefore.getRetryEvents().size() + 3);
+            .hasSize(retryEventListBefore.getRetryEvents().size() + 4);
 
         retryEventList = retryEvents("/actuator/retryevents/" + RETRY_BACKEND_B);
         assertThat(retryEventList.getRetryEvents())
-            .hasSize(retryEventListForBBefore.getRetryEvents().size() + 3);
+            .hasSize(retryEventListForBBefore.getRetryEvents().size() + 4);
 
         assertThat(retry.getRetryConfig().getExceptionPredicate().test(new IOException())).isTrue();
         assertThat(retry.getRetryConfig().getExceptionPredicate().test(new IgnoredException()))

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/retry/RetryAutoConfigurationReactorTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/retry/RetryAutoConfigurationReactorTest.java
@@ -91,11 +91,11 @@ public class RetryAutoConfigurationReactorTest {
         // expect retry-event actuator endpoint recorded both events
         RetryEventsEndpointResponse retryEventList = retryEventListBody("/actuator/retryevents");
         assertThat(retryEventList.getRetryEvents())
-            .hasSize(retryEventListBefore.getRetryEvents().size() + 3);
+            .hasSize(retryEventListBefore.getRetryEvents().size() + 4);
 
         retryEventList = retryEventListBody("/actuator/retryevents/" + BACKEND_C);
         assertThat(retryEventList.getRetryEvents())
-            .hasSize(retryEventListForCBefore.getRetryEvents().size() + 3);
+            .hasSize(retryEventListForCBefore.getRetryEvents().size() + 4);
 
         assertThat(
             retry.getRetryConfig().getExceptionPredicate().test(new IllegalArgumentException()))

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/retry/RetryAutoConfigurationRxJavaTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/retry/RetryAutoConfigurationRxJavaTest.java
@@ -90,11 +90,11 @@ public class RetryAutoConfigurationRxJavaTest {
         // expect retry-event actuator endpoint recorded both events
         RetryEventsEndpointResponse retryEventList = getRetryEventsBody("/actuator/retryevents");
         assertThat(retryEventList.getRetryEvents())
-            .hasSize(retryEventListBefore.getRetryEvents().size() + 3);
+            .hasSize(retryEventListBefore.getRetryEvents().size() + 4);
 
         retryEventList = getRetryEventsBody("/actuator/retryevents/" + BACKEND_C);
         assertThat(retryEventList.getRetryEvents())
-            .hasSize(retryEventsListOfCBefore.getRetryEvents().size() + 3);
+            .hasSize(retryEventsListOfCBefore.getRetryEvents().size() + 4);
 
         assertThat(
             retry.getRetryConfig().getExceptionPredicate().test(new IllegalArgumentException()))

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/retry/RetryAutoConfigurationTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/retry/RetryAutoConfigurationTest.java
@@ -116,11 +116,11 @@ public class RetryAutoConfigurationTest {
         // expect retry-event actuator endpoint recorded both events
         RetryEventsEndpointResponse retryEventList = retryEvents("/actuator/retryevents");
         assertThat(retryEventList.getRetryEvents())
-            .hasSize(retryEventListBefore.getRetryEvents().size() + 3);
+            .hasSize(retryEventListBefore.getRetryEvents().size() + 4);
 
         retryEventList = retryEvents("/actuator/retryevents/" + RETRY_DUMMY_FEIGN_CLIENT_NAME);
         assertThat(retryEventList.getRetryEvents())
-            .hasSize(retryEventsEndpointFeignListBefore.getRetryEvents().size() + 3);
+            .hasSize(retryEventsEndpointFeignListBefore.getRetryEvents().size() + 4);
 
         assertThat(retry.getRetryConfig().getExceptionPredicate().test(new IOException())).isTrue();
         assertThat(retry.getRetryConfig().getExceptionPredicate().test(new IgnoredException()))
@@ -172,11 +172,11 @@ public class RetryAutoConfigurationTest {
         // expect retry-event actuator endpoint recorded both events
         RetryEventsEndpointResponse retryEventList = retryEvents("/actuator/retryevents");
         assertThat(retryEventList.getRetryEvents())
-            .hasSize(retryEventListBefore.getRetryEvents().size() + 3);
+            .hasSize(retryEventListBefore.getRetryEvents().size() + 4);
 
         retryEventList = retryEvents("/actuator/retryevents/" + RETRY_BACKEND_A);
         assertThat(retryEventList.getRetryEvents())
-            .hasSize(retryEventsAListBefore.getRetryEvents().size() + 3);
+            .hasSize(retryEventsAListBefore.getRetryEvents().size() + 4);
 
         assertThat(retry.getRetryConfig().getExceptionPredicate().test(new IOException())).isTrue();
         assertThat(retry.getRetryConfig().getExceptionPredicate().test(new IgnoredException()))


### PR DESCRIPTION
The new one metric `resilience4j.retry.calls.aggregated`
has been added. It returns "delta" between calls. I.e.
if there was one success_without_retry the first call
pull gauge with value 1, the next one pull 0.