### PR TITLE
Remove previous meters before registering new one

### DIFF
--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractBulkheadMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractBulkheadMetrics.java
@@ -38,12 +38,15 @@ abstract class AbstractBulkheadMetrics extends AbstractMetrics {
 
     protected void addMetrics(MeterRegistry meterRegistry, Bulkhead bulkhead) {
         List<Tag> customTags = mapToTagsList(bulkhead.getTags().toJavaMap());
-        addMetrics(meterRegistry, bulkhead, customTags);
+        registerMetrics(meterRegistry, bulkhead, customTags);
     }
 
-    private void addMetrics(MeterRegistry meterRegistry, Bulkhead bulkhead, List<Tag> customTags) {
-        Set<Meter.Id> idSet = new HashSet<>();
+    private void registerMetrics(
+        MeterRegistry meterRegistry, Bulkhead bulkhead, List<Tag> customTags) {
+        // Remove previous meters before register
+        removeMetrics(meterRegistry, bulkhead.getName());
 
+        Set<Meter.Id> idSet = new HashSet<>();
         idSet.add(Gauge.builder(names.getAvailableConcurrentCallsMetricName(), bulkhead,
             bh -> bh.getMetrics().getAvailableConcurrentCalls())
             .description("The number of available permissions")

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractCircuitBreakerMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractCircuitBreakerMetrics.java
@@ -45,8 +45,11 @@ abstract class AbstractCircuitBreakerMetrics extends AbstractMetrics {
         registerMetrics(meterRegistry, circuitBreaker, customTags);
     }
 
-    private void registerMetrics(MeterRegistry meterRegistry, CircuitBreaker circuitBreaker,
-        List<Tag> customTags) {
+    private void registerMetrics(
+        MeterRegistry meterRegistry, CircuitBreaker circuitBreaker, List<Tag> customTags) {
+        // Remove previous meters before register
+        removeMetrics(meterRegistry, circuitBreaker.getName());
+
         Set<Meter.Id> idSet = new HashSet<>();
         final CircuitBreaker.State[] states = CircuitBreaker.State.values();
         for (CircuitBreaker.State state : states) {

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractRateLimiterMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractRateLimiterMetrics.java
@@ -42,8 +42,11 @@ abstract class AbstractRateLimiterMetrics extends AbstractMetrics {
         registerMetrics(meterRegistry, rateLimiter, customTags);
     }
 
-    private void registerMetrics(MeterRegistry meterRegistry, RateLimiter rateLimiter,
-        List<Tag> customTags) {
+    private void registerMetrics(
+        MeterRegistry meterRegistry, RateLimiter rateLimiter, List<Tag> customTags) {
+        // Remove previous meters before register
+        removeMetrics(meterRegistry, rateLimiter.getName());
+
         Set<Meter.Id> idSet = new HashSet<>();
         idSet.add(Gauge.builder(names.getAvailablePermissionsMetricName(), rateLimiter,
             rl -> rl.getMetrics().getAvailablePermissions())

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractRetryMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractRetryMetrics.java
@@ -43,6 +43,9 @@ abstract class AbstractRetryMetrics extends AbstractMetrics {
     }
 
     private void registerMetrics(MeterRegistry meterRegistry, Retry retry, List<Tag> customTags) {
+        // Remove previous meters before register
+        removeMetrics(meterRegistry, retry.getName());
+
         Set<Meter.Id> idSet = new HashSet<>();
         idSet.add(FunctionCounter.builder(names.getCallsMetricName(), retry,
             rt -> rt.getMetrics().getNumberOfSuccessfulCallsWithoutRetryAttempt())

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractThreadPoolBulkheadMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractThreadPoolBulkheadMetrics.java
@@ -38,11 +38,14 @@ abstract class AbstractThreadPoolBulkheadMetrics extends AbstractMetrics {
 
     protected void addMetrics(MeterRegistry meterRegistry, ThreadPoolBulkhead bulkhead) {
         List<Tag> customTags = mapToTagsList(bulkhead.getTags().toJavaMap());
-        addMetrics(meterRegistry, bulkhead, customTags);
+        registerMetrics(meterRegistry, bulkhead, customTags);
     }
 
-    private void addMetrics(MeterRegistry meterRegistry, ThreadPoolBulkhead bulkhead,
-        List<Tag> customTags) {
+    private void registerMetrics(
+        MeterRegistry meterRegistry, ThreadPoolBulkhead bulkhead, List<Tag> customTags) {
+        // Remove previous meters before register
+        removeMetrics(meterRegistry, bulkhead.getName());
+
         Set<Meter.Id> idSet = new HashSet<>();
         idSet.add(Gauge.builder(names.getQueueDepthMetricName(), bulkhead,
             bh -> bh.getMetrics().getQueueDepth())

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractTimeLimiterMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractTimeLimiterMetrics.java
@@ -40,6 +40,9 @@ abstract class AbstractTimeLimiterMetrics extends AbstractMetrics {
     }
 
     protected void addMetrics(MeterRegistry meterRegistry, TimeLimiter timeLimiter) {
+        // Remove previous meters before register
+        removeMetrics(meterRegistry, timeLimiter.getName());
+
         Counter successes = Counter.builder(names.getCallsMetricName())
             .description("The number of successful calls")
             .tag(TagNames.NAME, timeLimiter.getName())


### PR DESCRIPTION
If there is old meter with same id in MeterRegistry, MeterRegistry doesn’t do anything. new one cannot be registered.
Because of this, we cannot get metrics of new instance with same id after refreshing the spring context.

