### PR TITLE
Fix wait time calculation in AtomicRateLimiter

### DIFF
--- a/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/RateLimitersImplementationTest.java
+++ b/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/RateLimitersImplementationTest.java
@@ -115,14 +115,13 @@ public abstract class RateLimitersImplementationTest {
             long current = time.toMillis();
             long delta = Math.abs(previousDuration - current);
             runningDeltas.add(delta);
-            System.out.println("" + current + " [" + delta + "]");
             previousDuration = current;
         }
 
         then(runningDeltas.get(0)).isZero();
         then(runningDeltas.get(1)).isLessThan(20);
         then(runningDeltas.get(2)).isLessThan(20);
-        then(runningDeltas.get(3)).isBetween(200L, 1000L);
+        then(runningDeltas.get(3)).isBetween(200L, 1050L);
         then(runningDeltas.get(4)).isLessThan(20);
         then(runningDeltas.get(5)).isLessThan(20);
         then(times).hasSize(6);

--- a/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/RateLimitersImplementationTest.java
+++ b/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/RateLimitersImplementationTest.java
@@ -6,7 +6,15 @@ import org.junit.Test;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
+import static java.lang.Math.ceil;
+import static java.util.Collections.synchronizedList;
 import static org.assertj.core.api.BDDAssertions.then;
 
 /**
@@ -66,8 +74,62 @@ public abstract class RateLimitersImplementationTest {
         then(retryInSecondCyclePermission).isTrue();
     }
 
+    @Test
+    public void reservePermissionsUpfront() throws InterruptedException {
+        final int limitForPeriod = 3;
+        final int tasksNum = 9;
+        Duration limitRefreshPeriod = Duration.ofMillis(1000);
+        Duration timeoutDuration = Duration.ofMillis(1200);
+
+        Duration durationToWait = limitRefreshPeriod.multipliedBy((long) ceil(((double) tasksNum) / limitForPeriod));
+
+        RateLimiterConfig config = RateLimiterConfig.custom()
+            .limitForPeriod(limitForPeriod)
+            .limitRefreshPeriod(limitRefreshPeriod)
+            .timeoutDuration(timeoutDuration)
+            .build();
+
+        ExecutorService executorService = Executors.newFixedThreadPool(tasksNum);
+        List<Duration> times = synchronizedList(new ArrayList<>(9));
+
+        RateLimiter limiter = buildRateLimiter(config);
+        RateLimiter.Metrics metrics = limiter.getMetrics();
+        waitForRefresh(metrics, config, '$');
+
+        LocalDateTime testStart = LocalDateTime.now();
+        Runnable runnable = RateLimiter.decorateRunnable(limiter, () -> {
+            times.add(Duration.between(testStart, LocalDateTime.now()));
+        });
+        for (int i = 0; i < tasksNum; i++) {
+            executorService.submit(runnable);
+        }
+
+        executorService.shutdown();
+        boolean terminated = executorService.awaitTermination(durationToWait.toMillis(), TimeUnit.MILLISECONDS);
+        then(terminated).isTrue();
+
+
+        ArrayList<Long> runningDeltas = new ArrayList<>();
+        long previousDuration = times.get(0).toMillis();
+        for (Duration time : times) {
+            long current = time.toMillis();
+            long delta = Math.abs(previousDuration - current);
+            runningDeltas.add(delta);
+            System.out.println("" + current + " [" + delta + "]");
+            previousDuration = current;
+        }
+
+        then(runningDeltas.get(0)).isZero();
+        then(runningDeltas.get(1)).isLessThan(20);
+        then(runningDeltas.get(2)).isLessThan(20);
+        then(runningDeltas.get(3)).isBetween(200L, 1000L);
+        then(runningDeltas.get(4)).isLessThan(20);
+        then(runningDeltas.get(5)).isLessThan(20);
+        then(times).hasSize(6);
+    }
+
     protected void waitForRefresh(RateLimiter.Metrics metrics, RateLimiterConfig config,
-        char printedWhileWaiting) {
+                                  char printedWhileWaiting) {
         Instant start = Instant.now();
         while (Instant.now().isBefore(start.plus(config.getLimitRefreshPeriod()))) {
             try {


### PR DESCRIPTION
Bug fix of issue #822. Issue was introduced in PR #672.
Affected versions: 1.2.0
Summary: during concurrent permission reservations we were rounding down count of full cycles to wait for next permissions. So it was possible to get `permissionsPerCycle - 1` more permissions in the same cycle
