### PR TITLE
#1003- removed extra call to acquirePermission

### DIFF
--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreaker.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreaker.java
@@ -220,7 +220,6 @@ public interface CircuitBreaker {
         Supplier<Either<? extends Exception, T>> supplier) {
         return () -> {
             if (circuitBreaker.tryAcquirePermission()) {
-                circuitBreaker.acquirePermission();
                 long start = System.nanoTime();
                 Either<? extends Exception, T> result = supplier.get();
                 long durationInNanos = System.nanoTime() - start;


### PR DESCRIPTION
Issue #1003 Removed extra call to acquire permission from `circuitBreaker.decorateEitherSupplier()`.

@RobWin - Kindly review.