### PR TITLE
Support enabling both exponential backoff and randomized wait

### DIFF
--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/retry/configuration/RetryConfigurationPropertiesTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/retry/configuration/RetryConfigurationPropertiesTest.java
@@ -80,6 +80,29 @@ public class RetryConfigurationPropertiesTest {
     }
 
     @Test
+    public void testExponentialRandomBackoffConfig() {
+        //Given
+        RetryConfigurationProperties.InstanceProperties instanceProperties1 = new RetryConfigurationProperties.InstanceProperties();
+        instanceProperties1.setMaxRetryAttempts(3);
+        instanceProperties1.setWaitDuration(Duration.ofMillis(1000));
+        instanceProperties1.setEnableExponentialBackoff(true);
+        instanceProperties1.setEnableRandomizedWait(true);
+        instanceProperties1.setRandomizedWaitFactor(0.5D);
+        instanceProperties1.setExponentialBackoffMultiplier(2.0D);
+
+        RetryConfigurationProperties retryConfigurationProperties = new RetryConfigurationProperties();
+        retryConfigurationProperties.getInstances().put("backend1", instanceProperties1);
+
+        //Then
+        final RetryConfig retry1 = retryConfigurationProperties
+            .createRetryConfig("backend1", compositeRetryCustomizer());
+        assertThat(retry1).isNotNull();
+        assertThat(retry1.getIntervalFunction().apply(1)).isBetween(500L, 1500L);
+        assertThat(retry1.getIntervalFunction().apply(2)).isBetween(1000L, 3000L);
+
+    }
+
+    @Test
     public void testCreateRetryPropertiesWithSharedConfigs() {
         //Given
         RetryConfigurationProperties.InstanceProperties defaultProperties = new RetryConfigurationProperties.InstanceProperties();


### PR DESCRIPTION
This adds support for simultaneously enabling exponential backoff and randomized wait in RetryConfigurationProperties by reusing existing properties.

Fixes #982 

I'm not entirely satisfied with the unit test, but didn't want to test for e.g. not equal to the unrandomized value and then risk a random test failure.

Let me know if the slight cleanup I did is unwelcome - it helped me read it and Sonar was taunting me. :)

Thanks!