### PR TITLE
Issue #803: Support for metrics-only state

### DIFF
--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/event/CircuitBreakerEvent.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/event/CircuitBreakerEvent.java
@@ -82,7 +82,15 @@ public interface CircuitBreakerEvent {
         /**
          * A CircuitBreakerEvent which informs the CircuitBreaker has been disabled
          */
-        DISABLED(false);
+        DISABLED(false),
+        /**
+         * A CircuitBreakerEvent which informs the CircuitBreaker failure rate has been breached
+         */
+        FAILURE_RATE_EXCEEDED(false),
+        /**
+         * A CircuitBreakerEvent which informs the CircuitBreaker show call rate has been breached
+         */
+        SLOW_CALL_RATE_EXCEEDED(false);
 
         public final boolean forcePublish;
 

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/event/CircuitBreakerOnFailureRateExceededEvent.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/event/CircuitBreakerOnFailureRateExceededEvent.java
@@ -1,0 +1,29 @@
+package io.github.resilience4j.circuitbreaker.event;
+
+public class CircuitBreakerOnFailureRateExceededEvent extends AbstractCircuitBreakerEvent {
+
+    private final float failureRate;
+
+    public CircuitBreakerOnFailureRateExceededEvent(String circuitBreakerName, float failureRate) {
+        super(circuitBreakerName);
+        this.failureRate = failureRate;
+    }
+
+    public float getFailureRate() {
+        return failureRate;
+    }
+
+    @Override
+    public Type getEventType() {
+        return Type.FAILURE_RATE_EXCEEDED;
+    }
+
+    @Override
+    public String toString() {
+        return String
+            .format("%s: CircuitBreaker '%s' exceeded failure rate threshold. Current failure rate: %s",
+                getCreationTime(),
+                getCircuitBreakerName(),
+                getFailureRate());
+    }
+}

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/event/CircuitBreakerOnSlowCallRateExceededEvent.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/event/CircuitBreakerOnSlowCallRateExceededEvent.java
@@ -1,0 +1,29 @@
+package io.github.resilience4j.circuitbreaker.event;
+
+public class CircuitBreakerOnSlowCallRateExceededEvent extends AbstractCircuitBreakerEvent {
+
+    private final float slowCallRate;
+
+    public CircuitBreakerOnSlowCallRateExceededEvent(String circuitBreakerName, float slowCallRate) {
+        super(circuitBreakerName);
+        this.slowCallRate = slowCallRate;
+    }
+
+    public float getSlowCallRate() {
+        return slowCallRate;
+    }
+
+    @Override
+    public Type getEventType() {
+        return Type.SLOW_CALL_RATE_EXCEEDED;
+    }
+
+    @Override
+    public String toString() {
+        return String
+            .format("%s: CircuitBreaker '%s' exceeded slow call rate threshold. Current slow call rate: %s",
+                getCreationTime(),
+                getCircuitBreakerName(),
+                getSlowCallRate());
+    }
+}

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachine.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachine.java
@@ -45,7 +45,6 @@ import java.util.function.UnaryOperator;
 
 import static io.github.resilience4j.circuitbreaker.CircuitBreaker.State.*;
 import static io.github.resilience4j.circuitbreaker.internal.CircuitBreakerMetrics.Result;
-import static io.github.resilience4j.circuitbreaker.internal.CircuitBreakerMetrics.Result.ABOVE_THRESHOLDS;
 import static io.github.resilience4j.circuitbreaker.internal.CircuitBreakerMetrics.Result.BELOW_THRESHOLDS;
 import static java.time.temporal.ChronoUnit.MILLIS;
 
@@ -83,7 +82,6 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
         this.clock = clock;
         this.schedulerFactory = schedulerFactory;
         this.tags = Objects.requireNonNull(tags, "Tags must not be null");
-        ;
     }
 
     /**
@@ -307,6 +305,11 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
     }
 
     @Override
+    public void transitionToMetricsOnlyState() {
+        stateTransition(METRICS_ONLY, currentState -> new MetricsOnlyState());
+    }
+
+    @Override
     public void transitionToForcedOpenState() {
         stateTransition(FORCED_OPEN,
             currentState -> new ForcedOpenState(currentState.attempts() + 1));
@@ -385,6 +388,27 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
         final CircuitBreakerOnIgnoredErrorEvent event = new CircuitBreakerOnIgnoredErrorEvent(name,
             Duration.ofNanos(durationUnit.toNanos(duration)), throwable);
         publishEventIfPossible(event);
+    }
+
+    private void publishCircuitFailureRateExceededEvent(String name, float failureRate) {
+        final CircuitBreakerOnFailureRateExceededEvent event = new CircuitBreakerOnFailureRateExceededEvent(name,
+            failureRate);
+        publishEventIfPossible(event);
+    }
+
+    private void publishCircuitSlowCallRateExceededEvent(String name, float slowCallRate) {
+        final CircuitBreakerOnSlowCallRateExceededEvent event = new CircuitBreakerOnSlowCallRateExceededEvent(name,
+            slowCallRate);
+        publishEventIfPossible(event);
+    }
+
+    private void publishCircuitThresholdsExceededEvent(Result result, CircuitBreakerMetrics metrics) {
+        if (Result.hasFailureRateExceededThreshold(result)) {
+            publishCircuitFailureRateExceededEvent(getName(), metrics.getFailureRate());
+        }
+        if (Result.hasSlowCallRateExceededThreshold(result)) {
+            publishCircuitSlowCallRateExceededEvent(getName(), metrics.getFailureRate());
+        }
     }
 
     @Override
@@ -473,6 +497,22 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
         }
 
         @Override
+        public EventPublisher onFailureRateExceeded(
+            EventConsumer<CircuitBreakerOnFailureRateExceededEvent> onFailureRateExceededConsumer) {
+            registerConsumer(CircuitBreakerOnFailureRateExceededEvent.class.getSimpleName(),
+                onFailureRateExceededConsumer);
+            return this;
+        }
+
+        @Override
+        public EventPublisher onSlowCallRateExceeded(
+            EventConsumer<CircuitBreakerOnSlowCallRateExceededEvent> onSlowCallRateExceededConsumer) {
+            registerConsumer(CircuitBreakerOnSlowCallRateExceededEvent.class.getSimpleName(),
+                onSlowCallRateExceededConsumer);
+            return this;
+        }
+
+        @Override
         public void consumeEvent(CircuitBreakerEvent event) {
             super.processEvent(event);
         }
@@ -534,8 +574,9 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
          * @param result the Result
          */
         private void checkIfThresholdsExceeded(Result result) {
-            if (result == ABOVE_THRESHOLDS) {
+            if (Result.hasExceededThresholds(result)) {
                 if (isClosed.compareAndSet(true, false)) {
+                    publishCircuitThresholdsExceededEvent(result, circuitBreakerMetrics);
                     transitionToOpenState();
                 }
             }
@@ -691,7 +732,6 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
             // noOp
         }
 
-
         @Override
         public void onError(long duration, TimeUnit durationUnit, Throwable throwable) {
             // noOp
@@ -716,7 +756,99 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
         }
 
         /**
-         * Get metricsof the CircuitBreaker
+         * Get metrics of the CircuitBreaker
+         */
+        @Override
+        public CircuitBreakerMetrics getMetrics() {
+            return circuitBreakerMetrics;
+        }
+    }
+
+    private class MetricsOnlyState implements CircuitBreakerState {
+
+        private final CircuitBreakerMetrics circuitBreakerMetrics;
+        private final AtomicBoolean isFailureRateExceeded;
+        private final AtomicBoolean isSlowCallRateExceeded;
+
+        MetricsOnlyState() {
+            circuitBreakerMetrics = CircuitBreakerMetrics
+                .forMetricsOnly(getCircuitBreakerConfig());
+            isFailureRateExceeded = new AtomicBoolean(false);
+            isSlowCallRateExceeded = new AtomicBoolean(false);
+        }
+
+        /**
+         * Returns always true, because the CircuitBreaker is always closed in this state.
+         *
+         * @return always true, because the CircuitBreaker is always closed in this state.
+         */
+        @Override
+        public boolean tryAcquirePermission() {
+            return true;
+        }
+
+        /**
+         * Does not throw an exception, because the CircuitBreaker is always closed in this state.
+         */
+        @Override
+        public void acquirePermission() {
+            // noOp
+        }
+
+        @Override
+        public void releasePermission() {
+            // noOp
+        }
+
+        @Override
+        public void onError(long duration, TimeUnit durationUnit, Throwable throwable) {
+            checkIfThresholdsExceeded(circuitBreakerMetrics.onError(duration, durationUnit));
+        }
+
+        @Override
+        public void onSuccess(long duration, TimeUnit durationUnit) {
+            checkIfThresholdsExceeded(circuitBreakerMetrics.onSuccess(duration, durationUnit));
+        }
+
+        private void checkIfThresholdsExceeded(Result result) {
+            if (!Result.hasExceededThresholds(result)) {
+                return;
+            }
+
+            if (shouldPublishFailureRateExceededEvent(result)) {
+                publishCircuitThresholdsExceededEvent(result, circuitBreakerMetrics);
+            }
+
+            if (shouldPublishSlowCallRateExceededEvent(result)) {
+                publishCircuitThresholdsExceededEvent(result, circuitBreakerMetrics);
+            }
+        }
+
+        private boolean shouldPublishFailureRateExceededEvent(Result result) {
+            return Result.hasFailureRateExceededThreshold(result) &&
+                isFailureRateExceeded.compareAndSet(false, true);
+        }
+
+        private boolean shouldPublishSlowCallRateExceededEvent(Result result) {
+            return Result.hasSlowCallRateExceededThreshold(result) &&
+                isSlowCallRateExceeded.compareAndSet(false, true);
+        }
+
+        @Override
+        public int attempts() {
+            return 0;
+        }
+
+        /**
+         * Get the state of the CircuitBreaker
+         */
+        @Override
+        public CircuitBreaker.State getState() {
+            return CircuitBreaker.State.METRICS_ONLY;
+        }
+
+        /**
+         * Get metrics of the CircuitBreaker
          */
         @Override
         public CircuitBreakerMetrics getMetrics() {
@@ -797,7 +929,7 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
         private final AtomicInteger permittedNumberOfCalls;
         private final AtomicBoolean isHalfOpen;
         private final int attempts;
-        private CircuitBreakerMetrics circuitBreakerMetrics;
+        private final CircuitBreakerMetrics circuitBreakerMetrics;
 
         HalfOpenState(int attempts) {
             int permittedNumberOfCallsInHalfOpenState = circuitBreakerConfig
@@ -864,7 +996,7 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
          * @param result the result
          */
         private void checkIfThresholdsExceeded(Result result) {
-            if (result == ABOVE_THRESHOLDS) {
+            if (Result.hasExceededThresholds(result)) {
                 if (isHalfOpen.compareAndSet(true, false)) {
                     transitionToOpenState();
                 }

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachine.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachine.java
@@ -407,7 +407,7 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
             publishCircuitFailureRateExceededEvent(getName(), metrics.getFailureRate());
         }
         if (Result.hasSlowCallRateExceededThreshold(result)) {
-            publishCircuitSlowCallRateExceededEvent(getName(), metrics.getFailureRate());
+            publishCircuitSlowCallRateExceededEvent(getName(), metrics.getSlowCallRate());
         }
     }
 

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/utils/CircuitBreakerUtil.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/utils/CircuitBreakerUtil.java
@@ -15,6 +15,6 @@ public final class CircuitBreakerUtil {
      */
     public static boolean isCallPermitted(CircuitBreaker circuitBreaker) {
         State state = circuitBreaker.getState();
-        return state == CLOSED || state == HALF_OPEN || state == DISABLED;
+        return state == CLOSED || state == HALF_OPEN || state == DISABLED || state == METRICS_ONLY;
     }
 }

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerMetricsTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerMetricsTest.java
@@ -53,7 +53,7 @@ public class CircuitBreakerMetricsTest {
         // The failure rate must be -1, because the number of measured calls is below the buffer size of 10
         assertThat(circuitBreakerMetrics.getFailureRate()).isEqualTo(-1);
         assertThat(result)
-            .isEqualTo(Result.BELOW_MINIMUM_CALLS_THRESHOLD);
+            .isEqualTo(CircuitBreakerMetrics.Result.BELOW_MINIMUM_CALLS_THRESHOLD);
 
         circuitBreakerMetrics.onError(0, TimeUnit.NANOSECONDS);
         circuitBreakerMetrics.onError(0, TimeUnit.NANOSECONDS);
@@ -70,12 +70,12 @@ public class CircuitBreakerMetricsTest {
         assertThat(circuitBreakerMetrics.getNumberOfFailedCalls()).isEqualTo(6);
         assertThat(circuitBreakerMetrics.getNumberOfSuccessfulCalls()).isEqualTo(4);
         assertThat(circuitBreakerMetrics.getFailureRate()).isEqualTo(60);
-        assertThat(result).isEqualTo(Result.ABOVE_THRESHOLDS);
+        assertThat(Result.hasExceededThresholds(result)).isEqualTo(true);
 
         circuitBreakerMetrics.onSuccess(0, TimeUnit.NANOSECONDS);
         circuitBreakerMetrics.onSuccess(0, TimeUnit.NANOSECONDS);
         result = circuitBreakerMetrics.onSuccess(0, TimeUnit.NANOSECONDS);
-        assertThat(result).isEqualTo(Result.BELOW_THRESHOLDS);
+        assertThat(result).isEqualTo(CircuitBreakerMetrics.Result.BELOW_THRESHOLDS);
         assertThat(circuitBreakerMetrics.getFailureRate()).isEqualTo(30);
 
 

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/utils/CircuitBreakerUtilTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/utils/CircuitBreakerUtilTest.java
@@ -14,6 +14,6 @@ public class CircuitBreakerUtilTest {
             .describedAs("List of statuses changed." +
                 "Please consider updating CircuitBreakerUtil#isCallPermitted to handle" +
                 "new status properly.")
-            .containsOnly(DISABLED, CLOSED, OPEN, FORCED_OPEN, HALF_OPEN);
+            .containsOnly(DISABLED, CLOSED, OPEN, FORCED_OPEN, HALF_OPEN, METRICS_ONLY);
     }
 }

--- a/resilience4j-consumer/src/test/java/io/github/resilience4j/consumer/CircularEventConsumerTest.java
+++ b/resilience4j-consumer/src/test/java/io/github/resilience4j/consumer/CircularEventConsumerTest.java
@@ -75,10 +75,11 @@ public class CircularEventConsumerTest {
         assertThat(resetMetrics.getNumberOfBufferedCalls()).isEqualTo(0);
         assertThat(resetMetrics.getNumberOfFailedCalls()).isEqualTo(0);
         //Because circuit emits 2 error events and one state transition event
-        assertThat(ringBuffer.getBufferedEvents()).hasSize(7);
+        assertThat(ringBuffer.getBufferedEvents()).hasSize(8);
         assertThat(ringBuffer.getBufferedEvents()).extracting("eventType")
             .containsExactly(Type.SUCCESS, Type.ERROR, Type.IGNORED_ERROR, Type.ERROR,
-                Type.STATE_TRANSITION, Type.STATE_TRANSITION, Type.RESET);
+                Type.FAILURE_RATE_EXCEEDED, Type.STATE_TRANSITION, Type.STATE_TRANSITION,
+                Type.RESET);
     }
 
     @Test

--- a/resilience4j-documentation/src/docs/asciidoc/implementation_details.adoc
+++ b/resilience4j-documentation/src/docs/asciidoc/implementation_details.adoc
@@ -2,7 +2,7 @@
 
 === CircuitBreaker
 
-The CircuitBreaker is implemented via a finite state machine with three normal states: `CLOSED`, `OPEN` and `HALF_OPEN` and two special states `DISABLED` and `FORCED_OPEN`.
+The CircuitBreaker is implemented via a finite state machine with three normal states: `CLOSED`, `OPEN` and `HALF_OPEN` and three special states `METRICS_ONLY`, `DISABLED` and `FORCED_OPEN`.
 
 image::images/state_machine.jpg[]
 
@@ -48,7 +48,7 @@ CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
 circuitBreaker.reset();
 ----
 
-The CircuitBreaker supports two more special states, `DISABLED` (always allow access) and `FORCED_OPEN` (always deny access). In these two states no CircuitBreakerEvents (apart from the state transition) are generated, and no metrics are recorded. The only way to exit from those states are to trigger a state transition or to reset the CircuitBreaker.
+The CircuitBreaker supports three more special states, `METRICS_ONLY` (always allow access), `DISABLED` (always allow access) and `FORCED_OPEN` (always deny access). In `METRICS_ONLY` state all Circuit Breaker events (except state transition) are generated and metrics are recorded, similar to `CLOSED` state but the only difference being, the circuit does not open when any of the thresholds are breached. In `DISABLED` and `FORCED_OPEN` states no CircuitBreakerEvents (apart from the state transition) are generated, and no metrics are recorded. The only way to exit from those states is to trigger a state transition or to reset the CircuitBreaker.
 
 [source,java]
 ----

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetricsPublisherTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetricsPublisherTest.java
@@ -73,11 +73,11 @@ public class TaggedCircuitBreakerMetricsPublisherTest {
 
         assertThat(taggedCircuitBreakerMetricsPublisher.meterIdMap)
             .containsKeys("backendA", "backendB");
-        assertThat(taggedCircuitBreakerMetricsPublisher.meterIdMap.get("backendA")).hasSize(15);
-        assertThat(taggedCircuitBreakerMetricsPublisher.meterIdMap.get("backendB")).hasSize(15);
+        assertThat(taggedCircuitBreakerMetricsPublisher.meterIdMap.get("backendA")).hasSize(16);
+        assertThat(taggedCircuitBreakerMetricsPublisher.meterIdMap.get("backendB")).hasSize(16);
 
         List<Meter> meters = meterRegistry.getMeters();
-        assertThat(meters).hasSize(30);
+        assertThat(meters).hasSize(32);
 
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS)
             .gauges();
@@ -92,7 +92,7 @@ public class TaggedCircuitBreakerMetricsPublisherTest {
     @Test
     public void shouldRemovedMetricsForRemovedRetry() {
         List<Meter> meters = meterRegistry.getMeters();
-        assertThat(meters).hasSize(15);
+        assertThat(meters).hasSize(16);
 
         assertThat(taggedCircuitBreakerMetricsPublisher.meterIdMap).containsKeys("backendA");
         circuitBreakerRegistry.remove("backendA");
@@ -106,7 +106,7 @@ public class TaggedCircuitBreakerMetricsPublisherTest {
     @Test
     public void notPermittedCallsCounterReportsCorrespondingValue() {
         List<Meter> meters = meterRegistry.getMeters();
-        assertThat(meters).hasSize(15);
+        assertThat(meters).hasSize(16);
 
         Collection<Counter> counters = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_CALLS).counters();
 

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetricsTest.java
@@ -71,11 +71,11 @@ public class TaggedCircuitBreakerMetricsTest {
         newCircuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
 
         assertThat(taggedCircuitBreakerMetrics.meterIdMap).containsKeys("backendA", "backendB");
-        assertThat(taggedCircuitBreakerMetrics.meterIdMap.get("backendA")).hasSize(15);
-        assertThat(taggedCircuitBreakerMetrics.meterIdMap.get("backendB")).hasSize(15);
+        assertThat(taggedCircuitBreakerMetrics.meterIdMap.get("backendA")).hasSize(16);
+        assertThat(taggedCircuitBreakerMetrics.meterIdMap.get("backendB")).hasSize(16);
 
         List<Meter> meters = meterRegistry.getMeters();
-        assertThat(meters).hasSize(30);
+        assertThat(meters).hasSize(32);
 
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS)
             .gauges();
@@ -92,9 +92,9 @@ public class TaggedCircuitBreakerMetricsTest {
         CircuitBreaker circuitBreakerF = circuitBreakerRegistry.circuitBreaker("backendF", io.vavr.collection.HashMap.of("key1", "value1"));
         circuitBreakerF.onSuccess(0, TimeUnit.NANOSECONDS);
         assertThat(taggedCircuitBreakerMetrics.meterIdMap).containsKeys("backendA", "backendF");
-        assertThat(taggedCircuitBreakerMetrics.meterIdMap.get("backendF")).hasSize(15);
+        assertThat(taggedCircuitBreakerMetrics.meterIdMap.get("backendF")).hasSize(16);
         List<Meter> meters = meterRegistry.getMeters();
-        assertThat(meters).hasSize(30);
+        assertThat(meters).hasSize(32);
         final RequiredSearch match = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS).tags("key1", "value1");
         assertThat(match).isNotNull();
     }
@@ -102,7 +102,7 @@ public class TaggedCircuitBreakerMetricsTest {
     @Test
     public void shouldRemovedMetricsForRemovedRetry() {
         List<Meter> meters = meterRegistry.getMeters();
-        assertThat(meters).hasSize(15);
+        assertThat(meters).hasSize(16);
 
         assertThat(taggedCircuitBreakerMetrics.meterIdMap).containsKeys("backendA");
         circuitBreakerRegistry.remove("backendA");
@@ -116,7 +116,7 @@ public class TaggedCircuitBreakerMetricsTest {
     @Test
     public void notPermittedCallsCounterReportsCorrespondingValue() {
         List<Meter> meters = meterRegistry.getMeters();
-        assertThat(meters).hasSize(15);
+        assertThat(meters).hasSize(16);
 
         Collection<Counter> counters = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_CALLS).counters();
 


### PR DESCRIPTION
Adds the ability to record metrics and publish events while operating in a mode similar to DISABLED state, where all requests are allowed to pass through.

Related PR: https://github.com/resilience4j/resilience4j/pull/813