### PR TITLE
Add Kotlin DSL for building *Config and *Registry classes

### DIFF
--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/bulkhead/BulkheadConfig.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/bulkhead/BulkheadConfig.kt
@@ -1,0 +1,43 @@
+@file:Suppress("FunctionName")
+
+package io.github.resilience4j.kotlin.bulkhead
+
+import io.github.resilience4j.bulkhead.BulkheadConfig
+
+/**
+ * Creates new custom [BulkheadConfig].
+ *
+ * ```kotlin
+ * val bulkheadConfig = BulkheadConfig {
+ *     maxConcurrentCalls(1)
+ *     maxWaitDuration(Duration.ZERO)
+ * }
+ * ```
+ *
+ * @param config methods of [BulkheadConfig.Builder] that customize resulting `BulkheadConfig`
+ */
+inline fun BulkheadConfig(
+    config: BulkheadConfig.Builder.() -> Unit
+): BulkheadConfig {
+    return BulkheadConfig.custom().apply(config).build()
+}
+
+/**
+ * Creates new custom [BulkheadConfig] based on [baseConfig].
+ *
+ * ```kotlin
+ * val bulkheadConfig = BulkheadConfig(baseBulkheadConfig) {
+ *     maxConcurrentCalls(1)
+ *     maxWaitDuration(Duration.ZERO)
+ * }
+ * ```
+ *
+ * @param baseConfig base `BulkheadConfig`
+ * @param config methods of [BulkheadConfig.Builder] that customize resulting `BulkheadConfig`
+ */
+inline fun BulkheadConfig(
+    baseConfig: BulkheadConfig,
+    config: BulkheadConfig.Builder.() -> Unit
+): BulkheadConfig {
+    return BulkheadConfig.from(baseConfig).apply(config).build()
+}

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/bulkhead/BulkheadRegistry.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/bulkhead/BulkheadRegistry.kt
@@ -4,7 +4,7 @@ package io.github.resilience4j.kotlin.bulkhead
 
 import io.github.resilience4j.bulkhead.BulkheadConfig
 import io.github.resilience4j.bulkhead.BulkheadRegistry
