### PR TITLE
Update hibernate validator version

### DIFF
--- a/libraries.gradle
+++ b/libraries.gradle
@@ -27,7 +27,7 @@ ext {
     prometheusSimpleClientVersion = '0.8.1'
     reactiveStreamsVersion = '1.0.2'
     micrometerVersion = '1.1.4'
-    hibernateValidatorVersion = '6.0.16.Final'
+    hibernateValidatorVersion = '6.0.18.Final'
     wiremockVersion = '2.26.0'
     validationApiVersion = '2.0.1.Final'
     kotlinCoroutinesVersion = '1.3.2'


### PR DESCRIPTION
As mentioned in #889 we need to upgrade this library version and get rid of potentially affected dependency.