### PR TITLE
Support to extend Micrometer tags in TimeLimiter

### DIFF
--- a/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/timelimiter/configuration/TimeLimiterConfigurationProperties.java
+++ b/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/timelimiter/configuration/TimeLimiterConfigurationProperties.java
@@ -16,6 +16,7 @@
 
 package io.github.resilience4j.common.timelimiter.configuration;
 
+import io.github.resilience4j.common.CommonProperties;
 import io.github.resilience4j.common.utils.ConfigUtils;
 import io.github.resilience4j.core.ConfigurationNotFoundException;
 import io.github.resilience4j.core.StringUtils;
@@ -27,7 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-public class TimeLimiterConfigurationProperties {
+public class TimeLimiterConfigurationProperties extends CommonProperties {
 
     private final Map<String, InstanceProperties> instances = new HashMap<>();
     private final Map<String, InstanceProperties> configs = new HashMap<>();

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/timelimiter/configuration/TimeLimiterConfigurationPropertiesTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/timelimiter/configuration/TimeLimiterConfigurationPropertiesTest.java
@@ -5,6 +5,8 @@ import io.github.resilience4j.timelimiter.TimeLimiterConfig;
 import org.junit.Test;
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -27,8 +29,12 @@ public class TimeLimiterConfigurationPropertiesTest {
         TimeLimiterConfigurationProperties timeLimiterConfigurationProperties = new TimeLimiterConfigurationProperties();
         timeLimiterConfigurationProperties.getInstances().put("backend1", instanceProperties1);
         timeLimiterConfigurationProperties.getInstances().put("backend2", instanceProperties2);
+        Map<String,String> tags = new HashMap<>();
+        tags.put("testKey1","testKet2");
+        timeLimiterConfigurationProperties.setTags(tags);
 
         // Then
+        assertThat(timeLimiterConfigurationProperties.getTags()).isNotEmpty();
         assertThat(timeLimiterConfigurationProperties.getInstances().size()).isEqualTo(2);
         final TimeLimiterConfig timeLimiter1 = timeLimiterConfigurationProperties.createTimeLimiterConfig("backend1");
         final TimeLimiterConfig timeLimiter2 = timeLimiterConfigurationProperties.createTimeLimiterConfig("backend2");
@@ -71,7 +77,12 @@ public class TimeLimiterConfigurationPropertiesTest {
         timeLimiterConfigurationProperties.getInstances().put("backendWithDefaultConfig", backendWithDefaultConfig);
         timeLimiterConfigurationProperties.getInstances().put("backendWithSharedConfig", backendWithSharedConfig);
 
+        Map<String,String> globalTags = new HashMap<>();
+        globalTags.put("testKey1","testKet2");
+        timeLimiterConfigurationProperties.setTags(globalTags);
+
         //Then
+        assertThat(timeLimiterConfigurationProperties.getTags()).isNotEmpty();
         // Should get default config and overwrite max attempt and wait time
         TimeLimiterConfig timeLimiter1 = timeLimiterConfigurationProperties.createTimeLimiterConfig("backendWithDefaultConfig");
         assertThat(timeLimiter1).isNotNull();

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/internal/InMemoryRetryRegistry.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/internal/InMemoryRetryRegistry.java
@@ -79,7 +79,7 @@ public final class InMemoryRetryRegistry extends AbstractRegistry<Retry, RetryCo
         List<RegistryEventConsumer<Retry>> registryEventConsumers,
         io.vavr.collection.Map<String, String> tags) {
         this(configs.getOrDefault(DEFAULT_CONFIG, RetryConfig.ofDefaults()),
-            registryEventConsumers);
+            registryEventConsumers, tags);
         this.configurations.putAll(configs);
     }
 

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/timelimiter/TimeLimiterAutoConfigurationTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/timelimiter/TimeLimiterAutoConfigurationTest.java
@@ -46,6 +46,7 @@ public class TimeLimiterAutoConfigurationTest {
     public void testTimeLimiterAutoConfigurationTest() throws Exception {
         assertThat(timeLimiterRegistry).isNotNull();
         assertThat(timeLimiterProperties).isNotNull();
+        assertThat(timeLimiterRegistry.getTags()).isNotEmpty();
 
         TimeLimiterEventsEndpointResponse timeLimiterEventsBefore =
             timeLimiterEvents("/actuator/timelimiterevents");

--- a/resilience4j-spring-boot2/src/test/resources/application.yaml
+++ b/resilience4j-spring-boot2/src/test/resources/application.yaml
@@ -138,7 +138,7 @@ resilience4j.bulkhead:
       maxWaitDuration: 100
       maxConcurrentCalls: 10
 
-resilience4j.thread-pool-bulkhead":
+resilience4j.thread-pool-bulkhead:
   tags:
     tag1: tag1Value
     tag2: tag2Value
@@ -164,6 +164,9 @@ resilience4j.thread-pool-bulkhead":
         - io.github.resilience4j.TestThreadLocalContextPropagator
 
 resilience4j.timelimiter:
+  tags:
+    tag1: tag1Value
+    tag2: tag2Value
   time-limiter-aspect-order: 398
   configs:
     default:

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/timelimiter/configure/TimeLimiterConfiguration.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/timelimiter/configure/TimeLimiterConfiguration.java
@@ -28,6 +28,7 @@ import io.github.resilience4j.timelimiter.event.TimeLimiterEvent;
 import io.github.resilience4j.utils.AspectJOnClasspathCondition;
 import io.github.resilience4j.utils.ReactorOnClasspathCondition;
 import io.github.resilience4j.utils.RxJava2OnClasspathCondition;
+import io.vavr.collection.HashMap;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -108,7 +109,8 @@ public class TimeLimiterConfiguration {
                 .entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey,
                         entry -> timeLimiterConfigurationProperties.createTimeLimiterConfig(entry.getValue())));
 
-        return TimeLimiterRegistry.of(configs, timeLimiterRegistryEventConsumer);
+        return TimeLimiterRegistry.of(configs, timeLimiterRegistryEventConsumer,
+            HashMap.ofAll(timeLimiterConfigurationProperties.getTags()));
     }
 
     /**

--- a/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/TimeLimiter.java
+++ b/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/TimeLimiter.java
@@ -61,6 +61,23 @@ public interface TimeLimiter {
     }
 
     /**
+     * Creates a CircuitBreaker with a custom CircuitBreaker configuration.
+     * <p>
+     * The {@code tags} passed will be appended to the tags already configured for the registry.
+     * When tags (keys) of the two collide the tags passed with this method will override the tags
+     * of the registry.
+     *
+     * @param name                 the name of the CircuitBreaker
+     * @param timeLimiterConfig a custom CircuitBreaker configuration
+     * @param tags                 tags added to the Retry
+     * @return a CircuitBreaker with a custom CircuitBreaker configuration.
+     */
+    static TimeLimiter of(String name, TimeLimiterConfig timeLimiterConfig,
+        io.vavr.collection.Map<String, String> tags) {
+        return new TimeLimiterImpl(name, timeLimiterConfig, tags);
+    }
+
+    /**
      * Creates a TimeLimiter decorator with a timeout Duration.
      *
      * @param timeoutDuration the timeout Duration
@@ -103,6 +120,13 @@ public interface TimeLimiter {
     }
 
     String getName();
+
+    /**
+     * Returns an unmodifiable map with tags assigned to this TimeLimiter.
+     *
+     * @return the tags assigned to this TimeLimiter in an unmodifiable map
+     */
+    io.vavr.collection.Map<String, String> getTags();
 
     /**
      * Get the TimeLimiterConfig of this TimeLimiter decorator.

--- a/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/TimeLimiter.java
+++ b/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/TimeLimiter.java
@@ -61,16 +61,16 @@ public interface TimeLimiter {
     }
 
     /**
-     * Creates a CircuitBreaker with a custom CircuitBreaker configuration.
+     * Creates a TimeLimiter with a custom TimeLimiter configuration.
      * <p>
      * The {@code tags} passed will be appended to the tags already configured for the registry.
      * When tags (keys) of the two collide the tags passed with this method will override the tags
      * of the registry.
      *
-     * @param name                 the name of the CircuitBreaker
-     * @param timeLimiterConfig a custom CircuitBreaker configuration
+     * @param name                 the name of the TimeLimiter
+     * @param timeLimiterConfig    a custom TimeLimiter configuration
      * @param tags                 tags added to the Retry
-     * @return a CircuitBreaker with a custom CircuitBreaker configuration.
+     * @return a TimeLimiter with a custom TimeLimiter configuration.
      */
     static TimeLimiter of(String name, TimeLimiterConfig timeLimiterConfig,
         io.vavr.collection.Map<String, String> tags) {

--- a/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/TimeLimiterRegistry.java
+++ b/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/TimeLimiterRegistry.java
@@ -91,6 +91,20 @@ public interface TimeLimiterRegistry extends Registry<TimeLimiter, TimeLimiterCo
     }
 
     /**
+     * Creates a TimeLimiterRegistry with a Map of shared TimeLimiter configurations.
+     * <p>
+     * Tags added to the registry will be added to every instance created by this registry.
+     *
+     * @param configs a Map of shared TimeLimiter configurations
+     * @param tags    default tags to add to the registry
+     * @return a TimeLimiterRegistry with a Map of shared TimeLimiter configurations.
+     */
+    static TimeLimiterRegistry of(Map<String, TimeLimiterConfig> configs,
+        io.vavr.collection.Map<String, String> tags) {
+        return new InMemoryTimeLimiterRegistry(configs, tags);
+    }
+
+    /**
      * Creates a TimeLimiterRegistry with a Map of shared TimeLimiter configurations and a
      * TimeLimiter registry event consumer.
      *
@@ -102,6 +116,22 @@ public interface TimeLimiterRegistry extends Registry<TimeLimiter, TimeLimiterCo
     static TimeLimiterRegistry of(Map<String, TimeLimiterConfig> configs,
         RegistryEventConsumer<TimeLimiter> registryEventConsumer) {
         return new InMemoryTimeLimiterRegistry(configs, registryEventConsumer);
+    }
+
+    /**
+     * Creates a TimeLimiterRegistry with a Map of shared TimeLimiter configurations and a
+     * TimeLimiter registry event consumer.
+     *
+     * @param configs               a Map of shared TimeLimiter configurations.
+     * @param registryEventConsumer a TimeLimiter registry event consumer.
+     * @param tags                  default tags to add to the registry
+     * @return a TimeLimiterRegistry with a Map of shared TimeLimiter configurations and a
+     * TimeLimiter registry event consumer.
+     */
+    static TimeLimiterRegistry of(Map<String, TimeLimiterConfig> configs,
+        RegistryEventConsumer<TimeLimiter> registryEventConsumer,
+        io.vavr.collection.Map<String, String> tags) {
+        return new InMemoryTimeLimiterRegistry(configs, registryEventConsumer, tags);
     }
 
     /**
@@ -135,6 +165,20 @@ public interface TimeLimiterRegistry extends Registry<TimeLimiter, TimeLimiterCo
     TimeLimiter timeLimiter(String name);
 
     /**
+     * Returns a managed {@link TimeLimiter} or creates a new one with the default TimeLimiter
+     * configuration.
+     * <p>
+     * The {@code tags} passed will be appended to the tags already configured for the registry.
+     * When tags (keys) of the two collide the tags passed with this method will override the tags
+     * of the registry.
+     *
+     * @param name the name of the TimeLimiter
+     * @param tags tags added to the TimeLimiter
+     * @return The {@link TimeLimiter}
+     */
+    TimeLimiter timeLimiter(String name, io.vavr.collection.Map<String, String> tags);
+
+    /**
      * Returns a managed {@link TimeLimiter} or creates a new one with a custom TimeLimiter
      * configuration.
      *
@@ -143,6 +187,22 @@ public interface TimeLimiterRegistry extends Registry<TimeLimiter, TimeLimiterCo
      * @return The {@link TimeLimiter}
      */
     TimeLimiter timeLimiter(String name, TimeLimiterConfig timeLimiterConfig);
+
+    /**
+     * Returns a managed {@link TimeLimiter} or creates a new one with a custom TimeLimiter
+     * configuration.
+     * <p>
+     * The {@code tags} passed will be appended to the tags already configured for the registry.
+     * When tags (keys) of the two collide the tags passed with this method will override the tags
+     * of the registry.
+     *
+     * @param name              the name of the TimeLimiter
+     * @param timeLimiterConfig a custom TimeLimiter configuration
+     * @param tags              tags added to the TimeLimiter
+     * @return The {@link TimeLimiter}
+     */
+    TimeLimiter timeLimiter(String name, TimeLimiterConfig timeLimiterConfig,
+        io.vavr.collection.Map<String, String> tags);
 
     /**
      * Returns a managed {@link TimeLimiterConfig} or creates a new one with a custom
@@ -155,6 +215,23 @@ public interface TimeLimiterRegistry extends Registry<TimeLimiter, TimeLimiterCo
     TimeLimiter timeLimiter(String name, Supplier<TimeLimiterConfig> timeLimiterConfigSupplier);
 
     /**
+     * Returns a managed {@link TimeLimiter} or creates a new one with a custom TimeLimiter
+     * configuration.
+     * <p>
+     * The {@code tags} passed will be appended to the tags already configured for the registry.
+     * When tags (keys) of the two collide the tags passed with this method will override the tags
+     * of the registry.
+     *
+     * @param name                      the name of the TimeLimiter
+     * @param timeLimiterConfigSupplier a supplier of a custom TimeLimiter configuration
+     * @param tags                      tags added to the TimeLimiter
+     * @return The {@link TimeLimiter}
+     */
+    TimeLimiter timeLimiter(String name,
+        Supplier<TimeLimiterConfig> timeLimiterConfigSupplier,
+        io.vavr.collection.Map<String, String> tags);
+
+    /**
      * Returns a managed {@link TimeLimiter} or creates a new one.
      * The configuration must have been added upfront via {@link #addConfiguration(String, Object)}.
      *
@@ -163,5 +240,21 @@ public interface TimeLimiterRegistry extends Registry<TimeLimiter, TimeLimiterCo
      * @return The {@link TimeLimiter}
      */
     TimeLimiter timeLimiter(String name, String configName);
+
+    /**
+     * Returns a managed {@link TimeLimiter} or creates a new one.
+     * The configuration must have been added upfront via {@link #addConfiguration(String, Object)}.
+     * <p>
+     * The {@code tags} passed will be appended to the tags already configured for the registry.
+     * When tags (keys) of the two collide the tags passed with this method will override the tags
+     * of the registry.
+     *
+     * @param name       the name of the TimeLimiter
+     * @param configName the name of the shared configuration
+     * @param tags       tags added to the TimeLimiter
+     * @return The {@link TimeLimiter}
+     */
+    TimeLimiter timeLimiter(String name, String configName,
+        io.vavr.collection.Map<String, String> tags);
 
 }

--- a/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/internal/InMemoryTimeLimiterRegistry.java
+++ b/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/internal/InMemoryTimeLimiterRegistry.java
@@ -25,6 +25,7 @@ import io.github.resilience4j.timelimiter.TimeLimiter;
 import io.github.resilience4j.timelimiter.TimeLimiterConfig;
 import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
 import io.vavr.collection.Array;
+import io.vavr.collection.HashMap;
 import io.vavr.collection.Seq;
 
 import java.util.List;
@@ -42,11 +43,21 @@ public class InMemoryTimeLimiterRegistry extends
      * The constructor with default default.
      */
     public InMemoryTimeLimiterRegistry() {
-        this(TimeLimiterConfig.ofDefaults());
+        this(TimeLimiterConfig.ofDefaults(), HashMap.empty());
+    }
+
+    public InMemoryTimeLimiterRegistry(io.vavr.collection.Map<String, String> tags) {
+        this(TimeLimiterConfig.ofDefaults(), tags);
     }
 
     public InMemoryTimeLimiterRegistry(Map<String, TimeLimiterConfig> configs) {
         this(configs.getOrDefault(DEFAULT_CONFIG, TimeLimiterConfig.ofDefaults()));
+        this.configurations.putAll(configs);
+    }
+
+    public InMemoryTimeLimiterRegistry(Map<String, TimeLimiterConfig> configs,
+        io.vavr.collection.Map<String, String> tags) {
+        this(configs.getOrDefault(DEFAULT_CONFIG, TimeLimiterConfig.ofDefaults()), tags);
         this.configurations.putAll(configs);
     }
 
@@ -58,9 +69,25 @@ public class InMemoryTimeLimiterRegistry extends
     }
 
     public InMemoryTimeLimiterRegistry(Map<String, TimeLimiterConfig> configs,
+        RegistryEventConsumer<TimeLimiter> registryEventConsumer,
+        io.vavr.collection.Map<String, String> tags) {
+        this(configs.getOrDefault(DEFAULT_CONFIG, TimeLimiterConfig.ofDefaults()), registryEventConsumer,
+            tags);
+        this.configurations.putAll(configs);
+    }
+
+    public InMemoryTimeLimiterRegistry(Map<String, TimeLimiterConfig> configs,
         List<RegistryEventConsumer<TimeLimiter>> registryEventConsumers) {
         this(configs.getOrDefault(DEFAULT_CONFIG, TimeLimiterConfig.ofDefaults()),
             registryEventConsumers);
+        this.configurations.putAll(configs);
+    }
+
+    public InMemoryTimeLimiterRegistry(Map<String, TimeLimiterConfig> configs,
+        List<RegistryEventConsumer<TimeLimiter>> registryEventConsumers,
+        io.vavr.collection.Map<String, String> tags) {
+        this(configs.getOrDefault(DEFAULT_CONFIG, TimeLimiterConfig.ofDefaults()),
+            registryEventConsumers, tags);
         this.configurations.putAll(configs);
     }
 
