### PR TITLE
Issue #803: Support for metrics-only mode

### DIFF
--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/Bulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/Bulkhead.java
@@ -465,7 +465,7 @@ public interface Bulkhead {
     Metrics getMetrics();
 
     /**
-     * Returns an unmodifiable map with tags assigned to this Blukhead.
+     * Returns an unmodifiable map with tags assigned to this Bulkhead.
      *
      * @return the tags assigned to this Retry in an unmodifiable map
      */

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/event/AbstractBulkheadEvent.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/event/AbstractBulkheadEvent.java
@@ -11,7 +11,7 @@
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the speci`fic language governing permissions and
+ *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *
  *

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkhead.java
@@ -73,7 +73,7 @@ public class SemaphoreBulkhead implements Bulkhead {
      *
      * @param name           the name of this bulkhead
      * @param bulkheadConfig custom bulkhead configuration
-     * @param tags           the tags to add to the Bulkdhead
+     * @param tags           the tags to add to the Bulkhead
      */
     public SemaphoreBulkhead(String name, @Nullable BulkheadConfig bulkheadConfig,
         Map<String, String> tags) {

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreaker.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreaker.java
@@ -600,6 +600,16 @@ public interface CircuitBreaker {
     void transitionToDisabledState();
 
     /**
+     * Transitions the state machine to METRICS_ONLY state, stopping all state transitions but
+     * continues to capture metrics and publish events.
+     * <p>
+     * Should only be used when you want to collect metrics while keeping the circuit breaker
+     * disabled, allowing all calls to pass.
+     * To recover from this state you must force a new state transition.
+     */
+    void transitionToMetricsOnlyState();
+
+    /**
      * Transitions the state machine to a FORCED_OPEN state,  stopping state transition, metrics and
      * event publishing.
      * <p>
@@ -870,6 +880,11 @@ public interface CircuitBreaker {
          */
         DISABLED(3, false),
         /**
+         * A METRICS_ONLY breaker is collecting metrics, publishing events and allowing all requests
+         * through but is not transitioning to other states.
+         */
+        METRICS_ONLY(5, true),
+        /**
          * A CLOSED breaker is operating normally and allowing requests through.
          */
         CLOSED(0, true),
@@ -917,23 +932,33 @@ public interface CircuitBreaker {
     enum StateTransition {
         CLOSED_TO_OPEN(State.CLOSED, State.OPEN),
         CLOSED_TO_DISABLED(State.CLOSED, State.DISABLED),
+        CLOSED_TO_METRICS_ONLY(State.CLOSED, State.METRICS_ONLY),
         CLOSED_TO_FORCED_OPEN(State.CLOSED, State.FORCED_OPEN),
         HALF_OPEN_TO_CLOSED(State.HALF_OPEN, State.CLOSED),
         HALF_OPEN_TO_OPEN(State.HALF_OPEN, State.OPEN),
         HALF_OPEN_TO_DISABLED(State.HALF_OPEN, State.DISABLED),
+        HALF_OPEN_TO_METRICS_ONLY(State.HALF_OPEN, State.METRICS_ONLY),
         HALF_OPEN_TO_FORCED_OPEN(State.HALF_OPEN, State.FORCED_OPEN),
         OPEN_TO_CLOSED(State.OPEN, State.CLOSED),
         OPEN_TO_HALF_OPEN(State.OPEN, State.HALF_OPEN),
         OPEN_TO_DISABLED(State.OPEN, State.DISABLED),
+        OPEN_TO_METRICS_ONLY(State.OPEN, State.METRICS_ONLY),
         OPEN_TO_FORCED_OPEN(State.OPEN, State.FORCED_OPEN),
         FORCED_OPEN_TO_CLOSED(State.FORCED_OPEN, State.CLOSED),
         FORCED_OPEN_TO_OPEN(State.FORCED_OPEN, State.OPEN),
         FORCED_OPEN_TO_DISABLED(State.FORCED_OPEN, State.DISABLED),
+        FORCED_OPEN_TO_METRICS_ONLY(State.FORCED_OPEN, State.METRICS_ONLY),
         FORCED_OPEN_TO_HALF_OPEN(State.FORCED_OPEN, State.HALF_OPEN),
         DISABLED_TO_CLOSED(State.DISABLED, State.CLOSED),
         DISABLED_TO_OPEN(State.DISABLED, State.OPEN),
         DISABLED_TO_FORCED_OPEN(State.DISABLED, State.FORCED_OPEN),
-        DISABLED_TO_HALF_OPEN(State.DISABLED, State.HALF_OPEN);
+        DISABLED_TO_HALF_OPEN(State.DISABLED, State.HALF_OPEN),
+        DISABLED_TO_METRICS_ONLY(State.DISABLED, State.METRICS_ONLY),
+        METRICS_ONLY_TO_CLOSED(State.METRICS_ONLY, State.CLOSED),
+        METRICS_ONLY_TO_OPEN(State.METRICS_ONLY, State.OPEN),
+        METRICS_ONLY_TO_FORCED_OPEN(State.METRICS_ONLY, State.FORCED_OPEN),
+        METRICS_ONLY_TO_HALF_OPEN(State.METRICS_ONLY, State.HALF_OPEN),
+        METRICS_ONLY_TO_DISABLED(State.METRICS_ONLY, State.DISABLED);
 
         private static final Map<Tuple2<State, State>, StateTransition> STATE_TRANSITION_MAP = Arrays
             .stream(StateTransition.values())

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/event/CircuitBreakerEvent.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/event/CircuitBreakerEvent.java
@@ -82,7 +82,15 @@ public interface CircuitBreakerEvent {
         /**
          * A CircuitBreakerEvent which informs the CircuitBreaker has been disabled
          */
-        DISABLED(false);
+        DISABLED(false),
+        /**
+         * A CircuitBreakerEvent which informs the CircuitBreaker failure rate has been breached
+         */
+        FAILURE_RATE_EXCEEDED(false),
+        /**
+         * A CircuitBreakerEvent which informs the CircuitBreaker show call rate has been breached
+         */
+        SLOW_CALL_RATE_EXCEEDED(false);
 
         public final boolean forcePublish;
 

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/event/CircuitBreakerOnFailureRateExceededEvent.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/event/CircuitBreakerOnFailureRateExceededEvent.java
@@ -1,0 +1,29 @@
+package io.github.resilience4j.circuitbreaker.event;
+
+public class CircuitBreakerOnFailureRateExceededEvent extends AbstractCircuitBreakerEvent {
+
+    private final float failureRate;
+
+    public CircuitBreakerOnFailureRateExceededEvent(String circuitBreakerName, float failureRate) {
+        super(circuitBreakerName);
+        this.failureRate = failureRate;
+    }
+
+    public float getFailureRate() {
+        return failureRate;
+    }
+
+    @Override
+    public Type getEventType() {
+        return Type.FAILURE_RATE_EXCEEDED;
+    }
+
+    @Override
+    public String toString() {
+        return String
+            .format("%s: CircuitBreaker '%s' exceeded failure rate threshold. Current failure rate: %s",
+                getCreationTime(),
+                getCircuitBreakerName(),
+                getFailureRate());
+    }
+}

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/event/CircuitBreakerOnSlowCallRateExceededEvent.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/event/CircuitBreakerOnSlowCallRateExceededEvent.java
@@ -1,0 +1,29 @@
+package io.github.resilience4j.circuitbreaker.event;
+
+public class CircuitBreakerOnSlowCallRateExceededEvent extends AbstractCircuitBreakerEvent {
+
+    private final float slowCallRate;
+
+    public CircuitBreakerOnSlowCallRateExceededEvent(String circuitBreakerName, float slowCallRate) {
+        super(circuitBreakerName);
+        this.slowCallRate = slowCallRate;
+    }
+
+    public float getSlowCallRate() {
+        return slowCallRate;
+    }
+
+    @Override
+    public Type getEventType() {
+        return Type.SLOW_CALL_RATE_EXCEEDED;
+    }
+
+    @Override
+    public String toString() {
+        return String
+            .format("%s: CircuitBreaker '%s' exceeded slow call rate threshold. Current slow call rate: %s",
+                getCreationTime(),
+                getCircuitBreakerName(),
+                getSlowCallRate());
+    }
+}

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/utils/CircuitBreakerUtil.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/utils/CircuitBreakerUtil.java
@@ -15,6 +15,6 @@ public final class CircuitBreakerUtil {
      */
     public static boolean isCallPermitted(CircuitBreaker circuitBreaker) {
         State state = circuitBreaker.getState();
-        return state == CLOSED || state == HALF_OPEN || state == DISABLED;
+        return state == CLOSED || state == HALF_OPEN || state == DISABLED || state == METRICS_ONLY;
     }
 }

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerMetricsTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerMetricsTest.java
@@ -52,8 +52,8 @@ public class CircuitBreakerMetricsTest {
 
         // The failure rate must be -1, because the number of measured calls is below the buffer size of 10
         assertThat(circuitBreakerMetrics.getFailureRate()).isEqualTo(-1);
-        assertThat(result)
-            .isEqualTo(Result.BELOW_MINIMUM_CALLS_THRESHOLD);
+        assertThat(result.getComputeResult())
+            .isEqualTo(CircuitBreakerMetrics.ComputeResult.BELOW_MINIMUM_CALLS_THRESHOLD);
 
         circuitBreakerMetrics.onError(0, TimeUnit.NANOSECONDS);
         circuitBreakerMetrics.onError(0, TimeUnit.NANOSECONDS);
@@ -70,12 +70,12 @@ public class CircuitBreakerMetricsTest {
         assertThat(circuitBreakerMetrics.getNumberOfFailedCalls()).isEqualTo(6);
         assertThat(circuitBreakerMetrics.getNumberOfSuccessfulCalls()).isEqualTo(4);
         assertThat(circuitBreakerMetrics.getFailureRate()).isEqualTo(60);
-        assertThat(result).isEqualTo(Result.ABOVE_THRESHOLDS);
+        assertThat(result.getComputeResult()).isEqualTo(CircuitBreakerMetrics.ComputeResult.ABOVE_THRESHOLDS);
 
         circuitBreakerMetrics.onSuccess(0, TimeUnit.NANOSECONDS);
         circuitBreakerMetrics.onSuccess(0, TimeUnit.NANOSECONDS);
         result = circuitBreakerMetrics.onSuccess(0, TimeUnit.NANOSECONDS);
-        assertThat(result).isEqualTo(Result.BELOW_THRESHOLDS);
+        assertThat(result.getComputeResult()).isEqualTo(CircuitBreakerMetrics.ComputeResult.BELOW_THRESHOLDS);
         assertThat(circuitBreakerMetrics.getFailureRate()).isEqualTo(30);
 
 

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/utils/CircuitBreakerUtilTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/utils/CircuitBreakerUtilTest.java
@@ -14,6 +14,6 @@ public class CircuitBreakerUtilTest {
             .describedAs("List of statuses changed." +
                 "Please consider updating CircuitBreakerUtil#isCallPermitted to handle" +
                 "new status properly.")
-            .containsOnly(DISABLED, CLOSED, OPEN, FORCED_OPEN, HALF_OPEN);
+            .containsOnly(DISABLED, CLOSED, OPEN, FORCED_OPEN, HALF_OPEN, METRICS_ONLY);
     }
 }

--- a/resilience4j-documentation/src/docs/asciidoc/implementation_details.adoc
+++ b/resilience4j-documentation/src/docs/asciidoc/implementation_details.adoc
@@ -2,7 +2,7 @@
 
 === CircuitBreaker
 
-The CircuitBreaker is implemented via a finite state machine with three normal states: `CLOSED`, `OPEN` and `HALF_OPEN` and two special states `DISABLED` and `FORCED_OPEN`.
+The CircuitBreaker is implemented via a finite state machine with three normal states: `CLOSED`, `OPEN` and `HALF_OPEN` and three special states `METRICS_ONLY`, ``DISABLED` and `FORCED_OPEN`.
 
 image::images/state_machine.jpg[]
 
@@ -48,7 +48,7 @@ CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
 circuitBreaker.reset();
 ----
 
-The CircuitBreaker supports two more special states, `DISABLED` (always allow access) and `FORCED_OPEN` (always deny access). In these two states no CircuitBreakerEvents (apart from the state transition) are generated, and no metrics are recorded. The only way to exit from those states are to trigger a state transition or to reset the CircuitBreaker.
+The CircuitBreaker supports three more special states, `METRICS_ONLY` (always allow access), DISABLED` (always allow access) and `FORCED_OPEN` (always deny access). In `METRICS_ONLY` state all Circuit Breaker events (except state transition) are generated and metrics are recorded, similar to `CLOSED` state but the only difference being, the circuit does not open when any of the thresholds are breached. In `DISABLED` and `FORCED_OPEN` states no CircuitBreakerEvents (apart from the state transition) are generated, and no metrics are recorded. The only way to exit from those states is to trigger a state transition or to reset the CircuitBreaker.
 
 [source,java]
 ----

--- a/resilience4j-documentation/src/docs/asciidoc/implementation_details.adoc
+++ b/resilience4j-documentation/src/docs/asciidoc/implementation_details.adoc
@@ -2,7 +2,7 @@
 
 === CircuitBreaker
 
-The CircuitBreaker is implemented via a finite state machine with three normal states: `CLOSED`, `OPEN` and `HALF_OPEN` and three special states `METRICS_ONLY`, ``DISABLED` and `FORCED_OPEN`.
+The CircuitBreaker is implemented via a finite state machine with three normal states: `CLOSED`, `OPEN` and `HALF_OPEN` and three special states `METRICS_ONLY`, `DISABLED` and `FORCED_OPEN`.
 
 image::images/state_machine.jpg[]
 
@@ -48,7 +48,7 @@ CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
 circuitBreaker.reset();
 ----
 
-The CircuitBreaker supports three more special states, `METRICS_ONLY` (always allow access), DISABLED` (always allow access) and `FORCED_OPEN` (always deny access). In `METRICS_ONLY` state all Circuit Breaker events (except state transition) are generated and metrics are recorded, similar to `CLOSED` state but the only difference being, the circuit does not open when any of the thresholds are breached. In `DISABLED` and `FORCED_OPEN` states no CircuitBreakerEvents (apart from the state transition) are generated, and no metrics are recorded. The only way to exit from those states is to trigger a state transition or to reset the CircuitBreaker.
+The CircuitBreaker supports three more special states, `METRICS_ONLY` (always allow access), `DISABLED` (always allow access) and `FORCED_OPEN` (always deny access). In `METRICS_ONLY` state all Circuit Breaker events (except state transition) are generated and metrics are recorded, similar to `CLOSED` state but the only difference being, the circuit does not open when any of the thresholds are breached. In `DISABLED` and `FORCED_OPEN` states no CircuitBreakerEvents (apart from the state transition) are generated, and no metrics are recorded. The only way to exit from those states is to trigger a state transition or to reset the CircuitBreaker.
 
 [source,java]
 ----

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetricsPublisherTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetricsPublisherTest.java
@@ -73,11 +73,11 @@ public class TaggedCircuitBreakerMetricsPublisherTest {
 
         assertThat(taggedCircuitBreakerMetricsPublisher.meterIdMap)
             .containsKeys("backendA", "backendB");
-        assertThat(taggedCircuitBreakerMetricsPublisher.meterIdMap.get("backendA")).hasSize(15);
-        assertThat(taggedCircuitBreakerMetricsPublisher.meterIdMap.get("backendB")).hasSize(15);
+        assertThat(taggedCircuitBreakerMetricsPublisher.meterIdMap.get("backendA")).hasSize(16);
+        assertThat(taggedCircuitBreakerMetricsPublisher.meterIdMap.get("backendB")).hasSize(16);
 
         List<Meter> meters = meterRegistry.getMeters();
-        assertThat(meters).hasSize(30);
+        assertThat(meters).hasSize(32);
 
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS)
             .gauges();
@@ -92,7 +92,7 @@ public class TaggedCircuitBreakerMetricsPublisherTest {
     @Test
     public void shouldRemovedMetricsForRemovedRetry() {
         List<Meter> meters = meterRegistry.getMeters();
-        assertThat(meters).hasSize(15);
+        assertThat(meters).hasSize(16);
 
         assertThat(taggedCircuitBreakerMetricsPublisher.meterIdMap).containsKeys("backendA");
         circuitBreakerRegistry.remove("backendA");
@@ -106,7 +106,7 @@ public class TaggedCircuitBreakerMetricsPublisherTest {
     @Test
     public void notPermittedCallsCounterReportsCorrespondingValue() {
         List<Meter> meters = meterRegistry.getMeters();
-        assertThat(meters).hasSize(15);
+        assertThat(meters).hasSize(16);
 
         Collection<Counter> counters = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_CALLS).counters();
 

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetricsTest.java
@@ -71,11 +71,11 @@ public class TaggedCircuitBreakerMetricsTest {
         newCircuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
 
         assertThat(taggedCircuitBreakerMetrics.meterIdMap).containsKeys("backendA", "backendB");
-        assertThat(taggedCircuitBreakerMetrics.meterIdMap.get("backendA")).hasSize(15);
-        assertThat(taggedCircuitBreakerMetrics.meterIdMap.get("backendB")).hasSize(15);
+        assertThat(taggedCircuitBreakerMetrics.meterIdMap.get("backendA")).hasSize(16);
+        assertThat(taggedCircuitBreakerMetrics.meterIdMap.get("backendB")).hasSize(16);
 
         List<Meter> meters = meterRegistry.getMeters();
-        assertThat(meters).hasSize(30);
+        assertThat(meters).hasSize(32);
 
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS)
             .gauges();
@@ -92,9 +92,9 @@ public class TaggedCircuitBreakerMetricsTest {
         CircuitBreaker circuitBreakerF = circuitBreakerRegistry.circuitBreaker("backendF", io.vavr.collection.HashMap.of("key1", "value1"));
         circuitBreakerF.onSuccess(0, TimeUnit.NANOSECONDS);
         assertThat(taggedCircuitBreakerMetrics.meterIdMap).containsKeys("backendA", "backendF");
-        assertThat(taggedCircuitBreakerMetrics.meterIdMap.get("backendF")).hasSize(15);
+        assertThat(taggedCircuitBreakerMetrics.meterIdMap.get("backendF")).hasSize(16);
         List<Meter> meters = meterRegistry.getMeters();
-        assertThat(meters).hasSize(30);
+        assertThat(meters).hasSize(32);
         final RequiredSearch match = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS).tags("key1", "value1");
         assertThat(match).isNotNull();
     }
@@ -102,7 +102,7 @@ public class TaggedCircuitBreakerMetricsTest {
     @Test
     public void shouldRemovedMetricsForRemovedRetry() {
         List<Meter> meters = meterRegistry.getMeters();
-        assertThat(meters).hasSize(15);
+        assertThat(meters).hasSize(16);
 
         assertThat(taggedCircuitBreakerMetrics.meterIdMap).containsKeys("backendA");
         circuitBreakerRegistry.remove("backendA");
@@ -116,7 +116,7 @@ public class TaggedCircuitBreakerMetricsTest {
     @Test
     public void notPermittedCallsCounterReportsCorrespondingValue() {
         List<Meter> meters = meterRegistry.getMeters();
-        assertThat(meters).hasSize(15);
+        assertThat(meters).hasSize(16);
 
         Collection<Counter> counters = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_CALLS).counters();
 

--- a/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/RateLimiter.java
+++ b/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/RateLimiter.java
@@ -566,7 +566,7 @@ public interface RateLimiter {
      * Will wait for required number of permits within default timeout duration.
      *
      * @param rateLimiter the RateLimiter to get permission from
-     * @param permits     numer of permits we have to acquire
+     * @param permits     number of permits we have to acquire
      * @throws RequestNotPermitted                 if waiting time elapsed before a permit was
      *                                             acquired.
      * @throws AcquirePermissionCancelledException if thread was interrupted during permission wait

--- a/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/internal/SemaphoreBasedRateLimiter.java
+++ b/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/internal/SemaphoreBasedRateLimiter.java
@@ -177,7 +177,7 @@ public class SemaphoreBasedRateLimiter implements RateLimiter {
     }
 
     /**
-     * Reserving permissions is not supported in the spemaphore based implementation. Semaphores are
+     * Reserving permissions is not supported in the semaphore based implementation. Semaphores are
      * totally blocking by it's nature. So this non-blocking API isn't supported. Use {@link
      * #acquirePermission()}
      *
@@ -186,7 +186,7 @@ public class SemaphoreBasedRateLimiter implements RateLimiter {
     @Override
     public long reservePermission() {
         throw new UnsupportedOperationException(
-            "Reserving permissions is not supported in the spemaphore based implementation");
+            "Reserving permissions is not supported in the semaphore based implementation");
     }
 
     /**
@@ -196,7 +196,7 @@ public class SemaphoreBasedRateLimiter implements RateLimiter {
     @Override
     public long reservePermission(int permits) {
         throw new UnsupportedOperationException(
-            "Reserving permissions is not supported in the spemaphore based implementation");
+            "Reserving permissions is not supported in the semaphore based implementation");
     }
 
     /**

--- a/resilience4j-spring-boot-common/src/test/java/io/github/resilience4j/SpringBootCommonTest.java
+++ b/resilience4j-spring-boot-common/src/test/java/io/github/resilience4j/SpringBootCommonTest.java
@@ -41,7 +41,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 
-import static java.util.Collections.emptyList;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 /**
@@ -55,12 +54,12 @@ public class SpringBootCommonTest {
         assertThat(bulkheadConfigurationOnMissingBean
             .bulkheadRegistry(new BulkheadConfigurationProperties(),
                 new DefaultEventConsumerRegistry<>(),
-                new CompositeRegistryEventConsumer<>(emptyList()),
+                new CompositeRegistryEventConsumer<>(Collections.emptyList()),
                 new CompositeCustomizer<>(Collections.emptyList()))).isNotNull();
         assertThat(bulkheadConfigurationOnMissingBean
             .threadPoolBulkheadRegistry(new ThreadPoolBulkheadConfigurationProperties(),
                 new DefaultEventConsumerRegistry<>(),
-                new CompositeRegistryEventConsumer<>(emptyList()),
+                new CompositeRegistryEventConsumer<>(Collections.emptyList()),
                 new CompositeCustomizer<>(Collections.emptyList()))).isNotNull();
         assertThat(bulkheadConfigurationOnMissingBean.reactorBulkHeadAspectExt()).isNotNull();
         assertThat(bulkheadConfigurationOnMissingBean.rxJava2BulkHeadAspectExt()).isNotNull();
@@ -68,9 +67,9 @@ public class SpringBootCommonTest {
             .bulkheadAspect(new BulkheadConfigurationProperties(),
                 ThreadPoolBulkheadRegistry.ofDefaults(), BulkheadRegistry.ofDefaults(),
                 Collections.emptyList(),
-                new FallbackDecorators(Arrays.asList(new CompletionStageFallbackDecorator()))));
+                new FallbackDecorators(Arrays.asList(new CompletionStageFallbackDecorator())))).isNotNull();
         assertThat(
-            bulkheadConfigurationOnMissingBean.bulkheadRegistryEventConsumer(Optional.empty()));
+            bulkheadConfigurationOnMissingBean.bulkheadRegistryEventConsumer(Optional.empty())).isNotNull();
     }
 
     @Test
@@ -80,13 +79,12 @@ public class SpringBootCommonTest {
         assertThat(circuitBreakerConfig.reactorCircuitBreakerAspect()).isNotNull();
         assertThat(circuitBreakerConfig.rxJava2CircuitBreakerAspect()).isNotNull();
         assertThat(circuitBreakerConfig.circuitBreakerRegistry(new DefaultEventConsumerRegistry<>(),
-            new CompositeRegistryEventConsumer<>(emptyList()),
-            new CompositeCustomizer<>(Collections.singletonList(new TestCustomizer()))))
-            .isNotNull();
+            new CompositeRegistryEventConsumer<>(Collections.emptyList()),
+            new CompositeCustomizer<>(Collections.singletonList(new TestCustomizer())))).isNotNull();
         assertThat(circuitBreakerConfig
             .circuitBreakerAspect(CircuitBreakerRegistry.ofDefaults(), Collections.emptyList(),
-                new FallbackDecorators(Arrays.asList(new CompletionStageFallbackDecorator()))));
-        assertThat(circuitBreakerConfig.circuitBreakerRegistryEventConsumer(Optional.empty()));
+                new FallbackDecorators(Arrays.asList(new CompletionStageFallbackDecorator())))).isNotNull();
+        assertThat(circuitBreakerConfig.circuitBreakerRegistryEventConsumer(Optional.empty())).isNotNull();
     }
 
     @Test
@@ -96,13 +94,13 @@ public class SpringBootCommonTest {
         assertThat(retryConfigurationOnMissingBean.rxJava2RetryAspectExt()).isNotNull();
         assertThat(retryConfigurationOnMissingBean
             .retryRegistry(new RetryConfigurationProperties(), new DefaultEventConsumerRegistry<>(),
-                new CompositeRegistryEventConsumer<>(emptyList()),
+                new CompositeRegistryEventConsumer<>(Collections.emptyList()),
                 new CompositeCustomizer<>(Collections.emptyList()))).isNotNull();
         assertThat(retryConfigurationOnMissingBean
             .retryAspect(new RetryConfigurationProperties(), RetryRegistry.ofDefaults(),
                 Collections.emptyList(),
-                new FallbackDecorators(Arrays.asList(new CompletionStageFallbackDecorator()))));
-        assertThat(retryConfigurationOnMissingBean.retryRegistryEventConsumer(Optional.empty()));
+                new FallbackDecorators(Arrays.asList(new CompletionStageFallbackDecorator())))).isNotNull();
+        assertThat(retryConfigurationOnMissingBean.retryRegistryEventConsumer(Optional.empty())).isNotNull();
     }
 
     @Test
@@ -113,14 +111,14 @@ public class SpringBootCommonTest {
         assertThat(rateLimiterConfigurationOnMissingBean
             .rateLimiterRegistry(new RateLimiterConfigurationProperties(),
                 new DefaultEventConsumerRegistry<>(),
-                new CompositeRegistryEventConsumer<>(emptyList()),
+                new CompositeRegistryEventConsumer<>(Collections.emptyList()),
                 new CompositeCustomizer<>(Collections.emptyList()))).isNotNull();
         assertThat(rateLimiterConfigurationOnMissingBean
             .rateLimiterAspect(new RateLimiterConfigurationProperties(),
                 RateLimiterRegistry.ofDefaults(), Collections.emptyList(),
-                new FallbackDecorators(Arrays.asList(new CompletionStageFallbackDecorator()))));
+                new FallbackDecorators(Arrays.asList(new CompletionStageFallbackDecorator())))).isNotNull();
         assertThat(rateLimiterConfigurationOnMissingBean
-            .rateLimiterRegistryEventConsumer(Optional.empty()));
+            .rateLimiterRegistryEventConsumer(Optional.empty())).isNotNull();
     }
 
 

--- a/resilience4j-spring-boot/src/main/java/io/github/resilience4j/retry/monitoring/endpoint/RetryEventsEndpoint.java
+++ b/resilience4j-spring-boot/src/main/java/io/github/resilience4j/retry/monitoring/endpoint/RetryEventsEndpoint.java
@@ -47,7 +47,7 @@ public class RetryEventsEndpoint {
 
     @GetMapping(value = "events", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
-    public RetryEventsEndpointResponse getAllRetryEvenets() {
+    public RetryEventsEndpointResponse getAllRetryEvents() {
         return new RetryEventsEndpointResponse(eventConsumerRegistry.getAllEventConsumer()
             .flatMap(CircularEventConsumer::getBufferedEvents)
             .sorted(Comparator.comparing(RetryEvent::getCreationTime))
@@ -56,7 +56,7 @@ public class RetryEventsEndpoint {
 
     @GetMapping(value = "events/{name}", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
-    public RetryEventsEndpointResponse getEventsFilteredByRetryrName(
+    public RetryEventsEndpointResponse getEventsFilteredByRetryName(
         @PathVariable("name") String name) {
         return new RetryEventsEndpointResponse(getRetryEvents(name)
             .map(RetryEventDTOFactory::createRetryEventDTO).toJavaList());

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/retry/monitoring/endpoint/RetryEventsEndpoint.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/retry/monitoring/endpoint/RetryEventsEndpoint.java
@@ -45,7 +45,7 @@ public class RetryEventsEndpoint {
      * @return all retry generated events
      */
     @ReadOperation
-    public RetryEventsEndpointResponse getAllRetryEvenets() {
+    public RetryEventsEndpointResponse getAllRetryEvents() {
         return new RetryEventsEndpointResponse(eventConsumerRegistry.getAllEventConsumer()
             .flatMap(CircularEventConsumer::getBufferedEvents)
             .sorted(Comparator.comparing(RetryEvent::getCreationTime))
@@ -57,7 +57,7 @@ public class RetryEventsEndpoint {
      * @return the retry events generated for this backend
      */
     @ReadOperation
-    public RetryEventsEndpointResponse getEventsFilteredByRetryrName(@Selector String name) {
+    public RetryEventsEndpointResponse getEventsFilteredByRetryName(@Selector String name) {
         return new RetryEventsEndpointResponse(getRetryEvents(name)
             .map(RetryEventDTOFactory::createRetryEventDTO).toJavaList());
     }


### PR DESCRIPTION
Adds the ability to record metrics and publish events while operating in a mode similar to `DISABLED` state, where all requests are allowed to pass through.