### PR TITLE
WIP: #703 -Added custom RegistryStore and builder

### DIFF
--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerRegistry.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerRegistry.java
@@ -263,6 +263,11 @@ public interface CircuitBreakerRegistry extends Registry<CircuitBreaker, Circuit
         Supplier<CircuitBreakerConfig> circuitBreakerConfigSupplier,
         io.vavr.collection.Map<String, String> tags);
 
+    /**
+     * Returns a builder to create a custom CircuitBreakerRegistry.
+     *
+     * @return a {@link CircuitBreakerRegistry.Builder}
+     */
     static Builder custom() {
         return new Builder();
     }
@@ -285,16 +290,25 @@ public interface CircuitBreakerRegistry extends Registry<CircuitBreaker, Circuit
             return this;
         }
 
+        /**
+         * Configures a CircuitBreakerRegistry with a custom default CircuitBreaker configuration.
+         *
+         * @param circuitBreakerConfig a custom default CircuitBreaker configuration
+         * @return a {@link CircuitBreakerRegistry.Builder}
+         */
         public Builder withCircuitBreakerConfig(CircuitBreakerConfig circuitBreakerConfig) {
             circuitBreakerConfigsMap.put(DEFAULT_CONFIG, circuitBreakerConfig);
             return this;
         }
 
