### PR TITLE
Issue #935 WIP: Implementing token based permits in HalfOpen State

### DIFF
--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfig.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfig.java
@@ -38,6 +38,7 @@ public class CircuitBreakerConfig {
     public static final int DEFAULT_MINIMUM_NUMBER_OF_CALLS = 100;
     public static final int DEFAULT_SLIDING_WINDOW_SIZE = 100;
     public static final int DEFAULT_SLOW_CALL_DURATION_THRESHOLD = 60; // Seconds
+    public static final int DEFAULT_WAIT_DURATION_IN_HALF_OPEN_STATE = 0; // Seconds. It is an optional parameter
     public static final SlidingWindowType DEFAULT_SLIDING_WINDOW_TYPE = SlidingWindowType.COUNT_BASED;
     public static final boolean DEFAULT_WRITABLE_STACK_TRACE_ENABLED = true;
     private static final Predicate<Throwable> DEFAULT_RECORD_EXCEPTION_PREDICATE = throwable -> true;
@@ -64,6 +65,8 @@ public class CircuitBreakerConfig {
     private float slowCallRateThreshold = DEFAULT_SLOW_CALL_RATE_THRESHOLD;
     private Duration slowCallDurationThreshold = Duration
         .ofSeconds(DEFAULT_SLOW_CALL_DURATION_THRESHOLD);
+    private Duration waitDurationInHalfOpenState = Duration
+        .ofSeconds(DEFAULT_WAIT_DURATION_IN_HALF_OPEN_STATE);
 
 
     private CircuitBreakerConfig() {
@@ -159,6 +162,10 @@ public class CircuitBreakerConfig {
         return slowCallDurationThreshold;
     }
 
+    public Duration getWaitDurationInHalfOpenState() {
+        return waitDurationInHalfOpenState;
+    }
+
     public enum SlidingWindowType {
         TIME_BASED, COUNT_BASED
     }
@@ -189,6 +196,8 @@ public class CircuitBreakerConfig {
         private float slowCallRateThreshold = DEFAULT_SLOW_CALL_RATE_THRESHOLD;
         private Duration slowCallDurationThreshold = Duration
             .ofSeconds(DEFAULT_SLOW_CALL_DURATION_THRESHOLD);
+        private Duration waitDurationInHalfOpenState = Duration
+            .ofSeconds(DEFAULT_WAIT_DURATION_IN_HALF_OPEN_STATE);
 
 
         public Builder(CircuitBreakerConfig baseConfig) {
@@ -205,6 +214,7 @@ public class CircuitBreakerConfig {
             this.automaticTransitionFromOpenToHalfOpenEnabled = baseConfig.automaticTransitionFromOpenToHalfOpenEnabled;
             this.slowCallRateThreshold = baseConfig.slowCallRateThreshold;
             this.slowCallDurationThreshold = baseConfig.slowCallDurationThreshold;
+            this.waitDurationInHalfOpenState = baseConfig.waitDurationInHalfOpenState;
             this.writableStackTraceEnabled = baseConfig.writableStackTraceEnabled;
         }
 
@@ -324,6 +334,28 @@ public class CircuitBreakerConfig {
                     "slowCallDurationThreshold must be at least 1[ns]");
             }
             this.slowCallDurationThreshold = slowCallDurationThreshold;
+            return this;
+        }
+
+        /**
+         * Configures CircuitBreaker with a fixed wait duration which controls how long the
+         * CircuitBreaker should stay in Half Open state, before it switches to open. This is an
+         * Optional parameter.
+         *
+         * By default circuitBreaker will stay in Half Open state until
+         * {@code minimumNumberOfCalls} is completed with either success or failure.
+         *
+         * @param waitDurationInHalfOpenState the wait duration which specifies how long the
+         *                                CircuitBreaker should stay in Half Open
+         * @return the CircuitBreakerConfig.Builder
+         * @throws IllegalArgumentException if {@code waitDurationInOpenState.toMillis() < 1000}
+         */
+        public Builder waitDurationInHalfOpenState(Duration waitDurationInHalfOpenState) {
+            if (waitDurationInHalfOpenState.toMillis() < 1000) {
+                throw new IllegalArgumentException(
+                    "waitDurationInHalfOpenState must be at least 1[second]");
+            }
+            this.waitDurationInHalfOpenState = waitDurationInHalfOpenState;
             return this;
         }
 
@@ -615,6 +647,7 @@ public class CircuitBreakerConfig {
             config.waitIntervalFunctionInOpenState = waitIntervalFunctionInOpenState;
             config.slidingWindowType = slidingWindowType;
             config.slowCallDurationThreshold = slowCallDurationThreshold;
+            config.waitDurationInHalfOpenState = waitDurationInHalfOpenState;
             config.slowCallRateThreshold = slowCallRateThreshold;
             config.failureRateThreshold = failureRateThreshold;
             config.slidingWindowSize = slidingWindowSize;

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachine.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachine.java
@@ -942,6 +942,13 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
             this.permittedNumberOfCalls = new AtomicInteger(permittedNumberOfCallsInHalfOpenState);
             this.isHalfOpen = new AtomicBoolean(true);
             this.attempts = attempts;
+
+            final long waitDurationInHalfOpenState = circuitBreakerConfig.getWaitDurationInHalfOpenState().toMillis();
+            if (waitDurationInHalfOpenState >= 1000) {
+                ScheduledExecutorService scheduledExecutorService = schedulerFactory.getScheduler();
+                scheduledExecutorService
+                    .schedule(this::toOpenState, waitDurationInHalfOpenState, TimeUnit.MILLISECONDS);
+            }
         }
 
         /**
@@ -967,6 +974,12 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
             if (!tryAcquirePermission()) {
                 throw CallNotPermittedException
                     .createCallNotPermittedException(CircuitBreakerStateMachine.this);
+            }
+        }
+
+        private void toOpenState() {
+            if (isHalfOpen.compareAndSet(true, false)) {
+                transitionToOpenState();
             }
         }
 

--- a/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationProperties.java
+++ b/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationProperties.java
@@ -111,6 +111,10 @@ public class CircuitBreakerConfigurationProperties extends CommonProperties {
             builder.slowCallDurationThreshold(properties.getSlowCallDurationThreshold());
         }
 
+        if (properties.getWaitDurationInHalfOpenState() != null) {
+            builder.waitDurationInHalfOpenState(properties.getWaitDurationInHalfOpenState());
+        }
+
         if (properties.getRingBufferSizeInClosedState() != null) {
             builder.ringBufferSizeInClosedState(properties.getRingBufferSizeInClosedState());
         }
@@ -243,6 +247,9 @@ public class CircuitBreakerConfigurationProperties extends CommonProperties {
 
         @Nullable
         private Duration slowCallDurationThreshold;
+
+        @Nullable
+        private Duration waitDurationInHalfOpenState;
 
         @Nullable
         private Float failureRateThreshold;
@@ -646,6 +653,11 @@ public class CircuitBreakerConfigurationProperties extends CommonProperties {
             return slowCallDurationThreshold;
         }
 
+        @Nullable
+        public Duration getWaitDurationInHalfOpenState() {
+            return waitDurationInHalfOpenState;
+        }
+
         public void setSlowCallDurationThreshold(Duration slowCallDurationThreshold) {
             Objects.requireNonNull(slowCallDurationThreshold);
             if (slowCallDurationThreshold.toNanos() < 1) {
@@ -654,6 +666,16 @@ public class CircuitBreakerConfigurationProperties extends CommonProperties {
             }
 
             this.slowCallDurationThreshold = slowCallDurationThreshold;
+        }
+
+        public void setWaitDurationInHalfOpenState(Duration waitDurationInHalfOpenState) {
+            Objects.requireNonNull(waitDurationInHalfOpenState);
+            if (waitDurationInHalfOpenState.toMillis() < 1000) {
+                throw new IllegalArgumentException(
+                    "waitDurationInHalfOpenState must be greater than or equal to 1 second.");
+            }
+
+            this.waitDurationInHalfOpenState = waitDurationInHalfOpenState;
         }
 
         @Nullable


### PR DESCRIPTION
This PR is still under WIP as part of Issue #935 .

We have replaced existing acquire permission approach based on atomic Integer count to a token based permit mechanism. A `token` contains the timestamp when the token was issued to a permitted request. 

New config parameter has beed added to Circuit Breaker as `timeoutIntervalPerCallInHalfOpenState`, post the timeout duration requests will be considered unresponsive and will be marked as completed with Error.

When a request comes in HalfOpen state, `tryAcquirePermission`/`acquirePermission` returns a valid token to permitted request if `permittedNumberOfCallsInHalfOpenState` has not exceeded and stores the issued token into a HashSet. After completing the request, either successful completion or completion with error or ignoredException, request releases the issued token back and token is deleted from HashSet containing the used tokens marking the request appropriately `onError()` or `onSuccess()`.

When a new request comes in and `permittedNumberOfCallsInHalfOpenState` has exceeded, a `CallNotPermittedException` is thrown and no token is being issued to the request. On a request when `permittedNumberOfCallsInHalfOpenState` exceeds, we iterate through HashSet containing used token and remove all the token having `timeoutIntervalPerCallInHalfOpenState` exceeded, considering them unresponsive requests marking them failure by calling `onError()`.

This PR is WIP. Due to change in contract of `tryAcquirePermission()` and `acquirePermission`, many changes has to propagate down to the calling code keeping the new contract. Before I make those changes, I would like to get the implementation reviewed and agreed.
@RobWin Kindly review and provide your suggestions.