### PR TITLE
Issue #806 Switch resilience4j.retry.calls to Counter

### DIFF
--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractRetryMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractRetryMetrics.java
@@ -17,7 +17,7 @@
 package io.github.resilience4j.micrometer.tagged;
 
 import io.github.resilience4j.retry.Retry;
-import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
@@ -44,28 +44,28 @@ abstract class AbstractRetryMetrics extends AbstractMetrics {
 
     private void registerMetrics(MeterRegistry meterRegistry, Retry retry, List<Tag> customTags) {
         Set<Meter.Id> idSet = new HashSet<>();
-        idSet.add(Gauge.builder(names.getCallsMetricName(), retry,
+        idSet.add(FunctionCounter.builder(names.getCallsMetricName(), retry,
             rt -> rt.getMetrics().getNumberOfSuccessfulCallsWithoutRetryAttempt())
             .description("The number of successful calls without a retry attempt")
             .tag(TagNames.NAME, retry.getName())
             .tag(TagNames.KIND, "successful_without_retry")
             .tags(customTags)
             .register(meterRegistry).getId());
-        idSet.add(Gauge.builder(names.getCallsMetricName(), retry,
+        idSet.add(FunctionCounter.builder(names.getCallsMetricName(), retry,
             rt -> rt.getMetrics().getNumberOfSuccessfulCallsWithRetryAttempt())
             .description("The number of successful calls after a retry attempt")
             .tag(TagNames.NAME, retry.getName())
             .tag(TagNames.KIND, "successful_with_retry")
             .tags(customTags)
             .register(meterRegistry).getId());
-        idSet.add(Gauge.builder(names.getCallsMetricName(), retry,
+        idSet.add(FunctionCounter.builder(names.getCallsMetricName(), retry,
             rt -> rt.getMetrics().getNumberOfFailedCallsWithoutRetryAttempt())
             .description("The number of failed calls without a retry attempt")
             .tag(TagNames.NAME, retry.getName())
             .tag(TagNames.KIND, "failed_without_retry")
             .tags(customTags)
             .register(meterRegistry).getId());
-        idSet.add(Gauge.builder(names.getCallsMetricName(), retry,
+        idSet.add(FunctionCounter.builder(names.getCallsMetricName(), retry,
             rt -> rt.getMetrics().getNumberOfFailedCallsWithRetryAttempt())
             .description("The number of failed calls after a retry attempt")
             .tag(TagNames.NAME, retry.getName())

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/MetricsTestHelper.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/MetricsTestHelper.java
@@ -15,47 +15,23 @@
  */
 package io.github.resilience4j.micrometer.tagged;
 
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.Gauge;
-import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.Meter;
 
 import java.util.Collection;
 import java.util.Optional;
 
 final class MetricsTestHelper {
 
-    static Optional<Gauge> findGaugeByKindAndNameTags(Collection<Gauge> gauges, String kind,
+    static <T extends Meter> Optional<T> findMeterByKindAndNameTags(Collection<T> meters, String kind,
         String name) {
-        return gauges.stream()
+        return meters.stream()
             .filter(g -> kind.equals(g.getId().getTag(TagNames.KIND)))
             .filter(g -> name.equals(g.getId().getTag(TagNames.NAME)))
             .findAny();
     }
 
-    static Optional<Timer> findTimerByKindAndNameTags(Collection<Timer> timers, String kind,
-        String name) {
-        return timers.stream()
-            .filter(g -> kind.equals(g.getId().getTag(TagNames.KIND)))
-            .filter(g -> name.equals(g.getId().getTag(TagNames.NAME)))
-            .findAny();
-    }
-
-    static Optional<Counter> findCounterByKindAndNameTags(Collection<Counter> counters, String kind,
-        String name) {
-        return counters.stream()
-            .filter(g -> kind.equals(g.getId().getTag(TagNames.KIND)))
-            .filter(g -> name.equals(g.getId().getTag(TagNames.NAME)))
-            .findAny();
-    }
-
-    static Optional<Counter> findCounterByNamesTag(Collection<Counter> gauges, String name) {
-        return gauges.stream()
-            .filter(g -> name.equals(g.getId().getTag(TagNames.NAME)))
-            .findAny();
-    }
-
-    static Optional<Gauge> findGaugeByNamesTag(Collection<Gauge> gauges, String name) {
-        return gauges.stream()
+    static <T extends Meter> Optional<T> findMeterByNamesTag(Collection<T> meters, String name) {
+        return meters.stream()
             .filter(g -> name.equals(g.getId().getTag(TagNames.NAME)))
             .findAny();
     }

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedBulkheadMetricsPublisherTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedBulkheadMetricsPublisherTest.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 
 import static io.github.resilience4j.micrometer.tagged.AbstractBulkheadMetrics.MetricNames.DEFAULT_BULKHEAD_AVAILABLE_CONCURRENT_CALLS_METRIC_NAME;
 import static io.github.resilience4j.micrometer.tagged.AbstractBulkheadMetrics.MetricNames.DEFAULT_BULKHEAD_MAX_ALLOWED_CONCURRENT_CALLS_METRIC_NAME;
-import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findGaugeByNamesTag;
+import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByNamesTag;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TaggedBulkheadMetricsPublisherTest {
@@ -69,7 +69,7 @@ public class TaggedBulkheadMetricsPublisherTest {
         Collection<Gauge> gauges = meterRegistry
             .get(DEFAULT_BULKHEAD_MAX_ALLOWED_CONCURRENT_CALLS_METRIC_NAME).gauges();
 
-        Optional<Gauge> successful = findGaugeByNamesTag(gauges, newBulkhead.getName());
+        Optional<Gauge> successful = findMeterByNamesTag(gauges, newBulkhead.getName());
         assertThat(successful).isPresent();
         assertThat(successful.get().value())
             .isEqualTo(newBulkhead.getMetrics().getMaxAllowedConcurrentCalls());
@@ -94,7 +94,7 @@ public class TaggedBulkheadMetricsPublisherTest {
         Collection<Gauge> gauges = meterRegistry
             .get(DEFAULT_BULKHEAD_MAX_ALLOWED_CONCURRENT_CALLS_METRIC_NAME).gauges();
 
-        Optional<Gauge> successful = findGaugeByNamesTag(gauges, bulkhead.getName());
+        Optional<Gauge> successful = findMeterByNamesTag(gauges, bulkhead.getName());
         assertThat(successful).isPresent();
         assertThat(successful.get().value())
             .isEqualTo(bulkhead.getMetrics().getMaxAllowedConcurrentCalls());
@@ -107,7 +107,7 @@ public class TaggedBulkheadMetricsPublisherTest {
         gauges = meterRegistry.get(DEFAULT_BULKHEAD_MAX_ALLOWED_CONCURRENT_CALLS_METRIC_NAME)
             .gauges();
 
-        successful = findGaugeByNamesTag(gauges, newBulkhead.getName());
+        successful = findMeterByNamesTag(gauges, newBulkhead.getName());
         assertThat(successful).isPresent();
         assertThat(successful.get().value())
             .isEqualTo(newBulkhead.getMetrics().getMaxAllowedConcurrentCalls());

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedBulkheadMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedBulkheadMetricsTest.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 
 import static io.github.resilience4j.micrometer.tagged.AbstractBulkheadMetrics.MetricNames.DEFAULT_BULKHEAD_AVAILABLE_CONCURRENT_CALLS_METRIC_NAME;
 import static io.github.resilience4j.micrometer.tagged.AbstractBulkheadMetrics.MetricNames.DEFAULT_BULKHEAD_MAX_ALLOWED_CONCURRENT_CALLS_METRIC_NAME;
-import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findGaugeByNamesTag;
+import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByNamesTag;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TaggedBulkheadMetricsTest {
@@ -69,7 +69,7 @@ public class TaggedBulkheadMetricsTest {
         Collection<Gauge> gauges = meterRegistry
             .get(DEFAULT_BULKHEAD_MAX_ALLOWED_CONCURRENT_CALLS_METRIC_NAME).gauges();
 
-        Optional<Gauge> successful = findGaugeByNamesTag(gauges, newBulkhead.getName());
+        Optional<Gauge> successful = findMeterByNamesTag(gauges, newBulkhead.getName());
         assertThat(successful).isPresent();
         assertThat(successful.get().value())
             .isEqualTo(newBulkhead.getMetrics().getMaxAllowedConcurrentCalls());
@@ -94,7 +94,7 @@ public class TaggedBulkheadMetricsTest {
         Collection<Gauge> gauges = meterRegistry
             .get(DEFAULT_BULKHEAD_MAX_ALLOWED_CONCURRENT_CALLS_METRIC_NAME).gauges();
 
-        Optional<Gauge> successful = findGaugeByNamesTag(gauges, bulkhead.getName());
+        Optional<Gauge> successful = findMeterByNamesTag(gauges, bulkhead.getName());
         assertThat(successful).isPresent();
         assertThat(successful.get().value())
             .isEqualTo(bulkhead.getMetrics().getMaxAllowedConcurrentCalls());
@@ -107,7 +107,7 @@ public class TaggedBulkheadMetricsTest {
         gauges = meterRegistry.get(DEFAULT_BULKHEAD_MAX_ALLOWED_CONCURRENT_CALLS_METRIC_NAME)
             .gauges();
 
-        successful = findGaugeByNamesTag(gauges, newBulkhead.getName());
+        successful = findMeterByNamesTag(gauges, newBulkhead.getName());
         assertThat(successful).isPresent();
         assertThat(successful.get().value())
             .isEqualTo(newBulkhead.getMetrics().getMaxAllowedConcurrentCalls());

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetricsPublisherTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetricsPublisherTest.java
@@ -33,8 +33,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static io.github.resilience4j.micrometer.tagged.AbstractCircuitBreakerMetrics.MetricNames.*;
-import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findCounterByKindAndNameTags;
-import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findGaugeByKindAndNameTags;
+import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByKindAndNameTags;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TaggedCircuitBreakerMetricsPublisherTest {
@@ -82,7 +81,8 @@ public class TaggedCircuitBreakerMetricsPublisherTest {
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS)
             .gauges();
 
-        Optional<Gauge> successful = findGaugeByKindAndNameTags(gauges, "successful",
+        Optional<Gauge> successful = MetricsTestHelper
+            .findMeterByKindAndNameTags(gauges, "successful",
             newCircuitBreaker.getName());
         assertThat(successful).isPresent();
         assertThat(successful.get().value())
@@ -110,7 +110,7 @@ public class TaggedCircuitBreakerMetricsPublisherTest {
 
         Collection<Counter> counters = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_CALLS).counters();
 
-        Optional<Counter> notPermitted = findCounterByKindAndNameTags(counters, "not_permitted",
+        Optional<Counter> notPermitted = findMeterByKindAndNameTags(counters, "not_permitted",
             circuitBreaker.getName());
         assertThat(notPermitted).isPresent();
         assertThat(notPermitted.get().count())
@@ -122,7 +122,7 @@ public class TaggedCircuitBreakerMetricsPublisherTest {
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS)
             .gauges();
 
-        Optional<Gauge> failed = findGaugeByKindAndNameTags(gauges, "failed",
+        Optional<Gauge> failed = MetricsTestHelper.findMeterByKindAndNameTags(gauges, "failed",
             circuitBreaker.getName());
         assertThat(failed).isPresent();
         assertThat(failed.get().value())
@@ -134,7 +134,8 @@ public class TaggedCircuitBreakerMetricsPublisherTest {
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS)
             .gauges();
 
-        Optional<Gauge> successful = findGaugeByKindAndNameTags(gauges, "successful",
+        Optional<Gauge> successful = MetricsTestHelper
+            .findMeterByKindAndNameTags(gauges, "successful",
             circuitBreaker.getName());
         assertThat(successful).isPresent();
         assertThat(successful.get().value())
@@ -145,7 +146,7 @@ public class TaggedCircuitBreakerMetricsPublisherTest {
     public void slowSuccessFulCallsGaugeReportsCorrespondingValue() {
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_SLOW_CALLS).gauges();
 
-        Optional<Gauge> slow = findGaugeByKindAndNameTags(gauges, "successful",
+        Optional<Gauge> slow = MetricsTestHelper.findMeterByKindAndNameTags(gauges, "successful",
             circuitBreaker.getName());
         assertThat(slow).isPresent();
         assertThat(slow.get().value())
@@ -156,7 +157,7 @@ public class TaggedCircuitBreakerMetricsPublisherTest {
     public void slowFailedCallsGaugeReportsCorrespondingValue() {
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_SLOW_CALLS).gauges();
 
-        Optional<Gauge> slow = findGaugeByKindAndNameTags(gauges, "failed",
+        Optional<Gauge> slow = MetricsTestHelper.findMeterByKindAndNameTags(gauges, "failed",
             circuitBreaker.getName());
         assertThat(slow).isPresent();
         assertThat(slow.get().value())

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetricsTest.java
@@ -33,8 +33,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static io.github.resilience4j.micrometer.tagged.AbstractCircuitBreakerMetrics.MetricNames.*;
-import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findCounterByKindAndNameTags;
-import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findGaugeByKindAndNameTags;
+import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByKindAndNameTags;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TaggedCircuitBreakerMetricsTest {
@@ -80,7 +79,8 @@ public class TaggedCircuitBreakerMetricsTest {
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS)
             .gauges();
 
-        Optional<Gauge> successful = findGaugeByKindAndNameTags(gauges, "successful",
+        Optional<Gauge> successful = MetricsTestHelper
+            .findMeterByKindAndNameTags(gauges, "successful",
             newCircuitBreaker.getName());
         assertThat(successful).isPresent();
         assertThat(successful.get().value())
@@ -120,7 +120,7 @@ public class TaggedCircuitBreakerMetricsTest {
 
         Collection<Counter> counters = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_CALLS).counters();
 
-        Optional<Counter> notPermitted = findCounterByKindAndNameTags(counters, "not_permitted",
+        Optional<Counter> notPermitted = findMeterByKindAndNameTags(counters, "not_permitted",
             circuitBreaker.getName());
         assertThat(notPermitted).isPresent();
         assertThat(notPermitted.get().count())
@@ -132,7 +132,7 @@ public class TaggedCircuitBreakerMetricsTest {
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS)
             .gauges();
 
-        Optional<Gauge> failed = findGaugeByKindAndNameTags(gauges, "failed",
+        Optional<Gauge> failed = MetricsTestHelper.findMeterByKindAndNameTags(gauges, "failed",
             circuitBreaker.getName());
         assertThat(failed).isPresent();
         assertThat(failed.get().value())
@@ -144,7 +144,8 @@ public class TaggedCircuitBreakerMetricsTest {
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS)
             .gauges();
 
-        Optional<Gauge> successful = findGaugeByKindAndNameTags(gauges, "successful",
+        Optional<Gauge> successful = MetricsTestHelper
+            .findMeterByKindAndNameTags(gauges, "successful",
             circuitBreaker.getName());
         assertThat(successful).isPresent();
         assertThat(successful.get().value())
@@ -156,7 +157,7 @@ public class TaggedCircuitBreakerMetricsTest {
     public void slowSuccessfulGaugeReportsCorrespondingValue() {
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_SLOW_CALLS).gauges();
 
-        Optional<Gauge> slow = findGaugeByKindAndNameTags(gauges, "successful",
+        Optional<Gauge> slow = MetricsTestHelper.findMeterByKindAndNameTags(gauges, "successful",
             circuitBreaker.getName());
         assertThat(slow).isPresent();
         assertThat(slow.get().value())
@@ -168,7 +169,7 @@ public class TaggedCircuitBreakerMetricsTest {
     public void slowFailedCallsGaugeReportsCorrespondingValue() {
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_SLOW_CALLS).gauges();
 
-        Optional<Gauge> slow = findGaugeByKindAndNameTags(gauges, "failed",
+        Optional<Gauge> slow = MetricsTestHelper.findMeterByKindAndNameTags(gauges, "failed",
             circuitBreaker.getName());
         assertThat(slow).isPresent();
         assertThat(slow.get().value())

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRateLimiterMetricsPublisherTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRateLimiterMetricsPublisherTest.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 
 import static io.github.resilience4j.micrometer.tagged.AbstractRateLimiterMetrics.MetricNames.DEFAULT_AVAILABLE_PERMISSIONS_METRIC_NAME;
 import static io.github.resilience4j.micrometer.tagged.AbstractRateLimiterMetrics.MetricNames.DEFAULT_WAITING_THREADS_METRIC_NAME;
-import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findGaugeByNamesTag;
+import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByNamesTag;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TaggedRateLimiterMetricsPublisherTest {
@@ -66,7 +66,7 @@ public class TaggedRateLimiterMetricsPublisherTest {
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_AVAILABLE_PERMISSIONS_METRIC_NAME)
             .gauges();
 
-        Optional<Gauge> successful = findGaugeByNamesTag(gauges, newRateLimiter.getName());
+        Optional<Gauge> successful = findMeterByNamesTag(gauges, newRateLimiter.getName());
         assertThat(successful).isPresent();
         assertThat(successful.get().value())
             .isEqualTo(newRateLimiter.getMetrics().getAvailablePermissions());

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRateLimiterMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRateLimiterMetricsTest.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
 
 import static io.github.resilience4j.micrometer.tagged.AbstractRateLimiterMetrics.MetricNames.DEFAULT_AVAILABLE_PERMISSIONS_METRIC_NAME;
 import static io.github.resilience4j.micrometer.tagged.AbstractRateLimiterMetrics.MetricNames.DEFAULT_WAITING_THREADS_METRIC_NAME;
-import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findGaugeByNamesTag;
+import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByNamesTag;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TaggedRateLimiterMetricsTest {
@@ -65,7 +65,7 @@ public class TaggedRateLimiterMetricsTest {
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_AVAILABLE_PERMISSIONS_METRIC_NAME)
             .gauges();
 
-        Optional<Gauge> successful = findGaugeByNamesTag(gauges, newRateLimiter.getName());
+        Optional<Gauge> successful = findMeterByNamesTag(gauges, newRateLimiter.getName());
         assertThat(successful).isPresent();
         assertThat(successful.get().value())
             .isEqualTo(newRateLimiter.getMetrics().getAvailablePermissions());

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRetryMetricsPublisherTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRetryMetricsPublisherTest.java
@@ -19,7 +19,7 @@ package io.github.resilience4j.micrometer.tagged;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.retry.RetryRegistry;
-import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -30,7 +30,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static io.github.resilience4j.micrometer.tagged.AbstractRetryMetrics.MetricNames.DEFAULT_RETRY_CALLS;
-import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findGaugeByKindAndNameTags;
+import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByKindAndNameTags;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TaggedRetryMetricsPublisherTest {
@@ -63,12 +63,13 @@ public class TaggedRetryMetricsPublisherTest {
         List<Meter> meters = meterRegistry.getMeters();
         assertThat(meters).hasSize(8);
 
-        Collection<Gauge> gauges = meterRegistry.get(DEFAULT_RETRY_CALLS).gauges();
+        Collection<FunctionCounter> counters = meterRegistry.get(DEFAULT_RETRY_CALLS)
+            .functionCounters();
 
-        Optional<Gauge> successfulWithoutRetry = findGaugeByKindAndNameTags(gauges,
-            "successful_without_retry", newRetry.getName());
+        Optional<FunctionCounter> successfulWithoutRetry = MetricsTestHelper
+            .findMeterByKindAndNameTags(counters, "successful_without_retry", newRetry.getName());
         assertThat(successfulWithoutRetry).isPresent();
-        assertThat(successfulWithoutRetry.get().value())
+        assertThat(successfulWithoutRetry.get().count())
             .isEqualTo(newRetry.getMetrics().getNumberOfSuccessfulCallsWithoutRetryAttempt());
     }
 
@@ -88,66 +89,72 @@ public class TaggedRetryMetricsPublisherTest {
 
     @Test
     public void shouldReplaceMetrics() {
-        Collection<Gauge> gauges = meterRegistry.get(DEFAULT_RETRY_CALLS).gauges();
-        Optional<Gauge> successfulWithoutRetry = findGaugeByKindAndNameTags(gauges,
+        Collection<FunctionCounter> counters = meterRegistry.get(DEFAULT_RETRY_CALLS).functionCounters();
+        Optional<FunctionCounter> successfulWithoutRetry = MetricsTestHelper.findMeterByKindAndNameTags(counters,
             "successful_without_retry", retry.getName());
         assertThat(successfulWithoutRetry).isPresent();
-        assertThat(successfulWithoutRetry.get().value())
+        assertThat(successfulWithoutRetry.get().count())
             .isEqualTo(retry.getMetrics().getNumberOfSuccessfulCallsWithoutRetryAttempt());
 
         Retry newRetry = Retry.of(retry.getName(), RetryConfig.custom().maxAttempts(1).build());
 
         retryRegistry.replace(retry.getName(), newRetry);
 
-        gauges = meterRegistry.get(DEFAULT_RETRY_CALLS).gauges();
-        successfulWithoutRetry = findGaugeByKindAndNameTags(gauges, "successful_without_retry",
+        counters = meterRegistry.get(DEFAULT_RETRY_CALLS).functionCounters();
+        successfulWithoutRetry = MetricsTestHelper
+            .findMeterByKindAndNameTags(counters, "successful_without_retry",
             newRetry.getName());
         assertThat(successfulWithoutRetry).isPresent();
-        assertThat(successfulWithoutRetry.get().value())
+        assertThat(successfulWithoutRetry.get().count())
             .isEqualTo(newRetry.getMetrics().getNumberOfSuccessfulCallsWithoutRetryAttempt());
     }
 
     @Test
     public void successfulWithoutRetryCallsGaugeReportsCorrespondingValue() {
-        Collection<Gauge> gauges = meterRegistry.get(DEFAULT_RETRY_CALLS).gauges();
+        Collection<FunctionCounter> counters = meterRegistry.get(DEFAULT_RETRY_CALLS)
+            .functionCounters();
 
-        Optional<Gauge> successfulWithoutRetry = findGaugeByKindAndNameTags(gauges,
-            "successful_without_retry", retry.getName());
+        Optional<FunctionCounter> successfulWithoutRetry = findMeterByKindAndNameTags(
+            counters, "successful_without_retry", retry.getName());
         assertThat(successfulWithoutRetry).isPresent();
-        assertThat(successfulWithoutRetry.get().value())
+        assertThat(successfulWithoutRetry.get().count())
             .isEqualTo(retry.getMetrics().getNumberOfSuccessfulCallsWithoutRetryAttempt());
     }
 
     @Test
     public void successfulWithRetryCallsGaugeReportsCorrespondingValue() {
-        Collection<Gauge> gauges = meterRegistry.get(DEFAULT_RETRY_CALLS).gauges();
+        Collection<FunctionCounter> counters = meterRegistry.get(DEFAULT_RETRY_CALLS)
+            .functionCounters();
 
-        Optional<Gauge> successfulWithRetry = findGaugeByKindAndNameTags(gauges,
+        Optional<FunctionCounter> successfulWithRetry = MetricsTestHelper.findMeterByKindAndNameTags(counters,
             "successful_with_retry", retry.getName());
         assertThat(successfulWithRetry).isPresent();
-        assertThat(successfulWithRetry.get().value())
+        assertThat(successfulWithRetry.get().count())
             .isEqualTo(retry.getMetrics().getNumberOfSuccessfulCallsWithRetryAttempt());
     }
 
     @Test
     public void failedWithoutRetryCallsGaugeReportsCorrespondingValue() {
-        Collection<Gauge> gauges = meterRegistry.get(DEFAULT_RETRY_CALLS).gauges();
+        Collection<FunctionCounter> counters = meterRegistry.get(DEFAULT_RETRY_CALLS)
+            .functionCounters();
 
-        Optional<Gauge> failedWithoutRetry = findGaugeByKindAndNameTags(gauges,
-            "failed_without_retry", retry.getName());
+        Optional<FunctionCounter> failedWithoutRetry = MetricsTestHelper.findMeterByKindAndNameTags(
+            counters, "failed_without_retry", retry.getName());
         assertThat(failedWithoutRetry).isPresent();
-        assertThat(failedWithoutRetry.get().value())
+        assertThat(failedWithoutRetry.get().count())
             .isEqualTo(retry.getMetrics().getNumberOfFailedCallsWithoutRetryAttempt());
     }
 
     @Test
     public void failedWithRetryCallsGaugeReportsCorrespondingValue() {
-        Collection<Gauge> gauges = meterRegistry.get(DEFAULT_RETRY_CALLS).gauges();
+        Collection<FunctionCounter> counters = meterRegistry.get(DEFAULT_RETRY_CALLS).
+            functionCounters();
 
-        Optional<Gauge> failedWithRetry = findGaugeByKindAndNameTags(gauges, "failed_with_retry",
+        Optional<FunctionCounter> failedWithRetry = MetricsTestHelper
+            .findMeterByKindAndNameTags(counters, "failed_with_retry",
             retry.getName());
         assertThat(failedWithRetry).isPresent();
-        assertThat(failedWithRetry.get().value())
+        assertThat(failedWithRetry.get().count())
             .isEqualTo(retry.getMetrics().getNumberOfFailedCallsWithRetryAttempt());
     }
 

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRetryMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRetryMetricsTest.java
@@ -18,7 +18,7 @@ package io.github.resilience4j.micrometer.tagged;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.retry.RetryRegistry;
-import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -29,7 +29,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static io.github.resilience4j.micrometer.tagged.AbstractRetryMetrics.MetricNames.DEFAULT_RETRY_CALLS;
-import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findGaugeByKindAndNameTags;
+import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByKindAndNameTags;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TaggedRetryMetricsTest {
@@ -64,12 +64,13 @@ public class TaggedRetryMetricsTest {
         List<Meter> meters = meterRegistry.getMeters();
         assertThat(meters).hasSize(8);
 
-        Collection<Gauge> gauges = meterRegistry.get(DEFAULT_RETRY_CALLS).gauges();
+        Collection<FunctionCounter> counters = meterRegistry.get(DEFAULT_RETRY_CALLS)
+            .functionCounters();
 
-        Optional<Gauge> successfulWithoutRetry = findGaugeByKindAndNameTags(gauges,
+        Optional<FunctionCounter> successfulWithoutRetry = findMeterByKindAndNameTags(counters,
             "successful_without_retry", newRetry.getName());
         assertThat(successfulWithoutRetry).isPresent();
-        assertThat(successfulWithoutRetry.get().value())
+        assertThat(successfulWithoutRetry.get().count())
             .isEqualTo(newRetry.getMetrics().getNumberOfSuccessfulCallsWithoutRetryAttempt());
     }
 
@@ -101,66 +102,71 @@ public class TaggedRetryMetricsTest {
 
     @Test
     public void shouldReplaceMetrics() {
-        Collection<Gauge> gauges = meterRegistry.get(DEFAULT_RETRY_CALLS).gauges();
-        Optional<Gauge> successfulWithoutRetry = findGaugeByKindAndNameTags(gauges,
+        Collection<FunctionCounter> counters = meterRegistry.get(DEFAULT_RETRY_CALLS)
+            .functionCounters();
+        Optional<FunctionCounter> successfulWithoutRetry = findMeterByKindAndNameTags(counters,
             "successful_without_retry", retry.getName());
         assertThat(successfulWithoutRetry).isPresent();
-        assertThat(successfulWithoutRetry.get().value())
+        assertThat(successfulWithoutRetry.get().count())
             .isEqualTo(retry.getMetrics().getNumberOfSuccessfulCallsWithoutRetryAttempt());
 
         Retry newRetry = Retry.of(retry.getName(), RetryConfig.custom().maxAttempts(1).build());
 
         retryRegistry.replace(retry.getName(), newRetry);
 
-        gauges = meterRegistry.get(DEFAULT_RETRY_CALLS).gauges();
-        successfulWithoutRetry = findGaugeByKindAndNameTags(gauges, "successful_without_retry",
+        counters = meterRegistry.get(DEFAULT_RETRY_CALLS).functionCounters();
+        successfulWithoutRetry = findMeterByKindAndNameTags(counters, "successful_without_retry",
             newRetry.getName());
         assertThat(successfulWithoutRetry).isPresent();
-        assertThat(successfulWithoutRetry.get().value())
+        assertThat(successfulWithoutRetry.get().count())
             .isEqualTo(newRetry.getMetrics().getNumberOfSuccessfulCallsWithoutRetryAttempt());
     }
 
     @Test
     public void successfulWithoutRetryCallsGaugeReportsCorrespondingValue() {
-        Collection<Gauge> gauges = meterRegistry.get(DEFAULT_RETRY_CALLS).gauges();
+        Collection<FunctionCounter> counters = meterRegistry.get(DEFAULT_RETRY_CALLS)
+            .functionCounters();
 
-        Optional<Gauge> successfulWithoutRetry = findGaugeByKindAndNameTags(gauges,
+        Optional<FunctionCounter> successfulWithoutRetry = findMeterByKindAndNameTags(counters,
             "successful_without_retry", retry.getName());
         assertThat(successfulWithoutRetry).isPresent();
-        assertThat(successfulWithoutRetry.get().value())
+        assertThat(successfulWithoutRetry.get().count())
             .isEqualTo(retry.getMetrics().getNumberOfSuccessfulCallsWithoutRetryAttempt());
     }
 
     @Test
     public void successfulWithRetryCallsGaugeReportsCorrespondingValue() {
-        Collection<Gauge> gauges = meterRegistry.get(DEFAULT_RETRY_CALLS).gauges();
+        Collection<FunctionCounter> counters = meterRegistry.get(DEFAULT_RETRY_CALLS)
+            .functionCounters();
 
-        Optional<Gauge> successfulWithRetry = findGaugeByKindAndNameTags(gauges,
+        Optional<FunctionCounter> successfulWithRetry = findMeterByKindAndNameTags(counters,
             "successful_with_retry", retry.getName());
         assertThat(successfulWithRetry).isPresent();
-        assertThat(successfulWithRetry.get().value())
+        assertThat(successfulWithRetry.get().count())
             .isEqualTo(retry.getMetrics().getNumberOfSuccessfulCallsWithRetryAttempt());
     }
 
     @Test
     public void failedWithoutRetryCallsGaugeReportsCorrespondingValue() {
-        Collection<Gauge> gauges = meterRegistry.get(DEFAULT_RETRY_CALLS).gauges();
+        Collection<FunctionCounter> counters = meterRegistry.get(DEFAULT_RETRY_CALLS)
+            .functionCounters();
 
-        Optional<Gauge> failedWithoutRetry = findGaugeByKindAndNameTags(gauges,
+        Optional<FunctionCounter> failedWithoutRetry = findMeterByKindAndNameTags(counters,
             "failed_without_retry", retry.getName());
         assertThat(failedWithoutRetry).isPresent();
-        assertThat(failedWithoutRetry.get().value())
+        assertThat(failedWithoutRetry.get().count())
             .isEqualTo(retry.getMetrics().getNumberOfFailedCallsWithoutRetryAttempt());
     }
 
     @Test
     public void failedWithRetryCallsGaugeReportsCorrespondingValue() {
-        Collection<Gauge> gauges = meterRegistry.get(DEFAULT_RETRY_CALLS).gauges();
+        Collection<FunctionCounter> counters = meterRegistry.get(DEFAULT_RETRY_CALLS)
+            .functionCounters();
 
-        Optional<Gauge> failedWithRetry = findGaugeByKindAndNameTags(gauges, "failed_with_retry",
-            retry.getName());
+        Optional<FunctionCounter> failedWithRetry = findMeterByKindAndNameTags(counters,
+            "failed_with_retry", retry.getName());
         assertThat(failedWithRetry).isPresent();
-        assertThat(failedWithRetry.get().value())
+        assertThat(failedWithRetry.get().count())
             .isEqualTo(retry.getMetrics().getNumberOfFailedCallsWithRetryAttempt());
     }
 

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedThreadPoolBulkheadMetricsPublisherTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedThreadPoolBulkheadMetricsPublisherTest.java
@@ -30,7 +30,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static io.github.resilience4j.micrometer.tagged.AbstractThreadPoolBulkheadMetrics.MetricNames.*;
-import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findGaugeByNamesTag;
+import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByNamesTag;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TaggedThreadPoolBulkheadMetricsPublisherTest {
@@ -69,7 +69,7 @@ public class TaggedThreadPoolBulkheadMetricsPublisherTest {
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_MAX_THREAD_POOL_SIZE_METRIC_NAME)
             .gauges();
 
-        Optional<Gauge> successful = findGaugeByNamesTag(gauges, newBulkhead.getName());
+        Optional<Gauge> successful = findMeterByNamesTag(gauges, newBulkhead.getName());
         assertThat(successful).isPresent();
         assertThat(successful.get().value())
             .isEqualTo(newBulkhead.getMetrics().getMaximumThreadPoolSize());
@@ -94,7 +94,7 @@ public class TaggedThreadPoolBulkheadMetricsPublisherTest {
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_MAX_THREAD_POOL_SIZE_METRIC_NAME)
             .gauges();
 
-        Optional<Gauge> successful = findGaugeByNamesTag(gauges, bulkhead.getName());
+        Optional<Gauge> successful = findMeterByNamesTag(gauges, bulkhead.getName());
         assertThat(successful).isPresent();
         assertThat(successful.get().value())
             .isEqualTo(bulkhead.getMetrics().getMaximumThreadPoolSize());
@@ -107,7 +107,7 @@ public class TaggedThreadPoolBulkheadMetricsPublisherTest {
 
         gauges = meterRegistry.get(DEFAULT_MAX_THREAD_POOL_SIZE_METRIC_NAME).gauges();
 
-        successful = findGaugeByNamesTag(gauges, newBulkhead.getName());
+        successful = findMeterByNamesTag(gauges, newBulkhead.getName());
         assertThat(successful).isPresent();
         assertThat(successful.get().value())
             .isEqualTo(newBulkhead.getMetrics().getMaximumThreadPoolSize());

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedThreadPoolBulkheadMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedThreadPoolBulkheadMetricsTest.java
@@ -29,7 +29,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static io.github.resilience4j.micrometer.tagged.AbstractThreadPoolBulkheadMetrics.MetricNames.*;
-import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findGaugeByNamesTag;
+import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByNamesTag;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TaggedThreadPoolBulkheadMetricsTest {
@@ -68,7 +68,7 @@ public class TaggedThreadPoolBulkheadMetricsTest {
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_MAX_THREAD_POOL_SIZE_METRIC_NAME)
             .gauges();
 
-        Optional<Gauge> successful = findGaugeByNamesTag(gauges, newBulkhead.getName());
+        Optional<Gauge> successful = findMeterByNamesTag(gauges, newBulkhead.getName());
         assertThat(successful).isPresent();
         assertThat(successful.get().value())
             .isEqualTo(newBulkhead.getMetrics().getMaximumThreadPoolSize());
@@ -105,7 +105,7 @@ public class TaggedThreadPoolBulkheadMetricsTest {
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_MAX_THREAD_POOL_SIZE_METRIC_NAME)
             .gauges();
 
-        Optional<Gauge> successful = findGaugeByNamesTag(gauges, bulkhead.getName());
+        Optional<Gauge> successful = findMeterByNamesTag(gauges, bulkhead.getName());
         assertThat(successful).isPresent();
         assertThat(successful.get().value())
             .isEqualTo(bulkhead.getMetrics().getMaximumThreadPoolSize());
@@ -119,7 +119,7 @@ public class TaggedThreadPoolBulkheadMetricsTest {
 
         gauges = meterRegistry.get(DEFAULT_MAX_THREAD_POOL_SIZE_METRIC_NAME).gauges();
 
-        successful = findGaugeByNamesTag(gauges, newBulkhead.getName());
+        successful = findMeterByNamesTag(gauges, newBulkhead.getName());
         assertThat(successful).isPresent();
         assertThat(successful.get().value())
             .isEqualTo(newBulkhead.getMetrics().getMaximumThreadPoolSize());

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedTimeLimiterMetricsPublisherTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedTimeLimiterMetricsPublisherTest.java
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import static io.github.resilience4j.micrometer.tagged.AbstractTimeLimiterMetrics.MetricNames.DEFAULT_TIME_LIMITER_CALLS;
-import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findCounterByKindAndNameTags;
+import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByKindAndNameTags;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TaggedTimeLimiterMetricsPublisherTest {
@@ -68,7 +68,7 @@ public class TaggedTimeLimiterMetricsPublisherTest {
 
         Collection<Counter> counters = meterRegistry.get(DEFAULT_TIME_LIMITER_CALLS).counters();
 
-        Optional<Counter> successful = findCounterByKindAndNameTags(counters, "successful",
+        Optional<Counter> successful = findMeterByKindAndNameTags(counters, "successful",
             newTimeLimiter.getName());
         assertThat(successful).map(Counter::count).contains(1d);
     }
@@ -106,7 +106,7 @@ public class TaggedTimeLimiterMetricsPublisherTest {
         Collection<Counter> counters = meterRegistry.get(DEFAULT_TIME_LIMITER_CALLS).counters();
         timeLimiter.onSuccess();
 
-        Optional<Counter> successful = findCounterByKindAndNameTags(counters, "successful",
+        Optional<Counter> successful = findMeterByKindAndNameTags(counters, "successful",
             timeLimiter.getName());
         assertThat(successful).map(Counter::count).contains(1d);
     }
@@ -116,7 +116,7 @@ public class TaggedTimeLimiterMetricsPublisherTest {
         Collection<Counter> counters = meterRegistry.get(DEFAULT_TIME_LIMITER_CALLS).counters();
         timeLimiter.onError(new RuntimeException());
 
-        Optional<Counter> failed = findCounterByKindAndNameTags(counters, "failed",
+        Optional<Counter> failed = findMeterByKindAndNameTags(counters, "failed",
             timeLimiter.getName());
         assertThat(failed).map(Counter::count).contains(1d);
     }
@@ -126,7 +126,7 @@ public class TaggedTimeLimiterMetricsPublisherTest {
         Collection<Counter> counters = meterRegistry.get(DEFAULT_TIME_LIMITER_CALLS).counters();
         timeLimiter.onError(new TimeoutException());
 
-        Optional<Counter> timeout = findCounterByKindAndNameTags(counters, "timeout",
+        Optional<Counter> timeout = findMeterByKindAndNameTags(counters, "timeout",
             timeLimiter.getName());
         assertThat(timeout).map(Counter::count).contains(1d);
     }

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedTimeLimiterMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedTimeLimiterMetricsTest.java
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import static io.github.resilience4j.micrometer.tagged.AbstractTimeLimiterMetrics.MetricNames.DEFAULT_TIME_LIMITER_CALLS;
-import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findCounterByKindAndNameTags;
+import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByKindAndNameTags;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TaggedTimeLimiterMetricsTest {
@@ -66,7 +66,7 @@ public class TaggedTimeLimiterMetricsTest {
 
         Collection<Counter> counters = meterRegistry.get(DEFAULT_TIME_LIMITER_CALLS).counters();
 
-        Optional<Counter> successful = findCounterByKindAndNameTags(counters, "successful",
+        Optional<Counter> successful = findMeterByKindAndNameTags(counters, "successful",
             newTimeLimiter.getName());
         assertThat(successful).map(Counter::count).contains(1d);
     }
@@ -104,7 +104,7 @@ public class TaggedTimeLimiterMetricsTest {
         Collection<Counter> counters = meterRegistry.get(DEFAULT_TIME_LIMITER_CALLS).counters();
         timeLimiter.onSuccess();
 
-        Optional<Counter> successful = findCounterByKindAndNameTags(counters, "successful",
+        Optional<Counter> successful = findMeterByKindAndNameTags(counters, "successful",
             timeLimiter.getName());
         assertThat(successful).map(Counter::count).contains(1d);
     }
@@ -114,7 +114,7 @@ public class TaggedTimeLimiterMetricsTest {
         Collection<Counter> counters = meterRegistry.get(DEFAULT_TIME_LIMITER_CALLS).counters();
         timeLimiter.onError(new RuntimeException());
 
-        Optional<Counter> failed = findCounterByKindAndNameTags(counters, "failed",
+        Optional<Counter> failed = findMeterByKindAndNameTags(counters, "failed",
             timeLimiter.getName());
         assertThat(failed).map(Counter::count).contains(1d);
     }
@@ -124,7 +124,7 @@ public class TaggedTimeLimiterMetricsTest {
         Collection<Counter> counters = meterRegistry.get(DEFAULT_TIME_LIMITER_CALLS).counters();
         timeLimiter.onError(new TimeoutException());
 
-        Optional<Counter> timeout = findCounterByKindAndNameTags(counters, "timeout",
+        Optional<Counter> timeout = findMeterByKindAndNameTags(counters, "timeout",
             timeLimiter.getName());
         assertThat(timeout).map(Counter::count).contains(1d);
     }


### PR DESCRIPTION
In fact under the hood it is a change from Gauge
to FunctionCounter which better represents this metric
as it constantly grows.

Moreover I've polished MetricsTestHelper with generic
types to prevent bloating its API

Issue #806 