@@ -74,13 +101,30 @@ public class InMemoryTimeLimiterRegistry extends
     }
 
     public InMemoryTimeLimiterRegistry(TimeLimiterConfig defaultConfig,
+        io.vavr.collection.Map<String, String> tags) {
+        super(defaultConfig, tags);
+    }
+
+    public InMemoryTimeLimiterRegistry(TimeLimiterConfig defaultConfig,
         RegistryEventConsumer<TimeLimiter> registryEventConsumer) {
         super(defaultConfig, registryEventConsumer);
     }
 
     public InMemoryTimeLimiterRegistry(TimeLimiterConfig defaultConfig,
+        RegistryEventConsumer<TimeLimiter> registryEventConsumer,
+        io.vavr.collection.Map<String, String> tags) {
+        super(defaultConfig, registryEventConsumer, tags);
+    }
+
+    public InMemoryTimeLimiterRegistry(TimeLimiterConfig defaultConfig,
         List<RegistryEventConsumer<TimeLimiter>> registryEventConsumers) {
         super(defaultConfig, registryEventConsumers);
+    }
+
+    public InMemoryTimeLimiterRegistry(TimeLimiterConfig defaultConfig,
+        List<RegistryEventConsumer<TimeLimiter>> registryEventConsumers,
+        io.vavr.collection.Map<String, String> tags) {
+        super(defaultConfig, registryEventConsumers, tags);
     }
 
     /**
@@ -96,7 +140,13 @@ public class InMemoryTimeLimiterRegistry extends
      */
     @Override
     public TimeLimiter timeLimiter(final String name) {
-        return timeLimiter(name, getDefaultConfig());
+        return timeLimiter(name, getDefaultConfig(), HashMap.empty());
+    }
+
+    @Override
+    public TimeLimiter timeLimiter(String name,
+        io.vavr.collection.Map<String, String> tags) {
+        return timeLimiter(name, getDefaultConfig(), tags);
     }
 
     /**
@@ -104,8 +154,15 @@ public class InMemoryTimeLimiterRegistry extends
      */
     @Override
     public TimeLimiter timeLimiter(final String name, final TimeLimiterConfig config) {
-        return computeIfAbsent(name, () -> new TimeLimiterImpl(name,
-            Objects.requireNonNull(config, CONFIG_MUST_NOT_BE_NULL)));
+        return timeLimiter(name, config, HashMap.empty());
+    }
+
+    @Override
+    public TimeLimiter timeLimiter(String name,
+        TimeLimiterConfig timeLimiterConfig,
+        io.vavr.collection.Map<String, String> tags) {
+        return computeIfAbsent(name, () -> TimeLimiter.of(name,
+            Objects.requireNonNull(timeLimiterConfig, CONFIG_MUST_NOT_BE_NULL), getAllTags(tags)));
     }
 
     /**
@@ -117,9 +174,17 @@ public class InMemoryTimeLimiterRegistry extends
         return computeIfAbsent(name, () -> {
             TimeLimiterConfig config = Objects
                 .requireNonNull(timeLimiterConfigSupplier, SUPPLIER_MUST_NOT_BE_NULL).get();
-            return new TimeLimiterImpl(name,
-                Objects.requireNonNull(config, CONFIG_MUST_NOT_BE_NULL));
+            return timeLimiter(name, Objects.requireNonNull(config, CONFIG_MUST_NOT_BE_NULL), HashMap.empty());
         });
+    }
+
+    @Override
+    public TimeLimiter timeLimiter(String name,
+        Supplier<TimeLimiterConfig> timeLimiterConfigSupplier,
+        io.vavr.collection.Map<String, String> tags) {
+        return computeIfAbsent(name, () -> TimeLimiter.of(name, Objects.requireNonNull(
+            Objects.requireNonNull(timeLimiterConfigSupplier, SUPPLIER_MUST_NOT_BE_NULL).get(),
+            CONFIG_MUST_NOT_BE_NULL), getAllTags(tags)));
     }
 
     /**
@@ -127,10 +192,16 @@ public class InMemoryTimeLimiterRegistry extends
      */
     @Override
     public TimeLimiter timeLimiter(String name, String configName) {
+        return timeLimiter(name, configName, HashMap.empty());
+    }
+
+    @Override
+    public TimeLimiter timeLimiter(String name, String configName,
+        io.vavr.collection.Map<String, String> tags) {
         return computeIfAbsent(name, () -> {
             TimeLimiterConfig config = getConfiguration(configName)
                 .orElseThrow(() -> new ConfigurationNotFoundException(configName));
-            return TimeLimiter.of(name, config);
+            return TimeLimiter.of(name, config, tags);
         });
     }
 }

