### PR TITLE
Issue #718: Remove blocking for reactor RetryOperator.

### DIFF
--- a/libraries.gradle
+++ b/libraries.gradle
@@ -32,6 +32,7 @@ ext {
     validationApiVersion = '2.0.1.Final'
     kotlinCoroutinesVersion = '1.3.2'
     springBootOpenFeignVersion = '2.1.2.RELEASE'
+    blockhoundVersion = '1.0.1.RELEASE'
 
     libraries = [
             // compile
@@ -53,6 +54,7 @@ ext {
             reactor_test: "io.projectreactor:reactor-test:${reactorVersion}",
             reactive_streams_tck: "org.reactivestreams:reactive-streams-tck:${reactiveStreamsVersion}",
             mock_clock: "com.statemachinesystems:mock-clock:1.0",
+            blockhound: "io.projectreactor.tools:blockhound:${blockhoundVersion}",
 
             // Vert.x addon
             vertx: "io.vertx:vertx-core:${vertxVersion}",

--- a/resilience4j-reactor/build.gradle
+++ b/resilience4j-reactor/build.gradle
@@ -15,5 +15,6 @@ dependencies {
     testCompile(libraries.reactor_test)
     testCompile(libraries.assertj)
     testCompile(libraries.reactive_streams_tck)
+    testCompile(libraries.blockhound)
 }
 ext.moduleName = 'io.github.resilience4j.reactor'

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/retry/RetryOperator.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/retry/RetryOperator.java
@@ -17,11 +17,12 @@ package io.github.resilience4j.reactor.retry;
 
 import io.github.resilience4j.reactor.IllegalPublisherException;
 import io.github.resilience4j.retry.Retry;
+import io.vavr.control.Try;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.util.function.Consumer;
+import java.time.Duration;
 import java.util.function.UnaryOperator;
 
 /**
@@ -48,86 +49,59 @@ public class RetryOperator<T> implements UnaryOperator<Publisher<T>> {
         return new RetryOperator<>(retry);
     }
 
-    /**
-     * to handle checked exception handling in reactor Function java 8 doOnNext
-     */
-    private static <T> Consumer<T> throwingConsumerWrapper(
-        ThrowingConsumer<T, Exception> throwingConsumer) {
-
-        return i -> {
-            try {
-                throwingConsumer.accept(i);
-            } catch (Exception ex) {
-                throw new RetryExceptionWrapper(ex);
-            }
-        };
-    }
-
     @Override
     public Publisher<T> apply(Publisher<T> publisher) {
         if (publisher instanceof Mono) {
             Context<T> context = new Context<>(retry.context());
             Mono<T> upstream = (Mono<T>) publisher;
-            return upstream.doOnNext(context::throwExceptionToForceRetryOnResult)
-                .retryWhen(errors -> errors.doOnNext(throwingConsumerWrapper(context::onError)))
+            return upstream.doOnNext(context::handleResult)
+                .retryWhen(errors -> errors.flatMap(context::handleErrors))
                 .doOnSuccess(t -> context.onComplete());
         } else if (publisher instanceof Flux) {
             Context<T> context = new Context<>(retry.context());
             Flux<T> upstream = (Flux<T>) publisher;
-            return upstream.doOnNext(context::throwExceptionToForceRetryOnResult)
-                .retryWhen(errors -> errors.doOnNext(throwingConsumerWrapper(context::onError)))
+            return upstream.doOnNext(context::handleResult)
+                .retryWhen(errors -> errors.flatMap(context::handleErrors))
                 .doOnComplete(context::onComplete);
         } else {
             throw new IllegalPublisherException(publisher);
         }
     }
 
-    /**
-     * @param <T> input
-     * @param <E> possible thrown exception
-     */
-    @FunctionalInterface
-    public interface ThrowingConsumer<T, E extends Exception> {
-
-        void accept(T t) throws E;
-    }
-
     private static class Context<T> {
 
-        private final Retry.Context<T> context;
+        private final Retry.Context<T> retryContext;
 
-        Context(Retry.Context<T> context) {
-            this.context = context;
+        Context(Retry.Context<T> retryContext) {
+            this.retryContext = retryContext;
         }
 
         void onComplete() {
-            this.context.onComplete();
+            this.retryContext.onComplete();
         }
 
-        void throwExceptionToForceRetryOnResult(T value) {
-            if (context.onResult(value)) {
-                throw new RetryDueToResultException();
+        void handleResult(T result) {
+            long waitingDurationMillis = retryContext.onResultWaitingDurationMillis(result);
+            if (waitingDurationMillis != -1) {
+                throw new RetryDueToResultException(waitingDurationMillis);
             }
         }
 
-        void onError(Throwable throwable) throws Exception {
+        Mono<Long> handleErrors(Throwable throwable) {
             if (throwable instanceof RetryDueToResultException) {
-                return;
+                long waitDurationMillis = ((RetryDueToResultException) throwable).waitDurationMillis;
+                return Mono.delay(Duration.ofMillis(waitDurationMillis));
             }
             // Filter Error to not retry on it
             if (throwable instanceof Error) {
                 throw (Error) throwable;
             }
-            try {
-                if (throwable instanceof RetryExceptionWrapper) {
-                    context.onError(castToException(throwable.getCause()));
-                } else {
-                    context.onError(castToException(throwable));
-                }
 
-            } catch (Throwable t) {
-                throw castToException(t);
-            }
+            long waitingDurationMillis = Try.of(() -> retryContext
+                .onErrorWaitingDurationMillis(castToException(throwable)))
+                .get();
+
+            return Mono.delay(Duration.ofMillis(waitingDurationMillis));
         }
 
         private Exception castToException(Throwable throwable) {
@@ -136,9 +110,11 @@ public class RetryOperator<T> implements UnaryOperator<Publisher<T>> {
         }
 
         private static class RetryDueToResultException extends RuntimeException {
+            private final long waitDurationMillis;
 
-            RetryDueToResultException() {
+            RetryDueToResultException(long waitDurationMillis) {
                 super("retry due to retryOnResult predicate");
+                this.waitDurationMillis = waitDurationMillis;
             }
         }
     }

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/retry/RetryOperatorTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/retry/RetryOperatorTest.java
@@ -21,9 +21,13 @@ import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.test.HelloWorldException;
 import io.github.resilience4j.test.HelloWorldService;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import reactor.blockhound.BlockHound;
+import reactor.blockhound.integration.ReactorIntegration;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
 import java.io.IOException;
@@ -38,6 +42,11 @@ import static org.mockito.Mockito.times;
 public class RetryOperatorTest {
 
     private HelloWorldService helloWorldService;
+
+    @BeforeClass
+    public static void beforeClass() {
+        BlockHound.install(new ReactorIntegration());
+    }
 
     @Before
     public void setUp() {
@@ -55,10 +64,16 @@ public class RetryOperatorTest {
             .willThrow(new HelloWorldException())
             .willReturn("Hello world");
 
-        Mono.fromCallable(helloWorldService::returnHelloWorld).compose(retryOperator)
-            .block(Duration.ofMillis(100));
-        Mono.fromCallable(helloWorldService::returnHelloWorld).compose(retryOperator)
-            .block(Duration.ofMillis(100));
+        StepVerifier.create(Mono.fromCallable(helloWorldService::returnHelloWorld).compose(retryOperator)
+            .subscribeOn(Schedulers.single()))
+            .expectNext("Hello world")
+            .expectComplete()
+            .verify(Duration.ofMillis(50));
+        StepVerifier.create(Mono.fromCallable(helloWorldService::returnHelloWorld).compose(retryOperator)
+            .subscribeOn(Schedulers.single()))
+            .expectNext("Hello world")
+            .expectComplete()
+            .verify(Duration.ofMillis(50));
 
         then(helloWorldService).should(times(4)).returnHelloWorld();
         Retry.Metrics metrics = retry.getMetrics();
@@ -82,11 +97,6 @@ public class RetryOperatorTest {
             .expectSubscription()
             .expectError(StackOverflowError.class)
             .verify(Duration.ofMillis(50));
-
-        then(helloWorldService).should().returnHelloWorld();
-        Retry.Metrics metrics = retry.getMetrics();
-        assertThat(metrics.getNumberOfFailedCallsWithoutRetryAttempt()).isEqualTo(0);
-        assertThat(metrics.getNumberOfFailedCallsWithRetryAttempt()).isEqualTo(0);
     }
 
     @Test
@@ -119,15 +129,17 @@ public class RetryOperatorTest {
             .willThrow(new HelloWorldException());
 
         StepVerifier.create(Mono.fromCallable(helloWorldService::returnHelloWorld)
+            .subscribeOn(Schedulers.single())
             .compose(retryOperator))
             .expectSubscription()
-            .expectError(RetryExceptionWrapper.class)
+            .expectError(HelloWorldException.class)
             .verify(Duration.ofMillis(50));
 
         StepVerifier.create(Mono.fromCallable(helloWorldService::returnHelloWorld)
+            .subscribeOn(Schedulers.single())
             .compose(retryOperator))
             .expectSubscription()
-            .expectError(RetryExceptionWrapper.class)
+            .expectError(HelloWorldException.class)
             .verify(Duration.ofMillis(50));
 
         then(helloWorldService).should(times(6)).returnHelloWorld();
@@ -149,7 +161,7 @@ public class RetryOperatorTest {
         StepVerifier.create(Mono.fromCallable(helloWorldService::returnHelloWorld)
             .compose(RetryOperator.of(retry)))
             .expectSubscription()
-            .expectError(RetryExceptionWrapper.class)
+            .expectError(HelloWorldException.class)
             .verify(Duration.ofMillis(50));
 
         then(helloWorldService).should().returnHelloWorld();
@@ -162,7 +174,7 @@ public class RetryOperatorTest {
     public void retryOnResultUsingMono() {
         RetryConfig config = RetryConfig.<String>custom()
             .retryOnResult("retry"::equals)
-            .waitDuration(Duration.ofMillis(50))
+            .waitDuration(Duration.ofMillis(10))
             .maxAttempts(3).build();
         Retry retry = Retry.of("testName", config);
         given(helloWorldService.returnHelloWorld())
@@ -170,6 +182,7 @@ public class RetryOperatorTest {
             .willReturn("success");
 
         StepVerifier.create(Mono.fromCallable(helloWorldService::returnHelloWorld)
+            .subscribeOn(Schedulers.single())
             .compose(RetryOperator.of(retry)))
             .expectSubscription()
             .expectNext("success")
@@ -185,13 +198,14 @@ public class RetryOperatorTest {
     public void retryOnResultFailAfterMaxAttemptsUsingMono() {
         RetryConfig config = RetryConfig.<String>custom()
             .retryOnResult("retry"::equals)
-            .waitDuration(Duration.ofMillis(50))
+            .waitDuration(Duration.ofMillis(10))
             .maxAttempts(3).build();
         Retry retry = Retry.of("testName", config);
         given(helloWorldService.returnHelloWorld())
             .willReturn("retry");
 
         StepVerifier.create(Mono.fromCallable(helloWorldService::returnHelloWorld)
+            .subscribeOn(Schedulers.single())
             .compose(RetryOperator.of(retry)))
             .expectSubscription()
             .expectNextCount(1)
@@ -206,9 +220,11 @@ public class RetryOperatorTest {
         Retry retry = Retry.of("testName", config);
         RetryOperator<Object> retryOperator = RetryOperator.of(retry);
 
-        StepVerifier.create(Flux.error(new HelloWorldException()).compose(retryOperator))
+        StepVerifier.create(Flux.error(new HelloWorldException())
+            .subscribeOn(Schedulers.single())
+            .compose(retryOperator))
             .expectSubscription()
-            .expectError(RetryExceptionWrapper.class)
+            .expectError(HelloWorldException.class)
             .verify(Duration.ofMillis(50));
 
         Retry.Metrics metrics = retry.getMetrics();
@@ -222,16 +238,18 @@ public class RetryOperatorTest {
     public void retryOnResultUsingFlux() {
         RetryConfig config = RetryConfig.<String>custom()
             .retryOnResult("retry"::equals)
-            .waitDuration(Duration.ofMillis(50))
+            .waitDuration(Duration.ofMillis(10))
             .maxAttempts(3).build();
         Retry retry = Retry.of("testName", config);
 
         StepVerifier.create(Flux.just("retry", "success")
+            .subscribeOn(Schedulers.single())
             .compose(RetryOperator.of(retry)))
             .expectSubscription()
             .expectNext("retry")
             .expectNext("success")
-            .expectComplete().verify(Duration.ofMillis(50));
+            .expectComplete()
+            .verify(Duration.ofMillis(50));
 
         Retry.Metrics metrics = retry.getMetrics();
         assertThat(metrics.getNumberOfFailedCallsWithoutRetryAttempt()).isEqualTo(0);
@@ -242,11 +260,12 @@ public class RetryOperatorTest {
     public void retryOnResultFailAfterMaxAttemptsUsingFlux() {
         RetryConfig config = RetryConfig.<String>custom()
             .retryOnResult("retry"::equals)
-            .waitDuration(Duration.ofMillis(50))
+            .waitDuration(Duration.ofMillis(10))
             .maxAttempts(3).build();
         Retry retry = Retry.of("testName", config);
 
         StepVerifier.create(Flux.just("retry")
+            .subscribeOn(Schedulers.single())
             .compose(RetryOperator.of(retry)))
             .expectSubscription()
             .expectNextCount(1)
@@ -258,6 +277,6 @@ public class RetryOperatorTest {
     }
 
     private RetryConfig retryConfig() {
-        return RetryConfig.custom().waitDuration(Duration.ofMillis(50)).build();
+        return RetryConfig.custom().waitDuration(Duration.ofMillis(10)).build();
     }
 }

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/retry/RetryOperatorTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/retry/RetryOperatorTest.java
@@ -249,7 +249,7 @@ public class RetryOperatorTest {
             .expectNext("retry")
             .expectNext("success")
             .expectComplete()
-            .verify(Duration.ofMillis(50));
+            .verify(Duration.ofMillis(100));
 
         Retry.Metrics metrics = retry.getMetrics();
         assertThat(metrics.getNumberOfFailedCallsWithoutRetryAttempt()).isEqualTo(0);


### PR DESCRIPTION
I can't fix it without changing `io.github.resilience4j.retry.Retry.Context` API. So backward compatibility is broken.