### PR TITLE
Remove deprecated method usage

### DIFF
--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/retry/FlowRetry.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/retry/FlowRetry.kt
@@ -56,7 +56,7 @@ fun <T> Flow<T>.retry(retry: Retry): Flow<T> {
 
     }.onCompletion { e ->
         if (e == null)
-            retryContext.onSuccess()
+            retryContext.onComplete()
     }
 
 }

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/retry/Retry.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/retry/Retry.kt
@@ -33,7 +33,7 @@ suspend fun <T> Retry.executeSuspendFunction(block: suspend () -> T): T {
             val result = block()
             val delayMs = retryContext.onResult(result)
             if (delayMs < 1) {
-                retryContext.onSuccess()
+                retryContext.onComplete()
                 return result
             } else {
                 delay(delayMs)


### PR DESCRIPTION
In `Retry.kt` and `FlowRetry.kt`, still used deprecated method `onSuccess()`. 
Changed it to `onComplete()`.