--- a/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/internal/InMemoryTimeLimiterRegistry.java
+++ b/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/internal/InMemoryTimeLimiterRegistry.java
@@ -171,11 +171,7 @@ public class InMemoryTimeLimiterRegistry extends
     @Override
     public TimeLimiter timeLimiter(final String name,
         final Supplier<TimeLimiterConfig> timeLimiterConfigSupplier) {
-        return computeIfAbsent(name, () -> {
-            TimeLimiterConfig config = Objects
-                .requireNonNull(timeLimiterConfigSupplier, SUPPLIER_MUST_NOT_BE_NULL).get();
-            return timeLimiter(name, Objects.requireNonNull(config, CONFIG_MUST_NOT_BE_NULL), HashMap.empty());
-        });
+        return timeLimiter(name, timeLimiterConfigSupplier, HashMap.empty());
     }
 
     @Override
@@ -198,10 +194,8 @@ public class InMemoryTimeLimiterRegistry extends
     @Override
     public TimeLimiter timeLimiter(String name, String configName,
         io.vavr.collection.Map<String, String> tags) {
-        return computeIfAbsent(name, () -> {
-            TimeLimiterConfig config = getConfiguration(configName)
-                .orElseThrow(() -> new ConfigurationNotFoundException(configName));
-            return TimeLimiter.of(name, config, tags);
-        });
+        TimeLimiterConfig config = getConfiguration(configName)
+            .orElseThrow(() -> new ConfigurationNotFoundException(configName));
+        return timeLimiter(name, config, tags);
     }
 }

