### PR TITLE
WIP Feign thread pool bulkhead added (#819)

### DIFF
--- a/resilience4j-feign/build.gradle
+++ b/resilience4j-feign/build.gradle
@@ -1,9 +1,6 @@
 dependencies {
     compileOnly(libraries.feign)
-    compile project(':resilience4j-retry')
-    compile project(':resilience4j-circuitbreaker')
-    compile project(':resilience4j-ratelimiter')
-    compile project(':resilience4j-bulkhead')
+    compile project(':resilience4j-all')
     testCompile(libraries.feign_wiremock)
     testCompile(libraries.feign)
 }

--- a/resilience4j-feign/src/main/java/io/github/resilience4j/feign/CompletableFutureDecoder.java
+++ b/resilience4j-feign/src/main/java/io/github/resilience4j/feign/CompletableFutureDecoder.java
@@ -1,0 +1,45 @@
+package io.github.resilience4j.feign;
+
+import feign.FeignException;
+import feign.Response;
+import feign.Util;
+import feign.codec.DecodeException;
+import feign.codec.Decoder;
+
+import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+public class CompletableFutureDecoder implements Decoder {
+
+    private final Decoder delegate;
+
+    public CompletableFutureDecoder(Decoder delegate) {
+        Objects.requireNonNull(delegate, "Decoder must not be null.");
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Object decode(Response response, Type type) throws IOException, DecodeException, FeignException {
+        if (!accept(type)) {
+            return delegate.decode(response, type);
+        }
+        if (response.status() == 404 || response.status() == 204) {
+            return CompletableFuture.completedFuture(null);
+        }
+        Type enclosedType = Util.resolveLastTypeParameter(type, CompletableFuture.class);
+        Object decoded = delegate.decode(response, enclosedType);
+        return CompletableFuture.completedFuture(decoded);
+    }
+
+    static boolean accept(Type type) {
+        if (!(type instanceof ParameterizedType)) {
+            return false;
+        }
+        ParameterizedType parameterizedType = (ParameterizedType) type;
+        return parameterizedType.getRawType().equals(CompletableFuture.class);
+    }
+
+}

--- a/resilience4j-feign/src/main/java/io/github/resilience4j/feign/DecoratorPostponedInvocationHandler.java
+++ b/resilience4j-feign/src/main/java/io/github/resilience4j/feign/DecoratorPostponedInvocationHandler.java
@@ -1,0 +1,143 @@
+/*
+ *
+ * Copyright 2020
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *
+ */
+package io.github.resilience4j.feign;
+
+import feign.InvocationHandlerFactory.MethodHandler;
+import feign.Target;
+import io.vavr.CheckedFunction1;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static feign.Util.checkNotNull;
+
+/**
+ * An instance of {@link InvocationHandler} that uses {@link FeignDecorator}s to enhance the
+ * invocations of methods.
+ */
+class DecoratorPostponedInvocationHandler<T> implements InvocationHandler {
+
+    private final Target<?> target;
+    private final Map<Method, CheckedFunction1<Object[], Object>> decoratedDispatch;
+
+    public DecoratorPostponedInvocationHandler(Target<?> target,
+        Map<Method, MethodHandler> dispatch,
+        Function<Supplier<T>, Supplier<CompletionStage<T>>> completionStageWrapper) {
+        this.target = checkNotNull(target, "target");
+        checkNotNull(dispatch, "dispatch");
+        this.decoratedDispatch = decorateMethodHandlers(dispatch, completionStageWrapper, target);
+    }
+
+    /**
+     * Applies the specified {@link FeignDecorator} to all specified {@link MethodHandler}s and
+     * returns the result as a map of {@link CheckedFunction1}s. Invoking a {@link CheckedFunction1}
+     * will therefore invoke the decorator which, in turn, may invoke the corresponding {@link
+     * MethodHandler}.
+     *
+     * @param dispatch               a map of the methods from the feign interface to the {@link
+     *                               MethodHandler}s.
+     * @param completionStageWrapper the {@link FeignDecorator} with which to decorate the {@link
+     *                               MethodHandler}s.
+     * @param target                 the target feign interface.
+     * @return a new map where the {@link MethodHandler}s are decorated with the {@link
+     * FeignDecorator}.
+     */
+    private Map<Method, CheckedFunction1<Object[], Object>> decorateMethodHandlers(
+        Map<Method, MethodHandler> dispatch,
+        Function<Supplier<T>, Supplier<CompletionStage<T>>> completionStageWrapper,
+        Target<?> target) { // TODO
+        final Map<Method, CheckedFunction1<Object[], Object>> map = new HashMap<>();
+        for (final Map.Entry<Method, MethodHandler> entry : dispatch.entrySet()) {
+            final Method method = entry.getKey();
+            final MethodHandler methodHandler = entry.getValue();
+            if (methodHandler != null) {
+                CheckedFunction1<Object[], Object> checkedMethodHandler = methodHandler::invoke;
+                CheckedFunction1<Object[], Object> decorated = args ->
+                    completionStageWrapper.apply(() ->
+                        (T) // TODO
+                            checkedMethodHandler.unchecked().apply(args))
+                        .get();
+                if (method.getReturnType().isAssignableFrom(CompletableFuture.class)) {
+                    map.put(method, decorated);
+                } else {  // TODO
+                    CheckedFunction1<Object[], Object> unwrapped = args -> {
+                        CompletableFuture<?> future = ((CompletionStage<?>) decorated.apply(args))
+                            .toCompletableFuture();
+                        try {
+                            return future.get();
+                        } catch (ExecutionException e) {
+                            throw e.getCause();
+                        }
+                    };
+                    map.put(method, unwrapped);
+                }
+            }
+        }
+        return map;
+    }
+
+    @Override
+    public Object invoke(final Object proxy, final Method method, final Object[] args)
+        throws Throwable {
+        switch (method.getName()) {
+            case "equals":
+                return equals(args.length > 0 ? args[0] : null);
+            case "hashCode":
+                return hashCode();
+            case "toString":
+                return toString();
+            default:
+                break;
+        }
+
+        return decoratedDispatch.get(method).apply(args);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        Object compareTo = obj;
+        if (compareTo == null) {
+            return false;
+        }
+        if (Proxy.isProxyClass(compareTo.getClass())) {
+            compareTo = Proxy.getInvocationHandler(compareTo);
+        }
+        if (compareTo instanceof DecoratorPostponedInvocationHandler) {
+            final DecoratorPostponedInvocationHandler<?> other = (DecoratorPostponedInvocationHandler<?>) compareTo;
+            return target.equals(other.target);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return target.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return target.toString();
+    }
+}

--- a/resilience4j-feign/src/main/java/io/github/resilience4j/feign/FeignDecorators.java
+++ b/resilience4j-feign/src/main/java/io/github/resilience4j/feign/FeignDecorators.java
@@ -58,7 +58,7 @@ public class FeignDecorators implements FeignDecorator {
 
     private final List<FeignDecorator> decorators;
 
-    private FeignDecorators(List<FeignDecorator> decorators) {
+    FeignDecorators(List<FeignDecorator> decorators) {
         this.decorators = decorators;
     }
 

--- a/resilience4j-feign/src/main/java/io/github/resilience4j/feign/PostponedDecorators.java
+++ b/resilience4j-feign/src/main/java/io/github/resilience4j/feign/PostponedDecorators.java
@@ -1,0 +1,139 @@
+package io.github.resilience4j.feign;
+
+import io.github.resilience4j.bulkhead.Bulkhead;
+import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.core.CompletionStageUtils;
+import io.github.resilience4j.core.lang.Nullable;
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.timelimiter.TimeLimiter;
+import io.vavr.NotImplementedError;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.*;
+
+// TODO WIP
+public class PostponedDecorators<T> {
+
+    private final List<UnaryOperator<Supplier<CompletionStage<T>>>> operations;
+    @Nullable
+    private Function<Supplier<T>, Supplier<CompletionStage<T>>> completionStageWrapper;
+
+    public static PostponedDecorators<?> builder() {
+        return new PostponedDecorators<>();
+    }
+
+    private PostponedDecorators() {
+        this.operations = new ArrayList<>();
+    }
+
+    public PostponedDecorators<T> withThreadPoolBulkhead(ThreadPoolBulkhead threadPoolBulkhead) {
+        if (this.completionStageWrapper != null) {
+            throw new IllegalStateException(
+                "CompletionStageWrapper (threadPoolBulkhead) already defined!");
+        }
+        this.completionStageWrapper = threadPoolBulkhead::decorateSupplier;
+        return this;
+    }
+
+    public PostponedDecorators<T> withCircuitBreaker(CircuitBreaker circuitBreaker) {
+        operations.add(supplier ->
+            CircuitBreaker.decorateCompletionStage(circuitBreaker, supplier));
+        return this;
+    }
+
+    public PostponedDecorators<T> withRetry(Retry retryContext,
+        ScheduledExecutorService scheduler) {
+        operations.add(supplier ->
+            Retry.decorateCompletionStage(retryContext, scheduler, supplier));
+        return this;
+    }
+
+    public PostponedDecorators<T> withBulkhead(Bulkhead bulkhead) {
+        operations.add(supplier -> Bulkhead.decorateCompletionStage(bulkhead, supplier));
+        return this;
+    }
+
+    public PostponedDecorators<T> withTimeLimiter(TimeLimiter timeLimiter,
+        ScheduledExecutorService scheduler) {
+        operations.add(supplier -> timeLimiter.decorateCompletionStage(scheduler, supplier));
+        return this;
+    }
+
+    public PostponedDecorators<T> withRateLimiter(RateLimiter rateLimiter) {
+        return withRateLimiter(rateLimiter, 1);
+    }
+
+    public PostponedDecorators<T> withRateLimiter(RateLimiter rateLimiter, int permits) {
+        operations.add(supplier ->
+            RateLimiter.decorateCompletionStage(rateLimiter, permits, supplier));
+        return this;
+    }
+
+    public PostponedDecorators<T> withFallback(Predicate<T> resultPredicate,
+        UnaryOperator<T> resultHandler) {
+        operations.add(supplier ->
+            CompletionStageUtils.recover(supplier, resultPredicate, resultHandler));
+        return this;
+    }
+
+    public PostponedDecorators<T> withFallback(
+        BiFunction<T, Throwable, T> handler) {
+        operations.add(supplier -> CompletionStageUtils.andThen(supplier, handler));
+        return this;
+    }
+
+    public PostponedDecorators<T> withFallback(List<Class<? extends Throwable>> exceptionTypes,
+        Function<Throwable, T> exceptionHandler) {
+        operations.add(supplier ->
+            CompletionStageUtils.recover(supplier, exceptionTypes, exceptionHandler));
+        return this;
+    }
+
+    public PostponedDecorators<T> withFallback(Function<Throwable, T> exceptionHandler) {
+        operations.add(supplier -> CompletionStageUtils.recover(supplier, exceptionHandler));
+        return this;
+    }
+
+    public <X extends Throwable> PostponedDecorators<T> withFallback(Class<X> exceptionType,
+        Function<Throwable, T> exceptionHandler) {
+        operations.add(supplier ->
+            CompletionStageUtils.recover(supplier, exceptionType, exceptionHandler));
+        return this;
+    }
+
+    public PostponedDecorators<T> withFallbackFactory(Function<Exception, ?> fallbackFactory) {
+        throw new NotImplementedError("withFallbackFactory");
+//        decorators.add(new FallbackDecorator<>(new FallbackFactory<>(fallbackFactory)));
+//        return this;
+    }
+
+    public PostponedDecorators<T> withFallback(Object fallback) {
+        throw new NotImplementedError("withFallback Object");
+//        decorators.add(new FallbackDecorator<>(new DefaultFallbackHandler<>(fallback)));
+//        return this;
+    }
+
+    public Supplier<CompletionStage<T>> build(Supplier<T> supplier) {
+        if (completionStageWrapper != null) {
+            return compose(completionStageWrapper.apply(supplier));
+        } else {
+            return compose(() -> CompletableFuture.completedFuture(supplier.get()));
+        }
+    }
+
+
+    private Supplier<CompletionStage<T>> compose(Supplier<CompletionStage<T>> supplier) {
+        return operations.stream().reduce(
+            (UnaryOperator<Supplier<CompletionStage<T>>>) x -> x,
+            (a, b) -> b.compose(a)::apply,
+            (ignore, me) -> null
+        ).apply(supplier);
+    }
+
+}

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/DecoratorInvocationHandlerTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/DecoratorInvocationHandlerTest.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 public class DecoratorInvocationHandlerTest {

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignThreadPoolBulkheadTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignThreadPoolBulkheadTest.java
@@ -1,0 +1,163 @@
+package io.github.resilience4j.feign;
+
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import feign.FeignException;
+import feign.codec.StringDecoder;
+import io.github.resilience4j.bulkhead.BulkheadFullException;
+import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
+import io.github.resilience4j.bulkhead.ThreadPoolBulkheadConfig;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.circuitbreaker.event.CircuitBreakerEvent;
+import io.github.resilience4j.feign.test.CompletionStageTestService;
+import io.vavr.control.Try;
+import org.assertj.core.util.Throwables;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests the integration of the {@link Resilience4jFeign} with a ThreadPoolBulkhead.
+ */
+public class Resilience4jFeignThreadPoolBulkheadTest {
+
+    private static final String MOCK_URL = "http://localhost:8080/";
+    private static final String PATH = "/greeting";
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule();
+
+    private CompletionStageTestService testService;
+    private ThreadPoolBulkhead bulkhead;
+
+    @Before
+    public void setUp() {
+        bulkhead = createThreadPoolBulkhead();
+        PostponedDecorators<?> postponedDecorators = PostponedDecorators.builder()
+            .withThreadPoolBulkhead(bulkhead);
+        testService = createFeignTestService(postponedDecorators);
+    }
+
+    @After
+    public void tearDown() {
+        wireMockRule.resetAll();
+    }
+
+    public ThreadPoolBulkhead createThreadPoolBulkhead() {
+        ThreadPoolBulkheadConfig config = ThreadPoolBulkheadConfig.custom()
+            .queueCapacity(1)
+            .coreThreadPoolSize(1)
+            .maxThreadPoolSize(1)
+            .build();
+        return ThreadPoolBulkhead.of("test", config);
+    }
+
+    public CompletionStageTestService createFeignTestService(
+        PostponedDecorators<?> postponedDecorators) {
+        return Resilience4jFeign.builder(postponedDecorators::build)
+            .decoder(new CompletableFutureDecoder(new StringDecoder()))
+            .target(CompletionStageTestService.class, MOCK_URL);
+    }
+
+    private void givenHelloWithResponse(int statusCode) {
+        stubFor(get(urlPathEqualTo(PATH))
+            .willReturn(aResponse()
+                .withStatus(statusCode)
+                .withHeader("Content-Type", "text/plain")
+                .withBody("hello world")));
+    }
+
+    String getHelloSync() throws ExecutionException, InterruptedException {
+        return testService.greeting().toCompletableFuture().get();
+    }
+
+    @Test
+    public void testSuccessfulCall() throws Exception {
+        givenHelloWithResponse(200);
+
+        testService.greeting().toCompletableFuture().get();
+
+        verify(getRequestedFor(urlPathEqualTo(PATH)));
+    }
+
+    @Test
+    public void testSuccessfulWithCircuitBreaker() throws Exception {
+        CircuitBreaker circuitBreaker = CircuitBreaker
+            .of("test", CircuitBreakerConfig.ofDefaults());
+        bulkhead = createThreadPoolBulkhead();
+        PostponedDecorators<?> postponedDecorators = PostponedDecorators.builder()
+            .withThreadPoolBulkhead(bulkhead)
+            .withCircuitBreaker(circuitBreaker);
+        testService = createFeignTestService(postponedDecorators);
+        givenHelloWithResponse(200);
+
+        testService.greeting().toCompletableFuture().get();
+
+        verify(getRequestedFor(urlPathEqualTo(PATH)));
+    }
+
+    @Test
+    public void testFailedWithCircuitBreaker() {
+        CircuitBreaker circuitBreaker = CircuitBreaker
+            .of("test", CircuitBreakerConfig.ofDefaults());
+        circuitBreaker.transitionToOpenState();
+        AtomicReference<CircuitBreakerEvent> pastEvent = new AtomicReference<>();
+        circuitBreaker.getEventPublisher().onEvent(pastEvent::set);
+        bulkhead = createThreadPoolBulkhead();
+        PostponedDecorators<?> postponedDecorators = PostponedDecorators.builder()
+            .withThreadPoolBulkhead(bulkhead)
+            .withCircuitBreaker(circuitBreaker);
+        testService = createFeignTestService(postponedDecorators);
+        givenHelloWithResponse(200);
+
+        Try<String> result = Try.ofCallable(this::getHelloSync);
+
+        assertThat(result.getCause()).hasRootCauseInstanceOf(CallNotPermittedException.class);
+        verify(0, getRequestedFor(urlPathEqualTo(PATH)));
+    }
+
+    @Test
+    public void testBulkheadFull() throws Exception {
+        givenHelloWithResponse(200);
+
+        List<Callable<String>> tasks = Arrays.asList(
+            this::getHelloSync,
+            this::getHelloSync,
+            this::getHelloSync);
+        ExecutorService executorService = Executors.newFixedThreadPool(tasks.size());
+        List<Future<String>> futures = executorService.invokeAll(tasks);
+        executorService.shutdown();
+
+        List<Throwable> errors = io.vavr.collection.List.ofAll(futures)
+            .map(f -> Try.of(f::get))
+            .filter(Try::isFailure)
+            .map(Try::getCause)
+            .peek(Throwable::printStackTrace)
+            .map(Throwables::getRootCause)
+            .toJavaList();
+
+        assertThat(errors).extracting(Object::getClass)
+            .anyMatch(c -> c.equals(BulkheadFullException.class));
+        verify(2, getRequestedFor(urlPathEqualTo(PATH)));
+    }
+
+    @Test
+    public void testFailedCall() {
+        givenHelloWithResponse(400);
+
+        Try<String> result = Try.ofCallable(this::getHelloSync);
+
+        assertThat(result.getCause()).hasRootCauseInstanceOf(FeignException.BadRequest.class);
+    }
+}

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignThreadPoolBulkheadTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignThreadPoolBulkheadTest.java
@@ -44,8 +44,9 @@ public class Resilience4jFeignThreadPoolBulkheadTest {
     @Before
     public void setUp() {
         bulkhead = createThreadPoolBulkhead();
-        PostponedDecorators<?> postponedDecorators = PostponedDecorators.builder()
-            .withThreadPoolBulkhead(bulkhead);
+        PostponedDecorators<CompletionStageTestService> postponedDecorators =
+            PostponedDecorators.<CompletionStageTestService>builder()
+                .withThreadPoolBulkhead(bulkhead);
         testService = createFeignTestService(postponedDecorators);
     }
 
@@ -64,8 +65,8 @@ public class Resilience4jFeignThreadPoolBulkheadTest {
     }
 
     public CompletionStageTestService createFeignTestService(
-        PostponedDecorators<?> postponedDecorators) {
-        return Resilience4jFeign.builder(postponedDecorators::build)
+        PostponedDecorators<CompletionStageTestService> postponedDecorators) {
+        return Resilience4jFeign.builder(postponedDecorators)
             .decoder(new CompletableFutureDecoder(new StringDecoder()))
             .target(CompletionStageTestService.class, MOCK_URL);
     }
@@ -96,9 +97,10 @@ public class Resilience4jFeignThreadPoolBulkheadTest {
         CircuitBreaker circuitBreaker = CircuitBreaker
             .of("test", CircuitBreakerConfig.ofDefaults());
         bulkhead = createThreadPoolBulkhead();
-        PostponedDecorators<?> postponedDecorators = PostponedDecorators.builder()
-            .withThreadPoolBulkhead(bulkhead)
-            .withCircuitBreaker(circuitBreaker);
+        PostponedDecorators<CompletionStageTestService> postponedDecorators =
+            PostponedDecorators.<CompletionStageTestService>builder()
+                .withThreadPoolBulkhead(bulkhead)
+                .withCircuitBreaker(circuitBreaker);
         testService = createFeignTestService(postponedDecorators);
         givenHelloWithResponse(200);
 
@@ -115,9 +117,10 @@ public class Resilience4jFeignThreadPoolBulkheadTest {
         AtomicReference<CircuitBreakerEvent> pastEvent = new AtomicReference<>();
         circuitBreaker.getEventPublisher().onEvent(pastEvent::set);
         bulkhead = createThreadPoolBulkhead();
-        PostponedDecorators<?> postponedDecorators = PostponedDecorators.builder()
-            .withThreadPoolBulkhead(bulkhead)
-            .withCircuitBreaker(circuitBreaker);
+        PostponedDecorators<CompletionStageTestService> postponedDecorators =
+            PostponedDecorators.<CompletionStageTestService>builder()
+                .withThreadPoolBulkhead(bulkhead)
+                .withCircuitBreaker(circuitBreaker);
         testService = createFeignTestService(postponedDecorators);
         givenHelloWithResponse(200);
 

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/postponed/FeignDecoratorsTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/postponed/FeignDecoratorsTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+// PostponedDecorators isn't used
 @Ignore
 public class FeignDecoratorsTest {
 

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/postponed/FeignDecoratorsTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/postponed/FeignDecoratorsTest.java
@@ -1,0 +1,77 @@
+/*
+ *
+ * Copyright 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *
+ */
+package io.github.resilience4j.feign.postponed;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.feign.FeignDecorators;
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@Ignore
+public class FeignDecoratorsTest {
+
+    @Test
+    public void testWithNothing() throws Throwable {
+        final FeignDecorators testSubject = FeignDecorators.builder().build();
+
+        final Object result = testSubject.decorate(args -> args[0], null, null, null)
+            .apply(new Object[]{"test01"});
+
+        assertThat(result)
+            .describedAs("Returned result is correct")
+            .isEqualTo("test01");
+    }
+
+
+    @Test
+    public void testWithCircuitBreaker() throws Throwable {
+        final CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("test");
+        final CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        final FeignDecorators testSubject = FeignDecorators.builder()
+            .withCircuitBreaker(circuitBreaker).build();
+
+        final Object result = testSubject.decorate(args -> args[0], null, null, null)
+            .apply(new Object[]{"test01"});
+
+        assertThat(result)
+            .describedAs("Returned result is correct")
+            .isEqualTo("test01");
+        assertThat(metrics.getNumberOfSuccessfulCalls())
+            .describedAs("Successful Calls")
+            .isEqualTo(1);
+    }
+
+
+    @Test
+    public void testWithRateLimiter() throws Throwable {
+        final RateLimiter rateLimiter = spy(RateLimiter.ofDefaults("test"));
+        final FeignDecorators testSubject = FeignDecorators.builder().withRateLimiter(rateLimiter)
+            .build();
+
+        final Object result = testSubject.decorate(args -> args[0], null, null, null)
+            .apply(new Object[]{"test01"});
+
+        assertThat(result)
+            .describedAs("Returned result is correct")
+            .isEqualTo("test01");
+        verify(rateLimiter, times(1)).acquirePermission(1);
+    }
+}

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/postponed/Resilience4jFeignBulkheadTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/postponed/Resilience4jFeignBulkheadTest.java
@@ -35,7 +35,7 @@ public class Resilience4jFeignBulkheadTest {
         bulkhead = spy(Bulkhead.of("bulkheadTest", BulkheadConfig.ofDefaults()));
         PostponedDecorators<?> decorators = PostponedDecorators.builder()
             .withBulkhead(bulkhead);
-        testService = Resilience4jFeign.builder(decorators::build)
+        testService = Resilience4jFeign.builder(decorators)
                 .target(TestService.class, MOCK_URL);
     }
 

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/postponed/Resilience4jFeignBulkheadTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/postponed/Resilience4jFeignBulkheadTest.java
@@ -1,0 +1,79 @@
+package io.github.resilience4j.feign.postponed;
+
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import feign.FeignException;
+import io.github.resilience4j.bulkhead.Bulkhead;
+import io.github.resilience4j.bulkhead.BulkheadConfig;
+import io.github.resilience4j.bulkhead.BulkheadFullException;
+import io.github.resilience4j.feign.PostponedDecorators;
+import io.github.resilience4j.feign.Resilience4jFeign;
+import io.github.resilience4j.feign.test.TestService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests the integration of the {@link Resilience4jFeign} with a bulkhead.
+ */
+public class Resilience4jFeignBulkheadTest {
+
+    private static final String MOCK_URL = "http://localhost:8080/";
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule();
+
+    private TestService testService;
+    private Bulkhead bulkhead;
+
+    @Before
+    public void setUp() {
+        bulkhead = spy(Bulkhead.of("bulkheadTest", BulkheadConfig.ofDefaults()));
+        PostponedDecorators<?> decorators = PostponedDecorators.builder()
+            .withBulkhead(bulkhead);
+        testService = Resilience4jFeign.builder(decorators::build)
+                .target(TestService.class, MOCK_URL);
+    }
+
+    @Test
+    public void testSuccessfulCall() {
+        givenResponse(200);
+
+        testService.greeting();
+
+        verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+    }
+
+    @Test(expected = BulkheadFullException.class)
+    public void testBulkheadFull() {
+        givenResponse(200);
+
+        when(bulkhead.tryAcquirePermission()).thenReturn(false);
+
+        testService.greeting();
+
+        verify(0, getRequestedFor(urlPathEqualTo("/greeting")));
+    }
+
+    @Test(expected = FeignException.class)
+    public void testFailedCall() {
+        givenResponse(400);
+
+        when(bulkhead.tryAcquirePermission()).thenReturn(true);
+
+        testService.greeting();
+    }
+
+
+    private void givenResponse(int responseCode) {
+        stubFor(get(urlPathEqualTo("/greeting"))
+                .willReturn(aResponse()
+                        .withStatus(responseCode)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("hello world")));
+    }
+}

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/postponed/Resilience4jFeignCircuitBreakerTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/postponed/Resilience4jFeignCircuitBreakerTest.java
@@ -52,7 +52,7 @@ public class Resilience4jFeignCircuitBreakerTest {
         circuitBreaker = CircuitBreaker.of("test", circuitBreakerConfig);
         PostponedDecorators<?> decorators = PostponedDecorators.builder()
             .withCircuitBreaker(circuitBreaker);
-        testService = Resilience4jFeign.builder(decorators::build)
+        testService = Resilience4jFeign.builder(decorators)
             .target(TestService.class, "http://localhost:8080/");
     }
 

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/postponed/Resilience4jFeignCircuitBreakerTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/postponed/Resilience4jFeignCircuitBreakerTest.java
@@ -1,0 +1,156 @@
+/*
+ *
+ * Copyright 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *
+ */
+package io.github.resilience4j.feign.postponed;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import feign.FeignException;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.feign.PostponedDecorators;
+import io.github.resilience4j.feign.Resilience4jFeign;
+import io.github.resilience4j.feign.test.TestService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.time.Duration;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests the integration of the {@link Resilience4jFeign} with {@link CircuitBreaker}
+ */
+public class Resilience4jFeignCircuitBreakerTest {
+
+    private static final CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
+        .slidingWindowSize(3)
+        .waitDurationInOpenState(Duration.ofMillis(1000))
+        .build();
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule();
+    private CircuitBreaker circuitBreaker;
+    private TestService testService;
+
+    @Before
+    public void setUp() {
+        circuitBreaker = CircuitBreaker.of("test", circuitBreakerConfig);
+        PostponedDecorators<?> decorators = PostponedDecorators.builder()
+            .withCircuitBreaker(circuitBreaker);
+        testService = Resilience4jFeign.builder(decorators::build)
+            .target(TestService.class, "http://localhost:8080/");
+    }
+
+    @Test
+    public void testSuccessfulCall() throws Exception {
+        final CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+
+        setupStub(200);
+
+        testService.greeting();
+
+        verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+        assertThat(metrics.getNumberOfSuccessfulCalls())
+            .describedAs("Successful Calls")
+            .isEqualTo(1);
+    }
+
+    @Test
+    public void testFailedCall() throws Exception {
+        final CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        boolean exceptionThrown = false;
+
+        setupStub(400);
+
+        try {
+            testService.greeting();
+        } catch (final FeignException ex) {
+            exceptionThrown = true;
+        }
+
+        assertThat(exceptionThrown)
+            .describedAs("FeignException thrown")
+            .isTrue();
+        assertThat(metrics.getNumberOfFailedCalls())
+            .describedAs("Successful Calls")
+            .isEqualTo(1);
+    }
+
+    @Test
+    public void testCircuitBreakerOpen() throws Exception {
+        boolean exceptionThrown = false;
+        final int threshold = circuitBreaker
+            .getCircuitBreakerConfig()
+            .getSlidingWindowSize() + 1;
+
+        setupStub(400);
+
+        for (int i = 0; i < threshold; i++) {
+            try {
+                testService.greeting();
+            } catch (final FeignException ex) {
+                // ignore
+            } catch (final CallNotPermittedException ex) {
+                exceptionThrown = true;
+            }
+        }
+
+        assertThat(exceptionThrown)
+            .describedAs("CallNotPermittedException thrown")
+            .isTrue();
+        assertThat(circuitBreaker.tryAcquirePermission())
+            .describedAs("CircuitBreaker Closed")
+            .isFalse();
+    }
+
+
+    @Test
+    public void testCircuitBreakerClosed() throws Exception {
+        boolean exceptionThrown = false;
+        final int threshold = circuitBreaker
+            .getCircuitBreakerConfig()
+            .getSlidingWindowSize() - 1;
+
+        setupStub(400);
+
+        for (int i = 0; i < threshold; i++) {
+            try {
+                testService.greeting();
+            } catch (final FeignException ex) {
+                // ignore
+            } catch (final CallNotPermittedException ex) {
+                exceptionThrown = true;
+            }
+        }
+
+        assertThat(exceptionThrown)
+            .describedAs("CallNotPermittedException thrown")
+            .isFalse();
+        assertThat(circuitBreaker.tryAcquirePermission())
+            .describedAs("CircuitBreaker Closed")
+            .isTrue();
+    }
+
+    private void setupStub(int responseCode) {
+        stubFor(get(urlPathEqualTo("/greeting"))
+            .willReturn(aResponse()
+                .withStatus(responseCode)
+                .withHeader("Content-Type", "text/plain")
+                .withBody("hello world")));
+    }
+}

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/postponed/Resilience4jFeignFallbackFactoryTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/postponed/Resilience4jFeignFallbackFactoryTest.java
@@ -1,0 +1,194 @@
+/*
+ *
+ * Copyright 2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *
+ */
+package io.github.resilience4j.feign.postponed;
+
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import io.github.resilience4j.feign.PostponedDecorators;
+import io.github.resilience4j.feign.Resilience4jFeign;
+import io.github.resilience4j.feign.test.TestService;
+import io.github.resilience4j.feign.test.TestServiceFallbackThrowingException;
+import io.github.resilience4j.feign.test.TestServiceFallbackWithException;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.function.Function;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests on fallback factories.
+ */
+@Ignore
+public class Resilience4jFeignFallbackFactoryTest {
+
+    @ClassRule
+    public static final WireMockClassRule WIRE_MOCK_RULE = new WireMockClassRule(8080);
+    private static final String MOCK_URL = "http://localhost:8080/";
+    @Rule
+    public WireMockClassRule instanceRule = WIRE_MOCK_RULE;
+
+    private static TestService buildTestService(Function<Exception, ?> fallbackSupplier) {
+        PostponedDecorators<?> decorators = PostponedDecorators.builder()
+            .withFallbackFactory(fallbackSupplier);
+        return Resilience4jFeign.builder(decorators::build)
+            .target(TestService.class, MOCK_URL);
+    }
+
+    private static void setupStub(int responseCode) {
+        stubFor(get(urlPathEqualTo("/greeting"))
+            .willReturn(aResponse()
+                .withStatus(responseCode)
+                .withHeader("Content-Type", "text/plain")
+                .withBody("Hello, world!")));
+    }
+
+    @Test
+    public void should_successfully_get_a_response() {
+        setupStub(200);
+        TestService testService = buildTestService(e -> "my fallback");
+
+        String result = testService.greeting();
+
+        assertThat(result).isEqualTo("Hello, world!");
+        verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+    }
+
+    @Test
+    public void should_lazily_fail_on_invalid_fallback() {
+        TestService testService = buildTestService(e -> "my fallback");
+
+        Throwable throwable = catchThrowable(testService::greeting);
+
+        assertThat(throwable).isNotNull()
+            .hasMessageContaining(
+                "Cannot use the fallback [class java.lang.String] for [interface io.github.resilience4j.feign.test.TestService]");
+    }
+
+    @Test
+    public void should_go_to_fallback_and_consume_exception() {
+        setupStub(400);
+        TestService testService = buildTestService(TestServiceFallbackWithException::new);
+
+        String result = testService.greeting();
+
+        assertThat(result)
+            .isEqualTo("Message from exception: status 400 reading TestService#greeting()");
+        verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+    }
+
+    @Test
+    public void should_go_to_fallback_and_rethrow_an_exception_thrown_in_fallback() {
+        setupStub(400);
+        TestService testService = buildTestService(e -> new TestServiceFallbackThrowingException());
+
+        Throwable result = catchThrowable(testService::greeting);
+
+        assertThat(result).isNotNull()
+            .isInstanceOf(RuntimeException.class)
+            .hasMessageContaining("Exception in greeting fallback");
+        verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+    }
+
+    @Test
+    public void should_go_to_fallback_and_consume_exception_with_exception_filter() {
+        setupStub(400);
+        TestService uselessFallback = spy(TestService.class);
+        when(uselessFallback.greeting()).thenReturn("I should not be called");
+        PostponedDecorators<?> decorators = PostponedDecorators.builder()
+//            .withFallbackFactory(TestServiceFallbackWithException::new, FeignException.class)
+            .withFallbackFactory(e -> uselessFallback);
+        TestService testService = Resilience4jFeign.builder(decorators::build)
+            .target(TestService.class, MOCK_URL);
+
+        String result = testService.greeting();
+
+        assertThat(result)
+            .isEqualTo("Message from exception: status 400 reading TestService#greeting()");
+        verify(uselessFallback, times(0)).greeting();
+        verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+    }
+
+    @Test
+    public void should_go_to_second_fallback_and_consume_exception_with_exception_filter() {
+        setupStub(400);
+        TestService uselessFallback = spy(TestService.class);
+        when(uselessFallback.greeting()).thenReturn("I should not be called");
+//        FeignDecorators decorators = FeignDecorators.builder()
+        PostponedDecorators<?> decorators = PostponedDecorators.builder()
+//            .withFallbackFactory(e -> uselessFallback, MyException.class)
+            .withFallbackFactory(TestServiceFallbackWithException::new);
+        TestService testService = Resilience4jFeign.builder(decorators::build)
+            .target(TestService.class, MOCK_URL);
+
+        String result = testService.greeting();
+
+        assertThat(result)
+            .isEqualTo("Message from exception: status 400 reading TestService#greeting()");
+        verify(uselessFallback, times(0)).greeting();
+        verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+    }
+
+    @Test
+    public void should_go_to_fallback_and_consume_exception_with_predicate() {
+        setupStub(400);
+        TestService uselessFallback = spy(TestService.class);
+        when(uselessFallback.greeting()).thenReturn("I should not be called");
+        PostponedDecorators<?> decorators = PostponedDecorators.builder()
+//            .withFallbackFactory(TestServiceFallbackWithException::new,
+//                FeignException.class::isInstance)
+            .withFallbackFactory(e -> uselessFallback);
+        TestService testService = Resilience4jFeign.builder(decorators::build)
+            .target(TestService.class, MOCK_URL);
+
+        String result = testService.greeting();
+
+        assertThat(result)
+            .isEqualTo("Message from exception: status 400 reading TestService#greeting()");
+        verify(uselessFallback, times(0)).greeting();
+        verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+    }
+
+    @Test
+    public void should_go_to_second_fallback_and_consume_exception_with_predicate() {
+        setupStub(400);
+        TestService uselessFallback = spy(TestService.class);
+        when(uselessFallback.greeting()).thenReturn("I should not be called");
+        PostponedDecorators<?> decorators = PostponedDecorators.builder()
+//            .withFallbackFactory(e -> uselessFallback, MyException.class::isInstance)
+            .withFallbackFactory(TestServiceFallbackWithException::new);
+        TestService testService = Resilience4jFeign.builder(decorators::build)
+            .target(TestService.class, MOCK_URL);
+
+        String result = testService.greeting();
+
+        assertThat(result)
+            .isEqualTo("Message from exception: status 400 reading TestService#greeting()");
+        verify(uselessFallback, times(0)).greeting();
+        verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+    }
+
+    private static class MyException extends Exception {
+
+    }
+}

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/postponed/Resilience4jFeignFallbackFactoryTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/postponed/Resilience4jFeignFallbackFactoryTest.java
@@ -17,13 +17,13 @@
 package io.github.resilience4j.feign.postponed;
 
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import feign.FeignException;
 import io.github.resilience4j.feign.PostponedDecorators;
 import io.github.resilience4j.feign.Resilience4jFeign;
 import io.github.resilience4j.feign.test.TestService;
 import io.github.resilience4j.feign.test.TestServiceFallbackThrowingException;
 import io.github.resilience4j.feign.test.TestServiceFallbackWithException;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -39,7 +39,6 @@ import static org.mockito.Mockito.*;
 /**
  * Unit tests on fallback factories.
  */
-@Ignore
 public class Resilience4jFeignFallbackFactoryTest {
 
     @ClassRule
@@ -51,7 +50,7 @@ public class Resilience4jFeignFallbackFactoryTest {
     private static TestService buildTestService(Function<Exception, ?> fallbackSupplier) {
         PostponedDecorators<?> decorators = PostponedDecorators.builder()
             .withFallbackFactory(fallbackSupplier);
-        return Resilience4jFeign.builder(decorators::build)
+        return Resilience4jFeign.builder(decorators)
             .target(TestService.class, MOCK_URL);
     }
 
@@ -116,9 +115,9 @@ public class Resilience4jFeignFallbackFactoryTest {
         TestService uselessFallback = spy(TestService.class);
         when(uselessFallback.greeting()).thenReturn("I should not be called");
         PostponedDecorators<?> decorators = PostponedDecorators.builder()
-//            .withFallbackFactory(TestServiceFallbackWithException::new, FeignException.class)
+            .withFallbackFactory(TestServiceFallbackWithException::new, FeignException.class)
             .withFallbackFactory(e -> uselessFallback);
-        TestService testService = Resilience4jFeign.builder(decorators::build)
+        TestService testService = Resilience4jFeign.builder(decorators)
             .target(TestService.class, MOCK_URL);
 
         String result = testService.greeting();
@@ -134,11 +133,10 @@ public class Resilience4jFeignFallbackFactoryTest {
         setupStub(400);
         TestService uselessFallback = spy(TestService.class);
         when(uselessFallback.greeting()).thenReturn("I should not be called");
-//        FeignDecorators decorators = FeignDecorators.builder()
         PostponedDecorators<?> decorators = PostponedDecorators.builder()
-//            .withFallbackFactory(e -> uselessFallback, MyException.class)
+            .withFallbackFactory(e -> uselessFallback, MyException.class)
             .withFallbackFactory(TestServiceFallbackWithException::new);
-        TestService testService = Resilience4jFeign.builder(decorators::build)
+        TestService testService = Resilience4jFeign.builder(decorators)
             .target(TestService.class, MOCK_URL);
 
         String result = testService.greeting();
@@ -155,10 +153,10 @@ public class Resilience4jFeignFallbackFactoryTest {
         TestService uselessFallback = spy(TestService.class);
         when(uselessFallback.greeting()).thenReturn("I should not be called");
         PostponedDecorators<?> decorators = PostponedDecorators.builder()
-//            .withFallbackFactory(TestServiceFallbackWithException::new,
-//                FeignException.class::isInstance)
+            .withFallbackFactory(TestServiceFallbackWithException::new,
+                FeignException.class::isInstance)
             .withFallbackFactory(e -> uselessFallback);
-        TestService testService = Resilience4jFeign.builder(decorators::build)
+        TestService testService = Resilience4jFeign.builder(decorators)
             .target(TestService.class, MOCK_URL);
 
         String result = testService.greeting();
@@ -175,9 +173,9 @@ public class Resilience4jFeignFallbackFactoryTest {
         TestService uselessFallback = spy(TestService.class);
         when(uselessFallback.greeting()).thenReturn("I should not be called");
         PostponedDecorators<?> decorators = PostponedDecorators.builder()
-//            .withFallbackFactory(e -> uselessFallback, MyException.class::isInstance)
+            .withFallbackFactory(e -> uselessFallback, MyException.class::isInstance)
             .withFallbackFactory(TestServiceFallbackWithException::new);
-        TestService testService = Resilience4jFeign.builder(decorators::build)
+        TestService testService = Resilience4jFeign.builder(decorators)
             .target(TestService.class, MOCK_URL);
 
         String result = testService.greeting();

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/postponed/Resilience4jFeignFallbackLambdaTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/postponed/Resilience4jFeignFallbackLambdaTest.java
@@ -1,0 +1,70 @@
+/*
+ *
+ * Copyright 2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *
+ */
+package io.github.resilience4j.feign.postponed;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import io.github.resilience4j.feign.PostponedDecorators;
+import io.github.resilience4j.feign.Resilience4jFeign;
+import io.github.resilience4j.feign.test.Issue560;
+import io.github.resilience4j.feign.test.TestService;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Ignore
+/**
+ * Tests the integration of the {@link Resilience4jFeign} with the lambda as a fallback.
+ */
+public class Resilience4jFeignFallbackLambdaTest {
+
+    private static final String MOCK_URL = "http://localhost:8080/";
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule();
+
+    private TestService testService;
+
+    @Before
+    public void setUp() {
+        PostponedDecorators<?> decorators = PostponedDecorators.builder()
+            .withFallback(Issue560.createLambdaFallback());
+        testService = Resilience4jFeign.builder(decorators::build)
+            .target(TestService.class, MOCK_URL);
+    }
+
+    @Test
+    public void testFallback() {
+        setupStub();
+
+        final String result = testService.greeting();
+
+        assertThat(result).describedAs("Result").isEqualTo("fallback");
+        verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+    }
+
+    private void setupStub() {
+        stubFor(get(urlPathEqualTo("/greeting"))
+            .willReturn(aResponse()
+                .withStatus(400)
+                .withHeader("Content-Type", "text/plain")
+                .withBody("Hello, world!")));
+    }
+}

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/postponed/Resilience4jFeignFallbackLambdaTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/postponed/Resilience4jFeignFallbackLambdaTest.java
@@ -29,7 +29,6 @@ import org.junit.Test;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Ignore
 /**
  * Tests the integration of the {@link Resilience4jFeign} with the lambda as a fallback.
  */
@@ -46,7 +45,7 @@ public class Resilience4jFeignFallbackLambdaTest {
     public void setUp() {
         PostponedDecorators<?> decorators = PostponedDecorators.builder()
             .withFallback(Issue560.createLambdaFallback());
-        testService = Resilience4jFeign.builder(decorators::build)
+        testService = Resilience4jFeign.builder(decorators)
             .target(TestService.class, MOCK_URL);
     }
 

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/postponed/Resilience4jFeignFallbackTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/postponed/Resilience4jFeignFallbackTest.java
@@ -17,11 +17,12 @@
 package io.github.resilience4j.feign.postponed;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import feign.FeignException;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.feign.PostponedDecorators;
 import io.github.resilience4j.feign.Resilience4jFeign;
 import io.github.resilience4j.feign.test.TestService;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -31,7 +32,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.*;
 
-@Ignore
 /**
  * Tests the integration of the {@link Resilience4jFeign} with a fallback.
  */
@@ -50,10 +50,10 @@ public class Resilience4jFeignFallbackTest {
         testServiceFallback = mock(TestService.class);
         when(testServiceFallback.greeting()).thenReturn("fallback");
 
-        PostponedDecorators<?> decorators = PostponedDecorators.builder()
+        PostponedDecorators<TestService> decorators = PostponedDecorators.<TestService>builder()
             .withFallback(testServiceFallback);
 
-        testService = Resilience4jFeign.builder(decorators::build)
+        testService = Resilience4jFeign.builder(decorators)
             .target(TestService.class, MOCK_URL);
     }
 
@@ -70,9 +70,9 @@ public class Resilience4jFeignFallbackTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testInvalidFallback() throws Throwable {
-        PostponedDecorators<?> decorators = PostponedDecorators.builder()
+        PostponedDecorators<TestService> decorators = PostponedDecorators.<TestService>builder()
             .withFallback("not a fallback");
-        Resilience4jFeign.builder(decorators::build)
+        Resilience4jFeign.builder(decorators)
             .target(TestService.class, MOCK_URL);
     }
 
@@ -88,17 +88,16 @@ public class Resilience4jFeignFallbackTest {
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
     }
 
-    @Ignore
     @Test
     public void testFallbackExceptionFilter() throws Exception {
         final TestService testServiceExceptionFallback = mock(TestService.class);
         when(testServiceExceptionFallback.greeting()).thenReturn("exception fallback");
 
-        PostponedDecorators<?> decorators = PostponedDecorators.builder()
-//            .withFallback(testServiceExceptionFallback, FeignException.class)
+        PostponedDecorators<TestService> decorators = PostponedDecorators.<TestService>builder()
+            .withFallback(testServiceExceptionFallback, FeignException.class)
             .withFallback(testServiceFallback);
 
-        testService = Resilience4jFeign.builder(decorators::build)
+        testService = Resilience4jFeign.builder(decorators)
             .target(TestService.class, MOCK_URL);
         setupStub(400);
 
@@ -111,17 +110,16 @@ public class Resilience4jFeignFallbackTest {
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
     }
 
-    @Ignore
     @Test
     public void testFallbackExceptionFilterNotCalled() throws Exception {
         final TestService testServiceExceptionFallback = mock(TestService.class);
         when(testServiceExceptionFallback.greeting()).thenReturn("exception fallback");
 
-        PostponedDecorators<?> decorators = PostponedDecorators.builder()
-//            .withFallback(testServiceExceptionFallback, CallNotPermittedException.class)
+        PostponedDecorators<TestService> decorators = PostponedDecorators.<TestService>builder()
+            .withFallback(testServiceExceptionFallback, CallNotPermittedException.class)
             .withFallback(testServiceFallback);
 
-        testService = Resilience4jFeign.builder(decorators::build)
+        testService = Resilience4jFeign.builder(decorators)
             .target(TestService.class, MOCK_URL);
         setupStub(400);
 
@@ -134,17 +132,16 @@ public class Resilience4jFeignFallbackTest {
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
     }
 
-    @Ignore
     @Test
     public void testFallbackFilter() throws Exception {
         final TestService testServiceFilterFallback = mock(TestService.class);
         when(testServiceFilterFallback.greeting()).thenReturn("filter fallback");
 
-        PostponedDecorators<?> decorators = PostponedDecorators.builder()
-//            .withFallback(testServiceFilterFallback, ex -> true)
+        PostponedDecorators<TestService> decorators = PostponedDecorators.<TestService>builder()
+            .withFallback(testServiceFilterFallback, ex -> true)
             .withFallback(testServiceFallback);
 
-        testService = Resilience4jFeign.builder(decorators::build)
+        testService = Resilience4jFeign.builder(decorators)
             .target(TestService.class, MOCK_URL);
         setupStub(400);
 
@@ -157,17 +154,16 @@ public class Resilience4jFeignFallbackTest {
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
     }
 
-    @Ignore
     @Test
     public void testFallbackFilterNotCalled() throws Exception {
         final TestService testServiceFilterFallback = mock(TestService.class);
         when(testServiceFilterFallback.greeting()).thenReturn("filter fallback");
 
-        PostponedDecorators<?> decorators = PostponedDecorators.builder()
-//            .withFallback(testServiceFilterFallback, ex -> false)
+        PostponedDecorators<TestService> decorators = PostponedDecorators.<TestService>builder()
+            .withFallback(testServiceFilterFallback, ex -> false)
             .withFallback(testServiceFallback);
 
-        testService = Resilience4jFeign.builder(decorators::build)
+        testService = Resilience4jFeign.builder(decorators)
             .target(TestService.class, MOCK_URL);
         setupStub(400);
 

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/postponed/Resilience4jFeignFallbackTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/postponed/Resilience4jFeignFallbackTest.java
@@ -1,0 +1,204 @@
+/*
+ *
+ * Copyright 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *
+ */
+package io.github.resilience4j.feign.postponed;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import io.github.resilience4j.feign.PostponedDecorators;
+import io.github.resilience4j.feign.Resilience4jFeign;
+import io.github.resilience4j.feign.test.TestService;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
+
+@Ignore
+/**
+ * Tests the integration of the {@link Resilience4jFeign} with a fallback.
+ */
+public class Resilience4jFeignFallbackTest {
+
+    private static final String MOCK_URL = "http://localhost:8080/";
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule();
+
+    private TestService testService;
+    private TestService testServiceFallback;
+
+    @Before
+    public void setUp() {
+        testServiceFallback = mock(TestService.class);
+        when(testServiceFallback.greeting()).thenReturn("fallback");
+
+        PostponedDecorators<?> decorators = PostponedDecorators.builder()
+            .withFallback(testServiceFallback);
+
+        testService = Resilience4jFeign.builder(decorators::build)
+            .target(TestService.class, MOCK_URL);
+    }
+
+    @Test
+    public void testSuccessful() throws Exception {
+        setupStub(200);
+
+        final String result = testService.greeting();
+
+        assertThat(result).describedAs("Result").isEqualTo("Hello, world!");
+        verify(testServiceFallback, times(0)).greeting();
+        verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidFallback() throws Throwable {
+        PostponedDecorators<?> decorators = PostponedDecorators.builder()
+            .withFallback("not a fallback");
+        Resilience4jFeign.builder(decorators::build)
+            .target(TestService.class, MOCK_URL);
+    }
+
+    @Test
+    public void testFallback() throws Exception {
+        setupStub(400);
+
+        final String result = testService.greeting();
+
+        assertThat(result).describedAs("Result").isNotEqualTo("Hello, world!");
+        assertThat(result).describedAs("Result").isEqualTo("fallback");
+        verify(testServiceFallback, times(1)).greeting();
+        verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+    }
+
+    @Ignore
+    @Test
+    public void testFallbackExceptionFilter() throws Exception {
+        final TestService testServiceExceptionFallback = mock(TestService.class);
+        when(testServiceExceptionFallback.greeting()).thenReturn("exception fallback");
+
+        PostponedDecorators<?> decorators = PostponedDecorators.builder()
+//            .withFallback(testServiceExceptionFallback, FeignException.class)
+            .withFallback(testServiceFallback);
+
+        testService = Resilience4jFeign.builder(decorators::build)
+            .target(TestService.class, MOCK_URL);
+        setupStub(400);
+
+        final String result = testService.greeting();
+
+        assertThat(result).describedAs("Result").isNotEqualTo("Hello, world!");
+        assertThat(result).describedAs("Result").isEqualTo("exception fallback");
+        verify(testServiceFallback, times(0)).greeting();
+        verify(testServiceExceptionFallback, times(1)).greeting();
+        verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+    }
+
+    @Ignore
+    @Test
+    public void testFallbackExceptionFilterNotCalled() throws Exception {
+        final TestService testServiceExceptionFallback = mock(TestService.class);
+        when(testServiceExceptionFallback.greeting()).thenReturn("exception fallback");
+
+        PostponedDecorators<?> decorators = PostponedDecorators.builder()
+//            .withFallback(testServiceExceptionFallback, CallNotPermittedException.class)
+            .withFallback(testServiceFallback);
+
+        testService = Resilience4jFeign.builder(decorators::build)
+            .target(TestService.class, MOCK_URL);
+        setupStub(400);
+
+        final String result = testService.greeting();
+
+        assertThat(result).describedAs("Result").isNotEqualTo("Hello, world!");
+        assertThat(result).describedAs("Result").isEqualTo("fallback");
+        verify(testServiceFallback, times(1)).greeting();
+        verify(testServiceExceptionFallback, times(0)).greeting();
+        verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+    }
+
+    @Ignore
+    @Test
+    public void testFallbackFilter() throws Exception {
+        final TestService testServiceFilterFallback = mock(TestService.class);
+        when(testServiceFilterFallback.greeting()).thenReturn("filter fallback");
+
+        PostponedDecorators<?> decorators = PostponedDecorators.builder()
+//            .withFallback(testServiceFilterFallback, ex -> true)
+            .withFallback(testServiceFallback);
+
+        testService = Resilience4jFeign.builder(decorators::build)
+            .target(TestService.class, MOCK_URL);
+        setupStub(400);
+
+        final String result = testService.greeting();
+
+        assertThat(result).describedAs("Result").isNotEqualTo("Hello, world!");
+        assertThat(result).describedAs("Result").isEqualTo("filter fallback");
+        verify(testServiceFallback, times(0)).greeting();
+        verify(testServiceFilterFallback, times(1)).greeting();
+        verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+    }
+
+    @Ignore
+    @Test
+    public void testFallbackFilterNotCalled() throws Exception {
+        final TestService testServiceFilterFallback = mock(TestService.class);
+        when(testServiceFilterFallback.greeting()).thenReturn("filter fallback");
+
+        PostponedDecorators<?> decorators = PostponedDecorators.builder()
+//            .withFallback(testServiceFilterFallback, ex -> false)
+            .withFallback(testServiceFallback);
+
+        testService = Resilience4jFeign.builder(decorators::build)
+            .target(TestService.class, MOCK_URL);
+        setupStub(400);
+
+        final String result = testService.greeting();
+
+        assertThat(result).describedAs("Result").isNotEqualTo("Hello, world!");
+        assertThat(result).describedAs("Result").isEqualTo("fallback");
+        verify(testServiceFallback, times(1)).greeting();
+        verify(testServiceFilterFallback, times(0)).greeting();
+        verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+    }
+
+    @Test
+    public void testRevertFallback() throws Exception {
+        setupStub(400);
+
+        testService.greeting();
+        setupStub(200);
+        final String result = testService.greeting();
+
+        assertThat(result).describedAs("Result").isEqualTo("Hello, world!");
+        verify(testServiceFallback, times(1)).greeting();
+        verify(2, getRequestedFor(urlPathEqualTo("/greeting")));
+
+    }
+
+    private void setupStub(int responseCode) {
+        stubFor(get(urlPathEqualTo("/greeting"))
+            .willReturn(aResponse()
+                .withStatus(responseCode)
+                .withHeader("Content-Type", "text/plain")
+                .withBody("Hello, world!")));
+    }
+}

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/postponed/Resilience4jFeignRateLimiterTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/postponed/Resilience4jFeignRateLimiterTest.java
@@ -49,7 +49,7 @@ public class Resilience4jFeignRateLimiterTest {
         rateLimiter = mock(RateLimiter.class);
         PostponedDecorators<?> decorators = PostponedDecorators.builder()
             .withRateLimiter(rateLimiter);
-        testService = Resilience4jFeign.builder(decorators::build)
+        testService = Resilience4jFeign.builder(decorators)
             .target(TestService.class, MOCK_URL);
     }
 

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/postponed/Resilience4jFeignRateLimiterTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/postponed/Resilience4jFeignRateLimiterTest.java
@@ -1,0 +1,105 @@
+/*
+ *
+ * Copyright 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *
+ */
+package io.github.resilience4j.feign.postponed;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import feign.FeignException;
+import io.github.resilience4j.feign.PostponedDecorators;
+import io.github.resilience4j.feign.Resilience4jFeign;
+import io.github.resilience4j.feign.test.TestService;
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import io.github.resilience4j.ratelimiter.RateLimiterConfig;
+import io.github.resilience4j.ratelimiter.RequestNotPermitted;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests the integration of the {@link Resilience4jFeign} with {@link RateLimiter}
+ */
+public class Resilience4jFeignRateLimiterTest {
+
+    private static final String MOCK_URL = "http://localhost:8080/";
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule();
+
+    private TestService testService;
+    private RateLimiter rateLimiter;
+
+    @Before
+    public void setUp() {
+        rateLimiter = mock(RateLimiter.class);
+        PostponedDecorators<?> decorators = PostponedDecorators.builder()
+            .withRateLimiter(rateLimiter);
+        testService = Resilience4jFeign.builder(decorators::build)
+            .target(TestService.class, MOCK_URL);
+    }
+
+    @Test
+    public void testSuccessfulCall() {
+        givenResponse(200);
+        when(rateLimiter.acquirePermission(1)).thenReturn(true);
+
+        testService.greeting();
+
+        verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+    }
+
+    @Test(expected = RequestNotPermitted.class)
+    public void testRateLimiterLimiting() {
+        givenResponse(200);
+        when(rateLimiter.acquirePermission(1)).thenReturn(false);
+        when(rateLimiter.getRateLimiterConfig()).thenReturn(RateLimiterConfig.ofDefaults());
+
+        testService.greeting();
+
+        verify(0, getRequestedFor(urlPathEqualTo("/greeting")));
+    }
+
+    @Test(expected = FeignException.class)
+    public void testFailedHttpCall() {
+        givenResponse(400);
+        when(rateLimiter.acquirePermission(1)).thenReturn(true);
+
+        testService.greeting();
+    }
+
+    @Test(expected = RequestNotPermitted.class)
+    public void testRateLimiterCreateByStaticMethod() {
+        testService = TestService.create(MOCK_URL, rateLimiter);
+        givenResponse(200);
+        when(rateLimiter.acquirePermission(1)).thenReturn(false);
+        when(rateLimiter.getRateLimiterConfig()).thenReturn(RateLimiterConfig.ofDefaults());
+
+        testService.greeting();
+
+        verify(0, getRequestedFor(urlPathEqualTo("/greeting")));
+    }
+
+
+    private void givenResponse(int responseCode) {
+        stubFor(get(urlPathEqualTo("/greeting"))
+            .willReturn(aResponse()
+                .withStatus(responseCode)
+                .withHeader("Content-Type", "text/plain")
+                .withBody("hello world")));
+    }
+}

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/test/CompletionStageTestService.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/test/CompletionStageTestService.java
@@ -1,0 +1,11 @@
+package io.github.resilience4j.feign.test;
+
+import feign.RequestLine;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface CompletionStageTestService {
+
+    @RequestLine("GET /greeting")
+    CompletableFuture<String> greeting();
+}


### PR DESCRIPTION
It is just a draft and and we need to decide is it a good direction.
For now you can ignore implementation details of `DecoratorPostponedInvocationHandler`. The most important things are `PostponedDecorators` and `Resilience4jFeignThreadPoolBulkheadTest`.
Package `postponed` contains duplicated Feign tests but with `CompletionStage` handling under the hood. Fallbacks aren't implemented.