-import io.vavr.Tuple2
+import io.vavr.Tuple2 as VavrTuple2
 import io.vavr.collection.HashMap as VavrHashMap
 
 /**
@@ -37,7 +37,7 @@ inline fun BulkheadRegistry(
  * }
  * ```
  *
- * @param config methods of [BulkheadConfig.Builder] that customize resulting `BulkheadConfig`
+ * @param config methods of [BulkheadConfig.Builder] that customize the default `BulkheadConfig`
  */
 inline fun BulkheadRegistry.Builder.withBulkheadConfig(
     config: BulkheadConfig.Builder.() -> Unit
@@ -58,7 +58,7 @@ inline fun BulkheadRegistry.Builder.withBulkheadConfig(
  * ```
  *
  * @param baseConfig base `BulkheadConfig`
- * @param config methods of [BulkheadConfig.Builder] that customize resulting `BulkheadConfig`
+ * @param config methods of [BulkheadConfig.Builder] that customize the default `BulkheadConfig`
  */
 inline fun BulkheadRegistry.Builder.withBulkheadConfig(
     baseConfig: BulkheadConfig,
@@ -132,5 +132,5 @@ fun BulkheadRegistry.Builder.withTags(tags: Map<String, String>) {
  * @param tags default tags to add to the registry.
  */
 fun BulkheadRegistry.Builder.withTags(vararg tags: Pair<String, String>) {
-    withTags(VavrHashMap.ofEntries(tags.map { Tuple2(it.first, it.second) }))
+    withTags(VavrHashMap.ofEntries(tags.map { VavrTuple2(it.first, it.second) }))
 }

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/bulkhead/BulkheadRegistry.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/bulkhead/BulkheadRegistry.kt
@@ -1,0 +1,136 @@
+@file:Suppress("FunctionName")
+
+package io.github.resilience4j.kotlin.bulkhead
+
+import io.github.resilience4j.bulkhead.BulkheadConfig
+import io.github.resilience4j.bulkhead.BulkheadRegistry
+import io.vavr.Tuple2
+import io.vavr.collection.HashMap as VavrHashMap
+
+/**
+ * Creates new custom [BulkheadRegistry].
+ *
+ * ```kotlin
+ * val bulkheadRegistry = BulkheadRegistry {
+ *     withBulkheadConfig(defaultConfig)
+ *     withTags(commonTags)
+ * }
+ * ```
+ *
+ * @param config methods of [BulkheadRegistry.Builder] that customize resulting `BulkheadRegistry`
+ */
+inline fun BulkheadRegistry(
+    config: BulkheadRegistry.Builder.() -> Unit
+): BulkheadRegistry {
+    return BulkheadRegistry.custom().apply(config).build()
+}
+
+/**
+ * Configures a [BulkheadRegistry] with a custom default Bulkhead configuration.
+ *
+ * ```kotlin
+ * val bulkheadRegistry = BulkheadRegistry {
+ *     withBulkheadConfig {
+ *         maxConcurrentCalls(2)
+ *         maxWaitDuration(Duration.ZERO)
+ *     }
+ * }
+ * ```
+ *
+ * @param config methods of [BulkheadConfig.Builder] that customize resulting `BulkheadConfig`
+ */
+inline fun BulkheadRegistry.Builder.withBulkheadConfig(
+    config: BulkheadConfig.Builder.() -> Unit
+) {
+    withBulkheadConfig(BulkheadConfig(config))
+}
+
+/**
+ * Configures a [BulkheadRegistry] with a custom default Bulkhead configuration.
+ *
+ * ```kotlin
+ * val bulkheadRegistry = BulkheadRegistry {
+ *     withBulkheadConfig(baseBulkheadConfig) {
+ *         maxConcurrentCalls(2)
+ *         maxWaitDuration(Duration.ZERO)
+ *     }
+ * }
+ * ```
+ *
+ * @param baseConfig base `BulkheadConfig`
+ * @param config methods of [BulkheadConfig.Builder] that customize resulting `BulkheadConfig`
+ */
+inline fun BulkheadRegistry.Builder.withBulkheadConfig(
+    baseConfig: BulkheadConfig,
+    config: BulkheadConfig.Builder.() -> Unit
+) {
+    withBulkheadConfig(BulkheadConfig(baseConfig, config))
+}
+
+/**
+ * Configures a [BulkheadRegistry] with a custom Bulkhead configuration.
+ *
+ * ```kotlin
+ * val bulkheadRegistry = BulkheadRegistry {
+ *     addBulkheadConfig("sharedConfig1") {
+ *         maxConcurrentCalls(2)
+ *         maxWaitDuration(Duration.ZERO)
+ *     }
+ * }
+ * ```
+ *
+ * @param configName configName for a custom shared Bulkhead configuration
+ * @param config methods of [BulkheadConfig.Builder] that customize resulting `BulkheadConfig`
+ */
+inline fun BulkheadRegistry.Builder.addBulkheadConfig(
+    configName: String,
+    config: BulkheadConfig.Builder.() -> Unit
+) {
+    addBulkheadConfig(configName, BulkheadConfig(config))
+}
+
+/**
+ * Configures a [BulkheadRegistry] with a custom Bulkhead configuration.
+ *
+ * ```kotlin
+ * val bulkheadRegistry = BulkheadRegistry {
+ *     addBulkheadConfig("sharedConfig1", baseBulkheadConfig) {
+ *         maxConcurrentCalls(2)
+ *         maxWaitDuration(Duration.ZERO)
+ *     }
+ * }
+ * ```
+ *
+ * @param configName configName for a custom shared Bulkhead configuration
+ * @param baseConfig base `BulkheadConfig`
+ * @param config methods of [BulkheadConfig.Builder] that customize resulting `BulkheadConfig`
+ */
+inline fun BulkheadRegistry.Builder.addBulkheadConfig(
+    configName: String,
+    baseConfig: BulkheadConfig,
+    config: BulkheadConfig.Builder.() -> Unit
+) {
+    addBulkheadConfig(configName, BulkheadConfig(baseConfig, config))
+}
+
+/**
+ * Configures a [BulkheadRegistry] with Tags.
+ *
+ * Tags added to the registry will be added to every instance created by this registry.
+ *
+ * @param tags default tags to add to the registry.
+ */
+fun BulkheadRegistry.Builder.withTags(tags: Map<String, String>) {
+    withTags(VavrHashMap.ofAll(tags))
+}
+
+/**
+ * Configures a [BulkheadRegistry] with Tags.
+ *
+ * Tags added to the registry will be added to every instance created by this registry.
+ *
+ * @param tags default tags to add to the registry.
+ */
+fun BulkheadRegistry.Builder.withTags(vararg tags: Pair<String, String>) {
+    withTags(VavrHashMap.ofEntries(tags.map { Tuple2(it.first, it.second) }))
+}

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/bulkhead/ThreadPoolBulkheadConfig.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/bulkhead/ThreadPoolBulkheadConfig.kt
@@ -1,0 +1,45 @@
+@file:Suppress("FunctionName")
+
+package io.github.resilience4j.kotlin.bulkhead
+
+import io.github.resilience4j.bulkhead.ThreadPoolBulkheadConfig
+
+/**
+ * Creates new custom [ThreadPoolBulkheadConfig].
+ *
+ * ```kotlin
+ * val bulkheadConfig = ThreadPoolBulkheadConfig {
+ *     maxThreadPoolSize(8)
+ *     queueCapacity(10)
+ *     keepAliveDuration(Duration.ofSeconds(1))
+ * }
+ * ```
+ *
+ * @param config methods of [ThreadPoolBulkheadConfig.Builder] that customize resulting `ThreadPoolBulkheadConfig`
+ */
+inline fun ThreadPoolBulkheadConfig(
+    config: ThreadPoolBulkheadConfig.Builder.() -> Unit
+): ThreadPoolBulkheadConfig {
+    return ThreadPoolBulkheadConfig.custom().apply(config).build()
+}
+
+/**
+ * Creates new custom [ThreadPoolBulkheadConfig] based on [baseConfig].
+ *
+ * ```kotlin
+ * val bulkheadConfig = ThreadPoolBulkheadConfig(baseBulkheadConfig) {
+ *     maxThreadPoolSize(8)
+ *     queueCapacity(10)
+ *     keepAliveDuration(Duration.ofSeconds(1))
+ * }
+ * ```
+ *
+ * @param baseConfig base `ThreadPoolBulkheadConfig`
+ * @param config methods of [ThreadPoolBulkheadConfig.Builder] that customize resulting `ThreadPoolBulkheadConfig`
+ */
+inline fun ThreadPoolBulkheadConfig(
+    baseConfig: ThreadPoolBulkheadConfig,
+    config: ThreadPoolBulkheadConfig.Builder.() -> Unit
+): ThreadPoolBulkheadConfig {
+    return ThreadPoolBulkheadConfig.from(baseConfig).apply(config).build()
+}

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/bulkhead/ThreadPoolBulkheadRegistry.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/bulkhead/ThreadPoolBulkheadRegistry.kt
@@ -2,7 +2,10 @@
 
 package io.github.resilience4j.kotlin.bulkhead
 
+import io.github.resilience4j.bulkhead.ThreadPoolBulkheadConfig
 import io.github.resilience4j.bulkhead.ThreadPoolBulkheadRegistry
+import io.vavr.Tuple2 as VavrTuple2
+import io.vavr.collection.HashMap as VavrHashMap
 
 /**
  * Creates new custom [ThreadPoolBulkheadRegistry].
@@ -20,4 +23,114 @@ inline fun ThreadPoolBulkheadRegistry(
     config: ThreadPoolBulkheadRegistry.Builder.() -> Unit
 ): ThreadPoolBulkheadRegistry {
     return ThreadPoolBulkheadRegistry.custom().apply(config).build()
+}
+
+/**
+ * Configures a [ThreadPoolBulkheadRegistry] with a custom default ThreadPoolBulkhead configuration.
+ *
+ * ```kotlin
+ * val bulkheadRegistry = ThreadPoolBulkheadRegistry {
+ *     withThreadPoolBulkheadConfig {
+ *         maxConcurrentCalls(2)
+ *         maxWaitDuration(Duration.ZERO)
+ *     }
+ * }
+ * ```
+ *
+ * @param config methods of [ThreadPoolBulkheadConfig.Builder] that customize the default `ThreadPoolBulkheadConfig`
+ */
+inline fun ThreadPoolBulkheadRegistry.Builder.withThreadPoolBulkheadConfig(
+    config: ThreadPoolBulkheadConfig.Builder.() -> Unit
+) {
+    withThreadPoolBulkheadConfig(ThreadPoolBulkheadConfig(config))
+}
+
+/**
+ * Configures a [ThreadPoolBulkheadRegistry] with a custom default ThreadPoolBulkhead configuration.
+ *
+ * ```kotlin
+ * val bulkheadRegistry = ThreadPoolBulkheadRegistry {
+ *     withThreadPoolBulkheadConfig(baseThreadPoolBulkheadConfig) {
+ *         maxConcurrentCalls(2)
+ *         maxWaitDuration(Duration.ZERO)
+ *     }
+ * }
+ * ```
+ *
+ * @param baseConfig base `ThreadPoolBulkheadConfig`
+ * @param config methods of [ThreadPoolBulkheadConfig.Builder] that customize the default `ThreadPoolBulkheadConfig`
+ */
+inline fun ThreadPoolBulkheadRegistry.Builder.withThreadPoolBulkheadConfig(
+    baseConfig: ThreadPoolBulkheadConfig,
+    config: ThreadPoolBulkheadConfig.Builder.() -> Unit
+) {
+    withThreadPoolBulkheadConfig(ThreadPoolBulkheadConfig(baseConfig, config))
+}
+
+/**
+ * Configures a [ThreadPoolBulkheadRegistry] with a custom ThreadPoolBulkhead configuration.
+ *
+ * ```kotlin
+ * val bulkheadRegistry = ThreadPoolBulkheadRegistry {
+ *     addThreadPoolBulkheadConfig("sharedConfig1") {
+ *         maxConcurrentCalls(2)
+ *         maxWaitDuration(Duration.ZERO)
+ *     }
+ * }
+ * ```
+ *
+ * @param configName configName for a custom shared ThreadPoolBulkhead configuration
+ * @param config methods of [ThreadPoolBulkheadConfig.Builder] that customize resulting `ThreadPoolBulkheadConfig`
+ */
+inline fun ThreadPoolBulkheadRegistry.Builder.addThreadPoolBulkheadConfig(
+    configName: String,
+    config: ThreadPoolBulkheadConfig.Builder.() -> Unit
+) {
+    addThreadPoolBulkheadConfig(configName, ThreadPoolBulkheadConfig(config))
+}
+
+/**
+ * Configures a [ThreadPoolBulkheadRegistry] with a custom ThreadPoolBulkhead configuration.
+ *
+ * ```kotlin
+ * val bulkheadRegistry = ThreadPoolBulkheadRegistry {
+ *     addThreadPoolBulkheadConfig("sharedConfig1", baseThreadPoolBulkheadConfig) {
+ *         maxConcurrentCalls(2)
+ *         maxWaitDuration(Duration.ZERO)
+ *     }
+ * }
+ * ```
+ *
+ * @param configName configName for a custom shared ThreadPoolBulkhead configuration
+ * @param baseConfig base `ThreadPoolBulkheadConfig`
+ * @param config methods of [ThreadPoolBulkheadConfig.Builder] that customize resulting `ThreadPoolBulkheadConfig`
+ */
+inline fun ThreadPoolBulkheadRegistry.Builder.addThreadPoolBulkheadConfig(
+    configName: String,
+    baseConfig: ThreadPoolBulkheadConfig,
+    config: ThreadPoolBulkheadConfig.Builder.() -> Unit
+) {
+    addThreadPoolBulkheadConfig(configName, ThreadPoolBulkheadConfig(baseConfig, config))
+}
+
+/**
+ * Configures a [ThreadPoolBulkheadRegistry] with Tags.
+ *
+ * Tags added to the registry will be added to every instance created by this registry.
+ *
+ * @param tags default tags to add to the registry.
+ */
+fun ThreadPoolBulkheadRegistry.Builder.withTags(tags: Map<String, String>) {
+    withTags(VavrHashMap.ofAll(tags))
+}
+
+/**
+ * Configures a [ThreadPoolBulkheadRegistry] with Tags.
+ *
+ * Tags added to the registry will be added to every instance created by this registry.
+ *
+ * @param tags default tags to add to the registry.
+ */
+fun ThreadPoolBulkheadRegistry.Builder.withTags(vararg tags: Pair<String, String>) {
+    withTags(VavrHashMap.ofEntries(tags.map { VavrTuple2(it.first, it.second) }))
 }

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/bulkhead/ThreadPoolBulkheadRegistry.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/bulkhead/ThreadPoolBulkheadRegistry.kt
@@ -31,8 +31,9 @@ inline fun ThreadPoolBulkheadRegistry(
  * ```kotlin
  * val bulkheadRegistry = ThreadPoolBulkheadRegistry {
  *     withThreadPoolBulkheadConfig {
- *         maxConcurrentCalls(2)
- *         maxWaitDuration(Duration.ZERO)
+ *         maxThreadPoolSize(8)
+ *         queueCapacity(10)
+ *         keepAliveDuration(Duration.ofSeconds(1))
  *     }
  * }
  * ```
@@ -51,8 +52,9 @@ inline fun ThreadPoolBulkheadRegistry.Builder.withThreadPoolBulkheadConfig(
  * ```kotlin
  * val bulkheadRegistry = ThreadPoolBulkheadRegistry {
  *     withThreadPoolBulkheadConfig(baseThreadPoolBulkheadConfig) {
- *         maxConcurrentCalls(2)
- *         maxWaitDuration(Duration.ZERO)
+ *         maxThreadPoolSize(8)
+ *         queueCapacity(10)
+ *         keepAliveDuration(Duration.ofSeconds(1))
  *     }
  * }
  * ```
@@ -73,8 +75,9 @@ inline fun ThreadPoolBulkheadRegistry.Builder.withThreadPoolBulkheadConfig(
  * ```kotlin
  * val bulkheadRegistry = ThreadPoolBulkheadRegistry {
  *     addThreadPoolBulkheadConfig("sharedConfig1") {
- *         maxConcurrentCalls(2)
- *         maxWaitDuration(Duration.ZERO)
+ *         maxThreadPoolSize(8)
+ *         queueCapacity(10)
+ *         keepAliveDuration(Duration.ofSeconds(1))
  *     }
  * }
  * ```
@@ -95,8 +98,9 @@ inline fun ThreadPoolBulkheadRegistry.Builder.addThreadPoolBulkheadConfig(
  * ```kotlin
  * val bulkheadRegistry = ThreadPoolBulkheadRegistry {
  *     addThreadPoolBulkheadConfig("sharedConfig1", baseThreadPoolBulkheadConfig) {
- *         maxConcurrentCalls(2)
- *         maxWaitDuration(Duration.ZERO)
+ *         maxThreadPoolSize(8)
+ *         queueCapacity(10)
+ *         keepAliveDuration(Duration.ofSeconds(1))
  *     }
  * }
  * ```

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/bulkhead/ThreadPoolBulkheadRegistry.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/bulkhead/ThreadPoolBulkheadRegistry.kt
@@ -1,0 +1,23 @@
+@file:Suppress("FunctionName")
+
+package io.github.resilience4j.kotlin.bulkhead
+
+import io.github.resilience4j.bulkhead.ThreadPoolBulkheadRegistry
+
+/**
+ * Creates new custom [ThreadPoolBulkheadRegistry].
+ *
+ * ```kotlin
+ * val bulkheadRegistry = ThreadPoolBulkheadRegistry {
+ *     withThreadPoolBulkheadConfig(defaultConfig)
+ *     withTags(commonTags)
+ * }
+ * ```
+ *
+ * @param config methods of [ThreadPoolBulkheadRegistry.Builder] that customize resulting `ThreadPoolBulkheadRegistry`
+ */
+inline fun ThreadPoolBulkheadRegistry(
+    config: ThreadPoolBulkheadRegistry.Builder.() -> Unit
+): ThreadPoolBulkheadRegistry {
+    return ThreadPoolBulkheadRegistry.custom().apply(config).build()
+}

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/CircuitBreakerConfig.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/CircuitBreakerConfig.kt
@@ -1,0 +1,43 @@
+@file:Suppress("FunctionName")
+
+package io.github.resilience4j.kotlin.circuitbreaker
+
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig
+
+/**
+ * Creates new custom [CircuitBreakerConfig].
+ *
+ * ```kotlin
+ * val circuitBreakerConfig = CircuitBreakerConfig {
+ *     failureRateThreshold(50)
+ *     waitDurationInOpenState(Duration.ofSeconds(30))
+ * }
+ * ```
+ *
+ * @param config methods of [CircuitBreakerConfig.Builder] that customize resulting `CircuitBreakerConfig`
+ */
+inline fun CircuitBreakerConfig(
+    config: CircuitBreakerConfig.Builder.() -> Unit
+): CircuitBreakerConfig {
+    return CircuitBreakerConfig.custom().apply(config).build()
+}
+
+/**
+ * Creates new custom [CircuitBreakerConfig] based on [baseConfig].
+ *
+ * ```kotlin
+ * val circuitBreakerConfig = CircuitBreakerConfig(baseCircuitBreakerConfig) {
+ *     failureRateThreshold(50)
+ *     waitDurationInOpenState(Duration.ofSeconds(30))
+ * }
+ * ```
+ *
+ * @param baseConfig base `CircuitBreakerConfig`
+ * @param config methods of [CircuitBreakerConfig.Builder] that customize resulting `CircuitBreakerConfig`
+ */
+inline fun CircuitBreakerConfig(
+    baseConfig: CircuitBreakerConfig,
+    config: CircuitBreakerConfig.Builder.() -> Unit
+): CircuitBreakerConfig {
+    return CircuitBreakerConfig.from(baseConfig).apply(config).build()
+}

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/CircuitBreakerRegistry.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/CircuitBreakerRegistry.kt
@@ -31,8 +31,8 @@ inline fun CircuitBreakerRegistry(
  * ```kotlin
  * val circuitBreakerRegistry = CircuitBreakerRegistry {
  *     withCircuitBreakerConfig {
- *         maxConcurrentCalls(2)
- *         maxWaitDuration(Duration.ZERO)
+ *         failureRateThreshold(50)
+ *         waitDurationInOpenState(Duration.ofSeconds(30))
  *     }
  * }
  * ```
@@ -51,8 +51,8 @@ inline fun CircuitBreakerRegistry.Builder.withCircuitBreakerConfig(
  * ```kotlin
  * val circuitBreakerRegistry = CircuitBreakerRegistry {
  *     withCircuitBreakerConfig(baseCircuitBreakerConfig) {
- *         maxConcurrentCalls(2)
- *         maxWaitDuration(Duration.ZERO)
+ *         failureRateThreshold(50)
+ *         waitDurationInOpenState(Duration.ofSeconds(30))
  *     }
  * }
  * ```
@@ -73,8 +73,8 @@ inline fun CircuitBreakerRegistry.Builder.withCircuitBreakerConfig(
  * ```kotlin
  * val circuitBreakerRegistry = CircuitBreakerRegistry {
  *     addCircuitBreakerConfig("sharedConfig1") {
- *         maxConcurrentCalls(2)
- *         maxWaitDuration(Duration.ZERO)
+ *         failureRateThreshold(50)
+ *         waitDurationInOpenState(Duration.ofSeconds(30))
  *     }
  * }
  * ```
@@ -95,8 +95,8 @@ inline fun CircuitBreakerRegistry.Builder.addCircuitBreakerConfig(
  * ```kotlin
  * val circuitBreakerRegistry = CircuitBreakerRegistry {
  *     addCircuitBreakerConfig("sharedConfig1", baseCircuitBreakerConfig) {
- *         maxConcurrentCalls(2)
- *         maxWaitDuration(Duration.ZERO)
+ *         failureRateThreshold(50)
+ *         waitDurationInOpenState(Duration.ofSeconds(30))
  *     }
  * }
  * ```

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/CircuitBreakerRegistry.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/CircuitBreakerRegistry.kt
@@ -1,0 +1,23 @@
+@file:Suppress("FunctionName")
+
+package io.github.resilience4j.kotlin.circuitbreaker
+
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+
+/**
+ * Creates new custom [CircuitBreakerRegistry].
+ *
+ * ```kotlin
+ * val circuitBreakerRegistry = CircuitBreakerRegistry {
+ *     withCircuitBreaker(defaultConfig)
+ *     withTags(commonTags)
+ * }
+ * ```
+ *
+ * @param config methods of [CircuitBreakerRegistry.Builder] that customize resulting `CircuitBreakerRegistry`
+ */
+inline fun CircuitBreakerRegistry(
+    config: CircuitBreakerRegistry.Builder.() -> Unit
+): CircuitBreakerRegistry {
+    return CircuitBreakerRegistry.custom().apply(config).build()
+}

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/CircuitBreakerRegistry.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/CircuitBreakerRegistry.kt
@@ -2,7 +2,10 @@
 
 package io.github.resilience4j.kotlin.circuitbreaker
 
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+import io.vavr.Tuple2 as VavrTuple2
+import io.vavr.collection.HashMap as VavrHashMap
 
 /**
  * Creates new custom [CircuitBreakerRegistry].
@@ -20,4 +23,114 @@ inline fun CircuitBreakerRegistry(
     config: CircuitBreakerRegistry.Builder.() -> Unit
 ): CircuitBreakerRegistry {
     return CircuitBreakerRegistry.custom().apply(config).build()
+}
+
+/**
+ * Configures a [CircuitBreakerRegistry] with a custom default CircuitBreaker configuration.
+ *
+ * ```kotlin
+ * val circuitBreakerRegistry = CircuitBreakerRegistry {
+ *     withCircuitBreakerConfig {
+ *         maxConcurrentCalls(2)
+ *         maxWaitDuration(Duration.ZERO)
+ *     }
+ * }
+ * ```
+ *
+ * @param config methods of [CircuitBreakerConfig.Builder] that customize the default `CircuitBreakerConfig`
+ */
+inline fun CircuitBreakerRegistry.Builder.withCircuitBreakerConfig(
+    config: CircuitBreakerConfig.Builder.() -> Unit
+) {
+    withCircuitBreakerConfig(CircuitBreakerConfig(config))
+}
+
+/**
+ * Configures a [CircuitBreakerRegistry] with a custom default CircuitBreaker configuration.
+ *
+ * ```kotlin
+ * val circuitBreakerRegistry = CircuitBreakerRegistry {
+ *     withCircuitBreakerConfig(baseCircuitBreakerConfig) {
+ *         maxConcurrentCalls(2)
+ *         maxWaitDuration(Duration.ZERO)
+ *     }
+ * }
+ * ```
+ *
+ * @param baseConfig base `CircuitBreakerConfig`
+ * @param config methods of [CircuitBreakerConfig.Builder] that customize the default `CircuitBreakerConfig`
+ */
+inline fun CircuitBreakerRegistry.Builder.withCircuitBreakerConfig(
+    baseConfig: CircuitBreakerConfig,
+    config: CircuitBreakerConfig.Builder.() -> Unit
+) {
+    withCircuitBreakerConfig(CircuitBreakerConfig(baseConfig, config))
+}
+
+/**
+ * Configures a [CircuitBreakerRegistry] with a custom CircuitBreaker configuration.
+ *
+ * ```kotlin
+ * val circuitBreakerRegistry = CircuitBreakerRegistry {
+ *     addCircuitBreakerConfig("sharedConfig1") {
+ *         maxConcurrentCalls(2)
+ *         maxWaitDuration(Duration.ZERO)
+ *     }
+ * }
+ * ```
+ *
+ * @param configName configName for a custom shared CircuitBreaker configuration
+ * @param config methods of [CircuitBreakerConfig.Builder] that customize resulting `CircuitBreakerConfig`
+ */
+inline fun CircuitBreakerRegistry.Builder.addCircuitBreakerConfig(
+    configName: String,
+    config: CircuitBreakerConfig.Builder.() -> Unit
+) {
+    addCircuitBreakerConfig(configName, CircuitBreakerConfig(config))
+}
+
+/**
+ * Configures a [CircuitBreakerRegistry] with a custom CircuitBreaker configuration.
+ *
+ * ```kotlin
+ * val circuitBreakerRegistry = CircuitBreakerRegistry {
+ *     addCircuitBreakerConfig("sharedConfig1", baseCircuitBreakerConfig) {
+ *         maxConcurrentCalls(2)
+ *         maxWaitDuration(Duration.ZERO)
+ *     }
+ * }
+ * ```
+ *
+ * @param configName configName for a custom shared CircuitBreaker configuration
+ * @param baseConfig base `CircuitBreakerConfig`
+ * @param config methods of [CircuitBreakerConfig.Builder] that customize resulting `CircuitBreakerConfig`
+ */
+inline fun CircuitBreakerRegistry.Builder.addCircuitBreakerConfig(
+    configName: String,
+    baseConfig: CircuitBreakerConfig,
+    config: CircuitBreakerConfig.Builder.() -> Unit
+) {
+    addCircuitBreakerConfig(configName, CircuitBreakerConfig(baseConfig, config))
+}
+
+/**
+ * Configures a [CircuitBreakerRegistry] with Tags.
+ *
+ * Tags added to the registry will be added to every instance created by this registry.
+ *
+ * @param tags default tags to add to the registry.
+ */
+fun CircuitBreakerRegistry.Builder.withTags(tags: Map<String, String>) {
+    withTags(VavrHashMap.ofAll(tags))
+}
+
+/**
+ * Configures a [CircuitBreakerRegistry] with Tags.
+ *
+ * Tags added to the registry will be added to every instance created by this registry.
+ *
+ * @param tags default tags to add to the registry.
+ */
+fun CircuitBreakerRegistry.Builder.withTags(vararg tags: Pair<String, String>) {
+    withTags(VavrHashMap.ofEntries(tags.map { VavrTuple2(it.first, it.second) }))
 }

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/ratelimiter/RateLimiterConfig.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/ratelimiter/RateLimiterConfig.kt
@@ -1,0 +1,45 @@
+@file:Suppress("FunctionName")
+
+package io.github.resilience4j.kotlin.ratelimiter
+
+import io.github.resilience4j.ratelimiter.RateLimiterConfig
+
+/**
+ * Creates new custom [RateLimiterConfig].
+ *
+ * ```kotlin
+ * val rateLimiterConfig = RateLimiterConfig {
+ *     limitRefreshPeriod(Duration.ofSeconds(10))
+ *     limitForPeriod(10)
+ *     timeoutDuration(Duration.ofSeconds(1))
+ * }
+ * ```
+ *
+ * @param config methods of [RateLimiterConfig.Builder] that customize resulting `RateLimiterConfig`
+ */
+inline fun RateLimiterConfig(
+    config: RateLimiterConfig.Builder.() -> Unit
+): RateLimiterConfig {
+    return RateLimiterConfig.custom().apply(config).build()
+}
+
+/**
+ * Creates new custom [RateLimiterConfig] based on [baseConfig].
+ *
+ * ```kotlin
+ * val rateLimiterConfig = RateLimiterConfig(baseRateLimiterConfig) {
+ *     limitRefreshPeriod(Duration.ofSeconds(10))
+ *     limitForPeriod(10)
+ *     timeoutDuration(Duration.ofSeconds(1))
+ * }
+ * ```
+ *
+ * @param baseConfig base `RateLimiterConfig`
+ * @param config methods of [RateLimiterConfig.Builder] that customize resulting `RateLimiterConfig`
+ */
+inline fun RateLimiterConfig(
+    baseConfig: RateLimiterConfig,
+    config: RateLimiterConfig.Builder.() -> Unit
+): RateLimiterConfig {
+    return RateLimiterConfig.from(baseConfig).apply(config).build()
+}

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/ratelimiter/RateLimiterRegistry.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/ratelimiter/RateLimiterRegistry.kt
@@ -2,7 +2,10 @@
 
 package io.github.resilience4j.kotlin.ratelimiter
 
+import io.github.resilience4j.ratelimiter.RateLimiterConfig
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry
+import io.vavr.Tuple2 as VavrTuple2
+import io.vavr.collection.HashMap as VavrHashMap
 
 /**
  * Creates new custom [RateLimiterRegistry].
@@ -20,4 +23,114 @@ inline fun RateLimiterRegistry(
     config: RateLimiterRegistry.Builder.() -> Unit
 ): RateLimiterRegistry {
     return RateLimiterRegistry.custom().apply(config).build()
+}
+
+/**
+ * Configures a [RateLimiterRegistry] with a custom default RateLimiter configuration.
+ *
+ * ```kotlin
+ * val rateLimiterRegistry = RateLimiterRegistry {
+ *     withRateLimiterConfig {
+ *         maxConcurrentCalls(2)
+ *         maxWaitDuration(Duration.ZERO)
+ *     }
+ * }
+ * ```
+ *
+ * @param config methods of [RateLimiterConfig.Builder] that customize the default `RateLimiterConfig`
+ */
+inline fun RateLimiterRegistry.Builder.withRateLimiterConfig(
+    config: RateLimiterConfig.Builder.() -> Unit
+) {
+    withRateLimiterConfig(RateLimiterConfig(config))
+}
+
+/**
+ * Configures a [RateLimiterRegistry] with a custom default RateLimiter configuration.
+ *
+ * ```kotlin
+ * val rateLimiterRegistry = RateLimiterRegistry {
+ *     withRateLimiterConfig(baseRateLimiterConfig) {
+ *         maxConcurrentCalls(2)
+ *         maxWaitDuration(Duration.ZERO)
+ *     }
+ * }
+ * ```
+ *
+ * @param baseConfig base `RateLimiterConfig`
+ * @param config methods of [RateLimiterConfig.Builder] that customize the default `RateLimiterConfig`
+ */
+inline fun RateLimiterRegistry.Builder.withRateLimiterConfig(
+    baseConfig: RateLimiterConfig,
+    config: RateLimiterConfig.Builder.() -> Unit
+) {
+    withRateLimiterConfig(RateLimiterConfig(baseConfig, config))
+}
+
+/**
+ * Configures a [RateLimiterRegistry] with a custom RateLimiter configuration.
+ *
+ * ```kotlin
+ * val rateLimiterRegistry = RateLimiterRegistry {
+ *     addRateLimiterConfig("sharedConfig1") {
+ *         maxConcurrentCalls(2)
+ *         maxWaitDuration(Duration.ZERO)
+ *     }
+ * }
+ * ```
+ *
+ * @param configName configName for a custom shared RateLimiter configuration
+ * @param config methods of [RateLimiterConfig.Builder] that customize resulting `RateLimiterConfig`
+ */
+inline fun RateLimiterRegistry.Builder.addRateLimiterConfig(
+    configName: String,
+    config: RateLimiterConfig.Builder.() -> Unit
+) {
+    addRateLimiterConfig(configName, RateLimiterConfig(config))
+}
+
+/**
+ * Configures a [RateLimiterRegistry] with a custom RateLimiter configuration.
+ *
+ * ```kotlin
+ * val rateLimiterRegistry = RateLimiterRegistry {
+ *     addRateLimiterConfig("sharedConfig1", baseRateLimiterConfig) {
+ *         maxConcurrentCalls(2)
+ *         maxWaitDuration(Duration.ZERO)
+ *     }
+ * }
+ * ```
+ *
+ * @param configName configName for a custom shared RateLimiter configuration
+ * @param baseConfig base `RateLimiterConfig`
+ * @param config methods of [RateLimiterConfig.Builder] that customize resulting `RateLimiterConfig`
+ */
+inline fun RateLimiterRegistry.Builder.addRateLimiterConfig(
+    configName: String,
+    baseConfig: RateLimiterConfig,
+    config: RateLimiterConfig.Builder.() -> Unit
+) {
+    addRateLimiterConfig(configName, RateLimiterConfig(baseConfig, config))
+}
+
+/**
+ * Configures a [RateLimiterRegistry] with Tags.
+ *
+ * Tags added to the registry will be added to every instance created by this registry.
+ *
+ * @param tags default tags to add to the registry.
+ */
+fun RateLimiterRegistry.Builder.withTags(tags: Map<String, String>) {
+    withTags(VavrHashMap.ofAll(tags))
+}
+
+/**
+ * Configures a [RateLimiterRegistry] with Tags.
+ *
+ * Tags added to the registry will be added to every instance created by this registry.
+ *
+ * @param tags default tags to add to the registry.
+ */
+fun RateLimiterRegistry.Builder.withTags(vararg tags: Pair<String, String>) {
+    withTags(VavrHashMap.ofEntries(tags.map { VavrTuple2(it.first, it.second) }))
 }

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/ratelimiter/RateLimiterRegistry.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/ratelimiter/RateLimiterRegistry.kt
@@ -1,0 +1,23 @@
+@file:Suppress("FunctionName")
+
+package io.github.resilience4j.kotlin.ratelimiter
+
+import io.github.resilience4j.ratelimiter.RateLimiterRegistry
+
+/**
+ * Creates new custom [RateLimiterRegistry].
+ *
+ * ```kotlin
+ * val rateLimiterRegistry = RateLimiterRegistry {
+ *     withRateLimiterConfig(defaultConfig)
+ *     withTags(commonTags)
+ * }
+ * ```
+ *
+ * @param config methods of [RateLimiterRegistry.Builder] that customize resulting `RateLimiterRegistry`
+ */
+inline fun RateLimiterRegistry(
+    config: RateLimiterRegistry.Builder.() -> Unit
+): RateLimiterRegistry {
+    return RateLimiterRegistry.custom().apply(config).build()
+}

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/ratelimiter/RateLimiterRegistry.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/ratelimiter/RateLimiterRegistry.kt
@@ -31,8 +31,9 @@ inline fun RateLimiterRegistry(
  * ```kotlin
  * val rateLimiterRegistry = RateLimiterRegistry {
  *     withRateLimiterConfig {
- *         maxConcurrentCalls(2)
- *         maxWaitDuration(Duration.ZERO)
+ *         limitRefreshPeriod(Duration.ofSeconds(10))
+ *         limitForPeriod(10)
+ *         timeoutDuration(Duration.ofSeconds(1))
  *     }
  * }
  * ```
@@ -51,8 +52,9 @@ inline fun RateLimiterRegistry.Builder.withRateLimiterConfig(
  * ```kotlin
  * val rateLimiterRegistry = RateLimiterRegistry {
  *     withRateLimiterConfig(baseRateLimiterConfig) {
- *         maxConcurrentCalls(2)
- *         maxWaitDuration(Duration.ZERO)
+ *         limitRefreshPeriod(Duration.ofSeconds(10))
+ *         limitForPeriod(10)
+ *         timeoutDuration(Duration.ofSeconds(1))
  *     }
  * }
  * ```
@@ -73,8 +75,9 @@ inline fun RateLimiterRegistry.Builder.withRateLimiterConfig(
  * ```kotlin
  * val rateLimiterRegistry = RateLimiterRegistry {
  *     addRateLimiterConfig("sharedConfig1") {
- *         maxConcurrentCalls(2)
- *         maxWaitDuration(Duration.ZERO)
+ *         limitRefreshPeriod(Duration.ofSeconds(10))
+ *         limitForPeriod(10)
+ *         timeoutDuration(Duration.ofSeconds(1))
  *     }
  * }
  * ```
@@ -95,8 +98,9 @@ inline fun RateLimiterRegistry.Builder.addRateLimiterConfig(
  * ```kotlin
  * val rateLimiterRegistry = RateLimiterRegistry {
  *     addRateLimiterConfig("sharedConfig1", baseRateLimiterConfig) {
- *         maxConcurrentCalls(2)
- *         maxWaitDuration(Duration.ZERO)
+ *         limitRefreshPeriod(Duration.ofSeconds(10))
+ *         limitForPeriod(10)
+ *         timeoutDuration(Duration.ofSeconds(1))
  *     }
  * }
  * ```

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/retry/RetryConfig.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/retry/RetryConfig.kt
@@ -1,0 +1,83 @@
+@file:Suppress("FunctionName")
+
+package io.github.resilience4j.kotlin.retry
+
+import io.github.resilience4j.retry.RetryConfig
+
+/**
+ * Creates new custom [RetryConfig].
+ *
+ * ```kotlin
+ * val retryConfig = RetryConfig<String> {
+ *     waitDuration(Duration.ofMillis(10))
+ *     retryOnResult { result -> result == "ERROR" }
+ * }
+ * ```
+ *
+ * @param config methods of [RetryConfig.Builder] that customize resulting `RetryConfig`
+ * @param T input parameter type of `retryOnResult` predicate
+ */
+inline fun <T> RetryConfig(
+    config: RetryConfig.Builder<T>.() -> Unit
+): RetryConfig {
+    return RetryConfig.custom<T>().apply(config).build()
+}
+
+/**
+ * Creates new custom [RetryConfig].
+ *
+ * ```kotlin
+ * val retryConfig = RetryConfig {
+ *     waitDuration(Duration.ofMillis(10))
+ * }
+ * ```
+ *
+ * @param config methods of [RetryConfig.Builder] that customize resulting `RetryConfig`
+ */
+@JvmName("UntypedRetryConfig")
+inline fun RetryConfig(
+    config: RetryConfig.Builder<Any?>.() -> Unit
+): RetryConfig {
+    return RetryConfig.custom<Any?>().apply(config).build()
+}
+
+/**
+ * Creates new custom [RetryConfig] based on [baseConfig].
+ *
+ * ```kotlin
+ * val retryConfig = RetryConfig<String>(baseRetryConfig) {
+ *     waitDuration(Duration.ofMillis(10))
+ *     retryOnResult { result -> result == "ERROR" }
+ * }
+ * ```
+ *
+ * @param baseConfig base `RetryConfig`
+ * @param config methods of [RetryConfig.Builder] that customize resulting `RetryConfig`
+ * @param T input parameter type of `retryOnResult` predicate
+ */
+inline fun <T> RetryConfig(
+    baseConfig: RetryConfig,
+    config: RetryConfig.Builder<T>.() -> Unit
+): RetryConfig {
+    return RetryConfig.from<T>(baseConfig).apply(config).build()
+}
+
+/**
+ * Creates new custom [RetryConfig] based on [baseConfig].
+ *
+ * ```kotlin
+ * val retryConfig = RetryConfig(baseRetryConfig) {
+ *     waitDuration(Duration.ofMillis(10))
+ * }
+ * ```
+ *
+ * @param baseConfig base `RetryConfig`
+ * @param config methods of [RetryConfig.Builder] that customize resulting `RetryConfig`
+ */
+@JvmName("UntypedRetryConfig")
+inline fun RetryConfig(
+    baseConfig: RetryConfig,
+    config: RetryConfig.Builder<Any?>.() -> Unit
+): RetryConfig {
+    return RetryConfig.from<Any?>(baseConfig).apply(config).build()
+}

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/retry/RetryRegistry.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/retry/RetryRegistry.kt
@@ -1,0 +1,23 @@
+@file:Suppress("FunctionName")
+
+package io.github.resilience4j.kotlin.retry
+
+import io.github.resilience4j.retry.RetryRegistry
+
+/**
+ * Creates new custom [RetryRegistry].
+ *
+ * ```kotlin
+ * val retryRegistry = RetryRegistry {
+ *     withRetryConfig(defaultConfig)
+ *     withTags(commonTags)
+ * }
+ * ```
+ *
+ * @param config methods of [RetryRegistry.Builder] that customize resulting `RetryRegistry`
+ */
+inline fun RetryRegistry(
+    config: RetryRegistry.Builder.() -> Unit
+): RetryRegistry {
+    return RetryRegistry.custom().apply(config).build()
+}

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/retry/RetryRegistry.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/retry/RetryRegistry.kt
@@ -2,7 +2,10 @@
 
 package io.github.resilience4j.kotlin.retry
 
+import io.github.resilience4j.retry.RetryConfig
 import io.github.resilience4j.retry.RetryRegistry
+import io.vavr.Tuple2 as VavrTuple2
+import io.vavr.collection.HashMap as VavrHashMap
 
 /**
  * Creates new custom [RetryRegistry].
@@ -20,4 +23,203 @@ inline fun RetryRegistry(
     config: RetryRegistry.Builder.() -> Unit
 ): RetryRegistry {
     return RetryRegistry.custom().apply(config).build()
+}
+
+/**
+ * Configures a [RetryRegistry] with a custom default Retry configuration.
+ *
+ * ```kotlin
+ * val retryRegistry = RetryRegistry {
+ *     withRetryConfig<String> {
+ *         waitDuration(Duration.ofMillis(10))
+ *         retryOnResult { result -> result == "ERROR" }
+ *     }
+ * }
+ * ```
+ *
+ * @param config methods of [RetryConfig.Builder] that customize default `RetryConfig`
+ */
+inline fun <T> RetryRegistry.Builder.withRetryConfig(
+    config: RetryConfig.Builder<T>.() -> Unit
+) {
+    withRetryConfig(RetryConfig(config))
+}
+
+/**
+ * Configures a [RetryRegistry] with a custom default Retry configuration.
+ *
+ * ```kotlin
+ * val retryRegistry = RetryRegistry {
+ *     withRetryConfig {
+ *         waitDuration(Duration.ofMillis(10))
+ *         retryOnResult { result -> result == "ERROR" }
+ *     }
+ * }
+ * ```
+ *
+ * @param config methods of [RetryConfig.Builder] that customize default `RetryConfig`
+ */
+@JvmName("withUntypedRetryConfig")
+inline fun RetryRegistry.Builder.withRetryConfig(
+    config: RetryConfig.Builder<Any?>.() -> Unit
+) {
+    withRetryConfig(RetryConfig(config))
+}
+
+/**
+ * Configures a [RetryRegistry] with a custom default Retry configuration.
+ *
+ * ```kotlin
+ * val retryRegistry = RetryRegistry {
+ *     withRetryConfig<String>(baseRetryConfig) {
+ *         waitDuration(Duration.ofMillis(10))
+ *         retryOnResult { result -> result == "ERROR" }
+ *     }
+ * }
+ * ```
+ *
+ * @param baseConfig base `RetryConfig`
+ * @param config methods of [RetryConfig.Builder] that customize default `RetryConfig`
+ */
+inline fun <T> RetryRegistry.Builder.withRetryConfig(
+    baseConfig: RetryConfig,
+    config: RetryConfig.Builder<T>.() -> Unit
+) {
+    withRetryConfig(RetryConfig(baseConfig, config))
+}
+
+/**
+ * Configures a [RetryRegistry] with a custom default Retry configuration.
+ *
+ * ```kotlin
+ * val retryRegistry = RetryRegistry {
+ *     withRetryConfig(baseRetryConfig) {
+ *         waitDuration(Duration.ofMillis(10))
+ *     }
+ * }
+ * ```
+ *
+ * @param baseConfig base `RetryConfig`
+ * @param config methods of [RetryConfig.Builder] that customize default `RetryConfig`
+ */
+@JvmName("withUntypedRetryConfig")
+inline fun RetryRegistry.Builder.withRetryConfig(
+    baseConfig: RetryConfig,
+    config: RetryConfig.Builder<Any?>.() -> Unit
+) {
+    withRetryConfig(RetryConfig(baseConfig, config))
+}
+
+/**
+ * Configures a [RetryRegistry] with a custom Retry configuration.
+ *
+ * ```kotlin
+ * val retryRegistry = RetryRegistry {
+ *     addRetryConfig<String>("sharedConfig1") {
+ *         waitDuration(Duration.ofMillis(10))
+ *         retryOnResult { result -> result == "ERROR" }
+ *     }
+ * }
+ * ```
+ *
+ * @param configName configName for a custom shared Retry configuration
+ * @param config methods of [RetryConfig.Builder] that customize resulting `RetryConfig`
+ */
+inline fun <T> RetryRegistry.Builder.addRetryConfig(
+    configName: String,
+    config: RetryConfig.Builder<T>.() -> Unit
+) {
+    addRetryConfig(configName, RetryConfig(config))
+}
+
+/**
+ * Configures a [RetryRegistry] with a custom Retry configuration.
+ *
+ * ```kotlin
+ * val retryRegistry = RetryRegistry {
+ *     addRetryConfig("sharedConfig1") {
+ *         waitDuration(Duration.ofMillis(10))
+ *     }
+ * }
+ * ```
+ *
+ * @param configName configName for a custom shared Retry configuration
+ * @param config methods of [RetryConfig.Builder] that customize resulting `RetryConfig`
+ */
+@JvmName("addUntypedRetryConfig")
+inline fun RetryRegistry.Builder.addRetryConfig(
+    configName: String,
+    config: RetryConfig.Builder<Any?>.() -> Unit
+) {
+    addRetryConfig(configName, RetryConfig(config))
+}
+
+/**
+ * Configures a [RetryRegistry] with a custom Retry configuration.
+ *
+ * ```kotlin
+ * val retryRegistry = RetryRegistry {
+ *     addRetryConfig<String>("sharedConfig1", baseRetryConfig) {
+ *         waitDuration(Duration.ofMillis(10))
+ *         retryOnResult { result -> result == "ERROR" }
+ *     }
+ * }
+ * ```
+ *
+ * @param configName configName for a custom shared Retry configuration
+ * @param baseConfig base `RetryConfig`
+ * @param config methods of [RetryConfig.Builder] that customize resulting `RetryConfig`
+ */
+inline fun <T> RetryRegistry.Builder.addRetryConfig(
+    configName: String,
+    baseConfig: RetryConfig,
+    config: RetryConfig.Builder<T>.() -> Unit
+) {
+    addRetryConfig(configName, RetryConfig(baseConfig, config))
+}
+
+/**
+ * Configures a [RetryRegistry] with a custom Retry configuration.
+ *
+ * ```kotlin
+ * val retryRegistry = RetryRegistry {
+ *     addRetryConfig("sharedConfig1", baseRetryConfig) {
+ *         waitDuration(Duration.ofMillis(10))
+ *     }
+ * }
+ * ```
+ *
+ * @param configName configName for a custom shared Retry configuration
+ * @param baseConfig base `RetryConfig`
+ * @param config methods of [RetryConfig.Builder] that customize resulting `RetryConfig`
+ */
+@JvmName("addUntypedRetryConfig")
+inline fun RetryRegistry.Builder.addRetryConfig(
+    configName: String,
+    baseConfig: RetryConfig,
+    config: RetryConfig.Builder<Any?>.() -> Unit
+) {
+    addRetryConfig(configName, RetryConfig(baseConfig, config))
+}
+
+/**
+ * Configures a [RetryRegistry] with Tags.
+ *
+ * Tags added to the registry will be added to every instance created by this registry.
+ *
+ * @param tags default tags to add to the registry.
+ */
+fun RetryRegistry.Builder.withTags(tags: Map<String, String>) {
+    withTags(VavrHashMap.ofAll(tags))
+}
+
+/**
+ * Configures a [RetryRegistry] with Tags.
+ *
+ * Tags added to the registry will be added to every instance created by this registry.
+ *
+ * @param tags default tags to add to the registry.
+ */
+fun RetryRegistry.Builder.withTags(vararg tags: Pair<String, String>) {
+    withTags(VavrHashMap.ofEntries(tags.map { VavrTuple2(it.first, it.second) }))
 }

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/timelimiter/TimeLimiterConfig.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/timelimiter/TimeLimiterConfig.kt
@@ -1,0 +1,41 @@
+@file:Suppress("FunctionName")
+
+package io.github.resilience4j.kotlin.timelimiter
+
+import io.github.resilience4j.timelimiter.TimeLimiterConfig
+
+/**
+ * Creates new custom [TimeLimiterConfig].
+ *
+ * ```kotlin
+ * val timeLimiterConfig = TimeLimiterConfig {
+ *     timeoutDuration(Duration.ofMillis(10))
+ * }
+ * ```
+ *
+ * @param config methods of [TimeLimiterConfig.Builder] that customize resulting `TimeLimiterConfig`
+ */
+inline fun TimeLimiterConfig(
+    config: TimeLimiterConfig.Builder.() -> Unit
+): TimeLimiterConfig {
+    return TimeLimiterConfig.custom().apply(config).build()
+}
+
+/**
+ * Creates new custom [TimeLimiterConfig] based on [baseConfig].
+ *
+ * ```kotlin
+ * val timeLimiterConfig = TimeLimiterConfig(baseTimeLimiterConfig) {
+ *     timeoutDuration(Duration.ofMillis(10))
+ * }
+ * ```
+ *
+ * @param baseConfig base `TimeLimiterConfig`
+ * @param config methods of [TimeLimiterConfig.Builder] that customize resulting `TimeLimiterConfig`
+ */
+inline fun TimeLimiterConfig(
+    baseConfig: TimeLimiterConfig,
+    config: TimeLimiterConfig.Builder.() -> Unit
+): TimeLimiterConfig {
+    return TimeLimiterConfig.from(baseConfig).apply(config).build()
+}

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/bulkhead/BulkheadTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/bulkhead/BulkheadTest.kt
@@ -19,7 +19,6 @@
 package io.github.resilience4j.kotlin.bulkhead
 
 import io.github.resilience4j.bulkhead.Bulkhead
-import io.github.resilience4j.bulkhead.BulkheadConfig
 import io.github.resilience4j.bulkhead.BulkheadFullException
 import io.github.resilience4j.kotlin.HelloWorldService
 import org.assertj.core.api.Assertions
@@ -66,10 +65,10 @@ class BulkheadTest {
     @Test
     fun `should not execute function when full`() {
         val bulkhead = Bulkhead.of("testName") {
-            BulkheadConfig.custom()
-                .maxConcurrentCalls(1)
-                .maxWaitDuration(Duration.ZERO)
-                .build()
+            BulkheadConfig {
+                maxConcurrentCalls(1)
+                maxWaitDuration(Duration.ZERO)
+            }
         }.registerEventListener()
         val helloWorldService = HelloWorldService()
         val latch = CountDownLatch(1)

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/bulkhead/CoroutineBulkheadTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/bulkhead/CoroutineBulkheadTest.kt
@@ -19,7 +19,6 @@
 package io.github.resilience4j.kotlin.bulkhead
 
 import io.github.resilience4j.bulkhead.Bulkhead
-import io.github.resilience4j.bulkhead.BulkheadConfig
 import io.github.resilience4j.bulkhead.BulkheadFullException
 import io.github.resilience4j.kotlin.CoroutineHelloWorldService
 import kotlinx.coroutines.channels.Channel
@@ -70,10 +69,10 @@ class CoroutineBulkheadTest {
     fun `should not execute function when full`() {
         runBlocking {
             val bulkhead = Bulkhead.of("testName") {
-                BulkheadConfig.custom()
-                    .maxConcurrentCalls(1)
-                    .maxWaitDuration(Duration.ZERO)
-                    .build()
+                BulkheadConfig {
+                    maxConcurrentCalls(1)
+                    maxWaitDuration(Duration.ZERO)
+                }
             }.registerEventListener()
 
             val sync = Channel<Unit>(Channel.RENDEZVOUS)

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/bulkhead/FlowBulkheadTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/bulkhead/FlowBulkheadTest.kt
@@ -19,7 +19,6 @@
 package io.github.resilience4j.kotlin.bulkhead
 
 import io.github.resilience4j.bulkhead.Bulkhead
-import io.github.resilience4j.bulkhead.BulkheadConfig
 import io.github.resilience4j.bulkhead.BulkheadFullException
 import io.github.resilience4j.kotlin.CoroutineHelloWorldService
 import kotlinx.coroutines.*
@@ -79,10 +78,10 @@ class FlowBulkheadTest {
     fun `should not execute function when full`() {
         runBlocking {
             val bulkhead = Bulkhead.of("testName") {
-                BulkheadConfig.custom()
-                    .maxConcurrentCalls(1)
-                    .maxWaitDuration(Duration.ZERO)
-                    .build()
+                BulkheadConfig {
+                    maxConcurrentCalls(1)
+                    maxWaitDuration(Duration.ZERO)
+                }
             }.registerEventListener()
 
             val resultList = mutableListOf<Int>()
@@ -180,10 +179,10 @@ class FlowBulkheadTest {
             val phaser = Phaser(1)
             var flowCompleted = false
             val bulkhead = Bulkhead.of("testName") {
-                BulkheadConfig.custom()
-                    .maxConcurrentCalls(1)
-                    .maxWaitDuration(Duration.ZERO)
-                    .build()
+                BulkheadConfig {
+                    maxConcurrentCalls(1)
+                    maxWaitDuration(Duration.ZERO)
+                }
             }.registerEventListener()
 
             //When
@@ -219,10 +218,10 @@ class FlowBulkheadTest {
             val parentJob = Job()
             var flowCompleted = false
             val bulkhead = Bulkhead.of("testName") {
-                BulkheadConfig.custom()
-                    .maxConcurrentCalls(1)
-                    .maxWaitDuration(Duration.ZERO)
-                    .build()
+                BulkheadConfig {
+                    maxConcurrentCalls(1)
+                    maxWaitDuration(Duration.ZERO)
+                }
             }.registerEventListener()
 
             //When

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/ratelimiter/CoroutineRateLimiterTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/ratelimiter/CoroutineRateLimiterTest.kt
@@ -20,7 +20,6 @@ package io.github.resilience4j.kotlin.ratelimiter
 
 import io.github.resilience4j.kotlin.CoroutineHelloWorldService
 import io.github.resilience4j.ratelimiter.RateLimiter
-import io.github.resilience4j.ratelimiter.RateLimiterConfig
 import io.github.resilience4j.ratelimiter.RequestNotPermitted
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions
@@ -29,12 +28,11 @@ import java.time.Duration
 
 class CoroutineRateLimiterTest {
 
-    private fun noWaitConfig() = RateLimiterConfig
-        .custom()
-        .limitRefreshPeriod(Duration.ofSeconds(10))
-        .limitForPeriod(10)
-        .timeoutDuration(Duration.ZERO)
-        .build()
+    private fun noWaitConfig() = RateLimiterConfig {
+        limitRefreshPeriod(Duration.ofSeconds(10))
+        limitForPeriod(10)
+        timeoutDuration(Duration.ZERO)
+    }
 
     @Test
     fun `should execute successful function`() {

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/ratelimiter/FlowRateLimiterTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/ratelimiter/FlowRateLimiterTest.kt
@@ -20,7 +20,6 @@ package io.github.resilience4j.kotlin.ratelimiter
 
 import io.github.resilience4j.kotlin.CoroutineHelloWorldService
 import io.github.resilience4j.ratelimiter.RateLimiter
-import io.github.resilience4j.ratelimiter.RateLimiterConfig
 import io.github.resilience4j.ratelimiter.RequestNotPermitted
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.single
@@ -31,12 +30,11 @@ import java.time.Duration
 
 class FlowRateLimiterTest {
 
-    private fun noWaitConfig() = RateLimiterConfig
-        .custom()
-        .limitRefreshPeriod(Duration.ofSeconds(10))
-        .limitForPeriod(10)
-        .timeoutDuration(Duration.ZERO)
-        .build()
+    private fun noWaitConfig() = RateLimiterConfig {
+        limitRefreshPeriod(Duration.ofSeconds(10))
+        limitForPeriod(10)
+        timeoutDuration(Duration.ZERO)
+    }
 
     @Test
     fun `should execute successful function`() {

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/ratelimiter/RateLimiterTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/ratelimiter/RateLimiterTest.kt
@@ -20,7 +20,6 @@ package io.github.resilience4j.kotlin.ratelimiter
 
 import io.github.resilience4j.kotlin.HelloWorldService
 import io.github.resilience4j.ratelimiter.RateLimiter
-import io.github.resilience4j.ratelimiter.RateLimiterConfig
 import io.github.resilience4j.ratelimiter.RequestNotPermitted
 import org.assertj.core.api.Assertions
 import org.junit.Test
@@ -28,12 +27,11 @@ import java.time.Duration
 
 class RateLimiterTest {
 
-    private fun noWaitConfig() = RateLimiterConfig
-        .custom()
-        .limitRefreshPeriod(Duration.ofSeconds(10))
-        .limitForPeriod(10)
-        .timeoutDuration(Duration.ZERO)
-        .build()
+    private fun noWaitConfig() = RateLimiterConfig {
+        limitRefreshPeriod(Duration.ofSeconds(10))
+        limitForPeriod(10)
+        timeoutDuration(Duration.ZERO)
+    }
 
     @Test
     fun `should execute successful function`() {

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/retry/CoroutineRetryTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/retry/CoroutineRetryTest.kt
@@ -20,7 +20,6 @@ package io.github.resilience4j.kotlin.retry
 
 import io.github.resilience4j.kotlin.CoroutineHelloWorldService
 import io.github.resilience4j.retry.Retry
-import io.github.resilience4j.retry.RetryConfig
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions
 import org.junit.Test
@@ -54,7 +53,7 @@ class CoroutineRetryTest {
     fun `should execute function with retries`() {
         runBlocking {
             val retry = Retry.of("testName") {
-                RetryConfig.custom<Any?>().waitDuration(Duration.ofMillis(10)).build()
+                RetryConfig { waitDuration(Duration.ofMillis(10)) }
             }
             val metrics = retry.metrics
             val helloWorldService = CoroutineHelloWorldService()
@@ -83,10 +82,10 @@ class CoroutineRetryTest {
         runBlocking {
             val helloWorldService = CoroutineHelloWorldService()
             val retry = Retry.of("testName") {
-                RetryConfig.custom<Any?>()
-                    .waitDuration(Duration.ofMillis(10))
-                    .retryOnResult { helloWorldService.invocationCounter < 2 }
-                    .build()
+                RetryConfig {
+                    waitDuration(Duration.ofMillis(10))
+                    retryOnResult { helloWorldService.invocationCounter < 2 }
+                }
             }
             val metrics = retry.metrics
 
@@ -110,7 +109,7 @@ class CoroutineRetryTest {
     fun `should execute function with repeated failures`() {
         runBlocking {
             val retry = Retry.of("testName") {
-                RetryConfig.custom<Any?>().waitDuration(Duration.ofMillis(10)).build()
+                RetryConfig { waitDuration(Duration.ofMillis(10)) }
             }
             val metrics = retry.metrics
             val helloWorldService = CoroutineHelloWorldService()

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/retry/FlowRetryTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/retry/FlowRetryTest.kt
@@ -20,7 +20,6 @@ package io.github.resilience4j.kotlin.retry
 
 import io.github.resilience4j.kotlin.CoroutineHelloWorldService
 import io.github.resilience4j.retry.Retry
-import io.github.resilience4j.retry.RetryConfig
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
@@ -65,7 +64,7 @@ class FlowRetryTest {
     fun `should execute function with retries`() {
         runBlocking {
             val retry = Retry.of("testName") {
-                RetryConfig.custom<Any?>().waitDuration(Duration.ofMillis(10)).build()
+                RetryConfig { waitDuration(Duration.ofMillis(10)) }
             }
             val metrics = retry.metrics
             val helloWorldService = CoroutineHelloWorldService()
@@ -104,10 +103,10 @@ class FlowRetryTest {
             val helloWorldService = CoroutineHelloWorldService()
             val resultList = mutableListOf<String>()
             val retry = Retry.of("testName") {
-                RetryConfig.custom<Any?>()
-                    .waitDuration(Duration.ofMillis(10))
-                    .retryOnResult { helloWorldService.invocationCounter < 2 }
-                    .build()
+                RetryConfig {
+                    waitDuration(Duration.ofMillis(10))
+                    retryOnResult { helloWorldService.invocationCounter < 2 }
+                }
             }
             val metrics = retry.metrics
 
@@ -132,7 +131,7 @@ class FlowRetryTest {
     fun `should execute function with repeated failures`() {
         runBlocking {
             val retry = Retry.of("testName") {
-                RetryConfig.custom<Any?>().waitDuration(Duration.ofMillis(10)).build()
+                RetryConfig { waitDuration(Duration.ofMillis(10)) }
             }
             val metrics = retry.metrics
             val helloWorldService = CoroutineHelloWorldService()

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/retry/RetryTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/retry/RetryTest.kt
@@ -20,7 +20,6 @@ package io.github.resilience4j.kotlin.retry
 
 import io.github.resilience4j.kotlin.HelloWorldService
 import io.github.resilience4j.retry.Retry
-import io.github.resilience4j.retry.RetryConfig
 import org.assertj.core.api.Assertions
 import org.junit.Test
 import java.time.Duration
@@ -51,7 +50,7 @@ class RetryTest {
     @Test
     fun `should execute function with retries`() {
         val retry = Retry.of("testName") {
-            RetryConfig.custom<Any?>().waitDuration(Duration.ofMillis(10)).build()
+            RetryConfig { waitDuration(Duration.ofMillis(10)) }
         }
         val metrics = retry.metrics
         val helloWorldService = HelloWorldService()
@@ -78,10 +77,10 @@ class RetryTest {
     fun `should execute function with retry of result`() {
         val helloWorldService = HelloWorldService()
         val retry = Retry.of("testName") {
-            RetryConfig.custom<Any?>()
-                .waitDuration(Duration.ofMillis(10))
-                .retryOnResult { helloWorldService.invocationCounter < 2 }
-                .build()
+            RetryConfig {
+                waitDuration(Duration.ofMillis(10))
+                retryOnResult { helloWorldService.invocationCounter < 2 }
+            }
         }
         val metrics = retry.metrics
 
@@ -103,7 +102,7 @@ class RetryTest {
     @Test
     fun `should execute function with repeated failures`() {
         val retry = Retry.of("testName") {
-            RetryConfig.custom<Any?>().waitDuration(Duration.ofMillis(10)).build()
+            RetryConfig { waitDuration(Duration.ofMillis(10)) }
         }
         val metrics = retry.metrics
         val helloWorldService = HelloWorldService()

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/timelimiter/CoroutineTimeLimiterTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/timelimiter/CoroutineTimeLimiterTest.kt
@@ -20,7 +20,6 @@ package io.github.resilience4j.kotlin.timelimiter
 
 import io.github.resilience4j.kotlin.CoroutineHelloWorldService
 import io.github.resilience4j.timelimiter.TimeLimiter
-import io.github.resilience4j.timelimiter.TimeLimiterConfig
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions
@@ -71,7 +70,7 @@ class CoroutineTimeLimiterTest {
     @Test
     fun `should cancel operation that times out`() {
         runBlocking {
-            val timelimiter = TimeLimiter.of(TimeLimiterConfig.custom().timeoutDuration(Duration.ofMillis(10)).build())
+            val timelimiter = TimeLimiter.of(TimeLimiterConfig { timeoutDuration(Duration.ofMillis(10)) })
 
             val helloWorldService = CoroutineHelloWorldService()
 

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/timelimiter/FlowTimeLimiterTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/timelimiter/FlowTimeLimiterTest.kt
@@ -20,7 +20,6 @@ package io.github.resilience4j.kotlin.timelimiter
 
 import io.github.resilience4j.kotlin.CoroutineHelloWorldService
 import io.github.resilience4j.timelimiter.TimeLimiter
-import io.github.resilience4j.timelimiter.TimeLimiterConfig
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.toList
@@ -85,7 +84,7 @@ class FlowTimeLimiterTest {
     @Test
     fun `should cancel operation that times out`() {
         runBlocking {
-            val timelimiter = TimeLimiter.of(TimeLimiterConfig.custom().timeoutDuration(Duration.ofMillis(10)).build())
+            val timelimiter = TimeLimiter.of(TimeLimiterConfig { timeoutDuration(Duration.ofMillis(10)) })
 
             val helloWorldService = CoroutineHelloWorldService()
             val resultList = mutableListOf<String>()


### PR DESCRIPTION
## Overview

This proposal adds a DSL for building `BulkheadConfig`, `CircuitBreakerConfig`, `RateLimiterConfig`, `RetryConfig` and `TimeLimiterConfig`:

```kotlin
val circuitBreakerConfig = CircuitBreakerConfig {
    failureRateThreshold(50)
    waitDurationInOpenState(Duration.ofSeconds(30))
}

// instead of
val circuitBreakerConfig = CircuitBreakerConfig.custom()
    .failureRateThreshold(50)
    .waitDurationInOpenState(Duration.ofSeconds(30))
    .build()
```

In addition to a bit nicer syntax, this DSL also opens up a possibility for conditions in the configuration builders:
```kotlin
val circuitBreakerConfig = CircuitBreakerConfig {
    failureRateThreshold(50)
    waitDurationInOpenState(Duration.ofSeconds(30))
    if (limitSlowCalls) {
        slowCallDurationThreshold(Duration.ofSeconds(60))
        slowCallRateThreshold(20)
    }
}
```

**Open question**: all DSL methods are inline so it's hard to directly measure their code coverage. At the moment these builders are used in existing `resilience4j-kotlin` tests but no new tests were added.