### PR TITLE
extract MetricNames to public classes

### DIFF
--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractBulkheadMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractBulkheadMetrics.java
@@ -30,8 +30,13 @@ import static java.util.Objects.requireNonNull;
 
 abstract class AbstractBulkheadMetrics extends AbstractMetrics {
 
-    protected final MetricNames names;
+    protected final BulkheadMetricNames names;
 
+    protected AbstractBulkheadMetrics(BulkheadMetricNames names) {
+        this.names = requireNonNull(names);
+    }
+
+    @Deprecated
     protected AbstractBulkheadMetrics(MetricNames names) {
         this.names = requireNonNull(names);
     }
@@ -64,107 +69,6 @@ abstract class AbstractBulkheadMetrics extends AbstractMetrics {
 
     }
 
-    /**
-     * Defines possible configuration for metric names.
-     */
-    public static class MetricNames {
-
-        private static final String DEFAULT_PREFIX = "resilience4j.bulkhead";
-
-        public static final String DEFAULT_BULKHEAD_AVAILABLE_CONCURRENT_CALLS_METRIC_NAME =
-            DEFAULT_PREFIX + ".available.concurrent.calls";
-        public static final String DEFAULT_BULKHEAD_MAX_ALLOWED_CONCURRENT_CALLS_METRIC_NAME =
-            DEFAULT_PREFIX + ".max.allowed.concurrent.calls";
-        private String availableConcurrentCallsMetricName = DEFAULT_BULKHEAD_AVAILABLE_CONCURRENT_CALLS_METRIC_NAME;
-        private String maxAllowedConcurrentCallsMetricName = DEFAULT_BULKHEAD_MAX_ALLOWED_CONCURRENT_CALLS_METRIC_NAME;
-
-        private MetricNames() {
-        }
-
-        /**
-         * Returns a builder for creating custom metric names. Note that names have default values,
-         * so only desired metrics can be renamed.
-         *
-         * @return The builder.
-         */
-        public static Builder custom() {
-            return new Builder();
-        }
-
-        /**
-         * Returns default metric names.
-         *
-         * @return The default {@link TaggedBulkheadMetrics.MetricNames} instance.
-         */
-        public static MetricNames ofDefaults() {
-            return new MetricNames();
-        }
-
-        /**
-         * Returns the metric name for bulkhead concurrent calls, defaults to {@value
-         * DEFAULT_BULKHEAD_AVAILABLE_CONCURRENT_CALLS_METRIC_NAME}.
-         *
-         * @return The available concurrent calls metric name.
-         */
-        public String getAvailableConcurrentCallsMetricName() {
-            return availableConcurrentCallsMetricName;
-        }
-
-        /**
-         * Returns the metric name for bulkhead max available concurrent calls, defaults to {@value
-         * DEFAULT_BULKHEAD_MAX_ALLOWED_CONCURRENT_CALLS_METRIC_NAME}.
-         *
-         * @return The max allowed concurrent calls metric name.
-         */
-        public String getMaxAllowedConcurrentCallsMetricName() {
-            return maxAllowedConcurrentCallsMetricName;
-        }
-
-        /**
-         * Helps building custom instance of {@link TaggedBulkheadMetrics.MetricNames}.
-         */
-        public static class Builder {
-
-            private final MetricNames metricNames = new MetricNames();
-
-            /**
-             * Overrides the default metric name {@value TaggedBulkheadMetrics.MetricNames#DEFAULT_BULKHEAD_AVAILABLE_CONCURRENT_CALLS_METRIC_NAME}
-             * with a given one.
-             *
-             * @param availableConcurrentCallsMetricName The available concurrent calls metric
-             *                                           name.
-             * @return The builder.
-             */
-            public Builder availableConcurrentCallsMetricName(
-                String availableConcurrentCallsMetricName) {
-                metricNames.availableConcurrentCallsMetricName = requireNonNull(
-                    availableConcurrentCallsMetricName);
-                return this;
-            }
-
-            /**
-             * Overrides the default metric name {@value TaggedBulkheadMetrics.MetricNames#DEFAULT_BULKHEAD_MAX_ALLOWED_CONCURRENT_CALLS_METRIC_NAME}
-             * with a given one.
-             *
-             * @param maxAllowedConcurrentCallsMetricName The max allowed concurrent calls metric
-             *                                            name.
-             * @return The builder.
-             */
-            public Builder maxAllowedConcurrentCallsMetricName(
-                String maxAllowedConcurrentCallsMetricName) {
-                metricNames.maxAllowedConcurrentCallsMetricName = requireNonNull(
-                    maxAllowedConcurrentCallsMetricName);
-                return this;
-            }
-
-            /**
-             * Builds {@link TaggedBulkheadMetrics.MetricNames} instance.
-             *
-             * @return The built {@link TaggedBulkheadMetrics.MetricNames} instance.
-             */
-            public MetricNames build() {
-                return metricNames;
-            }
-        }
-    }
+    @Deprecated
+    public static class MetricNames extends BulkheadMetricNames { }
 }

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractCircuitBreakerMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractCircuitBreakerMetrics.java
@@ -33,8 +33,13 @@ abstract class AbstractCircuitBreakerMetrics extends AbstractMetrics {
     private static final String KIND_IGNORED = "ignored";
     private static final String KIND_NOT_PERMITTED = "not_permitted";
 
-    protected final MetricNames names;
+    protected final CircuitBreakerMetricNames names;
 
+    protected AbstractCircuitBreakerMetrics(CircuitBreakerMetricNames names) {
+        this.names = requireNonNull(names);
+    }
+
+    @Deprecated
     protected AbstractCircuitBreakerMetrics(MetricNames names) {
         this.names = requireNonNull(names);
     }
@@ -146,195 +151,7 @@ abstract class AbstractCircuitBreakerMetrics extends AbstractMetrics {
         meterIdMap.put(circuitBreaker.getName(), idSet);
     }
 
-    public static class MetricNames {
-
-        private static final String DEFAULT_PREFIX = "resilience4j.circuitbreaker";
-
-        public static final String DEFAULT_CIRCUIT_BREAKER_CALLS = DEFAULT_PREFIX + ".calls";
-        public static final String DEFAULT_CIRCUIT_BREAKER_STATE = DEFAULT_PREFIX + ".state";
-        public static final String DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS =
-            DEFAULT_PREFIX + ".buffered.calls";
-        public static final String DEFAULT_CIRCUIT_BREAKER_SLOW_CALLS =
-            DEFAULT_PREFIX + ".slow.calls";
-        public static final String DEFAULT_CIRCUIT_BREAKER_FAILURE_RATE =
-            DEFAULT_PREFIX + ".failure.rate";
-        public static final String DEFAULT_CIRCUIT_BREAKER_SLOW_CALL_RATE =
-            DEFAULT_PREFIX + ".slow.call.rate";
-        private String callsMetricName = DEFAULT_CIRCUIT_BREAKER_CALLS;
-        private String stateMetricName = DEFAULT_CIRCUIT_BREAKER_STATE;
-        private String bufferedCallsMetricName = DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS;
-        private String slowCallsMetricName = DEFAULT_CIRCUIT_BREAKER_SLOW_CALLS;
-        private String failureRateMetricName = DEFAULT_CIRCUIT_BREAKER_FAILURE_RATE;
-        private String slowCallRateMetricName = DEFAULT_CIRCUIT_BREAKER_SLOW_CALL_RATE;
-
-        private MetricNames() {
-        }
-
-        /**
-         * Returns a builder for creating custom metric names. Note that names have default values,
-         * so only desired metrics can be renamed.
-         *
-         * @return The builder.
-         */
-        public static Builder custom() {
-            return new Builder();
-        }
-
-        /**
-         * Returns default metric names.
-         *
-         * @return The default {@link MetricNames} instance.
-         */
-        public static MetricNames ofDefaults() {
-            return new MetricNames();
-        }
-
-        /**
-         * Returns the metric name for circuit breaker calls, defaults to {@value
-         * DEFAULT_CIRCUIT_BREAKER_CALLS}.
-         *
-         * @return The circuit breaker calls metric name.
-         */
-        public String getCallsMetricName() {
-            return callsMetricName;
-        }
-
-        /**
-         * Returns the metric name for currently buffered calls, defaults to {@value
-         * DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS}.
-         *
-         * @return The buffered calls metric name.
-         */
-        public String getBufferedCallsMetricName() {
-            return bufferedCallsMetricName;
-        }
-
-        /**
-         * Returns the metric name for currently slow calls, defaults to {@value
-         * DEFAULT_CIRCUIT_BREAKER_SLOW_CALLS}.
-         *
-         * @return The slow calls metric name.
-         */
-        public String getSlowCallsMetricName() {
-            return slowCallsMetricName;
-        }
-
-        /**
-         * Returns the metric name for state, defaults to {@value DEFAULT_CIRCUIT_BREAKER_STATE}.
-         *
-         * @return The state metric name.
-         */
-        public String getStateMetricName() {
-            return stateMetricName;
-        }
-
-        /**
-         * Returns the metric name for failure rate, defaults to {@value
-         * DEFAULT_CIRCUIT_BREAKER_FAILURE_RATE}.
-         *
-         * @return The failure rate metric name.
-         */
-        public String getFailureRateMetricName() {
-            return failureRateMetricName;
-        }
-
-        /**
-         * Returns the metric name for slow call rate, defaults to {@value
-         * DEFAULT_CIRCUIT_BREAKER_SLOW_CALL_RATE}.
-         *
-         * @return The failure rate metric name.
-         */
-        public String getSlowCallRateMetricName() {
-            return slowCallRateMetricName;
-        }
-
-        /**
-         * Helps building custom instance of {@link MetricNames}.
-         */
-        public static class Builder {
-
-            private final MetricNames metricNames = new MetricNames();
-
-            /**
-             * Overrides the default metric name {@value MetricNames#DEFAULT_CIRCUIT_BREAKER_CALLS}
-             * with a given one.
-             *
-             * @param callsMetricName The calls metric name.
-             * @return The builder.
-             */
-            public Builder callsMetricName(String callsMetricName) {
-                metricNames.callsMetricName = requireNonNull(callsMetricName);
-                return this;
-            }
-
-            /**
-             * Overrides the default metric name {@value MetricNames#DEFAULT_CIRCUIT_BREAKER_STATE}
-             * with a given one.
-             *
-             * @param stateMetricName The state metric name.
-             * @return The builder.
-             */
-            public Builder stateMetricName(String stateMetricName) {
-                metricNames.stateMetricName = requireNonNull(stateMetricName);
-                return this;
-            }
-
-            /**
-             * Overrides the default metric name {@value MetricNames#DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS}
-             * with a given one.
-             *
-             * @param bufferedCallsMetricName The bufferd calls metric name.
-             * @return The builder.
-             */
-            public Builder bufferedCallsMetricName(String bufferedCallsMetricName) {
-                metricNames.bufferedCallsMetricName = requireNonNull(bufferedCallsMetricName);
-                return this;
-            }
-
-            /**
-             * Overrides the default metric name {@value MetricNames#DEFAULT_CIRCUIT_BREAKER_SLOW_CALLS}
-             * with a given one.
-             *
-             * @param slowCallsMetricName The slow calls metric name.
-             * @return The builder.
-             */
-            public Builder slowCallsMetricName(String slowCallsMetricName) {
-                metricNames.slowCallsMetricName = requireNonNull(slowCallsMetricName);
-                return this;
-            }
-
-            /**
-             * Overrides the default metric name {@value MetricNames#DEFAULT_CIRCUIT_BREAKER_FAILURE_RATE}
-             * with a given one.
-             *
-             * @param failureRateMetricName The failure rate metric name.
-             * @return The builder.
-             */
-            public Builder failureRateMetricName(String failureRateMetricName) {
-                metricNames.failureRateMetricName = requireNonNull(failureRateMetricName);
-                return this;
-            }
-
-            /**
-             * Overrides the default metric name {@value MetricNames#DEFAULT_CIRCUIT_BREAKER_SLOW_CALL_RATE}
-             * with a given one.
-             *
-             * @param slowCallRateMetricName The slow call rate metric name.
-             * @return The builder.
-             */
-            public Builder slowCallRateMetricName(String slowCallRateMetricName) {
-                metricNames.slowCallRateMetricName = requireNonNull(slowCallRateMetricName);
-                return this;
-            }
-
-            /**
-             * Builds {@link MetricNames} instance.
-             *
-             * @return The built {@link MetricNames} instance.
-             */
-            public MetricNames build() {
-                return metricNames;
-            }
-        }
+    @Deprecated
+    public static class MetricNames extends CircuitBreakerMetricNames {
     }
 }

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractRateLimiterMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractRateLimiterMetrics.java
@@ -30,8 +30,13 @@ import static java.util.Objects.requireNonNull;
 
 abstract class AbstractRateLimiterMetrics extends AbstractMetrics {
 
-    protected final MetricNames names;
+    protected final RateLimiterMetricNames names;
 
+    protected AbstractRateLimiterMetrics(RateLimiterMetricNames names) {
+        this.names = requireNonNull(names);
+    }
+
+    @Deprecated
     protected AbstractRateLimiterMetrics(MetricNames names) {
         this.names = requireNonNull(names);
     }
@@ -63,96 +68,7 @@ abstract class AbstractRateLimiterMetrics extends AbstractMetrics {
         meterIdMap.put(rateLimiter.getName(), idSet);
     }
 
-    public static class MetricNames {
-
-        private static final String DEFAULT_PREFIX = "resilience4j.ratelimiter";
-
-        public static final String DEFAULT_AVAILABLE_PERMISSIONS_METRIC_NAME =
-            DEFAULT_PREFIX + ".available.permissions";
-        public static final String DEFAULT_WAITING_THREADS_METRIC_NAME =
-            DEFAULT_PREFIX + ".waiting_threads";
-        private String availablePermissionsMetricName = DEFAULT_AVAILABLE_PERMISSIONS_METRIC_NAME;
-        private String waitingThreadsMetricName = DEFAULT_WAITING_THREADS_METRIC_NAME;
-
-        /**
-         * Returns a builder for creating custom metric names. Note that names have default values,
-         * so only desired metrics can be renamed.
-         *
-         * @return The builder.
-         */
-        public static Builder custom() {
-            return new Builder();
-        }
-
-        /**
-         * Returns default metric names.
-         *
-         * @return The default {@link MetricNames} instance.
-         */
-        public static MetricNames ofDefaults() {
-            return new MetricNames();
-        }
-
-        /**
-         * Returns the metric name for available permissions, defaults to {@value
-         * DEFAULT_AVAILABLE_PERMISSIONS_METRIC_NAME}.
-         *
-         * @return The available permissions metric name.
-         */
-        public String getAvailablePermissionsMetricName() {
-            return availablePermissionsMetricName;
-        }
-
-        /**
-         * Returns the metric name for waiting threads, defaults to {@value
-         * DEFAULT_WAITING_THREADS_METRIC_NAME}.
-         *
-         * @return The waiting threads metric name.
-         */
-        public String getWaitingThreadsMetricName() {
-            return waitingThreadsMetricName;
-        }
-
-        /**
-         * Helps building custom instance of {@link MetricNames}.
-         */
-        public static class Builder {
-
-            private final MetricNames metricNames = new MetricNames();
-
-            /**
-             * Overrides the default metric name {@value MetricNames#DEFAULT_AVAILABLE_PERMISSIONS_METRIC_NAME}
-             * with a given one.
-             *
-             * @param availablePermissionsMetricName The available permissions metric name.
-             * @return The builder.
-             */
-            public Builder availablePermissionsMetricName(String availablePermissionsMetricName) {
-                metricNames.availablePermissionsMetricName = requireNonNull(
-                    availablePermissionsMetricName);
-                return this;
-            }
-
-            /**
-             * Overrides the default metric name {@value MetricNames#DEFAULT_WAITING_THREADS_METRIC_NAME}
-             * with a given one.
-             *
-             * @param waitingThreadsMetricName The waiting threads metric name.
-             * @return The builder.
-             */
-            public Builder waitingThreadsMetricName(String waitingThreadsMetricName) {
-                metricNames.waitingThreadsMetricName = requireNonNull(waitingThreadsMetricName);
-                return this;
-            }
-
-            /**
-             * Builds {@link MetricNames} instance.
-             *
-             * @return The built {@link MetricNames} instance.
-             */
-            public MetricNames build() {
-                return metricNames;
-            }
-        }
+    @Deprecated
+    public static class MetricNames extends RateLimiterMetricNames {
     }
 }

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractRetryMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractRetryMetrics.java
@@ -30,8 +30,13 @@ import static java.util.Objects.requireNonNull;
 
 abstract class AbstractRetryMetrics extends AbstractMetrics {
 
-    protected final MetricNames names;
+    protected final RetryMetricNames names;
 
+    protected AbstractRetryMetrics(RetryMetricNames names) {
+        this.names = requireNonNull(names);
+    }
+
+    @Deprecated
     protected AbstractRetryMetrics(MetricNames names) {
         this.names = requireNonNull(names);
     }
@@ -78,71 +83,7 @@ abstract class AbstractRetryMetrics extends AbstractMetrics {
         meterIdMap.put(retry.getName(), idSet);
     }
 
-
-    public static class MetricNames {
-
-        public static final String DEFAULT_RETRY_CALLS = "resilience4j.retry.calls";
-
-        /**
-         * Returns a builder for creating custom metric names. Note that names have default values,
-         * so only desired metrics can be renamed.
-         *
-         * @return The builder.
-         */
-        public static Builder custom() {
-            return new Builder();
-        }
-
-        /**
-         * Returns default metric names.
-         *
-         * @return The default {@link MetricNames} instance.
-         */
-        public static MetricNames ofDefaults() {
-            return new MetricNames();
-        }
-
-        private String callsMetricName = DEFAULT_RETRY_CALLS;
-
-        private MetricNames() {
-        }
-
-        /**
-         * Returns the metric name for retry calls, defaults to {@value DEFAULT_RETRY_CALLS}.
-         *
-         * @return The metric name for retry calls.
-         */
-        public String getCallsMetricName() {
-            return callsMetricName;
-        }
-
-        /**
-         * Helps building custom instance of {@link MetricNames}.
-         */
-        public static class Builder {
-
-            private final MetricNames metricNames = new MetricNames();
-
-            /**
-             * Overrides the default metric name {@value MetricNames#DEFAULT_RETRY_CALLS} with a
-             * given one.
-             *
-             * @param callsMetricName The metric name for retry calls.
-             * @return The builder.
-             */
-            public Builder callsMetricName(String callsMetricName) {
-                metricNames.callsMetricName = requireNonNull(callsMetricName);
-                return this;
-            }
-
-            /**
-             * Builds {@link MetricNames} instance.
-             *
-             * @return The built {@link MetricNames} instance.
-             */
-            public MetricNames build() {
-                return metricNames;
-            }
-        }
+    @Deprecated
+    public static class MetricNames extends RetryMetricNames {
     }
 }

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractThreadPoolBulkheadMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractThreadPoolBulkheadMetrics.java
@@ -30,8 +30,13 @@ import static java.util.Objects.requireNonNull;
 
 abstract class AbstractThreadPoolBulkheadMetrics extends AbstractMetrics {
 
-    protected final MetricNames names;
+    protected final ThreadPoolBulkheadMetricNames names;
 
+    protected AbstractThreadPoolBulkheadMetrics(ThreadPoolBulkheadMetricNames names) {
+        this.names = requireNonNull(names);
+    }
+
+    @Deprecated
     protected AbstractThreadPoolBulkheadMetrics(MetricNames names) {
         this.names = requireNonNull(names);
     }
@@ -84,176 +89,7 @@ abstract class AbstractThreadPoolBulkheadMetrics extends AbstractMetrics {
         meterIdMap.put(bulkhead.getName(), idSet);
     }
 
-    public static class MetricNames {
-
-        private static final String DEFAULT_PREFIX = "resilience4j.bulkhead";
-
-        public static final String DEFAULT_BULKHEAD_QUEUE_DEPTH_METRIC_NAME =
-            DEFAULT_PREFIX + ".queue.depth";
-        public static final String DEFAULT_BULKHEAD_QUEUE_CAPACITY_METRIC_NAME =
-            DEFAULT_PREFIX + ".queue.capacity";
-        public static final String DEFAULT_THREAD_POOL_SIZE_METRIC_NAME =
-            DEFAULT_PREFIX + ".thread.pool.size";
-        public static final String DEFAULT_MAX_THREAD_POOL_SIZE_METRIC_NAME =
-            DEFAULT_PREFIX + ".max.thread.pool.size";
-        public static final String DEFAULT_CORE_THREAD_POOL_SIZE_METRIC_NAME =
-            DEFAULT_PREFIX + ".core.thread.pool.size";
-        private String queueDepthMetricName = DEFAULT_BULKHEAD_QUEUE_DEPTH_METRIC_NAME;
-        private String threadPoolSizeMetricName = DEFAULT_THREAD_POOL_SIZE_METRIC_NAME;
-        private String maxThreadPoolSizeMetricName = DEFAULT_MAX_THREAD_POOL_SIZE_METRIC_NAME;
-        private String coreThreadPoolSizeMetricName = DEFAULT_CORE_THREAD_POOL_SIZE_METRIC_NAME;
-        private String queueCapacityMetricName = DEFAULT_BULKHEAD_QUEUE_CAPACITY_METRIC_NAME;
-
-        private MetricNames() {
-        }
-
-        /**
-         * Returns a builder for creating custom metric names. Note that names have default values,
-         * so only desired metrics can be renamed.
-         *
-         * @return The builder.
-         */
-        public static Builder custom() {
-            return new Builder();
-        }
-
-        /**
-         * Returns default metric names.
-         *
-         * @return The default {@link MetricNames} instance.
-         */
-        public static MetricNames ofDefaults() {
-            return new MetricNames();
-        }
-
-        /**
-         * Returns the metric name for queue depth, defaults to {@value
-         * DEFAULT_BULKHEAD_QUEUE_DEPTH_METRIC_NAME}.
-         *
-         * @return The queue depth metric name.
-         */
-        public String getQueueDepthMetricName() {
-            return queueDepthMetricName;
-        }
-
-        /**
-         * Returns the metric name for thread pool size, defaults to {@value
-         * DEFAULT_THREAD_POOL_SIZE_METRIC_NAME}.
-         *
-         * @return The thread pool size metric name.
-         */
-        public String getThreadPoolSizeMetricName() {
-            return threadPoolSizeMetricName;
-        }
-
-        /**
-         * Returns the metric name for max thread pool size, defaults to {@value
-         * DEFAULT_MAX_THREAD_POOL_SIZE_METRIC_NAME}.
-         *
-         * @return The max thread pool size metric name.
-         */
-        public String getMaxThreadPoolSizeMetricName() {
-            return maxThreadPoolSizeMetricName;
-        }
-
-        /**
-         * Returns the metric name for core thread pool size, defaults to {@value
-         * DEFAULT_CORE_THREAD_POOL_SIZE_METRIC_NAME}.
-         *
-         * @return The core thread pool size metric name.
-         */
-        public String getCoreThreadPoolSizeMetricName() {
-            return coreThreadPoolSizeMetricName;
-        }
-
-        /**
-         * Returns the metric name for queue capacity, defaults to {@value
-         * DEFAULT_BULKHEAD_QUEUE_CAPACITY_METRIC_NAME}.
-         *
-         * @return The queue capacity metric name.
-         */
-        public String getQueueCapacityMetricName() {
-            return queueCapacityMetricName;
-        }
-
-        /**
-         * Helps building custom instance of {@link MetricNames}.
-         */
-        public static class Builder {
-
-            private final MetricNames metricNames = new MetricNames();
-
-            /**
-             * Overrides the default metric name {@value MetricNames#DEFAULT_BULKHEAD_QUEUE_DEPTH_METRIC_NAME}
-             * with a given one.
-             *
-             * @param queueDepthMetricName The queue depth metric name.
-             * @return The builder.
-             */
-            public Builder queueDepthMetricName(String queueDepthMetricName) {
-                metricNames.queueDepthMetricName = requireNonNull(queueDepthMetricName);
-                return this;
-            }
-
-            /**
-             * Overrides the default metric name {@value MetricNames#DEFAULT_THREAD_POOL_SIZE_METRIC_NAME}
-             * with a given one.
-             *
-             * @param threadPoolSizeMetricName The thread pool size metric name.
-             * @return The builder.
-             */
-            public Builder threadPoolSizeMetricName(String threadPoolSizeMetricName) {
-                metricNames.threadPoolSizeMetricName = requireNonNull(threadPoolSizeMetricName);
-                return this;
-            }
-
-            /**
-             * Overrides the default metric name {@value MetricNames#DEFAULT_MAX_THREAD_POOL_SIZE_METRIC_NAME}
-             * with a given one.
-             *
-             * @param maxThreadPoolSizeMetricName The max thread pool size metric name.
-             * @return The builder.
-             */
-            public Builder maxThreadPoolSizeMetricName(String maxThreadPoolSizeMetricName) {
-                metricNames.maxThreadPoolSizeMetricName = requireNonNull(
-                    maxThreadPoolSizeMetricName);
-                return this;
-            }
-
-            /**
-             * Overrides the default metric name {@value MetricNames#DEFAULT_CORE_THREAD_POOL_SIZE_METRIC_NAME}
-             * with a given one.
-             *
-             * @param coreThreadPoolSizeMetricName The core thread pool size metric name.
-             * @return The builder.
-             */
-            public Builder coreThreadPoolSizeMetricName(String coreThreadPoolSizeMetricName) {
-                metricNames.coreThreadPoolSizeMetricName = requireNonNull(
-                    coreThreadPoolSizeMetricName);
-                return this;
-            }
-
-            /**
-             * Overrides the default metric name {@value MetricNames#DEFAULT_BULKHEAD_QUEUE_CAPACITY_METRIC_NAME}
-             * with a given one.
-             *
-             * @param queueCapacityMetricName The queue capacity metric name.
-             * @return The builder.
-             */
-            public Builder queueCapacityMetricName(String queueCapacityMetricName) {
-                metricNames.queueCapacityMetricName = requireNonNull(queueCapacityMetricName);
-                return this;
-            }
-
-            /**
-             * Builds {@link MetricNames} instance.
-             *
-             * @return The built {@link MetricNames} instance.
-             */
-            public MetricNames build() {
-                return metricNames;
-            }
-        }
+    @Deprecated
+    public static class MetricNames extends ThreadPoolBulkheadMetricNames {
     }
-
 }

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractTimeLimiterMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractTimeLimiterMetrics.java
@@ -34,8 +34,13 @@ abstract class AbstractTimeLimiterMetrics extends AbstractMetrics {
     private static final String KIND_SUCCESSFUL = "successful";
     private static final String KIND_TIMEOUT = "timeout";
 
-    protected final MetricNames names;
+    protected final TimeLimiterMetricNames names;
 
+    protected AbstractTimeLimiterMetrics(TimeLimiterMetricNames names) {
+        this.names = requireNonNull(names);
+    }
+
+    @Deprecated
     protected AbstractTimeLimiterMetrics(MetricNames names) {
         this.names = requireNonNull(names);
     }
@@ -77,69 +82,7 @@ abstract class AbstractTimeLimiterMetrics extends AbstractMetrics {
         meterIdMap.put(timeLimiter.getName(), new HashSet<>(ids));
     }
 
-    public static class MetricNames {
-
-        private static final String DEFAULT_PREFIX = "resilience4j.timelimiter";
-        public static final String DEFAULT_TIME_LIMITER_CALLS = DEFAULT_PREFIX + ".calls";
-
-        private String callsMetricName = DEFAULT_TIME_LIMITER_CALLS;
-
-        /**
-         * Returns a builder for creating custom metric names. Note that names have default values,
-         * so only desired metrics can be renamed.
-         *
-         * @return The builder.
-         */
-        public static Builder custom() {
-            return new Builder();
-        }
-
-        /**
-         * Returns default metric names.
-         *
-         * @return The default {@link MetricNames} instance.
-         */
-        public static MetricNames ofDefaults() {
-            return new MetricNames();
-        }
-
-        /**
-         * Returns the metric name for circuit breaker calls, defaults to {@value
-         * DEFAULT_TIME_LIMITER_CALLS}.
-         *
-         * @return The circuit breaker calls metric name.
-         */
-        public String getCallsMetricName() {
-            return callsMetricName;
-        }
-
-        /**
-         * Helps building custom instance of {@link MetricNames}.
-         */
-        public static class Builder {
-
-            private final MetricNames metricNames = new MetricNames();
-
-            /**
-             * Overrides the default metric name {@value MetricNames#DEFAULT_TIME_LIMITER_CALLS}
-             * with a given one.
-             *
-             * @param callsMetricName The calls metric name.
-             * @return The builder.
-             */
-            public Builder callsMetricName(String callsMetricName) {
-                metricNames.callsMetricName = requireNonNull(callsMetricName);
-                return this;
-            }
-
-            /**
-             * Builds {@link MetricNames} instance.
-             *
-             * @return The built {@link MetricNames} instance.
-             */
-            public MetricNames build() {
-                return metricNames;
-            }
-        }
+    @Deprecated
+    public static class MetricNames extends TimeLimiterMetricNames {
     }
 }

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/BulkheadMetricNames.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/BulkheadMetricNames.java
@@ -1,0 +1,106 @@
+package io.github.resilience4j.micrometer.tagged;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Defines possible configuration for metric names.
+ */
+public class BulkheadMetricNames {
+    private static final String DEFAULT_PREFIX = "resilience4j.bulkhead";
+
+    public static final String DEFAULT_BULKHEAD_AVAILABLE_CONCURRENT_CALLS_METRIC_NAME =
+        DEFAULT_PREFIX + ".available.concurrent.calls";
+    public static final String DEFAULT_BULKHEAD_MAX_ALLOWED_CONCURRENT_CALLS_METRIC_NAME =
+        DEFAULT_PREFIX + ".max.allowed.concurrent.calls";
+    private String availableConcurrentCallsMetricName = DEFAULT_BULKHEAD_AVAILABLE_CONCURRENT_CALLS_METRIC_NAME;
+    private String maxAllowedConcurrentCallsMetricName = DEFAULT_BULKHEAD_MAX_ALLOWED_CONCURRENT_CALLS_METRIC_NAME;
+
+    protected BulkheadMetricNames() {
+    }
+
+    /**
+     * Returns a builder for creating custom metric names. Note that names have default values,
+     * so only desired metrics can be renamed.
+     *
+     * @return The builder.
+     */
+    public static Builder custom() {
+        return new Builder();
+    }
+
+    /**
+     * Returns default metric names.
+     *
+     * @return The default {@link BulkheadMetricNames} instance.
+     */
+    public static BulkheadMetricNames ofDefaults() {
+        return new BulkheadMetricNames();
+    }
+
+    /**
+     * Returns the metric name for bulkhead concurrent calls, defaults to {@value
+     * DEFAULT_BULKHEAD_AVAILABLE_CONCURRENT_CALLS_METRIC_NAME}.
+     *
+     * @return The available concurrent calls metric name.
+     */
+    public String getAvailableConcurrentCallsMetricName() {
+        return availableConcurrentCallsMetricName;
+    }
+
+    /**
+     * Returns the metric name for bulkhead max available concurrent calls, defaults to {@value
+     * DEFAULT_BULKHEAD_MAX_ALLOWED_CONCURRENT_CALLS_METRIC_NAME}.
+     *
+     * @return The max allowed concurrent calls metric name.
+     */
+    public String getMaxAllowedConcurrentCallsMetricName() {
+        return maxAllowedConcurrentCallsMetricName;
+    }
+
+    /**
+     * Helps building custom instance of {@link BulkheadMetricNames}.
+     */
+    public static class Builder {
+
+        private final BulkheadMetricNames metricNames = new BulkheadMetricNames();
+
+        /**
+         * Overrides the default metric name {@value BulkheadMetricNames#DEFAULT_BULKHEAD_AVAILABLE_CONCURRENT_CALLS_METRIC_NAME}
+         * with a given one.
+         *
+         * @param availableConcurrentCallsMetricName The available concurrent calls metric
+         *                                           name.
+         * @return The builder.
+         */
+        public Builder availableConcurrentCallsMetricName(
+            String availableConcurrentCallsMetricName) {
+            metricNames.availableConcurrentCallsMetricName = requireNonNull(
+                availableConcurrentCallsMetricName);
+            return this;
+        }
+
+        /**
+         * Overrides the default metric name {@value BulkheadMetricNames#DEFAULT_BULKHEAD_MAX_ALLOWED_CONCURRENT_CALLS_METRIC_NAME}
+         * with a given one.
+         *
+         * @param maxAllowedConcurrentCallsMetricName The max allowed concurrent calls metric
+         *                                            name.
+         * @return The builder.
+         */
+        public Builder maxAllowedConcurrentCallsMetricName(
+            String maxAllowedConcurrentCallsMetricName) {
+            metricNames.maxAllowedConcurrentCallsMetricName = requireNonNull(
+                maxAllowedConcurrentCallsMetricName);
+            return this;
+        }
+
+        /**
+         * Builds {@link BulkheadMetricNames} instance.
+         *
+         * @return The built {@link BulkheadMetricNames} instance.
+         */
+        public BulkheadMetricNames build() {
+            return metricNames;
+        }
+    }
+}

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/CircuitBreakerMetricNames.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/CircuitBreakerMetricNames.java
@@ -1,0 +1,195 @@
+package io.github.resilience4j.micrometer.tagged;
+
+import static java.util.Objects.requireNonNull;
+
+public class CircuitBreakerMetricNames {
+
+    private static final String DEFAULT_PREFIX = "resilience4j.circuitbreaker";
+
+    public static final String DEFAULT_CIRCUIT_BREAKER_CALLS = DEFAULT_PREFIX + ".calls";
+    public static final String DEFAULT_CIRCUIT_BREAKER_STATE = DEFAULT_PREFIX + ".state";
+    public static final String DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS =
+        DEFAULT_PREFIX + ".buffered.calls";
+    public static final String DEFAULT_CIRCUIT_BREAKER_SLOW_CALLS =
+        DEFAULT_PREFIX + ".slow.calls";
+    public static final String DEFAULT_CIRCUIT_BREAKER_FAILURE_RATE =
+        DEFAULT_PREFIX + ".failure.rate";
+    public static final String DEFAULT_CIRCUIT_BREAKER_SLOW_CALL_RATE =
+        DEFAULT_PREFIX + ".slow.call.rate";
+    private String callsMetricName = DEFAULT_CIRCUIT_BREAKER_CALLS;
+    private String stateMetricName = DEFAULT_CIRCUIT_BREAKER_STATE;
+    private String bufferedCallsMetricName = DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS;
+    private String slowCallsMetricName = DEFAULT_CIRCUIT_BREAKER_SLOW_CALLS;
+    private String failureRateMetricName = DEFAULT_CIRCUIT_BREAKER_FAILURE_RATE;
+    private String slowCallRateMetricName = DEFAULT_CIRCUIT_BREAKER_SLOW_CALL_RATE;
+
+    protected CircuitBreakerMetricNames() {
+    }
+
+    /**
+     * Returns a builder for creating custom metric names. Note that names have default values,
+     * so only desired metrics can be renamed.
+     *
+     * @return The builder.
+     */
+    public static Builder custom() {
+        return new Builder();
+    }
+
+    /**
+     * Returns default metric names.
+     *
+     * @return The default {@link CircuitBreakerMetricNames} instance.
+     */
+    public static CircuitBreakerMetricNames ofDefaults() {
+        return new CircuitBreakerMetricNames();
+    }
+
+    /**
+     * Returns the metric name for circuit breaker calls, defaults to {@value
+     * DEFAULT_CIRCUIT_BREAKER_CALLS}.
+     *
+     * @return The circuit breaker calls metric name.
+     */
+    public String getCallsMetricName() {
+        return callsMetricName;
+    }
+
+    /**
+     * Returns the metric name for currently buffered calls, defaults to {@value
+     * DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS}.
+     *
+     * @return The buffered calls metric name.
+     */
+    public String getBufferedCallsMetricName() {
+        return bufferedCallsMetricName;
+    }
+
+    /**
+     * Returns the metric name for currently slow calls, defaults to {@value
+     * DEFAULT_CIRCUIT_BREAKER_SLOW_CALLS}.
+     *
+     * @return The slow calls metric name.
+     */
+    public String getSlowCallsMetricName() {
+        return slowCallsMetricName;
+    }
+
+    /**
+     * Returns the metric name for state, defaults to {@value DEFAULT_CIRCUIT_BREAKER_STATE}.
+     *
+     * @return The state metric name.
+     */
+    public String getStateMetricName() {
+        return stateMetricName;
+    }
+
+    /**
+     * Returns the metric name for failure rate, defaults to {@value
+     * DEFAULT_CIRCUIT_BREAKER_FAILURE_RATE}.
+     *
+     * @return The failure rate metric name.
+     */
+    public String getFailureRateMetricName() {
+        return failureRateMetricName;
+    }
+
+    /**
+     * Returns the metric name for slow call rate, defaults to {@value
+     * DEFAULT_CIRCUIT_BREAKER_SLOW_CALL_RATE}.
+     *
+     * @return The failure rate metric name.
+     */
+    public String getSlowCallRateMetricName() {
+        return slowCallRateMetricName;
+    }
+
+    /**
+     * Helps building custom instance of {@link CircuitBreakerMetricNames}.
+     */
+    public static class Builder {
+
+        private final CircuitBreakerMetricNames metricNames = new CircuitBreakerMetricNames();
+
+        /**
+         * Overrides the default metric name {@value CircuitBreakerMetricNames#DEFAULT_CIRCUIT_BREAKER_CALLS}
+         * with a given one.
+         *
+         * @param callsMetricName The calls metric name.
+         * @return The builder.
+         */
+        public Builder callsMetricName(String callsMetricName) {
+            metricNames.callsMetricName = requireNonNull(callsMetricName);
+            return this;
+        }
+
+        /**
+         * Overrides the default metric name {@value CircuitBreakerMetricNames#DEFAULT_CIRCUIT_BREAKER_STATE}
+         * with a given one.
+         *
+         * @param stateMetricName The state metric name.
+         * @return The builder.
+         */
+        public Builder stateMetricName(String stateMetricName) {
+            metricNames.stateMetricName = requireNonNull(stateMetricName);
+            return this;
+        }
+
+        /**
+         * Overrides the default metric name {@value CircuitBreakerMetricNames#DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS}
+         * with a given one.
+         *
+         * @param bufferedCallsMetricName The bufferd calls metric name.
+         * @return The builder.
+         */
+        public Builder bufferedCallsMetricName(String bufferedCallsMetricName) {
+            metricNames.bufferedCallsMetricName = requireNonNull(bufferedCallsMetricName);
+            return this;
+        }
+
+        /**
+         * Overrides the default metric name {@value CircuitBreakerMetricNames#DEFAULT_CIRCUIT_BREAKER_SLOW_CALLS}
+         * with a given one.
+         *
+         * @param slowCallsMetricName The slow calls metric name.
+         * @return The builder.
+         */
+        public Builder slowCallsMetricName(String slowCallsMetricName) {
+            metricNames.slowCallsMetricName = requireNonNull(slowCallsMetricName);
+            return this;
+        }
+
+        /**
+         * Overrides the default metric name {@value CircuitBreakerMetricNames#DEFAULT_CIRCUIT_BREAKER_FAILURE_RATE}
+         * with a given one.
+         *
+         * @param failureRateMetricName The failure rate metric name.
+         * @return The builder.
+         */
+        public Builder failureRateMetricName(String failureRateMetricName) {
+            metricNames.failureRateMetricName = requireNonNull(failureRateMetricName);
+            return this;
+        }
+
+        /**
+         * Overrides the default metric name {@value CircuitBreakerMetricNames#DEFAULT_CIRCUIT_BREAKER_SLOW_CALL_RATE}
+         * with a given one.
+         *
+         * @param slowCallRateMetricName The slow call rate metric name.
+         * @return The builder.
+         */
+        public Builder slowCallRateMetricName(String slowCallRateMetricName) {
+            metricNames.slowCallRateMetricName = requireNonNull(slowCallRateMetricName);
+            return this;
+        }
+
+        /**
+         * Builds {@link CircuitBreakerMetricNames} instance.
+         *
+         * @return The built {@link CircuitBreakerMetricNames} instance.
+         */
+        public CircuitBreakerMetricNames build() {
+            return metricNames;
+        }
+    }
+}

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/RateLimiterMetricNames.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/RateLimiterMetricNames.java
@@ -1,0 +1,96 @@
+package io.github.resilience4j.micrometer.tagged;
+
+import static java.util.Objects.requireNonNull;
+
+public class RateLimiterMetricNames {
+
+    private static final String DEFAULT_PREFIX = "resilience4j.ratelimiter";
+
+    public static final String DEFAULT_AVAILABLE_PERMISSIONS_METRIC_NAME =
+        DEFAULT_PREFIX + ".available.permissions";
+    public static final String DEFAULT_WAITING_THREADS_METRIC_NAME =
+        DEFAULT_PREFIX + ".waiting_threads";
+    private String availablePermissionsMetricName = DEFAULT_AVAILABLE_PERMISSIONS_METRIC_NAME;
+    private String waitingThreadsMetricName = DEFAULT_WAITING_THREADS_METRIC_NAME;
+
+    /**
+     * Returns a builder for creating custom metric names. Note that names have default values,
+     * so only desired metrics can be renamed.
+     *
+     * @return The builder.
+     */
+    public static Builder custom() {
+        return new Builder();
+    }
+
+    /**
+     * Returns default metric names.
+     *
+     * @return The default {@link RateLimiterMetricNames} instance.
+     */
+    public static RateLimiterMetricNames ofDefaults() {
+        return new RateLimiterMetricNames();
+    }
+
+    /**
+     * Returns the metric name for available permissions, defaults to {@value
+     * DEFAULT_AVAILABLE_PERMISSIONS_METRIC_NAME}.
+     *
+     * @return The available permissions metric name.
+     */
+    public String getAvailablePermissionsMetricName() {
+        return availablePermissionsMetricName;
+    }
+
+    /**
+     * Returns the metric name for waiting threads, defaults to {@value
+     * DEFAULT_WAITING_THREADS_METRIC_NAME}.
+     *
+     * @return The waiting threads metric name.
+     */
+    public String getWaitingThreadsMetricName() {
+        return waitingThreadsMetricName;
+    }
+
+    /**
+     * Helps building custom instance of {@link RateLimiterMetricNames}.
+     */
+    public static class Builder {
+
+        private final RateLimiterMetricNames metricNames = new RateLimiterMetricNames();
+
+        /**
+         * Overrides the default metric name {@value RateLimiterMetricNames#DEFAULT_AVAILABLE_PERMISSIONS_METRIC_NAME}
+         * with a given one.
+         *
+         * @param availablePermissionsMetricName The available permissions metric name.
+         * @return The builder.
+         */
+        public Builder availablePermissionsMetricName(String availablePermissionsMetricName) {
+            metricNames.availablePermissionsMetricName = requireNonNull(
+                availablePermissionsMetricName);
+            return this;
+        }
+
+        /**
+         * Overrides the default metric name {@value RateLimiterMetricNames#DEFAULT_WAITING_THREADS_METRIC_NAME}
+         * with a given one.
+         *
+         * @param waitingThreadsMetricName The waiting threads metric name.
+         * @return The builder.
+         */
+        public Builder waitingThreadsMetricName(String waitingThreadsMetricName) {
+            metricNames.waitingThreadsMetricName = requireNonNull(waitingThreadsMetricName);
+            return this;
+        }
+
+        /**
+         * Builds {@link RateLimiterMetricNames} instance.
+         *
+         * @return The built {@link RateLimiterMetricNames} instance.
+         */
+        public RateLimiterMetricNames build() {
+            return metricNames;
+        }
+    }
+}

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/RetryMetricNames.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/RetryMetricNames.java
@@ -1,0 +1,70 @@
+package io.github.resilience4j.micrometer.tagged;
+
+import static java.util.Objects.requireNonNull;
+
+public class RetryMetricNames {
+
+    public static final String DEFAULT_RETRY_CALLS = "resilience4j.retry.calls";
+
+    /**
+     * Returns a builder for creating custom metric names. Note that names have default values,
+     * so only desired metrics can be renamed.
+     *
+     * @return The builder.
+     */
+    public static Builder custom() {
+        return new Builder();
+    }
+
+    /**
+     * Returns default metric names.
+     *
+     * @return The default {@link RetryMetricNames} instance.
+     */
+    public static RetryMetricNames ofDefaults() {
+        return new RetryMetricNames();
+    }
+
+    private String callsMetricName = DEFAULT_RETRY_CALLS;
+
+    protected RetryMetricNames() {
+    }
+
+    /**
+     * Returns the metric name for retry calls, defaults to {@value DEFAULT_RETRY_CALLS}.
+     *
+     * @return The metric name for retry calls.
+     */
+    public String getCallsMetricName() {
+        return callsMetricName;
+    }
+
+    /**
+     * Helps building custom instance of {@link RetryMetricNames}.
+     */
+    public static class Builder {
+
+        private final RetryMetricNames retryMetricNames = new RetryMetricNames();
+
+        /**
+         * Overrides the default metric name {@value RetryMetricNames#DEFAULT_RETRY_CALLS} with a
+         * given one.
+         *
+         * @param callsMetricName The metric name for retry calls.
+         * @return The builder.
+         */
+        public Builder callsMetricName(String callsMetricName) {
+            retryMetricNames.callsMetricName = requireNonNull(callsMetricName);
+            return this;
+        }
+
+        /**
+         * Builds {@link RetryMetricNames} instance.
+         *
+         * @return The built {@link RetryMetricNames} instance.
+         */
+        public RetryMetricNames build() {
+            return retryMetricNames;
+        }
+    }
+}

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedBulkheadMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedBulkheadMetrics.java
@@ -30,7 +30,7 @@ public class TaggedBulkheadMetrics extends AbstractBulkheadMetrics implements Me
 
     private final BulkheadRegistry bulkheadRegistry;
 
-    private TaggedBulkheadMetrics(MetricNames names, BulkheadRegistry bulkheadRegistry) {
+    private TaggedBulkheadMetrics(BulkheadMetricNames names, BulkheadRegistry bulkheadRegistry) {
         super(names);
         this.bulkheadRegistry = requireNonNull(bulkheadRegistry);
     }
@@ -42,7 +42,7 @@ public class TaggedBulkheadMetrics extends AbstractBulkheadMetrics implements Me
      * @return The {@link TaggedBulkheadMetrics} instance.
      */
     public static TaggedBulkheadMetrics ofBulkheadRegistry(BulkheadRegistry bulkheadRegistry) {
-        return new TaggedBulkheadMetrics(MetricNames.ofDefaults(), bulkheadRegistry);
+        return new TaggedBulkheadMetrics(BulkheadMetricNames.ofDefaults(), bulkheadRegistry);
     }
 
     /**
@@ -53,8 +53,24 @@ public class TaggedBulkheadMetrics extends AbstractBulkheadMetrics implements Me
      * @param bulkheadRegistry the source of bulkheads
      * @return The {@link TaggedBulkheadMetrics} instance.
      */
+    public static TaggedBulkheadMetrics ofBulkheadRegistry(BulkheadMetricNames names,
+                                                           BulkheadRegistry bulkheadRegistry) {
+        return new TaggedBulkheadMetrics(names, bulkheadRegistry);
+    }
+
+    /**
+     * Creates a new binder defining custom metric names and using given {@code registry} as source
+     * of bulkheads.
+     *
+     * @deprecated Use {@link TaggedBulkheadMetrics#ofBulkheadRegistry(BulkheadMetricNames, BulkheadRegistry)} instead
+     *
+     * @param names            custom names of the metrics
+     * @param bulkheadRegistry the source of bulkheads
+     * @return The {@link TaggedBulkheadMetrics} instance.
+     */
+    @Deprecated
     public static TaggedBulkheadMetrics ofBulkheadRegistry(MetricNames names,
-        BulkheadRegistry bulkheadRegistry) {
+                                                           BulkheadRegistry bulkheadRegistry) {
         return new TaggedBulkheadMetrics(names, bulkheadRegistry);
     }
 

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedBulkheadMetricsPublisher.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedBulkheadMetricsPublisher.java
@@ -28,10 +28,16 @@ public class TaggedBulkheadMetricsPublisher
     private final MeterRegistry meterRegistry;
 
     public TaggedBulkheadMetricsPublisher(MeterRegistry meterRegistry) {
-        super(MetricNames.ofDefaults());
+        super(BulkheadMetricNames.ofDefaults());
         this.meterRegistry = requireNonNull(meterRegistry);
     }
 
+    public TaggedBulkheadMetricsPublisher(BulkheadMetricNames names, MeterRegistry meterRegistry) {
+        super(names);
+        this.meterRegistry = requireNonNull(meterRegistry);
+    }
+
+    @Deprecated
     public TaggedBulkheadMetricsPublisher(MetricNames names, MeterRegistry meterRegistry) {
         super(names);
         this.meterRegistry = requireNonNull(meterRegistry);

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetrics.java
@@ -31,8 +31,8 @@ public class TaggedCircuitBreakerMetrics extends AbstractCircuitBreakerMetrics i
 
     private final CircuitBreakerRegistry circuitBreakerRegistry;
 
-    private TaggedCircuitBreakerMetrics(MetricNames names,
-        CircuitBreakerRegistry circuitBreakerRegistry) {
+    private TaggedCircuitBreakerMetrics(CircuitBreakerMetricNames names,
+                                        CircuitBreakerRegistry circuitBreakerRegistry) {
         super(names);
         this.circuitBreakerRegistry = requireNonNull(circuitBreakerRegistry);
     }
@@ -45,19 +45,34 @@ public class TaggedCircuitBreakerMetrics extends AbstractCircuitBreakerMetrics i
      */
     public static TaggedCircuitBreakerMetrics ofCircuitBreakerRegistry(
         CircuitBreakerRegistry circuitBreakerRegistry) {
-        return new TaggedCircuitBreakerMetrics(MetricNames.ofDefaults(), circuitBreakerRegistry);
+        return new TaggedCircuitBreakerMetrics(CircuitBreakerMetricNames.ofDefaults(), circuitBreakerRegistry);
     }
 
     /**
      * Creates a new binder that uses given {@code registry} as source of circuit breakers.
      *
-     * @param metricNames            custom metric names
+     * @param circuitBreakerMetricNames            custom metric names
      * @param circuitBreakerRegistry the source of circuit breakers
      * @return The {@link TaggedCircuitBreakerMetrics} instance.
      */
-    public static TaggedCircuitBreakerMetrics ofCircuitBreakerRegistry(MetricNames metricNames,
-        CircuitBreakerRegistry circuitBreakerRegistry) {
-        return new TaggedCircuitBreakerMetrics(metricNames, circuitBreakerRegistry);
+    public static TaggedCircuitBreakerMetrics ofCircuitBreakerRegistry(CircuitBreakerMetricNames circuitBreakerMetricNames,
+                                                                       CircuitBreakerRegistry circuitBreakerRegistry) {
+        return new TaggedCircuitBreakerMetrics(circuitBreakerMetricNames, circuitBreakerRegistry);
+    }
+
+    /**
+     * Creates a new binder that uses given {@code registry} as source of circuit breakers.
+     *
+     * @deprecated Use {@link TaggedCircuitBreakerMetrics#ofCircuitBreakerRegistry(CircuitBreakerMetricNames, CircuitBreakerRegistry)} instead
+     *
+     * @param circuitBreakerMetricNames            custom metric names
+     * @param circuitBreakerRegistry the source of circuit breakers
+     * @return The {@link TaggedCircuitBreakerMetrics} instance.
+     */
+    @Deprecated
+    public static TaggedCircuitBreakerMetrics ofCircuitBreakerRegistry(MetricNames circuitBreakerMetricNames,
+                                                                       CircuitBreakerRegistry circuitBreakerRegistry) {
+        return new TaggedCircuitBreakerMetrics(circuitBreakerMetricNames, circuitBreakerRegistry);
     }
 
     @Override

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetricsPublisher.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetricsPublisher.java
@@ -28,10 +28,16 @@ public class TaggedCircuitBreakerMetricsPublisher
     private final MeterRegistry meterRegistry;
 
     public TaggedCircuitBreakerMetricsPublisher(MeterRegistry meterRegistry) {
-        super(MetricNames.ofDefaults());
+        super(CircuitBreakerMetricNames.ofDefaults());
         this.meterRegistry = requireNonNull(meterRegistry);
     }
 
+    public TaggedCircuitBreakerMetricsPublisher(CircuitBreakerMetricNames names, MeterRegistry meterRegistry) {
+        super(names);
+        this.meterRegistry = requireNonNull(meterRegistry);
+    }
+
+    @Deprecated
     public TaggedCircuitBreakerMetricsPublisher(MetricNames names, MeterRegistry meterRegistry) {
         super(names);
         this.meterRegistry = requireNonNull(meterRegistry);

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedRateLimiterMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedRateLimiterMetrics.java
@@ -30,7 +30,7 @@ public class TaggedRateLimiterMetrics extends AbstractRateLimiterMetrics impleme
 
     private final RateLimiterRegistry rateLimiterRegistry;
 
-    private TaggedRateLimiterMetrics(MetricNames names, RateLimiterRegistry rateLimiterRegistry) {
+    private TaggedRateLimiterMetrics(RateLimiterMetricNames names, RateLimiterRegistry rateLimiterRegistry) {
         super(names);
         this.rateLimiterRegistry = requireNonNull(rateLimiterRegistry);
     }
@@ -43,7 +43,7 @@ public class TaggedRateLimiterMetrics extends AbstractRateLimiterMetrics impleme
      */
     public static TaggedRateLimiterMetrics ofRateLimiterRegistry(
         RateLimiterRegistry rateLimiterRegistry) {
-        return new TaggedRateLimiterMetrics(MetricNames.ofDefaults(), rateLimiterRegistry);
+        return new TaggedRateLimiterMetrics(RateLimiterMetricNames.ofDefaults(), rateLimiterRegistry);
     }
 
     /**
@@ -53,8 +53,23 @@ public class TaggedRateLimiterMetrics extends AbstractRateLimiterMetrics impleme
      * @param rateLimiterRegistry the source of rate limiters
      * @return The {@link TaggedRateLimiterMetrics} instance.
      */
+    public static TaggedRateLimiterMetrics ofRateLimiterRegistry(RateLimiterMetricNames names,
+                                                                 RateLimiterRegistry rateLimiterRegistry) {
+        return new TaggedRateLimiterMetrics(names, rateLimiterRegistry);
+    }
+
+    /**
+     * Creates a new binder that uses given {@code registry} as source of rate limiters.
+     *
+     * @deprecated Use {@link TaggedRateLimiterMetrics#ofRateLimiterRegistry(RateLimiterMetricNames, RateLimiterRegistry)} instead
+     *
+     * @param names               custom metric names
+     * @param rateLimiterRegistry the source of rate limiters
+     * @return The {@link TaggedRateLimiterMetrics} instance.
+     */
+    @Deprecated
     public static TaggedRateLimiterMetrics ofRateLimiterRegistry(MetricNames names,
-        RateLimiterRegistry rateLimiterRegistry) {
+                                                                 RateLimiterRegistry rateLimiterRegistry) {
         return new TaggedRateLimiterMetrics(names, rateLimiterRegistry);
     }
 

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedRateLimiterMetricsPublisher.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedRateLimiterMetricsPublisher.java
@@ -28,10 +28,16 @@ public class TaggedRateLimiterMetricsPublisher
     private final MeterRegistry meterRegistry;
 
     public TaggedRateLimiterMetricsPublisher(MeterRegistry meterRegistry) {
-        super(MetricNames.ofDefaults());
+        super(RateLimiterMetricNames.ofDefaults());
         this.meterRegistry = requireNonNull(meterRegistry);
     }
 
+    public TaggedRateLimiterMetricsPublisher(RateLimiterMetricNames names, MeterRegistry meterRegistry) {
+        super(names);
+        this.meterRegistry = requireNonNull(meterRegistry);
+    }
+
+    @Deprecated
     public TaggedRateLimiterMetricsPublisher(MetricNames names, MeterRegistry meterRegistry) {
         super(names);
         this.meterRegistry = requireNonNull(meterRegistry);

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedRetryMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedRetryMetrics.java
@@ -30,7 +30,7 @@ public class TaggedRetryMetrics extends AbstractRetryMetrics implements MeterBin
 
     private final RetryRegistry retryRegistry;
 
-    private TaggedRetryMetrics(MetricNames names, RetryRegistry retryRegistry) {
+    private TaggedRetryMetrics(RetryMetricNames names, RetryRegistry retryRegistry) {
         super(names);
         this.retryRegistry = requireNonNull(retryRegistry);
     }
@@ -42,7 +42,7 @@ public class TaggedRetryMetrics extends AbstractRetryMetrics implements MeterBin
      * @return The {@link TaggedRetryMetrics} instance.
      */
     public static TaggedRetryMetrics ofRetryRegistry(RetryRegistry retryRegistry) {
-        return new TaggedRetryMetrics(MetricNames.ofDefaults(), retryRegistry);
+        return new TaggedRetryMetrics(RetryMetricNames.ofDefaults(), retryRegistry);
     }
 
     /**
@@ -52,8 +52,23 @@ public class TaggedRetryMetrics extends AbstractRetryMetrics implements MeterBin
      * @param retryRegistry the source of retries
      * @return The {@link TaggedRetryMetrics} instance.
      */
+    public static TaggedRetryMetrics ofRetryRegistry(RetryMetricNames names,
+                                                     RetryRegistry retryRegistry) {
+        return new TaggedRetryMetrics(names, retryRegistry);
+    }
+
+    /**
+     * Creates a new binder that uses given {@code registry} as source of retries.
+     *
+     * @deprecated Use {@link TaggedRetryMetrics#ofRetryRegistry(RetryMetricNames, RetryRegistry)} instead
+     *
+     * @param names         custom metric names
+     * @param retryRegistry the source of retries
+     * @return The {@link TaggedRetryMetrics} instance.
+     */
+    @Deprecated
     public static TaggedRetryMetrics ofRetryRegistry(MetricNames names,
-        RetryRegistry retryRegistry) {
+                                                     RetryRegistry retryRegistry) {
         return new TaggedRetryMetrics(names, retryRegistry);
     }
 

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedRetryMetricsPublisher.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedRetryMetricsPublisher.java
@@ -28,10 +28,16 @@ public class TaggedRetryMetricsPublisher
     private final MeterRegistry meterRegistry;
 
     public TaggedRetryMetricsPublisher(MeterRegistry meterRegistry) {
-        super(MetricNames.ofDefaults());
+        super(RetryMetricNames.ofDefaults());
         this.meterRegistry = requireNonNull(meterRegistry);
     }
 
+    public TaggedRetryMetricsPublisher(RetryMetricNames names, MeterRegistry meterRegistry) {
+        super(names);
+        this.meterRegistry = requireNonNull(meterRegistry);
+    }
+
+    @Deprecated
     public TaggedRetryMetricsPublisher(MetricNames names, MeterRegistry meterRegistry) {
         super(names);
         this.meterRegistry = requireNonNull(meterRegistry);

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedThreadPoolBulkheadMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedThreadPoolBulkheadMetrics.java
@@ -32,8 +32,8 @@ public class TaggedThreadPoolBulkheadMetrics extends AbstractThreadPoolBulkheadM
 
     private final ThreadPoolBulkheadRegistry bulkheadRegistry;
 
-    private TaggedThreadPoolBulkheadMetrics(MetricNames names,
-        ThreadPoolBulkheadRegistry bulkheadRegistry) {
+    private TaggedThreadPoolBulkheadMetrics(ThreadPoolBulkheadMetricNames names,
+                                            ThreadPoolBulkheadRegistry bulkheadRegistry) {
         super(names);
         this.bulkheadRegistry = requireNonNull(bulkheadRegistry);
     }
@@ -46,7 +46,7 @@ public class TaggedThreadPoolBulkheadMetrics extends AbstractThreadPoolBulkheadM
      */
     public static TaggedThreadPoolBulkheadMetrics ofThreadPoolBulkheadRegistry(
         ThreadPoolBulkheadRegistry bulkheadRegistry) {
-        return new TaggedThreadPoolBulkheadMetrics(MetricNames.ofDefaults(), bulkheadRegistry);
+        return new TaggedThreadPoolBulkheadMetrics(ThreadPoolBulkheadMetricNames.ofDefaults(), bulkheadRegistry);
     }
 
     /**
@@ -57,8 +57,24 @@ public class TaggedThreadPoolBulkheadMetrics extends AbstractThreadPoolBulkheadM
      * @param bulkheadRegistry the source of bulkheads
      * @return The {@link TaggedThreadPoolBulkheadMetrics} instance.
      */
+    public static TaggedThreadPoolBulkheadMetrics ofThreadPoolBulkheadRegistry(ThreadPoolBulkheadMetricNames names,
+                                                                               ThreadPoolBulkheadRegistry bulkheadRegistry) {
+        return new TaggedThreadPoolBulkheadMetrics(names, bulkheadRegistry);
+    }
+
+    /**
+     * Creates a new binder defining custom metric names and using given {@code registry} as source
+     * of bulkheads.
+     *
+     * @deprecated Use {@link TaggedThreadPoolBulkheadMetrics#ofThreadPoolBulkheadRegistry(ThreadPoolBulkheadMetricNames, ThreadPoolBulkheadRegistry)} instead
+     *
+     * @param names            custom names of the metrics
+     * @param bulkheadRegistry the source of bulkheads
+     * @return The {@link TaggedThreadPoolBulkheadMetrics} instance.
+     */
+    @Deprecated
     public static TaggedThreadPoolBulkheadMetrics ofThreadPoolBulkheadRegistry(MetricNames names,
-        ThreadPoolBulkheadRegistry bulkheadRegistry) {
+                                                                               ThreadPoolBulkheadRegistry bulkheadRegistry) {
         return new TaggedThreadPoolBulkheadMetrics(names, bulkheadRegistry);
     }
 

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedThreadPoolBulkheadMetricsPublisher.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedThreadPoolBulkheadMetricsPublisher.java
@@ -28,12 +28,19 @@ public class TaggedThreadPoolBulkheadMetricsPublisher
     private final MeterRegistry meterRegistry;
 
     public TaggedThreadPoolBulkheadMetricsPublisher(MeterRegistry meterRegistry) {
-        super(MetricNames.ofDefaults());
+        super(ThreadPoolBulkheadMetricNames.ofDefaults());
         this.meterRegistry = requireNonNull(meterRegistry);
     }
 
+    public TaggedThreadPoolBulkheadMetricsPublisher(ThreadPoolBulkheadMetricNames names,
+                                                    MeterRegistry meterRegistry) {
+        super(names);
+        this.meterRegistry = requireNonNull(meterRegistry);
+    }
+
+    @Deprecated
     public TaggedThreadPoolBulkheadMetricsPublisher(MetricNames names,
-        MeterRegistry meterRegistry) {
+                                                    MeterRegistry meterRegistry) {
         super(names);
         this.meterRegistry = requireNonNull(meterRegistry);
     }

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedTimeLimiterMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedTimeLimiterMetrics.java
@@ -29,7 +29,7 @@ public class TaggedTimeLimiterMetrics extends AbstractTimeLimiterMetrics impleme
 
     private final TimeLimiterRegistry timeLimiterRegistry;
 
-    private TaggedTimeLimiterMetrics(MetricNames names, TimeLimiterRegistry timeLimiterRegistry) {
+    private TaggedTimeLimiterMetrics(TimeLimiterMetricNames names, TimeLimiterRegistry timeLimiterRegistry) {
         super(names);
         this.timeLimiterRegistry = requireNonNull(timeLimiterRegistry);
     }
@@ -42,7 +42,7 @@ public class TaggedTimeLimiterMetrics extends AbstractTimeLimiterMetrics impleme
      */
     public static TaggedTimeLimiterMetrics ofTimeLimiterRegistry(
         TimeLimiterRegistry timeLimiterRegistry) {
-        return new TaggedTimeLimiterMetrics(MetricNames.ofDefaults(), timeLimiterRegistry);
+        return new TaggedTimeLimiterMetrics(TimeLimiterMetricNames.ofDefaults(), timeLimiterRegistry);
     }
 
     /**
@@ -52,8 +52,23 @@ public class TaggedTimeLimiterMetrics extends AbstractTimeLimiterMetrics impleme
      * @param timeLimiterRegistry the source of time limiters
      * @return The {@link TaggedTimeLimiterMetrics} instance.
      */
+    public static TaggedTimeLimiterMetrics ofTimeLimiterRegistry(TimeLimiterMetricNames names,
+                                                                 TimeLimiterRegistry timeLimiterRegistry) {
+        return new TaggedTimeLimiterMetrics(names, timeLimiterRegistry);
+    }
+
+    /**
+     * Creates a new binder that uses given {@code registry} as source of time limiters.
+     *
+     * @deprecated Use {@link TaggedTimeLimiterMetrics#ofTimeLimiterRegistry(TimeLimiterMetricNames, TimeLimiterRegistry)} instead
+     *
+     * @param names               custom metric names
+     * @param timeLimiterRegistry the source of time limiters
+     * @return The {@link TaggedTimeLimiterMetrics} instance.
+     */
+    @Deprecated
     public static TaggedTimeLimiterMetrics ofTimeLimiterRegistry(MetricNames names,
-        TimeLimiterRegistry timeLimiterRegistry) {
+                                                                 TimeLimiterRegistry timeLimiterRegistry) {
         return new TaggedTimeLimiterMetrics(names, timeLimiterRegistry);
     }
 

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedTimeLimiterMetricsPublisher.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TaggedTimeLimiterMetricsPublisher.java
@@ -28,10 +28,16 @@ public class TaggedTimeLimiterMetricsPublisher
     private final MeterRegistry meterRegistry;
 
     public TaggedTimeLimiterMetricsPublisher(MeterRegistry meterRegistry) {
-        super(MetricNames.ofDefaults());
+        super(TimeLimiterMetricNames.ofDefaults());
         this.meterRegistry = requireNonNull(meterRegistry);
     }
 
+    public TaggedTimeLimiterMetricsPublisher(TimeLimiterMetricNames names, MeterRegistry meterRegistry) {
+        super(names);
+        this.meterRegistry = requireNonNull(meterRegistry);
+    }
+
+    @Deprecated
     public TaggedTimeLimiterMetricsPublisher(MetricNames names, MeterRegistry meterRegistry) {
         super(names);
         this.meterRegistry = requireNonNull(meterRegistry);

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/ThreadPoolBulkheadMetricNames.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/ThreadPoolBulkheadMetricNames.java
@@ -1,0 +1,174 @@
+package io.github.resilience4j.micrometer.tagged;
+
+import static java.util.Objects.requireNonNull;
+
+public class ThreadPoolBulkheadMetricNames {
+    private static final String DEFAULT_PREFIX = "resilience4j.bulkhead";
+
+    public static final String DEFAULT_BULKHEAD_QUEUE_DEPTH_METRIC_NAME =
+        DEFAULT_PREFIX + ".queue.depth";
+    public static final String DEFAULT_BULKHEAD_QUEUE_CAPACITY_METRIC_NAME =
+        DEFAULT_PREFIX + ".queue.capacity";
+    public static final String DEFAULT_THREAD_POOL_SIZE_METRIC_NAME =
+        DEFAULT_PREFIX + ".thread.pool.size";
+    public static final String DEFAULT_MAX_THREAD_POOL_SIZE_METRIC_NAME =
+        DEFAULT_PREFIX + ".max.thread.pool.size";
+    public static final String DEFAULT_CORE_THREAD_POOL_SIZE_METRIC_NAME =
+        DEFAULT_PREFIX + ".core.thread.pool.size";
+    private String queueDepthMetricName = DEFAULT_BULKHEAD_QUEUE_DEPTH_METRIC_NAME;
+    private String threadPoolSizeMetricName = DEFAULT_THREAD_POOL_SIZE_METRIC_NAME;
+    private String maxThreadPoolSizeMetricName = DEFAULT_MAX_THREAD_POOL_SIZE_METRIC_NAME;
+    private String coreThreadPoolSizeMetricName = DEFAULT_CORE_THREAD_POOL_SIZE_METRIC_NAME;
+    private String queueCapacityMetricName = DEFAULT_BULKHEAD_QUEUE_CAPACITY_METRIC_NAME;
+
+    protected ThreadPoolBulkheadMetricNames() {
+    }
+
+    /**
+     * Returns a builder for creating custom metric names. Note that names have default values,
+     * so only desired metrics can be renamed.
+     *
+     * @return The builder.
+     */
+    public static Builder custom() {
+        return new Builder();
+    }
+
+    /**
+     * Returns default metric names.
+     *
+     * @return The default {@link ThreadPoolBulkheadMetricNames} instance.
+     */
+    public static ThreadPoolBulkheadMetricNames ofDefaults() {
+        return new ThreadPoolBulkheadMetricNames();
+    }
+
+    /**
+     * Returns the metric name for queue depth, defaults to {@value
+     * DEFAULT_BULKHEAD_QUEUE_DEPTH_METRIC_NAME}.
+     *
+     * @return The queue depth metric name.
+     */
+    public String getQueueDepthMetricName() {
+        return queueDepthMetricName;
+    }
+
+    /**
+     * Returns the metric name for thread pool size, defaults to {@value
+     * DEFAULT_THREAD_POOL_SIZE_METRIC_NAME}.
+     *
+     * @return The thread pool size metric name.
+     */
+    public String getThreadPoolSizeMetricName() {
+        return threadPoolSizeMetricName;
+    }
+
+    /**
+     * Returns the metric name for max thread pool size, defaults to {@value
+     * DEFAULT_MAX_THREAD_POOL_SIZE_METRIC_NAME}.
+     *
+     * @return The max thread pool size metric name.
+     */
+    public String getMaxThreadPoolSizeMetricName() {
+        return maxThreadPoolSizeMetricName;
+    }
+
+    /**
+     * Returns the metric name for core thread pool size, defaults to {@value
+     * DEFAULT_CORE_THREAD_POOL_SIZE_METRIC_NAME}.
+     *
+     * @return The core thread pool size metric name.
+     */
+    public String getCoreThreadPoolSizeMetricName() {
+        return coreThreadPoolSizeMetricName;
+    }
+
+    /**
+     * Returns the metric name for queue capacity, defaults to {@value
+     * DEFAULT_BULKHEAD_QUEUE_CAPACITY_METRIC_NAME}.
+     *
+     * @return The queue capacity metric name.
+     */
+    public String getQueueCapacityMetricName() {
+        return queueCapacityMetricName;
+    }
+
+    /**
+     * Helps building custom instance of {@link ThreadPoolBulkheadMetricNames}.
+     */
+    public static class Builder {
+
+        private final ThreadPoolBulkheadMetricNames metricNames = new ThreadPoolBulkheadMetricNames();
+
+        /**
+         * Overrides the default metric name {@value ThreadPoolBulkheadMetricNames#DEFAULT_BULKHEAD_QUEUE_DEPTH_METRIC_NAME}
+         * with a given one.
+         *
+         * @param queueDepthMetricName The queue depth metric name.
+         * @return The builder.
+         */
+        public Builder queueDepthMetricName(String queueDepthMetricName) {
+            metricNames.queueDepthMetricName = requireNonNull(queueDepthMetricName);
+            return this;
+        }
+
+        /**
+         * Overrides the default metric name {@value ThreadPoolBulkheadMetricNames#DEFAULT_THREAD_POOL_SIZE_METRIC_NAME}
+         * with a given one.
+         *
+         * @param threadPoolSizeMetricName The thread pool size metric name.
+         * @return The builder.
+         */
+        public Builder threadPoolSizeMetricName(String threadPoolSizeMetricName) {
+            metricNames.threadPoolSizeMetricName =  requireNonNull(threadPoolSizeMetricName);
+            return this;
+        }
+
+        /**
+         * Overrides the default metric name {@value ThreadPoolBulkheadMetricNames#DEFAULT_MAX_THREAD_POOL_SIZE_METRIC_NAME}
+         * with a given one.
+         *
+         * @param maxThreadPoolSizeMetricName The max thread pool size metric name.
+         * @return The builder.
+         */
+        public Builder maxThreadPoolSizeMetricName(String maxThreadPoolSizeMetricName) {
+            metricNames.maxThreadPoolSizeMetricName = requireNonNull(
+                maxThreadPoolSizeMetricName);
+            return this;
+        }
+
+        /**
+         * Overrides the default metric name {@value ThreadPoolBulkheadMetricNames#DEFAULT_CORE_THREAD_POOL_SIZE_METRIC_NAME}
+         * with a given one.
+         *
+         * @param coreThreadPoolSizeMetricName The core thread pool size metric name.
+         * @return The builder.
+         */
+        public Builder coreThreadPoolSizeMetricName(String coreThreadPoolSizeMetricName) {
+            metricNames.coreThreadPoolSizeMetricName = requireNonNull(
+                coreThreadPoolSizeMetricName);
+            return this;
+        }
+
+        /**
+         * Overrides the default metric name {@value ThreadPoolBulkheadMetricNames#DEFAULT_BULKHEAD_QUEUE_CAPACITY_METRIC_NAME}
+         * with a given one.
+         *
+         * @param queueCapacityMetricName The queue capacity metric name.
+         * @return The builder.
+         */
+        public Builder queueCapacityMetricName(String queueCapacityMetricName) {
+            metricNames.queueCapacityMetricName = requireNonNull(queueCapacityMetricName);
+            return this;
+        }
+
+        /**
+         * Builds {@link ThreadPoolBulkheadMetricNames} instance.
+         *
+         * @return The built {@link ThreadPoolBulkheadMetricNames} instance.
+         */
+        public ThreadPoolBulkheadMetricNames build() {
+            return metricNames;
+        }
+    }
+}

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TimeLimiterMetricNames.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/TimeLimiterMetricNames.java
@@ -1,0 +1,69 @@
+package io.github.resilience4j.micrometer.tagged;
+
+import static java.util.Objects.requireNonNull;
+
+public class TimeLimiterMetricNames {
+
+    private static final String DEFAULT_PREFIX = "resilience4j.timelimiter";
+    public static final String DEFAULT_TIME_LIMITER_CALLS = DEFAULT_PREFIX + ".calls";
+
+    private String callsMetricName = DEFAULT_TIME_LIMITER_CALLS;
+
+    /**
+     * Returns a builder for creating custom metric names. Note that names have default values,
+     * so only desired metrics can be renamed.
+     *
+     * @return The builder.
+     */
+    public static Builder custom() {
+        return new Builder();
+    }
+
+    /**
+     * Returns default metric names.
+     *
+     * @return The default {@link TimeLimiterMetricNames} instance.
+     */
+    public static TimeLimiterMetricNames ofDefaults() {
+        return new TimeLimiterMetricNames();
+    }
+
+    /**
+     * Returns the metric name for circuit breaker calls, defaults to {@value
+     * DEFAULT_TIME_LIMITER_CALLS}.
+     *
+     * @return The circuit breaker calls metric name.
+     */
+    public String getCallsMetricName() {
+        return callsMetricName;
+    }
+
+    /**
+     * Helps building custom instance of {@link TimeLimiterMetricNames}.
+     */
+    public static class Builder {
+
+        private final TimeLimiterMetricNames metricNames = new TimeLimiterMetricNames();
+
+        /**
+         * Overrides the default metric name {@value TimeLimiterMetricNames#DEFAULT_TIME_LIMITER_CALLS}
+         * with a given one.
+         *
+         * @param callsMetricName The calls metric name.
+         * @return The builder.
+         */
+        public Builder callsMetricName(String callsMetricName) {
+            metricNames.callsMetricName = requireNonNull(callsMetricName);
+            return this;
+        }
+
+        /**
+         * Builds {@link TimeLimiterMetricNames} instance.
+         *
+         * @return The built {@link TimeLimiterMetricNames} instance.
+         */
+        public TimeLimiterMetricNames build() {
+            return metricNames;
+        }
+    }
+}

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedBulkheadMetricsPublisherTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedBulkheadMetricsPublisherTest.java
@@ -29,8 +29,8 @@ import org.junit.Test;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static io.github.resilience4j.micrometer.tagged.AbstractBulkheadMetrics.MetricNames.DEFAULT_BULKHEAD_AVAILABLE_CONCURRENT_CALLS_METRIC_NAME;
-import static io.github.resilience4j.micrometer.tagged.AbstractBulkheadMetrics.MetricNames.DEFAULT_BULKHEAD_MAX_ALLOWED_CONCURRENT_CALLS_METRIC_NAME;
+import static io.github.resilience4j.micrometer.tagged.BulkheadMetricNames.DEFAULT_BULKHEAD_AVAILABLE_CONCURRENT_CALLS_METRIC_NAME;
+import static io.github.resilience4j.micrometer.tagged.BulkheadMetricNames.DEFAULT_BULKHEAD_MAX_ALLOWED_CONCURRENT_CALLS_METRIC_NAME;
 import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByNamesTag;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -139,7 +139,7 @@ public class TaggedBulkheadMetricsPublisherTest {
     public void customMetricNamesGetApplied() {
         MeterRegistry meterRegistry = new SimpleMeterRegistry();
         TaggedBulkheadMetricsPublisher taggedBulkheadMetricsPublisher = new TaggedBulkheadMetricsPublisher(
-            TaggedBulkheadMetricsPublisher.MetricNames.custom()
+            BulkheadMetricNames.custom()
                 .availableConcurrentCallsMetricName("custom_available_calls")
                 .maxAllowedConcurrentCallsMetricName("custom_max_allowed_calls")
                 .build(), meterRegistry);

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedBulkheadMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedBulkheadMetricsTest.java
@@ -29,8 +29,8 @@ import org.junit.Test;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static io.github.resilience4j.micrometer.tagged.AbstractBulkheadMetrics.MetricNames.DEFAULT_BULKHEAD_AVAILABLE_CONCURRENT_CALLS_METRIC_NAME;
-import static io.github.resilience4j.micrometer.tagged.AbstractBulkheadMetrics.MetricNames.DEFAULT_BULKHEAD_MAX_ALLOWED_CONCURRENT_CALLS_METRIC_NAME;
+import static io.github.resilience4j.micrometer.tagged.BulkheadMetricNames.DEFAULT_BULKHEAD_AVAILABLE_CONCURRENT_CALLS_METRIC_NAME;
+import static io.github.resilience4j.micrometer.tagged.BulkheadMetricNames.DEFAULT_BULKHEAD_MAX_ALLOWED_CONCURRENT_CALLS_METRIC_NAME;
 import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByNamesTag;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -154,7 +154,7 @@ public class TaggedBulkheadMetricsTest {
         BulkheadRegistry bulkheadRegistry = BulkheadRegistry.ofDefaults();
         bulkhead = bulkheadRegistry.bulkhead("backendA");
         TaggedBulkheadMetrics.ofBulkheadRegistry(
-            TaggedBulkheadMetrics.MetricNames.custom()
+            BulkheadMetricNames.custom()
                 .availableConcurrentCallsMetricName("custom_available_calls")
                 .maxAllowedConcurrentCallsMetricName("custom_max_allowed_calls")
                 .build(),

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetricsPublisherTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetricsPublisherTest.java
@@ -32,7 +32,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static io.github.resilience4j.micrometer.tagged.AbstractCircuitBreakerMetrics.MetricNames.*;
+import static io.github.resilience4j.micrometer.tagged.CircuitBreakerMetricNames.*;
 import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByKindAndNameTags;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -193,7 +193,7 @@ public class TaggedCircuitBreakerMetricsPublisherTest {
     public void metricsAreRegisteredWithCustomName() {
         MeterRegistry meterRegistry = new SimpleMeterRegistry();
         TaggedCircuitBreakerMetricsPublisher taggedCircuitBreakerMetricsPublisher = new TaggedCircuitBreakerMetricsPublisher(
-            TaggedCircuitBreakerMetricsPublisher.MetricNames.custom()
+            CircuitBreakerMetricNames.custom()
                 .callsMetricName("custom_calls")
                 .stateMetricName("custom_state")
                 .bufferedCallsMetricName("custom_buffered_calls")

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetricsTest.java
@@ -32,7 +32,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static io.github.resilience4j.micrometer.tagged.AbstractCircuitBreakerMetrics.MetricNames.*;
+import static io.github.resilience4j.micrometer.tagged.CircuitBreakerMetricNames.*;
 import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByKindAndNameTags;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -208,7 +208,7 @@ public class TaggedCircuitBreakerMetricsTest {
         CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
         circuitBreakerRegistry.circuitBreaker("backendA");
         TaggedCircuitBreakerMetrics.ofCircuitBreakerRegistry(
-            TaggedCircuitBreakerMetrics.MetricNames.custom()
+            CircuitBreakerMetricNames.custom()
                 .callsMetricName("custom_calls")
                 .stateMetricName("custom_state")
                 .bufferedCallsMetricName("custom_buffered_calls")

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRateLimiterMetricsPublisherTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRateLimiterMetricsPublisherTest.java
@@ -29,8 +29,8 @@ import org.junit.Test;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static io.github.resilience4j.micrometer.tagged.AbstractRateLimiterMetrics.MetricNames.DEFAULT_AVAILABLE_PERMISSIONS_METRIC_NAME;
-import static io.github.resilience4j.micrometer.tagged.AbstractRateLimiterMetrics.MetricNames.DEFAULT_WAITING_THREADS_METRIC_NAME;
+import static io.github.resilience4j.micrometer.tagged.RateLimiterMetricNames.DEFAULT_AVAILABLE_PERMISSIONS_METRIC_NAME;
+import static io.github.resilience4j.micrometer.tagged.RateLimiterMetricNames.DEFAULT_WAITING_THREADS_METRIC_NAME;
 import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByNamesTag;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -137,7 +137,7 @@ public class TaggedRateLimiterMetricsPublisherTest {
     public void customMetricNamesGetApplied() {
         MeterRegistry meterRegistry = new SimpleMeterRegistry();
         TaggedRateLimiterMetricsPublisher taggedRateLimiterMetricsPublisher = new TaggedRateLimiterMetricsPublisher(
-            TaggedRateLimiterMetricsPublisher.MetricNames.custom()
+            RateLimiterMetricNames.custom()
                 .availablePermissionsMetricName("custom_available_permissions")
                 .waitingThreadsMetricName("custom_waiting_threads")
                 .build(), meterRegistry);

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRateLimiterMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRateLimiterMetricsTest.java
@@ -28,8 +28,8 @@ import org.junit.Test;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static io.github.resilience4j.micrometer.tagged.AbstractRateLimiterMetrics.MetricNames.DEFAULT_AVAILABLE_PERMISSIONS_METRIC_NAME;
-import static io.github.resilience4j.micrometer.tagged.AbstractRateLimiterMetrics.MetricNames.DEFAULT_WAITING_THREADS_METRIC_NAME;
+import static io.github.resilience4j.micrometer.tagged.RateLimiterMetricNames.DEFAULT_AVAILABLE_PERMISSIONS_METRIC_NAME;
+import static io.github.resilience4j.micrometer.tagged.RateLimiterMetricNames.DEFAULT_WAITING_THREADS_METRIC_NAME;
 import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByNamesTag;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -149,7 +149,7 @@ public class TaggedRateLimiterMetricsTest {
         RateLimiterRegistry rateLimiterRegistry = RateLimiterRegistry.ofDefaults();
         rateLimiterRegistry.rateLimiter("backendA");
         TaggedRateLimiterMetrics.ofRateLimiterRegistry(
-            TaggedRateLimiterMetrics.MetricNames.custom()
+            RateLimiterMetricNames.custom()
                 .availablePermissionsMetricName("custom_available_permissions")
                 .waitingThreadsMetricName("custom_waiting_threads")
                 .build(),

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRetryMetricsPublisherTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRetryMetricsPublisherTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static io.github.resilience4j.micrometer.tagged.AbstractRetryMetrics.MetricNames.DEFAULT_RETRY_CALLS;
+import static io.github.resilience4j.micrometer.tagged.RetryMetricNames.DEFAULT_RETRY_CALLS;
 import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByKindAndNameTags;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -162,7 +162,7 @@ public class TaggedRetryMetricsPublisherTest {
     public void metricsAreRegisteredWithCustomNames() {
         MeterRegistry meterRegistry = new SimpleMeterRegistry();
         TaggedRetryMetricsPublisher taggedRetryMetricsPublisher = new TaggedRetryMetricsPublisher(
-            TaggedRetryMetricsPublisher.MetricNames.custom()
+            RetryMetricNames.custom()
                 .callsMetricName("custom_calls")
                 .build(), meterRegistry);
         RetryRegistry retryRegistry = RetryRegistry

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRetryMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRetryMetricsTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static io.github.resilience4j.micrometer.tagged.AbstractRetryMetrics.MetricNames.DEFAULT_RETRY_CALLS;
+import static io.github.resilience4j.micrometer.tagged.RetryMetricNames.DEFAULT_RETRY_CALLS;
 import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByKindAndNameTags;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -176,7 +176,7 @@ public class TaggedRetryMetricsTest {
         RetryRegistry retryRegistry = RetryRegistry.ofDefaults();
         retryRegistry.retry("backendA");
         TaggedRetryMetrics.ofRetryRegistry(
-            TaggedRetryMetrics.MetricNames.custom()
+            RetryMetricNames.custom()
                 .callsMetricName("custom_calls")
                 .build(),
             retryRegistry

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedThreadPoolBulkheadMetricsPublisherTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedThreadPoolBulkheadMetricsPublisherTest.java
@@ -29,8 +29,8 @@ import org.junit.Test;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static io.github.resilience4j.micrometer.tagged.AbstractThreadPoolBulkheadMetrics.MetricNames.*;
 import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByNamesTag;
+import static io.github.resilience4j.micrometer.tagged.ThreadPoolBulkheadMetricNames.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TaggedThreadPoolBulkheadMetricsPublisherTest {
@@ -163,7 +163,7 @@ public class TaggedThreadPoolBulkheadMetricsPublisherTest {
         MeterRegistry meterRegistry = new SimpleMeterRegistry();
         TaggedThreadPoolBulkheadMetricsPublisher taggedBulkheadMetricsPublisher =
             new TaggedThreadPoolBulkheadMetricsPublisher(
-                TaggedThreadPoolBulkheadMetricsPublisher.MetricNames.custom()
+                ThreadPoolBulkheadMetricNames.custom()
                     .maxThreadPoolSizeMetricName("custom.max.thread.pool.size")
                     .coreThreadPoolSizeMetricName("custom.core.thread.pool.size")
                     .build(), meterRegistry);

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedThreadPoolBulkheadMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedThreadPoolBulkheadMetricsTest.java
@@ -28,8 +28,8 @@ import org.junit.Test;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static io.github.resilience4j.micrometer.tagged.AbstractThreadPoolBulkheadMetrics.MetricNames.*;
 import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByNamesTag;
+import static io.github.resilience4j.micrometer.tagged.ThreadPoolBulkheadMetricNames.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TaggedThreadPoolBulkheadMetricsTest {
@@ -176,7 +176,7 @@ public class TaggedThreadPoolBulkheadMetricsTest {
         ThreadPoolBulkheadRegistry bulkheadRegistry = ThreadPoolBulkheadRegistry.ofDefaults();
         bulkhead = bulkheadRegistry.bulkhead("backendA");
         TaggedThreadPoolBulkheadMetrics.ofThreadPoolBulkheadRegistry(
-            TaggedThreadPoolBulkheadMetrics.MetricNames.custom()
+            ThreadPoolBulkheadMetricNames.custom()
                 .maxThreadPoolSizeMetricName("custom.max.thread.pool.size")
                 .coreThreadPoolSizeMetricName("custom.core.thread.pool.size")
                 .build(),

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedTimeLimiterMetricsPublisherTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedTimeLimiterMetricsPublisherTest.java
@@ -34,8 +34,8 @@ import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
-import static io.github.resilience4j.micrometer.tagged.AbstractTimeLimiterMetrics.MetricNames.DEFAULT_TIME_LIMITER_CALLS;
 import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByKindAndNameTags;
+import static io.github.resilience4j.micrometer.tagged.TimeLimiterMetricNames.DEFAULT_TIME_LIMITER_CALLS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TaggedTimeLimiterMetricsPublisherTest {
@@ -148,7 +148,7 @@ public class TaggedTimeLimiterMetricsPublisherTest {
     public void customMetricNamesGetApplied() {
         MeterRegistry meterRegistry = new SimpleMeterRegistry();
         TaggedTimeLimiterMetricsPublisher taggedTimeLimiterMetricsPublisher = new TaggedTimeLimiterMetricsPublisher(
-            TaggedTimeLimiterMetricsPublisher.MetricNames.custom()
+            TimeLimiterMetricNames.custom()
                 .callsMetricName("custom_calls")
                 .build(), meterRegistry);
 

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedTimeLimiterMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedTimeLimiterMetricsTest.java
@@ -31,8 +31,8 @@ import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
-import static io.github.resilience4j.micrometer.tagged.AbstractTimeLimiterMetrics.MetricNames.DEFAULT_TIME_LIMITER_CALLS;
 import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByKindAndNameTags;
+import static io.github.resilience4j.micrometer.tagged.TimeLimiterMetricNames.DEFAULT_TIME_LIMITER_CALLS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TaggedTimeLimiterMetricsTest {
@@ -135,7 +135,7 @@ public class TaggedTimeLimiterMetricsTest {
         TimeLimiterRegistry timeLimiterRegistry = TimeLimiterRegistry.ofDefaults();
         timeLimiterRegistry.timeLimiter("backendA");
         TaggedTimeLimiterMetrics.ofTimeLimiterRegistry(
-            TaggedTimeLimiterMetrics.MetricNames.custom()
+            TimeLimiterMetricNames.custom()
                 .callsMetricName("custom_calls")
                 .build(),
             timeLimiterRegistry


### PR DESCRIPTION
Extracted metric names to public classes in order to improve Kotlin interoperability. Extracted nested classes `MetricNames` from `Abstract*Metrics` in micrometer module to public classes `*MetricNames`

https://github.com/resilience4j/resilience4j/issues/900