--- a/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/internal/TimeLimiterImpl.java
+++ b/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/internal/TimeLimiterImpl.java
@@ -6,9 +6,13 @@ import io.github.resilience4j.timelimiter.event.TimeLimiterEvent;
 import io.github.resilience4j.timelimiter.event.TimeLimiterOnErrorEvent;
 import io.github.resilience4j.timelimiter.event.TimeLimiterOnSuccessEvent;
 import io.github.resilience4j.timelimiter.event.TimeLimiterOnTimeoutEvent;
+import io.vavr.collection.HashMap;
+import io.vavr.collection.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Clock;
+import java.util.Objects;
 import java.util.concurrent.*;
 import java.util.function.Supplier;
 
@@ -17,14 +21,23 @@ public class TimeLimiterImpl implements TimeLimiter {
     private static final Logger LOG = LoggerFactory.getLogger(TimeLimiterImpl.class);
 
     private final String name;
+    private final Map<String, String> tags;
     private final TimeLimiterConfig timeLimiterConfig;
     private final TimeLimiterEventProcessor eventProcessor;
 
     public TimeLimiterImpl(String name, TimeLimiterConfig timeLimiterConfig) {
+        this(name, timeLimiterConfig, HashMap.empty());
+
+    }
+
+    public TimeLimiterImpl(String name, TimeLimiterConfig timeLimiterConfig,
+        io.vavr.collection.Map<String, String> tags) {
         this.name = name;
+        this.tags = Objects.requireNonNull(tags, "Tags must not be null");
         this.timeLimiterConfig = timeLimiterConfig;
         this.eventProcessor = new TimeLimiterEventProcessor();
     }
+
 
     @Override
     public <T, F extends Future<T>> Callable<T> decorateFutureSupplier(Supplier<F> futureSupplier) {
@@ -99,6 +112,11 @@ public class TimeLimiterImpl implements TimeLimiter {
     @Override
     public String getName() {
         return name;
+    }
+
+    @Override
+    public Map<String, String> getTags() {
+        return tags;
     }
 
     @Override

--- a/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/internal/TimeLimiterImpl.java
+++ b/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/internal/TimeLimiterImpl.java
@@ -11,7 +11,6 @@ import io.vavr.collection.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Clock;
 import java.util.Objects;
 import java.util.concurrent.*;
 import java.util.function.Supplier;

--- a/resilience4j-timelimiter/src/test/java/io/github/resilience4j/timelimiter/TimeLimiterRegistryTest.java
+++ b/resilience4j-timelimiter/src/test/java/io/github/resilience4j/timelimiter/TimeLimiterRegistryTest.java
@@ -7,6 +7,7 @@ import io.github.resilience4j.core.registry.EntryAddedEvent;
 import io.github.resilience4j.core.registry.EntryRemovedEvent;
 import io.github.resilience4j.core.registry.EntryReplacedEvent;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
+import io.vavr.Tuple;
 import org.junit.Test;
 
 import java.time.Duration;
@@ -38,6 +39,84 @@ public class TimeLimiterRegistryTest {
 
         TimeLimiterConfig timeLimiterConfig = timeLimiterRegistry.getDefaultConfig();
         assertThat(timeLimiterConfig).isSameAs(config);
+    }
+
+    @Test
+    public void shouldInitRegistryTags() {
+        TimeLimiterConfig timeLimiterConfig = TimeLimiterConfig.ofDefaults();
+        Map<String, TimeLimiterConfig> timeLimiterConfigs = Collections
+            .singletonMap("default", timeLimiterConfig);
+        TimeLimiterRegistry registry = TimeLimiterRegistry.of(timeLimiterConfigs, new NoOpTimeLimiterEventConsumer(),io.vavr.collection.HashMap.of("Tag1Key","Tag1Value"));
+        assertThat(registry.getTags()).isNotEmpty();
+        assertThat(registry.getTags()).containsOnly(Tuple.of("Tag1Key","Tag1Value"));
+    }
+
+    @Test
+    public void noTagsByDefault() {
+        TimeLimiter TimeLimiter = TimeLimiterRegistry.ofDefaults()
+            .timeLimiter("testName");
+        assertThat(TimeLimiter.getTags()).hasSize(0);
+    }
+
+    @Test
+    public void tagsOfRegistryAddedToInstance() {
+        TimeLimiterConfig timeLimiterConfig = TimeLimiterConfig.ofDefaults();
+        Map<String, TimeLimiterConfig> timeLimiterConfigs = Collections
+            .singletonMap("default", timeLimiterConfig);
+        io.vavr.collection.Map<String, String> timeLimiterTags = io.vavr.collection.HashMap
+            .of("key1", "value1", "key2", "value2");
+        TimeLimiterRegistry timeLimiterRegistry = TimeLimiterRegistry
+            .of(timeLimiterConfigs, timeLimiterTags);
+        TimeLimiter TimeLimiter = timeLimiterRegistry.timeLimiter("testName");
+
+        assertThat(TimeLimiter.getTags()).containsOnlyElementsOf(timeLimiterTags);
+    }
+
+    @Test
+    public void tagsAddedToInstance() {
+        TimeLimiterRegistry timeLimiterRegistry = TimeLimiterRegistry.ofDefaults();
+        io.vavr.collection.Map<String, String> timeLimiterTags = io.vavr.collection.HashMap
+            .of("key1", "value1", "key2", "value2");
+        TimeLimiter TimeLimiter = timeLimiterRegistry
+            .timeLimiter("testName", timeLimiterTags);
+
+        assertThat(TimeLimiter.getTags()).containsOnlyElementsOf(timeLimiterTags);
+    }
+
+    @Test
+    public void tagsOfTimeLimitersShouldNotBeMixed() {
+        TimeLimiterRegistry timeLimiterRegistry = TimeLimiterRegistry.ofDefaults();
+        TimeLimiterConfig timeLimiterConfig = TimeLimiterConfig.ofDefaults();
+        io.vavr.collection.Map<String, String> timeLimiterTags = io.vavr.collection.HashMap
+            .of("key1", "value1", "key2", "value2");
+        TimeLimiter TimeLimiter = timeLimiterRegistry
+            .timeLimiter("testName", timeLimiterConfig, timeLimiterTags);
+        io.vavr.collection.Map<String, String> timeLimiterTags2 = io.vavr.collection.HashMap
+            .of("key3", "value3", "key4", "value4");
+        TimeLimiter TimeLimiter2 = timeLimiterRegistry
+            .timeLimiter("otherTestName", timeLimiterConfig, timeLimiterTags2);
+
+        assertThat(TimeLimiter.getTags()).containsOnlyElementsOf(timeLimiterTags);
+        assertThat(TimeLimiter2.getTags()).containsOnlyElementsOf(timeLimiterTags2);
+    }
+
+    @Test
+    public void tagsOfInstanceTagsShouldOverrideRegistryTags() {
+        TimeLimiterConfig timeLimiterConfig = TimeLimiterConfig.ofDefaults();
+        Map<String, TimeLimiterConfig> timeLimiterConfigs = Collections
+            .singletonMap("default", timeLimiterConfig);
+        io.vavr.collection.Map<String, String> timeLimiterTags = io.vavr.collection.HashMap
+            .of("key1", "value1", "key2", "value2");
+        io.vavr.collection.Map<String, String> instanceTags = io.vavr.collection.HashMap
+            .of("key1", "value3", "key4", "value4");
+        TimeLimiterRegistry timeLimiterRegistry = TimeLimiterRegistry
+            .of(timeLimiterConfigs, timeLimiterTags);
+        TimeLimiter timeLimiter = timeLimiterRegistry
+            .timeLimiter("testName", timeLimiterConfig, instanceTags);
+
+        io.vavr.collection.Map<String, String> expectedTags = io.vavr.collection.HashMap
+            .of("key1", "value3", "key2", "value2", "key4", "value4");
+        assertThat(timeLimiter.getTags()).containsOnlyElementsOf(expectedTags);
     }
 
     @Test


### PR DESCRIPTION
Related with https://github.com/resilience4j/resilience4j/pull/749. 
Added support to extend tags in TimeLimiter.
