### PR TITLE
Delete self-closing element in javadoc

### DIFF
--- a/resilience4j-all/src/main/java/io/github/resilience4j/decorators/Decorators.java
+++ b/resilience4j-all/src/main/java/io/github/resilience4j/decorators/Decorators.java
@@ -37,7 +37,7 @@ import java.util.function.*;
  *     .decorate();
  * }</pre>
  *
- * This results in the following composition when executing the supplier: <br/>
+ * This results in the following composition when executing the supplier: <br>
  * <pre>Fallback(Retry(CircuitBreaker(Supplier)))</pre>
  *
  * This means the Supplier is called first, then it’s result is handled by the CircuitBreaker, then Retry and then Fallback.


### PR DESCRIPTION
https://travis-ci.org/resilience4j/resilience4j/builds/645325375#L806-L807

Travis CI was failed because self-closing element is not allowed in javadoc.