### PR TITLE
#924 Added RegistryStore and builder to RetryRegistry

### DIFF
--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/internal/InMemoryRetryRegistry.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/internal/InMemoryRetryRegistry.java
@@ -16,7 +16,9 @@
 package io.github.resilience4j.retry.internal;
 
 import io.github.resilience4j.core.ConfigurationNotFoundException;
+import io.github.resilience4j.core.RegistryStore;
 import io.github.resilience4j.core.registry.AbstractRegistry;
+import io.github.resilience4j.core.registry.InMemoryRegistryStore;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
@@ -28,6 +30,7 @@ import io.vavr.collection.Seq;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 /**
@@ -80,6 +83,15 @@ public final class InMemoryRetryRegistry extends AbstractRegistry<Retry, RetryCo
         io.vavr.collection.Map<String, String> tags) {
         this(configs.getOrDefault(DEFAULT_CONFIG, RetryConfig.ofDefaults()),
             registryEventConsumers, tags);
+        this.configurations.putAll(configs);
+    }
+
+    public InMemoryRetryRegistry(Map<String, RetryConfig> configs,
+                                          List<RegistryEventConsumer<Retry>> registryEventConsumers,
+                                          io.vavr.collection.Map<String, String> tags, RegistryStore<Retry> registryStore) {
+        super(configs.getOrDefault(DEFAULT_CONFIG, RetryConfig.ofDefaults()),
+            registryEventConsumers, Optional.ofNullable(tags).orElse(HashMap.empty()),
+            Optional.ofNullable(registryStore).orElse(new InMemoryRegistryStore<>()));
         this.configurations.putAll(configs);
     }
 

--- a/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/InMemoryRetryRegistryTest.java
+++ b/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/InMemoryRetryRegistryTest.java
@@ -1,0 +1,67 @@
+/*
+ *
+ *  Copyright 2020 KrnSaurabh
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.retry.internal;
+
+import io.github.resilience4j.core.registry.*;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryConfig;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class InMemoryRetryRegistryTest {
+
+    @Test
+    public void shouldCreateRetryRegistryWithRegistryStore() {
+        RegistryEventConsumer<Retry> registryEventConsumer = getNoOpsRegistryEventConsumer();
+        List<RegistryEventConsumer<Retry>> registryEventConsumers = new ArrayList<>();
+        registryEventConsumers.add(registryEventConsumer);
+        Map<String, RetryConfig> configs = new HashMap<>();
+        final RetryConfig defaultConfig = RetryConfig.ofDefaults();
+        configs.put("default", defaultConfig);
+        final InMemoryRetryRegistry inMemoryRetryRegistry =
+            new InMemoryRetryRegistry(configs, registryEventConsumers,
+                io.vavr.collection.HashMap.of("Tag1", "Tag1Value"), new InMemoryRegistryStore());
+
+        assertThat(inMemoryRetryRegistry).isNotNull();
+        assertThat(inMemoryRetryRegistry.getDefaultConfig()).isEqualTo(defaultConfig);
+        assertThat(inMemoryRetryRegistry.getConfiguration("testNotFound")).isEmpty();
+        inMemoryRetryRegistry.addConfiguration("testConfig", defaultConfig);
+        assertThat(inMemoryRetryRegistry.getConfiguration("testConfig")).isNotNull();
+    }
+
+    private RegistryEventConsumer<Retry> getNoOpsRegistryEventConsumer() {
+        return new RegistryEventConsumer<Retry>() {
+            @Override
+            public void onEntryAddedEvent(EntryAddedEvent<Retry> entryAddedEvent) {
+            }
+            @Override
+            public void onEntryRemovedEvent(EntryRemovedEvent<Retry> entryRemoveEvent) {
+            }
+            @Override
+            public void onEntryReplacedEvent(EntryReplacedEvent<Retry> entryReplacedEvent) {
+            }
+        };
+    }
+}


### PR DESCRIPTION
This PR references #924  .
Implemented builder for RetryRegistry along with added builder method to construct RetryRegistry with RegistryStore. RetryRegistry can be constructed with default implementation of RegistryStore or user can provide custom implementation of RegistryStore.
@RobWin  Kindly review.