-        public Builder withCircuitBreakerConfigDefaults() {
-            circuitBreakerConfigsMap.put(DEFAULT_CONFIG, CircuitBreakerConfig.ofDefaults());
-            return this;
-        }
-
+        /**
+         * Configures a CircuitBreakerRegistry with a custom CircuitBreaker configuration.
+         *
+         * @param configName configName for a custom shared CircuitBreaker configuration
+         * @param configuration a custom shared CircuitBreaker configuration
+         * @return a {@link CircuitBreakerRegistry.Builder}
+         * @throws IllegalArgumentException if {@code configName.equals("default")}
+         */
         public Builder addCircuitBreakerConfig(String configName, CircuitBreakerConfig configuration) {
             if (configName.equals(DEFAULT_CONFIG)) {
                 throw new IllegalArgumentException(
@@ -304,18 +318,38 @@ public interface CircuitBreakerRegistry extends Registry<CircuitBreaker, Circuit
             return this;
         }
 
+        /**
+         * Configures a CircuitBreakerRegistry with a CircuitBreaker registry event consumer.
+         *
+         * @param registryEventConsumer a CircuitBreaker registry event consumer.
+         * @return a {@link CircuitBreakerRegistry.Builder}
+         */
         public Builder addRegistryEventConsumer(RegistryEventConsumer<CircuitBreaker> registryEventConsumer) {
             this.registryEventConsumers.add(registryEventConsumer);
             return this;
         }
 
+        /**
+         * Configures a CircuitBreakerRegistry with Tags.
+         * <p>
+         * Tags added to the registry will be added to every instance created by this registry.
+         *
+         * @param tags default tags to add to the registry.
+         * @return a {@link CircuitBreakerRegistry.Builder}
+         */
         public Builder withTags(io.vavr.collection.Map<String, String> tags) {
             this.tags = tags;
             return this;
         }
 
-        public CircuitBreakerRegistry build(){
-            return new InMemoryCircuitBreakerRegistry(circuitBreakerConfigsMap, registryEventConsumers, tags, registryStore);
+        /**
+         * Builds a CircuitBreakerRegistry
+         *
+         * @return the CircuitBreakerRegistry
+         */
+        public CircuitBreakerRegistry build() {
+            return new InMemoryCircuitBreakerRegistry(circuitBreakerConfigsMap, registryEventConsumers, tags,
+                registryStore);
         }
     }
 

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/InMemoryCircuitBreakerRegistry.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/InMemoryCircuitBreakerRegistry.java
@@ -22,7 +22,9 @@ import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.core.ConfigurationNotFoundException;
+import io.github.resilience4j.core.RegistryStore;
 import io.github.resilience4j.core.registry.AbstractRegistry;
+import io.github.resilience4j.core.registry.InMemoryRegistryStore;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
 import io.vavr.collection.Array;
 import io.vavr.collection.HashMap;
@@ -31,6 +33,7 @@ import io.vavr.collection.Seq;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 /**
@@ -73,6 +76,15 @@ public final class InMemoryCircuitBreakerRegistry extends
         io.vavr.collection.Map<String, String> tags) {
         this(configs.getOrDefault(DEFAULT_CONFIG, CircuitBreakerConfig.ofDefaults()),
             registryEventConsumer, tags);
+        this.configurations.putAll(configs);
+    }
+
+    public InMemoryCircuitBreakerRegistry(Map<String, CircuitBreakerConfig> configs,
+                                          List<RegistryEventConsumer<CircuitBreaker>> registryEventConsumers,
+                                          io.vavr.collection.Map<String, String> tags, RegistryStore<CircuitBreaker> registryStore) {
+        super(configs.getOrDefault(DEFAULT_CONFIG, CircuitBreakerConfig.ofDefaults()),
+            registryEventConsumers, Optional.ofNullable(tags).orElse(HashMap.empty()),
+            Optional.ofNullable(registryStore).orElse(new InMemoryRegistryStore<>()));
         this.configurations.putAll(configs);
     }
 

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/InMemoryCircuitBreakerRegistryTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/InMemoryCircuitBreakerRegistryTest.java
@@ -4,11 +4,18 @@ import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.core.ConfigurationNotFoundException;
+import io.github.resilience4j.core.registry.EntryAddedEvent;
+import io.github.resilience4j.core.registry.EntryRemovedEvent;
+import io.github.resilience4j.core.registry.EntryReplacedEvent;
+import io.github.resilience4j.core.registry.InMemoryRegistryStore;
+import io.github.resilience4j.core.registry.RegistryEventConsumer;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -98,4 +105,36 @@ public class InMemoryCircuitBreakerRegistryTest {
             "testConfig")).isInstanceOf(ConfigurationNotFoundException.class);
     }
 
+    @Test
+    public void shouldCreateCircuitBreakerRegistryWithRegistryStore() {
+        RegistryEventConsumer<CircuitBreaker> registryEventConsumer = getNoOpsRegistryEventConsumer();
+        List<RegistryEventConsumer<CircuitBreaker>> registryEventConsumers = new ArrayList<>();
+        registryEventConsumers.add(registryEventConsumer);
+        Map<String, CircuitBreakerConfig> configs = new HashMap<>();
+        final CircuitBreakerConfig defaultConfig = CircuitBreakerConfig.ofDefaults();
+        configs.put("default", defaultConfig);
+        final InMemoryCircuitBreakerRegistry inMemoryCircuitBreakerRegistry =
+            new InMemoryCircuitBreakerRegistry(configs, registryEventConsumers,
+                io.vavr.collection.HashMap.of("Tag1", "Tag1Value"), new InMemoryRegistryStore());
+
+        assertThat(inMemoryCircuitBreakerRegistry).isNotNull();
+        assertThat(inMemoryCircuitBreakerRegistry.getDefaultConfig()).isEqualTo(defaultConfig);
+        assertThat(inMemoryCircuitBreakerRegistry.getConfiguration("testNotFound")).isEmpty();
+        inMemoryCircuitBreakerRegistry.addConfiguration("testConfig", defaultConfig);
+        assertThat(inMemoryCircuitBreakerRegistry.getConfiguration("testConfig")).isNotNull();
+    }
+
+    private RegistryEventConsumer<CircuitBreaker> getNoOpsRegistryEventConsumer() {
+        return new RegistryEventConsumer<CircuitBreaker>() {
+            @Override
+            public void onEntryAddedEvent(EntryAddedEvent<CircuitBreaker> entryAddedEvent) {
+            }
+            @Override
+            public void onEntryRemovedEvent(EntryRemovedEvent<CircuitBreaker> entryRemoveEvent) {
+            }
+            @Override
+            public void onEntryReplacedEvent(EntryReplacedEvent<CircuitBreaker> entryReplacedEvent) {
+            }
+        };
+    }
 }

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/RegistryStore.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/RegistryStore.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 KrnSaurabh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.github.resilience4j.core;
 
 import java.util.Collection;

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/RegistryStore.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/RegistryStore.java
@@ -1,0 +1,22 @@
+package io.github.resilience4j.core;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.Function;
+
+public interface RegistryStore<E> {
+
+    E computeIfAbsent(String key,
+        Function<? super String, ? extends E> mappingFunction);
+
+    E putIfAbsent(String key, E value);
+
+    Optional<E> find(String key);
+
+    Optional<E> remove(String name);
+
+    Optional<E> replace(String name, E newEntry);
+
+    Collection<E> values();
+
+}

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/registry/InMemoryRegistryStore.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/registry/InMemoryRegistryStore.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 KrnSaurabh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.github.resilience4j.core.registry;
 
 import io.github.resilience4j.core.RegistryStore;
@@ -8,6 +24,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 
+/**
+ * Default Implementation Of RegistryStore using ConcurrentHashMap
+ */
 public class InMemoryRegistryStore<E> implements RegistryStore<E> {
 
     private final ConcurrentMap<String, E> entryMap;

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/registry/InMemoryRegistryStore.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/registry/InMemoryRegistryStore.java
@@ -1,0 +1,47 @@
+package io.github.resilience4j.core.registry;
+
+import io.github.resilience4j.core.RegistryStore;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
+
+public class InMemoryRegistryStore<E> implements RegistryStore<E> {
+
+    private final ConcurrentMap<String, E> entryMap;
+
+    public InMemoryRegistryStore() {
+        this.entryMap = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public E computeIfAbsent(String key,
+                             Function<? super String, ? extends E> mappingFunction) {
+        return entryMap.computeIfAbsent(key, mappingFunction);
+    }
+
+    @Override
+    public E putIfAbsent(String key, E value) { return entryMap.putIfAbsent(key, value); }
+
+    @Override
+    public Optional<E> find(String key) {
+        return Optional.ofNullable(entryMap.get(key));
+    }
+
+    @Override
+    public Optional<E> remove(String name) {
+        return Optional.ofNullable(entryMap.remove(name));
+    }
+
+    @Override
+    public Optional<E> replace(String name, E newEntry) {
+        return Optional.ofNullable(entryMap.replace(name, newEntry));
+    }
+
+    @Override
+    public Collection<E> values() {
+        return entryMap.values();
+    }
+}

--- a/resilience4j-core/src/test/java/io/github/resilience4j/core/registry/AbstractRegistryTest.java
+++ b/resilience4j-core/src/test/java/io/github/resilience4j/core/registry/AbstractRegistryTest.java
@@ -1,5 +1,6 @@
 package io.github.resilience4j.core.registry;
 
+import io.github.resilience4j.core.RegistryStore;
 import io.vavr.Tuple;
 import io.vavr.collection.Map;
 import org.junit.Test;
@@ -11,6 +12,7 @@ import java.util.Optional;
 import static io.github.resilience4j.core.registry.RegistryEvent.Type;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
 
 
 public class AbstractRegistryTest {
@@ -165,6 +167,58 @@ public class AbstractRegistryTest {
             super("default", tags);
             this.configurations.put(DEFAULT_CONFIG, "default");
         }
+
+        TestRegistry(List<RegistryEventConsumer<String>> registryEventConsumer, Map<String,String> tags, RegistryStore registryStore) {
+            super("default", registryEventConsumer, tags, registryStore);
+            this.configurations.put(DEFAULT_CONFIG, "default");
+        }
     }
 
+    @Test
+    public void shouldCreateRegistryWithRegistryStore() {
+        List<EntryAddedEvent<String>> addedEvents = new ArrayList<>();
+        List<EntryRemovedEvent<String>> removedEvents = new ArrayList<>();
+        List<EntryReplacedEvent<String>> replacedEvents = new ArrayList<>();
+        RegistryEventConsumer<String> registryEventConsumer = new RegistryEventConsumer<String>() {
+            @Override
+            public void onEntryAddedEvent(EntryAddedEvent<String> entryAddedEvent) {
+                addedEvents.add(entryAddedEvent);
+            }
+
+            @Override
+            public void onEntryRemovedEvent(EntryRemovedEvent<String> entryRemoveEvent) {
+                removedEvents.add(entryRemoveEvent);
+            }
+
+            @Override
+            public void onEntryReplacedEvent(EntryReplacedEvent<String> entryReplacedEvent) {
+                replacedEvents.add(entryReplacedEvent);
+            }
+        };
+        List<RegistryEventConsumer<String>> registryEventConsumers = new ArrayList<>();
+        registryEventConsumers.add(registryEventConsumer);
+        TestRegistry testRegistry  = new TestRegistry(
+            registryEventConsumers, io.vavr.collection.HashMap.of("Tag1","Tag1Value"), new InMemoryRegistryStore());
+
+        assertEquals("Wrong Value", "default", testRegistry.getDefaultConfig());
+        assertThat(testRegistry.getDefaultConfig()).isEqualTo("default");
+        assertThat(testRegistry.getTags()).isNotEmpty();
+        assertThat(testRegistry.getTags()).containsOnly(Tuple.of("Tag1","Tag1Value"));
+
+        String addedEntry1 = testRegistry.computeIfAbsent("name", () -> "entry1");
+        assertThat(addedEntry1).isEqualTo("entry1");
+
+        String addedEntry2 = testRegistry.computeIfAbsent("name2", () -> "entry2");
+        assertThat(addedEntry2).isEqualTo("entry2");
+
+        Optional<String> removedEntry = testRegistry.remove("name");
+        assertThat(removedEntry).isNotEmpty().hasValue("entry1");
+
+        Optional<String> replacedEntry = testRegistry.replace("name2", "entry3");
+        assertThat(replacedEntry).isNotEmpty().hasValue("entry2");
+
+        assertThat(addedEvents).hasSize(2);
+        assertThat(removedEvents).hasSize(1);
+        assertThat(replacedEvents).hasSize(1);
+    }
 }

--- a/resilience4j-core/src/test/java/io/github/resilience4j/core/registry/AbstractRegistryTest.java
+++ b/resilience4j-core/src/test/java/io/github/resilience4j/core/registry/AbstractRegistryTest.java
@@ -145,7 +145,7 @@ public class AbstractRegistryTest {
         TestRegistry testRegistry = new TestRegistry();
 
         assertThat(testRegistry.find("test")).isEmpty();
-        testRegistry.entryMap.put("test", "value");
+        testRegistry.entryMap.putIfAbsent("test", "value");
         assertThat(testRegistry.find("test")).contains("value");
     }
 

--- a/resilience4j-core/src/test/java/io/github/resilience4j/core/registry/InMemoryRegistryStoreTest.java
+++ b/resilience4j-core/src/test/java/io/github/resilience4j/core/registry/InMemoryRegistryStoreTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 KrnSaurabh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.resilience4j.core.registry;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class InMemoryRegistryStoreTest {
+
+    private static final String DEFAULT_CONFIG_VALUE = "defaultConfig";
+    private static final String DEFAULT_CONFIG = "default";
+    private static final String NEW_CONFIG = "newConfig";
+    private static final String CUSTOM_CONFIG = "custom";
+    private InMemoryRegistryStore<String> inMemoryRegistryStore;
+
+    @Before
+    public void initialiseInMemoryRegistryStore() {
+        inMemoryRegistryStore = new InMemoryRegistryStore<>();
+    }
+
+    @Test
+    public void shouldComputeValueWhenKeyNotPresentInRegistryStore() {
+        assertEquals("Wrong Value",
+            DEFAULT_CONFIG_VALUE, inMemoryRegistryStore.computeIfAbsent(DEFAULT_CONFIG, k -> DEFAULT_CONFIG_VALUE));
+        assertThat(inMemoryRegistryStore.values()).hasSize(1);
+        assertEquals("Wrong Value", DEFAULT_CONFIG_VALUE, inMemoryRegistryStore.computeIfAbsent(DEFAULT_CONFIG, k -> NEW_CONFIG));
+    }
+
+    @Test
+    public void shouldPutKeyIntoRegistryStoreAndReturnOldValue() {
+        assertNull(inMemoryRegistryStore.putIfAbsent(DEFAULT_CONFIG, DEFAULT_CONFIG_VALUE));
+        assertThat(inMemoryRegistryStore.values()).hasSize(1);
+        assertEquals("Wrong Value", DEFAULT_CONFIG_VALUE, inMemoryRegistryStore.putIfAbsent(DEFAULT_CONFIG, NEW_CONFIG));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowNPEWhenValueIsNull() {
+        inMemoryRegistryStore.putIfAbsent(DEFAULT_CONFIG, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowNPEWhenKeyIsNull() {
+        inMemoryRegistryStore.putIfAbsent(null, DEFAULT_CONFIG_VALUE);
+    }
+
+    @Test
+    public void shouldFindConfigFromRegistryStore() {
+        inMemoryRegistryStore.putIfAbsent(DEFAULT_CONFIG, DEFAULT_CONFIG_VALUE);
+        assertThat(inMemoryRegistryStore.find(DEFAULT_CONFIG)).isNotEmpty();
+        assertThat(inMemoryRegistryStore.find(DEFAULT_CONFIG)).hasValue(DEFAULT_CONFIG_VALUE);
+        assertThat(inMemoryRegistryStore.find(NEW_CONFIG)).isEmpty();
+    }
+
+    @Test
+    public void shouldRemoveConfigFromRegistryStore() {
+        inMemoryRegistryStore.putIfAbsent(DEFAULT_CONFIG, DEFAULT_CONFIG_VALUE);
+        inMemoryRegistryStore.putIfAbsent(CUSTOM_CONFIG, NEW_CONFIG);
+        assertThat(inMemoryRegistryStore.remove(DEFAULT_CONFIG)).hasValue(DEFAULT_CONFIG_VALUE);
+        assertThat(inMemoryRegistryStore.values()).hasSize(1);
+    }
+
+    @Test
+    public void shouldReplaceKeyWithNewConfigValueWhenKeyPresent() {
+        inMemoryRegistryStore.putIfAbsent(DEFAULT_CONFIG, DEFAULT_CONFIG_VALUE);
+        assertThat(inMemoryRegistryStore.replace(DEFAULT_CONFIG, NEW_CONFIG)).hasValue(DEFAULT_CONFIG_VALUE);
+        assertThat(inMemoryRegistryStore.find(DEFAULT_CONFIG)).hasValue(NEW_CONFIG);
+    }
+
+    @Test
+    public void shouldNotReplaceKeyWithNewConfigValueWhenKeyAbsent() {
+        assertThat(inMemoryRegistryStore.replace(NEW_CONFIG, NEW_CONFIG)).isEmpty();
+        assertThat(inMemoryRegistryStore.values()).isEmpty();
+    }
+
+    @Test
+    public void shouldReturnCollectionOfConfigs() {
+        inMemoryRegistryStore.putIfAbsent(DEFAULT_CONFIG, DEFAULT_CONFIG_VALUE);
+        inMemoryRegistryStore.putIfAbsent(CUSTOM_CONFIG, NEW_CONFIG);
+        assertThat(inMemoryRegistryStore.values()).containsExactlyInAnyOrder(NEW_CONFIG, DEFAULT_CONFIG_VALUE);
+    }
+}


### PR DESCRIPTION
This PR is WIP for #703  and created to get initial review. I have added `RegistryStore` Interface and its default implementation that replaces the Concurrent HashMap in `AbstractRegistry` Class. Also I have added builder methods in `CircuitBreakerRegistry` so that any custom implementation of `RegistryStore` can be added to the `CircuitBreakerRegistry`.

I am still working on unit tests/ comments/ javadocs.