### PR TITLE
Issue:960: Fix Automatic-Module-Name: A Java module name follows the …

### DIFF
--- a/resilience4j-framework-common/build.gradle
+++ b/resilience4j-framework-common/build.gradle
@@ -7,4 +7,4 @@ dependencies {
     compile project(':resilience4j-timelimiter')
 }
 
-ext.moduleName = 'io.github.resilience4j.framework-common'
+ext.moduleName = 'io.github.resilience4j.framework.common'


### PR DESCRIPTION
Module names should follow same naming rules as Java packages. However, you should not use underscores (_) in module names (or package names, class names, method names, variable names etc.) from Java 9 and forward, because Java wants to use underscore as a reserved identifier in the future.