### PR TITLE
Fixed BulkheadAspect: An ExecutionException is wrapped by a Completio…

### DIFF
--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/FixedThreadPoolBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/FixedThreadPoolBulkhead.java
@@ -143,6 +143,9 @@ public class FixedThreadPoolBulkhead implements ThreadPoolBulkhead {
                     publishBulkheadEvent(() -> new BulkheadOnCallPermittedEvent(name));
                     return callable.call();
                 } catch (Exception e) {
+                    if(e instanceof CompletionException){
+                        throw (CompletionException)e;
+                    }
                     throw new CompletionException(e);
                 }
             }), executorService).whenComplete((result, throwable) -> {

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/bulkhead/configure/BulkheadAspect.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/bulkhead/configure/BulkheadAspect.java
@@ -43,6 +43,7 @@ import java.lang.reflect.Proxy;
 import java.util.List;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
 
 /**
  * This Spring AOP aspect intercepts all methods which are annotated with a {@link Bulkhead}
@@ -249,8 +250,10 @@ public class BulkheadAspect implements EmbeddedValueResolverAware, Ordered {
                 try {
                     return ((CompletionStage<?>) proceedingJoinPoint.proceed())
                         .toCompletableFuture().get();
-                } catch (Throwable throwable) {
-                    throw new CompletionException(throwable);
+                } catch (ExecutionException e) {
+                    throw new CompletionException(e.getCause());
+                } catch (Throwable e) {
+                    throw new CompletionException(e);
                 }
             });
         } else {


### PR DESCRIPTION
…nException, but instead the cause should be wrapped.

Fixed FixedThreadPoolBulkhead: A CompletionException should not be wrapped inside of another CompletionException.