### PR TITLE
Add predicate to record a failure depending on the result

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,6 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
     <option name="USE_PER_PROJECT_SETTINGS" value="true" />
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Project copy" />
   </state>
 </component>

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfig.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfig.java
@@ -209,8 +209,6 @@ public class CircuitBreakerConfig {
 	public static class Builder {
 
         @Nullable
-        private Predicate<Object> recordResultPredicate;
-        @Nullable
         private Predicate<Throwable> recordExceptionPredicate;
         @Nullable
         private Predicate<Throwable> ignoreExceptionPredicate;
@@ -225,6 +223,7 @@ public class CircuitBreakerConfig {
         private boolean writableStackTraceEnabled = DEFAULT_WRITABLE_STACK_TRACE_ENABLED;
         private int permittedNumberOfCallsInHalfOpenState = DEFAULT_PERMITTED_CALLS_IN_HALF_OPEN_STATE;
         private int slidingWindowSize = DEFAULT_SLIDING_WINDOW_SIZE;
+        private Predicate<Object> recordResultPredicate = DEFAULT_RECORD_RESULT_PREDICATE;
 
         private IntervalFunction waitIntervalFunctionInOpenState = IntervalFunction
             .of(Duration.ofSeconds(DEFAULT_SLOW_CALL_DURATION_THRESHOLD));
@@ -687,6 +686,7 @@ public class CircuitBreakerConfig {
             config.writableStackTraceEnabled = writableStackTraceEnabled;
             config.recordExceptionPredicate = createRecordExceptionPredicate();
             config.ignoreExceptionPredicate = createIgnoreFailurePredicate();
+            config.recordResultPredicate = recordResultPredicate;
             return config;
         }
 

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfig.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfig.java
@@ -43,10 +43,13 @@ public class CircuitBreakerConfig {
     public static final boolean DEFAULT_WRITABLE_STACK_TRACE_ENABLED = true;
     private static final Predicate<Throwable> DEFAULT_RECORD_EXCEPTION_PREDICATE = throwable -> true;
     private static final Predicate<Throwable> DEFAULT_IGNORE_EXCEPTION_PREDICATE = throwable -> false;
+    private static final Predicate<Object> DEFAULT_RECORD_RESULT_PREDICATE = Object -> false;
     // The default exception predicate counts all exceptions as failures.
     private Predicate<Throwable> recordExceptionPredicate = DEFAULT_RECORD_EXCEPTION_PREDICATE;
     // The default exception predicate ignores no exceptions.
     private Predicate<Throwable> ignoreExceptionPredicate = DEFAULT_IGNORE_EXCEPTION_PREDICATE;
+
+    private Predicate<Object> recordResultPredicate = DEFAULT_RECORD_RESULT_PREDICATE;
 
     @SuppressWarnings("unchecked")
     private Class<? extends Throwable>[] recordExceptions = new Class[0];
@@ -128,6 +131,10 @@ public class CircuitBreakerConfig {
         return recordExceptionPredicate;
     }
 
+    public Predicate<Object> getRecordResultPredicate() {
+        return recordResultPredicate;
+    }
+
     public Predicate<Throwable> getIgnoreExceptionPredicate() {
         return ignoreExceptionPredicate;
     }
@@ -202,6 +209,8 @@ public class CircuitBreakerConfig {
 	public static class Builder {
 
         @Nullable
+        private Predicate<Object> recordResultPredicate;
+        @Nullable
         private Predicate<Throwable> recordExceptionPredicate;
         @Nullable
         private Predicate<Throwable> ignoreExceptionPredicate;
@@ -242,6 +251,7 @@ public class CircuitBreakerConfig {
             this.slowCallRateThreshold = baseConfig.slowCallRateThreshold;
             this.slowCallDurationThreshold = baseConfig.slowCallDurationThreshold;
             this.writableStackTraceEnabled = baseConfig.writableStackTraceEnabled;
+            this.recordResultPredicate = baseConfig.recordResultPredicate;
         }
 
         public Builder() {
@@ -547,6 +557,21 @@ public class CircuitBreakerConfig {
          */
         public Builder recordException(Predicate<Throwable> predicate) {
             this.recordExceptionPredicate = predicate;
+            return this;
+        }
+
+        /**
+         * Configures a Predicate which evaluates if the result of the protected function call
+         * should be recorded as a failure and thus increase the failure rate.
+         * The Predicate must return true if the result should count as a failure.
+         * The Predicate must return false, if the result should count
+         * as a success.
+         *
+         * @param predicate the Predicate which evaluates if a result should count as a failure
+         * @return the CircuitBreakerConfig.Builder
+         */
+        public Builder recordResult(Predicate<Object> predicate) {
+            this.recordResultPredicate = predicate;
             return this;
         }
 

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/ResultRecordedAsFailureException.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/ResultRecordedAsFailureException.java
@@ -1,0 +1,25 @@
+package io.github.resilience4j.circuitbreaker;
+
+/**
+ * A {@link ResultRecordedAsFailureException} signals that a result has been recorded as a circuit breaker failure.
+ */
+public class ResultRecordedAsFailureException extends RuntimeException {
+
+    private final String circuitBreakerName;
+
+    private final Object result;
+
+    public ResultRecordedAsFailureException(String circuitBreakerName, Object result) {
+        super(String.format("CircuitBreaker '%s' has recorded '%s' as a failure", circuitBreakerName, result.toString()));
+        this.result = result;
+        this.circuitBreakerName = circuitBreakerName;
+    }
+
+    public Object getResult() {
+        return result;
+    }
+
+    public String getCircuitBreakerName() {
+        return circuitBreakerName;
+    }
+}

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfigTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfigTest.java
@@ -30,6 +30,9 @@ import static org.assertj.core.api.BDDAssertions.then;
 
 public class CircuitBreakerConfigTest {
 
+
+//    TODO: add tests here for record Result
+
     @Test(expected = IllegalArgumentException.class)
     public void zeroMaxFailuresShouldFail() {
         custom().failureRateThreshold(0).build();

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerEventPublisherTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerEventPublisherTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -55,7 +56,7 @@ public class CircuitBreakerEventPublisherTest {
         circuitBreaker.getEventPublisher()
             .onEvent(this::logEventType);
 
-        circuitBreaker.onSuccess(1000, TimeUnit.NANOSECONDS);
+        circuitBreaker.onSuccess(1000, TimeUnit.NANOSECONDS, Optional.empty());
 
         then(logger).should(times(1)).info("SUCCESS");
     }
@@ -65,7 +66,7 @@ public class CircuitBreakerEventPublisherTest {
         circuitBreaker.getEventPublisher()
             .onSuccess(this::logEventType);
 
-        circuitBreaker.onSuccess(1000, TimeUnit.NANOSECONDS);
+        circuitBreaker.onSuccess(1000, TimeUnit.NANOSECONDS, Optional.empty());
 
         then(logger).should(times(1)).info("SUCCESS");
     }
@@ -130,7 +131,7 @@ public class CircuitBreakerEventPublisherTest {
         circuitBreaker.onError(1000, TimeUnit.NANOSECONDS, new IOException("BAM!"));
         circuitBreaker.onError(1000, TimeUnit.NANOSECONDS, new IOException("BAM!"));
         circuitBreaker.tryAcquirePermission();
-        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
+        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty());
         circuitBreaker.onError(1000, TimeUnit.NANOSECONDS, new IOException("BAM!"));
 
         //Then we do not produce events

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerMetricsTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerMetricsTest.java
@@ -30,6 +30,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class CircuitBreakerMetricsTest {
 
+//    TODO: add tests here for record Result
+
     @Test
     public void testCircuitBreakerMetrics() {
         CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerResultHandlingTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerResultHandlingTest.java
@@ -1,0 +1,63 @@
+package io.github.resilience4j.circuitbreaker.internal;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.vavr.control.Either;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.custom;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CircuitBreakerResultHandlingTest {
+
+    @Test
+    public void shouldRecordSpecificStringResultAsAFailureAndAnyOtherAsSuccess() {
+        CircuitBreaker circuitBreaker = new CircuitBreakerStateMachine("testName", custom()
+            .slidingWindowSize(5)
+            .recordResult(result -> result.equals("failure"))
+            .build());
+
+        assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
+        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS, Optional.of("success"));
+
+        // Call 2 is a failure
+        assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
+        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS, Optional.of("failure"));
+
+        assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls()).isEqualTo(1);
+        assertThat(circuitBreaker.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(1);
+        assertThat(circuitBreaker.getMetrics().getNumberOfBufferedCalls()).isEqualTo(2);
+    }
+
+    @Test
+    public void shouldRecordSpecificComplexResultAsAFailureAndAnyOtherAsSuccess() {
+        CircuitBreaker circuitBreaker = new CircuitBreakerStateMachine("testName", custom()
+            .slidingWindowSize(5)
+            .recordResult(result ->
+                result instanceof Either && ((Either) result).isLeft() && ((Either) result).getLeft().equals("failure")
+            )
+            .build());
+
+        assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
+        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS, Optional.of(Either.left("accepted fail")));
+
+        // Call 2 is a failure
+        assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
+        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS, Optional.of(Either.left("failure")));
+
+        assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls()).isEqualTo(1);
+        assertThat(circuitBreaker.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(1);
+        assertThat(circuitBreaker.getMetrics().getNumberOfBufferedCalls()).isEqualTo(2);
+    }
+
+    private static class BusinessException extends Exception {
+
+        public BusinessException(String message) {
+            super(message);
+        }
+    }
+}

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachineTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachineTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 
 import java.time.Duration;
 import java.time.ZoneId;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static io.github.resilience4j.circuitbreaker.CircuitBreaker.State.FORCED_OPEN;
@@ -147,15 +148,15 @@ public class CircuitBreakerStateMachineTest {
 
     @Test
     public void shouldOpenAfterFailureRateThresholdExceeded2() {
-        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
+        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty());
 
         mockClock.advanceBySeconds(1);
 
-        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
+        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty());
 
         mockClock.advanceBySeconds(1);
 
-        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
+        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty());
 
         mockClock.advanceBySeconds(1);
 
@@ -209,13 +210,13 @@ public class CircuitBreakerStateMachineTest {
         // Call 4 is a success
         assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
         circuitBreaker
-            .onSuccess(0, TimeUnit.NANOSECONDS); // Should create a CircuitBreakerOnSuccessEvent
+            .onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty()); // Should create a CircuitBreakerOnSuccessEvent
         assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
         assertCircuitBreakerMetricsEqualTo(-1f, 1, 4, 3, 0L);
 
         // Call 5 is a success
         circuitBreaker
-            .onSuccess(0, TimeUnit.NANOSECONDS); // Should create a CircuitBreakerOnSuccessEvent
+            .onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty()); // Should create a CircuitBreakerOnSuccessEvent
 
         // The ring buffer is filled and the failure rate is above 50%
         assertThat(circuitBreaker.getState()).isEqualTo(
@@ -246,7 +247,7 @@ public class CircuitBreakerStateMachineTest {
 
         // Call 2 is slow
         assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
-        circuitBreaker.onSuccess(5, TimeUnit.SECONDS); // Should create a CircuitBreakerOnErrorEvent
+        circuitBreaker.onSuccess(5, TimeUnit.SECONDS, Optional.empty()); // Should create a CircuitBreakerOnErrorEvent
         assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
 
         // Call 3 is fast
@@ -258,12 +259,12 @@ public class CircuitBreakerStateMachineTest {
         // Call 4 is fast
         assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
         circuitBreaker
-            .onSuccess(100, TimeUnit.MILLISECONDS); // Should create a CircuitBreakerOnSuccessEvent
+            .onSuccess(100, TimeUnit.MILLISECONDS, Optional.empty()); // Should create a CircuitBreakerOnSuccessEvent
         assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
 
         // Call 5 is slow
         circuitBreaker
-            .onSuccess(5, TimeUnit.SECONDS); // Should create a CircuitBreakerOnSuccessEvent
+            .onSuccess(5, TimeUnit.SECONDS, Optional.empty()); // Should create a CircuitBreakerOnSuccessEvent
 
         // The ring buffer is filled and the slow call rate is above 50%
         assertThat(circuitBreaker.getState()).isEqualTo(
@@ -377,7 +378,7 @@ public class CircuitBreakerStateMachineTest {
         // Call 3 is a success
         assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
         circuitBreaker.onSuccess(0,
-            TimeUnit.NANOSECONDS); // Should create a CircuitBreakerOnSuccessEvent (12)
+            TimeUnit.NANOSECONDS, Optional.empty()); // Should create a CircuitBreakerOnSuccessEvent (12)
         // Call 2 is a failure
         assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
         circuitBreaker.onError(0, TimeUnit.NANOSECONDS,
@@ -399,19 +400,19 @@ public class CircuitBreakerStateMachineTest {
 
         // Call 1 is slow
         assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
-        circuitBreaker.onSuccess(5, TimeUnit.SECONDS);
+        circuitBreaker.onSuccess(5, TimeUnit.SECONDS, Optional.empty());
 
         // Call 2 is slow
         assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
-        circuitBreaker.onSuccess(5, TimeUnit.SECONDS);
+        circuitBreaker.onSuccess(5, TimeUnit.SECONDS, Optional.empty());
 
         // Call 3 is slow
         assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
-        circuitBreaker.onSuccess(5, TimeUnit.SECONDS);
+        circuitBreaker.onSuccess(5, TimeUnit.SECONDS, Optional.empty());
 
         // Call 4 is fast
         assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
-        circuitBreaker.onSuccess(1, TimeUnit.SECONDS);
+        circuitBreaker.onSuccess(1, TimeUnit.SECONDS, Optional.empty());
 
         // The failure rate is blow 50%, but slow call rate is above 50%
         // The state machine transitions back to OPEN state
@@ -438,17 +439,17 @@ public class CircuitBreakerStateMachineTest {
         // Call 2 is a success
         assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
         circuitBreaker
-            .onSuccess(0, TimeUnit.NANOSECONDS); // Should create a CircuitBreakerOnSuccessEvent
+            .onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty()); // Should create a CircuitBreakerOnSuccessEvent
 
         // Call 3 is a success
         assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
         circuitBreaker
-            .onSuccess(0, TimeUnit.NANOSECONDS); // Should create a CircuitBreakerOnSuccessEvent
+            .onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty()); // Should create a CircuitBreakerOnSuccessEvent
 
         // Call 4 is a success
         assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
         circuitBreaker
-            .onSuccess(0, TimeUnit.NANOSECONDS); // Should create a CircuitBreakerOnSuccessEvent
+            .onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty()); // Should create a CircuitBreakerOnSuccessEvent
 
         // The ring buffer is filled and the failure rate is below 50%
         // The state machine transitions back to CLOSED state
@@ -460,7 +461,7 @@ public class CircuitBreakerStateMachineTest {
         // // Call 5 is a success and fills the buffer in closed state
         assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
         circuitBreaker
-            .onSuccess(0, TimeUnit.NANOSECONDS); // Should create a CircuitBreakerOnSuccessEvent
+            .onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty()); // Should create a CircuitBreakerOnSuccessEvent
         assertCircuitBreakerMetricsEqualTo(-1f, 1, 1, 0, 0L);
 
     }
@@ -471,7 +472,7 @@ public class CircuitBreakerStateMachineTest {
             CircuitBreaker.State.CLOSED); // Should create a CircuitBreakerOnStateTransitionEvent (21)
         assertThatMetricsAreReset();
 
-        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
+        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty());
         circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new RuntimeException());
 
         assertCircuitBreakerMetricsEqualTo(-1f, 1, 2, 1, 0L);
@@ -492,7 +493,7 @@ public class CircuitBreakerStateMachineTest {
 
         assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
         circuitBreaker
-            .onSuccess(0, TimeUnit.NANOSECONDS); // Should not create a CircuitBreakerOnSuccessEvent
+            .onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty()); // Should not create a CircuitBreakerOnSuccessEvent
 
         assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
         circuitBreaker.onError(0, TimeUnit.NANOSECONDS,
@@ -541,17 +542,17 @@ public class CircuitBreakerStateMachineTest {
         assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.HALF_OPEN);
 
         assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
-        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
+        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty());
         assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.HALF_OPEN);
         assertCircuitBreakerMetricsEqualTo(-1f, 1, 1, 0, 0L);
 
         assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
-        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
+        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty());
         assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.HALF_OPEN);
         assertCircuitBreakerMetricsEqualTo(-1f, 2, 2, 0, 0L);
 
         assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
-        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS); //
+        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty()); //
         assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.HALF_OPEN);
         assertCircuitBreakerMetricsEqualTo(-1f, 3, 3, 0, 0L);
 
@@ -596,21 +597,21 @@ public class CircuitBreakerStateMachineTest {
         assertCircuitBreakerMetricsEqualTo(-1f, 0, 0, 0, 0L);
 
         assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
-        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS); //
+        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty()); //
         assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.HALF_OPEN);
 
         assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
-        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS); //
+        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty()); //
         assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.HALF_OPEN);
 
         assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
-        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS); //
+        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty()); //
         assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.HALF_OPEN);
 
         assertCircuitBreakerMetricsEqualTo(-1f, 3, 3, 0, 0L);
 
         assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
-        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS); //
+        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty()); //
         assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
 
         assertCircuitBreakerMetricsEqualTo(-1f, 0, 0, 0, 0L);
@@ -635,8 +636,8 @@ public class CircuitBreakerStateMachineTest {
 
     @Test
     public void shouldResetClosedState() {
-        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
-        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
+        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty());
+        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty());
         assertThat(circuitBreaker.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(2);
 
         circuitBreaker.reset();
@@ -646,8 +647,8 @@ public class CircuitBreakerStateMachineTest {
 
     @Test
     public void shouldResetMetricsAfterMetricsOnlyStateTransition() {
-        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
-        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
+        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty());
+        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty());
         assertThat(circuitBreaker.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(2);
 
         circuitBreaker.transitionToMetricsOnlyState();
@@ -691,13 +692,13 @@ public class CircuitBreakerStateMachineTest {
 
         // Call 4 is a success
         assertThat(circuitBreaker.tryAcquirePermission()).isEqualTo(true);
-        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
+        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty());
         verify(mockOnSuccessEventConsumer, times(1)).consumeEvent(any(CircuitBreakerOnSuccessEvent.class));
         assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.METRICS_ONLY);
         assertCircuitBreakerMetricsEqualTo(-1f, 1, 4, 3, 0L);
 
         // Call 5 is a success
-        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
+        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty());
         verify(mockOnSuccessEventConsumer, times(2)).consumeEvent(any(CircuitBreakerOnSuccessEvent.class));
 
         // The ring buffer is filled and the failure rate is above 50%

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachineTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachineTest.java
@@ -55,6 +55,8 @@ public class CircuitBreakerStateMachineTest {
     private EventConsumer<CircuitBreakerOnFailureRateExceededEvent> mockOnFailureRateExceededEventConsumer;
     private EventConsumer<CircuitBreakerOnSlowCallRateExceededEvent> mockOnSlowCallRateExceededEventConsumer;
 
+//    TODO: add tests here for record Result
+
     @Before
     public void setUp() {
         mockOnSuccessEventConsumer = (EventConsumer<CircuitBreakerOnSuccessEvent>) mock(EventConsumer.class);

--- a/resilience4j-consumer/src/test/java/io/github/resilience4j/consumer/CircularEventConsumerTest.java
+++ b/resilience4j-consumer/src/test/java/io/github/resilience4j/consumer/CircularEventConsumerTest.java
@@ -24,6 +24,7 @@ import io.github.resilience4j.circuitbreaker.event.CircuitBreakerEvent;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static io.github.resilience4j.circuitbreaker.event.CircuitBreakerEvent.Type;
@@ -62,7 +63,7 @@ public class CircularEventConsumerTest {
         circuitBreaker.getEventPublisher().onEvent(ringBuffer);
         assertThat(ringBuffer.getBufferedEvents()).isEmpty();
 
-        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
+        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty());
         circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new RuntimeException("Bla"));
         circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new IOException("Bla"));
         circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new RuntimeException("Bla"));

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/CircuitBreaker.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/CircuitBreaker.kt
@@ -20,6 +20,7 @@ package io.github.resilience4j.kotlin.circuitbreaker
 
 import io.github.resilience4j.circuitbreaker.CircuitBreaker
 import io.github.resilience4j.kotlin.isCancellation
+import java.util.*
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.coroutineContext
 
@@ -32,7 +33,7 @@ suspend fun <T> CircuitBreaker.executeSuspendFunction(block: suspend () -> T): T
     try {
         val result = block()
         val durationInNanos = System.nanoTime() - start
-        onSuccess(durationInNanos, TimeUnit.NANOSECONDS)
+        onSuccess(durationInNanos, TimeUnit.NANOSECONDS, Optional.of(result))
         return result
     } catch (exception: Throwable) {
         if (isCancellation(coroutineContext, exception)) {

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/FlowCircuitBreaker.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/FlowCircuitBreaker.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onCompletion
+import java.util.*
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.coroutineContext
 
@@ -57,7 +58,7 @@ fun <T> Flow<T>.circuitBreaker(circuitBreaker: CircuitBreaker): Flow<T> =
                     .releasePermission()
 
                 e == null -> circuitBreaker
-                    .onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS)
+                    .onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS, Optional.empty<T>())
 
                 else -> circuitBreaker
                     .onError(System.nanoTime() - start, TimeUnit.NANOSECONDS, e)
@@ -66,4 +67,3 @@ fun <T> Flow<T>.circuitBreaker(circuitBreaker: CircuitBreaker): Flow<T> =
 
         emitAll(source)
     }
-

--- a/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/StateTransitionMetricsTest.java
+++ b/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/StateTransitionMetricsTest.java
@@ -28,6 +28,7 @@ import io.github.resilience4j.metrics.publisher.CircuitBreakerMetricsPublisher;
 import org.junit.Test;
 
 import java.time.Duration;
+import java.util.Optional;
 import java.util.SortedMap;
 import java.util.concurrent.TimeUnit;
 
@@ -83,7 +84,7 @@ public class StateTransitionMetricsTest {
                 return circuitBreaker.getState().equals(CircuitBreaker.State.HALF_OPEN);
             });
 
-        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
+        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty());
         assertThat(circuitBreaker.getState(), equalTo(CircuitBreaker.State.HALF_OPEN));
         assertThat(circuitBreaker.getMetrics().getNumberOfBufferedCalls(), equalTo(1));
         assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls(), equalTo(0));
@@ -94,7 +95,7 @@ public class StateTransitionMetricsTest {
         assertThat(gauges.get("resilience4j.circuitbreaker.test.failed").getValue(), equalTo(0));
         assertThat(gauges.get("resilience4j.circuitbreaker.test.successful").getValue(),
             equalTo(1));
-        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
+        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty());
         assertThat(circuitBreaker.getState(), equalTo(CircuitBreaker.State.HALF_OPEN));
         assertThat(circuitBreaker.getMetrics().getNumberOfBufferedCalls(), equalTo(2));
         assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls(), equalTo(0));
@@ -105,7 +106,7 @@ public class StateTransitionMetricsTest {
         assertThat(gauges.get("resilience4j.circuitbreaker.test.failed").getValue(), equalTo(0));
         assertThat(gauges.get("resilience4j.circuitbreaker.test.successful").getValue(),
             equalTo(2));
-        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
+        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty());
         assertThat(circuitBreaker.getState(), equalTo(CircuitBreaker.State.CLOSED));
         assertThat(circuitBreaker.getMetrics().getNumberOfBufferedCalls(), equalTo(0));
         assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls(), equalTo(0));

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetricsPublisherTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetricsPublisherTest.java
@@ -57,10 +57,10 @@ public class TaggedCircuitBreakerMetricsPublisherTest {
         circuitBreaker = circuitBreakerRegistry
             .circuitBreaker("backendA", configWithSlowCallThreshold);
         // record some basic stats
-        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
+        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty());
         circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new RuntimeException("oops"));
         // record slow call
-        circuitBreaker.onSuccess(2000, TimeUnit.NANOSECONDS);
+        circuitBreaker.onSuccess(2000, TimeUnit.NANOSECONDS, Optional.empty());
         circuitBreaker.onError(2000, TimeUnit.NANOSECONDS, new RuntimeException("oops"));
 
     }
@@ -68,7 +68,7 @@ public class TaggedCircuitBreakerMetricsPublisherTest {
     @Test
     public void shouldAddMetricsForANewlyCreatedCircuitBreaker() {
         CircuitBreaker newCircuitBreaker = circuitBreakerRegistry.circuitBreaker("backendB");
-        newCircuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
+        newCircuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty());
 
         assertThat(taggedCircuitBreakerMetricsPublisher.meterIdMap)
             .containsKeys("backendA", "backendB");
@@ -230,7 +230,7 @@ public class TaggedCircuitBreakerMetricsPublisherTest {
         // add meters of old
         taggedCircuitBreakerMetricsPublisher.addMetrics(meterRegistry, oldOne);
         // one success call
-        oldOne.onSuccess(0, TimeUnit.NANOSECONDS);
+        oldOne.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty());
 
         assertThat(taggedCircuitBreakerMetricsPublisher.meterIdMap).containsKeys("backendC");
         assertThat(taggedCircuitBreakerMetricsPublisher.meterIdMap.get("backendC")).hasSize(16);
@@ -245,9 +245,9 @@ public class TaggedCircuitBreakerMetricsPublisherTest {
         // add meters of new
         taggedCircuitBreakerMetricsPublisher.addMetrics(meterRegistry, newOne);
         // three success call
-        newOne.onSuccess(0, TimeUnit.NANOSECONDS);
-        newOne.onSuccess(0, TimeUnit.NANOSECONDS);
-        newOne.onSuccess(0, TimeUnit.NANOSECONDS);
+        newOne.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty());
+        newOne.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty());
+        newOne.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty());
 
         assertThat(taggedCircuitBreakerMetricsPublisher.meterIdMap).containsKeys("backendC");
         assertThat(taggedCircuitBreakerMetricsPublisher.meterIdMap.get("backendC")).hasSize(16);

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetricsTest.java
@@ -53,10 +53,10 @@ public class TaggedCircuitBreakerMetricsTest {
         circuitBreaker = circuitBreakerRegistry
             .circuitBreaker("backendA", configWithSlowCallThreshold);
         // record some basic stats
-        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
+        circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty());
         circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new RuntimeException("oops"));
         // record slow calls
-        circuitBreaker.onSuccess(2000, TimeUnit.NANOSECONDS);
+        circuitBreaker.onSuccess(2000, TimeUnit.NANOSECONDS, Optional.empty());
         circuitBreaker.onError(2000, TimeUnit.NANOSECONDS, new RuntimeException("oops"));
 
         taggedCircuitBreakerMetrics = TaggedCircuitBreakerMetrics
@@ -67,7 +67,7 @@ public class TaggedCircuitBreakerMetricsTest {
     @Test
     public void shouldAddMetricsForANewlyCreatedCircuitBreaker() {
         CircuitBreaker newCircuitBreaker = circuitBreakerRegistry.circuitBreaker("backendB");
-        newCircuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
+        newCircuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty());
 
         assertThat(taggedCircuitBreakerMetrics.meterIdMap).containsKeys("backendA", "backendB");
         assertThat(taggedCircuitBreakerMetrics.meterIdMap.get("backendA")).hasSize(16);
@@ -90,7 +90,7 @@ public class TaggedCircuitBreakerMetricsTest {
     @Test
     public void shouldAddCustomTags() {
         CircuitBreaker circuitBreakerF = circuitBreakerRegistry.circuitBreaker("backendF", io.vavr.collection.HashMap.of("key1", "value1"));
-        circuitBreakerF.onSuccess(0, TimeUnit.NANOSECONDS);
+        circuitBreakerF.onSuccess(0, TimeUnit.NANOSECONDS, Optional.empty());
         assertThat(taggedCircuitBreakerMetrics.meterIdMap).containsKeys("backendA", "backendF");
         assertThat(taggedCircuitBreakerMetrics.meterIdMap.get("backendF")).hasSize(16);
         List<Meter> meters = meterRegistry.getMeters();

--- a/resilience4j-prometheus/src/test/java/io/github/resilience4j/prometheus/collectors/CircuitBreakerMetricsCollectorTest.java
+++ b/resilience4j-prometheus/src/test/java/io/github/resilience4j/prometheus/collectors/CircuitBreakerMetricsCollectorTest.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static io.github.resilience4j.prometheus.AbstractCircuitBreakerMetrics.MetricNames;
@@ -51,7 +52,7 @@ public class CircuitBreakerMetricsCollectorTest {
 
         // record some basic stats
         // SLOW_SUCCESS
-        circuitBreaker.onSuccess(2000, TimeUnit.NANOSECONDS);
+        circuitBreaker.onSuccess(2000, TimeUnit.NANOSECONDS, Optional.empty());
         circuitBreaker.onError(100, TimeUnit.NANOSECONDS, new RuntimeException("oops"));
         circuitBreaker.transitionToOpenState();
     }
@@ -252,7 +253,7 @@ public class CircuitBreakerMetricsCollectorTest {
             MetricOptions.custom().buckets(new double[]{.005, .01}).build(),
             circuitBreakerRegistry).register(registry);
 
-        circuitBreaker.onSuccess(2000, TimeUnit.NANOSECONDS);
+        circuitBreaker.onSuccess(2000, TimeUnit.NANOSECONDS, Optional.empty());
 
         assertThat(registry.getSampleValue(
             DEFAULT_CIRCUIT_BREAKER_CALLS + "_bucket",

--- a/resilience4j-prometheus/src/test/java/io/github/resilience4j/prometheus/publisher/CircuitBreakerMetricsPublisherTest.java
+++ b/resilience4j-prometheus/src/test/java/io/github/resilience4j/prometheus/publisher/CircuitBreakerMetricsPublisherTest.java
@@ -24,6 +24,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static io.github.resilience4j.prometheus.AbstractCircuitBreakerMetrics.MetricNames;
@@ -53,7 +54,7 @@ public class CircuitBreakerMetricsPublisherTest {
 
         // record some basic stats
         // SLOW_SUCCESS
-        circuitBreaker.onSuccess(2000, TimeUnit.NANOSECONDS);
+        circuitBreaker.onSuccess(2000, TimeUnit.NANOSECONDS, Optional.empty());
         circuitBreaker.onError(100, TimeUnit.NANOSECONDS, new RuntimeException("oops"));
         circuitBreaker.transitionToOpenState();
     }
@@ -261,7 +262,7 @@ public class CircuitBreakerMetricsPublisherTest {
             .of(CircuitBreakerConfig.ofDefaults(), circuitBreakerMetricsPublisher);
         CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("backendA");
 
-        circuitBreaker.onSuccess(2000, TimeUnit.NANOSECONDS);
+        circuitBreaker.onSuccess(2000, TimeUnit.NANOSECONDS, Optional.empty());
 
         assertThat(registry.getSampleValue(
             DEFAULT_CIRCUIT_BREAKER_CALLS + "_bucket",

--- a/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/circuitbreaker/CircuitBreakerMethodInterceptor.java
+++ b/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/circuitbreaker/CircuitBreakerMethodInterceptor.java
@@ -125,7 +125,7 @@ public class CircuitBreakerMethodInterceptor extends AbstractMethodInterceptor {
                             breaker.onError(durationInNanos, TimeUnit.NANOSECONDS, t);
                             completeFailedFuture(t, fallbackMethod, promise);
                         } else {
-                            breaker.onSuccess(durationInNanos, TimeUnit.NANOSECONDS);
+                            breaker.onSuccess(durationInNanos, TimeUnit.NANOSECONDS, Optional.of(v));
                             promise.complete(v);
                         }
                     });

--- a/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/circuitbreaker/CircuitBreakerTransformer.java
+++ b/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/circuitbreaker/CircuitBreakerTransformer.java
@@ -22,6 +22,7 @@ import ratpack.exec.Downstream;
 import ratpack.exec.Upstream;
 import ratpack.func.Function;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 public class CircuitBreakerTransformer<T> extends AbstractTransformer<T> {
@@ -67,7 +68,7 @@ public class CircuitBreakerTransformer<T> extends AbstractTransformer<T> {
                     @Override
                     public void success(T value) {
                         long durationInNanos = System.nanoTime() - start;
-                        circuitBreaker.onSuccess(durationInNanos, TimeUnit.NANOSECONDS);
+                        circuitBreaker.onSuccess(durationInNanos, TimeUnit.NANOSECONDS, Optional.of(value));
                         down.success(value);
                     }
 

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/FluxCircuitBreakerTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/FluxCircuitBreakerTest.java
@@ -25,6 +25,7 @@ import reactor.test.StepVerifier;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.BDDMockito.given;
@@ -50,7 +51,7 @@ public class FluxCircuitBreakerTest {
             .expectNext("Event 2")
             .verifyComplete();
 
-        verify(circuitBreaker, times(1)).onSuccess(anyLong(), any(TimeUnit.class));
+        verify(circuitBreaker, times(1)).onSuccess(anyLong(), any(TimeUnit.class), Optional.of("Event 1"));
         verify(circuitBreaker, never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }
@@ -67,7 +68,7 @@ public class FluxCircuitBreakerTest {
 
         verify(circuitBreaker, times(1))
             .onError(anyLong(), any(TimeUnit.class), any(IOException.class));
-        verify(circuitBreaker, never()).onSuccess(anyLong(), any(TimeUnit.class));
+        verify(circuitBreaker, never()).onSuccess(anyLong(), any(TimeUnit.class), any());
     }
 
     @Test
@@ -82,7 +83,7 @@ public class FluxCircuitBreakerTest {
 
         verify(circuitBreaker, times(1))
             .onError(anyLong(), any(TimeUnit.class), any(IOException.class));
-        verify(circuitBreaker, never()).onSuccess(anyLong(), any(TimeUnit.class));
+        verify(circuitBreaker, never()).onSuccess(anyLong(), any(TimeUnit.class), any());
     }
 
     @Test
@@ -96,7 +97,7 @@ public class FluxCircuitBreakerTest {
             .expectNext("Bla Event 2")
             .verifyComplete();
 
-        verify(circuitBreaker, times(2)).onSuccess(anyLong(), any(TimeUnit.class));
+        verify(circuitBreaker, times(2)).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
         verify(circuitBreaker, never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }
@@ -113,7 +114,7 @@ public class FluxCircuitBreakerTest {
 
         verify(circuitBreaker, never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
-        verify(circuitBreaker, never()).onSuccess(anyLong(), any(TimeUnit.class));
+        verify(circuitBreaker, never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
     }
 
     @Test
@@ -128,7 +129,7 @@ public class FluxCircuitBreakerTest {
 
         verify(circuitBreaker, never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
-        verify(circuitBreaker, never()).onSuccess(anyLong(), any(TimeUnit.class));
+        verify(circuitBreaker, never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
     }
 
     @Test
@@ -143,7 +144,7 @@ public class FluxCircuitBreakerTest {
 
         verify(circuitBreaker, never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
-        verify(circuitBreaker, never()).onSuccess(anyLong(), any(TimeUnit.class));
+        verify(circuitBreaker, never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
     }
 
     @Test
@@ -161,7 +162,7 @@ public class FluxCircuitBreakerTest {
         verify(circuitBreaker, times(1)).releasePermission();
         verify(circuitBreaker, never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
-        verify(circuitBreaker, never()).onSuccess(anyLong(), any(TimeUnit.class));
+        verify(circuitBreaker, never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
     }
 
     @Test
@@ -179,6 +180,6 @@ public class FluxCircuitBreakerTest {
         verify(circuitBreaker, never()).releasePermission();
         verify(circuitBreaker, never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
-        verify(circuitBreaker, times(1)).onSuccess(anyLong(), any(TimeUnit.class));
+        verify(circuitBreaker, times(1)).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
     }
 }

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/MonoCircuitBreakerTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/MonoCircuitBreakerTest.java
@@ -25,6 +25,7 @@ import reactor.test.StepVerifier;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -58,7 +59,7 @@ public class MonoCircuitBreakerTest {
             .verifyComplete();
 
         then(helloWorldService).should().returnHelloWorld();
-        verify(circuitBreaker, times(1)).onSuccess(anyLong(), any(TimeUnit.class));
+        verify(circuitBreaker, times(1)).onSuccess(anyLong(), any(TimeUnit.class), Optional.of("Hello World"));
         verify(circuitBreaker, never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }
@@ -75,7 +76,7 @@ public class MonoCircuitBreakerTest {
             .verifyComplete();
 
         then(helloWorldService).should().returnHelloWorld();
-        verify(circuitBreaker, times(1)).onSuccess(anyLong(), any(TimeUnit.class));
+        verify(circuitBreaker, times(1)).onSuccess(anyLong(), any(TimeUnit.class), Optional.of("Hello World"));
         verify(circuitBreaker, never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }
@@ -95,7 +96,7 @@ public class MonoCircuitBreakerTest {
             .verifyComplete();
 
         then(helloWorldService).should(times(3)).returnHelloWorld();
-        verify(circuitBreaker, times(3)).onSuccess(anyLong(), any(TimeUnit.class));
+        verify(circuitBreaker, times(3)).onSuccess(anyLong(), any(TimeUnit.class), Optional.of("Hello World"));
         verify(circuitBreaker, never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }
@@ -109,7 +110,7 @@ public class MonoCircuitBreakerTest {
                 .transformDeferred(CircuitBreakerOperator.of(circuitBreaker)))
             .verifyComplete();
 
-        verify(circuitBreaker, times(1)).onSuccess(anyLong(), any(TimeUnit.class));
+        verify(circuitBreaker, times(1)).onSuccess(anyLong(), any(TimeUnit.class), Optional.of("Hello World"));
         verify(circuitBreaker, never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }
@@ -126,7 +127,7 @@ public class MonoCircuitBreakerTest {
 
         verify(circuitBreaker, times(1))
             .onError(anyLong(), any(TimeUnit.class), any(IOException.class));
-        verify(circuitBreaker, never()).onSuccess(anyLong(), any(TimeUnit.class));
+        verify(circuitBreaker, never()).onSuccess(anyLong(), any(TimeUnit.class), Optional.of("Hello World"));
     }
 
     @Test
@@ -141,7 +142,7 @@ public class MonoCircuitBreakerTest {
 
         verify(circuitBreaker, never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
-        verify(circuitBreaker, never()).onSuccess(anyLong(), any(TimeUnit.class));
+        verify(circuitBreaker, never()).onSuccess(anyLong(), any(TimeUnit.class), Optional.of("Hello World"));
     }
 
     @Test
@@ -156,7 +157,7 @@ public class MonoCircuitBreakerTest {
 
         verify(circuitBreaker, never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
-        verify(circuitBreaker, never()).onSuccess(anyLong(), any(TimeUnit.class));
+        verify(circuitBreaker, never()).onSuccess(anyLong(), any(TimeUnit.class), Optional.of("Hello World"));
     }
 
     @Test
@@ -174,7 +175,7 @@ public class MonoCircuitBreakerTest {
         verify(circuitBreaker, times(1)).releasePermission();
         verify(circuitBreaker, never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
-        verify(circuitBreaker, never()).onSuccess(anyLong(), any(TimeUnit.class));
+        verify(circuitBreaker, never()).onSuccess(anyLong(), any(TimeUnit.class), Optional.of("Hello World"));
     }
 
     @Test
@@ -190,7 +191,7 @@ public class MonoCircuitBreakerTest {
             .verify();
 
         then(helloWorldService).should(never()).returnHelloWorld();
-        verify(circuitBreaker, never()).onSuccess(anyLong(), any(TimeUnit.class));
+        verify(circuitBreaker, never()).onSuccess(anyLong(), any(TimeUnit.class), Optional.of("Hello World"));
         verify(circuitBreaker, never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }

--- a/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/RetrofitCircuitBreaker.java
+++ b/resilience4j-retrofit/src/main/java/io/github/resilience4j/retrofit/RetrofitCircuitBreaker.java
@@ -27,6 +27,7 @@ import retrofit2.Callback;
 import retrofit2.Response;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
@@ -84,7 +85,7 @@ public interface RetrofitCircuitBreaker {
                 @Override
                 public void onResponse(final Call<T> call, final Response<T> response) {
                     if (responseSuccess.test(response)) {
-                        circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+                        circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS, Optional.of(response));
                     } else {
                         final Throwable throwable = new Throwable(
                             "Response error: HTTP " + response.code() + " - " + response.message());
@@ -114,7 +115,7 @@ public interface RetrofitCircuitBreaker {
                 final Response<T> response = call.execute();
 
                 if (responseSuccess.test(response)) {
-                    circuitBreaker.onSuccess(stopWatch.stop().toNanos(), TimeUnit.NANOSECONDS);
+                    circuitBreaker.onSuccess(stopWatch.stop().toNanos(), TimeUnit.NANOSECONDS, Optional.of(response));
                 } else {
                     final Throwable throwable = new Throwable(
                         "Response error: HTTP " + response.code() + " - " + response.message());

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/AbstractMaybeObserver.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/AbstractMaybeObserver.java
@@ -41,11 +41,11 @@ public abstract class AbstractMaybeObserver<T> extends AbstractDisposable implem
     @Override
     public void onSuccess(T value) {
         whenNotCompleted(() -> {
-            hookOnSuccess();
+            hookOnSuccess(value);
             downstreamObserver.onSuccess(value);
         });
     }
 
-    protected abstract void hookOnSuccess();
+    protected abstract void hookOnSuccess(T value);
 
 }

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/AbstractSingleObserver.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/AbstractSingleObserver.java
@@ -31,11 +31,11 @@ public abstract class AbstractSingleObserver<T> extends AbstractDisposable imple
     @Override
     public void onSuccess(T value) {
         whenNotCompleted(() -> {
-            hookOnSuccess();
+            hookOnSuccess(value);
             downstreamObserver.onSuccess(value);
         });
     }
 
-    protected abstract void hookOnSuccess();
+    protected abstract void hookOnSuccess(T value);
 
 }

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/MaybeBulkhead.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/MaybeBulkhead.java
@@ -59,7 +59,7 @@ class MaybeBulkhead<T> extends Maybe<T> {
         }
 
         @Override
-        protected void hookOnSuccess() {
+        protected void hookOnSuccess(T value) {
             bulkhead.onComplete();
         }
 

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/SingleBulkhead.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/bulkhead/operator/SingleBulkhead.java
@@ -54,7 +54,7 @@ class SingleBulkhead<T> extends Single<T> {
         }
 
         @Override
-        protected void hookOnSuccess() {
+        protected void hookOnSuccess(T value) {
             bulkhead.onComplete();
         }
 

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/CompletableCircuitBreaker.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/CompletableCircuitBreaker.java
@@ -21,6 +21,7 @@ import io.reactivex.Completable;
 import io.reactivex.CompletableObserver;
 import io.reactivex.internal.disposables.EmptyDisposable;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static io.github.resilience4j.circuitbreaker.CallNotPermittedException.createCallNotPermittedException;
@@ -56,7 +57,7 @@ class CompletableCircuitBreaker extends Completable {
 
         @Override
         protected void hookOnComplete() {
-            circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+            circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS, Optional.empty());
         }
 
         @Override

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/FlowableCircuitBreaker.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/FlowableCircuitBreaker.java
@@ -23,6 +23,7 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static io.github.resilience4j.circuitbreaker.CallNotPermittedException.createCallNotPermittedException;
@@ -64,13 +65,13 @@ class FlowableCircuitBreaker<T> extends Flowable<T> {
 
         @Override
         public void hookOnComplete() {
-            circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+            circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS, Optional.empty());
         }
 
         @Override
         public void hookOnCancel() {
             if (eventWasEmitted.get()) {
-                circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+                circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS, Optional.empty());
             } else {
                 circuitBreaker.releasePermission();
             }

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/MaybeCircuitBreaker.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/MaybeCircuitBreaker.java
@@ -21,6 +21,7 @@ import io.reactivex.Maybe;
 import io.reactivex.MaybeObserver;
 import io.reactivex.internal.disposables.EmptyDisposable;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static io.github.resilience4j.circuitbreaker.CallNotPermittedException.createCallNotPermittedException;
@@ -56,7 +57,7 @@ class MaybeCircuitBreaker<T> extends Maybe<T> {
 
         @Override
         protected void hookOnComplete() {
-            circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+            circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS, Optional.empty());
         }
 
         @Override
@@ -65,8 +66,8 @@ class MaybeCircuitBreaker<T> extends Maybe<T> {
         }
 
         @Override
-        protected void hookOnSuccess() {
-            circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+        protected void hookOnSuccess(T value) {
+            circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS, Optional.of(value));
         }
 
         @Override

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/ObserverCircuitBreaker.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/ObserverCircuitBreaker.java
@@ -21,6 +21,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.internal.disposables.EmptyDisposable;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static io.github.resilience4j.circuitbreaker.CallNotPermittedException.createCallNotPermittedException;
@@ -61,13 +62,13 @@ class ObserverCircuitBreaker<T> extends Observable<T> {
 
         @Override
         protected void hookOnComplete() {
-            circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+            circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS, Optional.empty());
         }
 
         @Override
         protected void hookOnCancel() {
             if (eventWasEmitted.get()) {
-                circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+                circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS, Optional.empty());
             } else {
                 circuitBreaker.releasePermission();
             }

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/SingleCircuitBreaker.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/SingleCircuitBreaker.java
@@ -21,6 +21,7 @@ import io.reactivex.Single;
 import io.reactivex.SingleObserver;
 import io.reactivex.internal.disposables.EmptyDisposable;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static io.github.resilience4j.circuitbreaker.CallNotPermittedException.createCallNotPermittedException;
@@ -60,8 +61,8 @@ class SingleCircuitBreaker<T> extends Single<T> {
         }
 
         @Override
-        protected void hookOnSuccess() {
-            circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+        protected void hookOnSuccess(T value) {
+            circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS, Optional.of(value));
         }
 
         @Override

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/ratelimiter/operator/MaybeRateLimiter.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/ratelimiter/operator/MaybeRateLimiter.java
@@ -68,7 +68,7 @@ class MaybeRateLimiter<T> extends Maybe<T> {
         }
 
         @Override
-        protected void hookOnSuccess() {
+        protected void hookOnSuccess(T value) {
             // NoOp
         }
 

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/ratelimiter/operator/SingleRateLimiter.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/ratelimiter/operator/SingleRateLimiter.java
@@ -63,7 +63,7 @@ class SingleRateLimiter<T> extends Single<T> {
         }
 
         @Override
-        protected void hookOnSuccess() {
+        protected void hookOnSuccess(T value) {
             // NoOp
         }
 

--- a/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/CompletableCircuitBreakerTest.java
+++ b/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/CompletableCircuitBreakerTest.java
@@ -5,6 +5,7 @@ import io.reactivex.Completable;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -28,7 +29,7 @@ public class CompletableCircuitBreakerTest extends BaseCircuitBreakerTest {
             .assertSubscribed()
             .assertComplete();
 
-        then(circuitBreaker).should().onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should().onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }
@@ -46,7 +47,7 @@ public class CompletableCircuitBreakerTest extends BaseCircuitBreakerTest {
 
         then(circuitBreaker).should()
             .onError(anyLong(), any(TimeUnit.class), any(IOException.class));
-        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
     }
 
     @Test
@@ -60,7 +61,7 @@ public class CompletableCircuitBreakerTest extends BaseCircuitBreakerTest {
             .assertError(CallNotPermittedException.class)
             .assertNotComplete();
 
-        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }

--- a/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/FlowableCircuitBreakerTest.java
+++ b/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/FlowableCircuitBreakerTest.java
@@ -5,6 +5,7 @@ import io.reactivex.Flowable;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -27,7 +28,7 @@ public class FlowableCircuitBreakerTest extends BaseCircuitBreakerTest {
             .test()
             .assertResult("Event 1", "Event 2");
 
-        then(circuitBreaker).should().onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should().onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }
@@ -45,7 +46,7 @@ public class FlowableCircuitBreakerTest extends BaseCircuitBreakerTest {
 
         then(circuitBreaker).should()
             .onError(anyLong(), any(TimeUnit.class), any(IOException.class));
-        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
     }
 
     @Test
@@ -59,7 +60,7 @@ public class FlowableCircuitBreakerTest extends BaseCircuitBreakerTest {
             .assertError(CallNotPermittedException.class)
             .assertNotComplete();
 
-        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }
@@ -77,7 +78,7 @@ public class FlowableCircuitBreakerTest extends BaseCircuitBreakerTest {
         then(circuitBreaker).should().releasePermission();
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
-        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
     }
 
     @Test
@@ -92,6 +93,6 @@ public class FlowableCircuitBreakerTest extends BaseCircuitBreakerTest {
         then(circuitBreaker).should(never()).releasePermission();
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
-        then(circuitBreaker).should().onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should().onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
     }
 }

--- a/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/MaybeCircuitBreakerTest.java
+++ b/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/MaybeCircuitBreakerTest.java
@@ -5,6 +5,7 @@ import io.reactivex.Maybe;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -27,7 +28,7 @@ public class MaybeCircuitBreakerTest extends BaseCircuitBreakerTest {
             .test()
             .assertResult(1);
 
-        then(circuitBreaker).should().onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should().onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }
@@ -45,7 +46,7 @@ public class MaybeCircuitBreakerTest extends BaseCircuitBreakerTest {
 
         then(circuitBreaker).should()
             .onError(anyLong(), any(TimeUnit.class), any(IOException.class));
-        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
     }
 
 
@@ -60,7 +61,7 @@ public class MaybeCircuitBreakerTest extends BaseCircuitBreakerTest {
             .assertError(CallNotPermittedException.class)
             .assertNotComplete();
 
-        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }
@@ -78,7 +79,7 @@ public class MaybeCircuitBreakerTest extends BaseCircuitBreakerTest {
         then(circuitBreaker).should().releasePermission();
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
-        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
     }
 
 }

--- a/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/ObserverCircuitBreakerTest.java
+++ b/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/ObserverCircuitBreakerTest.java
@@ -5,6 +5,7 @@ import io.reactivex.Observable;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -27,7 +28,7 @@ public class ObserverCircuitBreakerTest extends BaseCircuitBreakerTest {
             .test()
             .assertResult("Event 1", "Event 2");
 
-        then(circuitBreaker).should().onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should().onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }
@@ -45,7 +46,7 @@ public class ObserverCircuitBreakerTest extends BaseCircuitBreakerTest {
 
         then(circuitBreaker).should()
             .onError(anyLong(), any(TimeUnit.class), any(IOException.class));
-        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
     }
 
     @Test
@@ -59,7 +60,7 @@ public class ObserverCircuitBreakerTest extends BaseCircuitBreakerTest {
             .assertError(CallNotPermittedException.class)
             .assertNotComplete();
 
-        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }
@@ -77,6 +78,6 @@ public class ObserverCircuitBreakerTest extends BaseCircuitBreakerTest {
         then(circuitBreaker).should().releasePermission();
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
-        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
     }
 }

--- a/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/SingleCircuitBreakerTest.java
+++ b/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/SingleCircuitBreakerTest.java
@@ -5,6 +5,7 @@ import io.reactivex.Single;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -28,7 +29,7 @@ public class SingleCircuitBreakerTest extends BaseCircuitBreakerTest {
             .test()
             .assertResult(1);
 
-        then(circuitBreaker).should().onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should().onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }
@@ -45,7 +46,7 @@ public class SingleCircuitBreakerTest extends BaseCircuitBreakerTest {
             .assertResult("Hello World", "Hello World");
 
         then(helloWorldService).should(times(2)).returnHelloWorld();
-        then(circuitBreaker).should(times(2)).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(times(2)).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }
@@ -63,7 +64,7 @@ public class SingleCircuitBreakerTest extends BaseCircuitBreakerTest {
             .assertNotComplete();
 
         then(helloWorldService).should(never()).returnHelloWorld();
-        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }
@@ -81,7 +82,7 @@ public class SingleCircuitBreakerTest extends BaseCircuitBreakerTest {
 
         then(circuitBreaker).should()
             .onError(anyLong(), any(TimeUnit.class), any(IOException.class));
-        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
     }
 
     @Test
@@ -95,7 +96,7 @@ public class SingleCircuitBreakerTest extends BaseCircuitBreakerTest {
             .assertError(CallNotPermittedException.class)
             .assertNotComplete();
 
-        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }
@@ -113,6 +114,6 @@ public class SingleCircuitBreakerTest extends BaseCircuitBreakerTest {
         then(circuitBreaker).should().releasePermission();
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
-        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
     }
 }

--- a/resilience4j-rxjava3/src/main/java/io/github/resilience4j/rxjava3/AbstractMaybeObserver.java
+++ b/resilience4j-rxjava3/src/main/java/io/github/resilience4j/rxjava3/AbstractMaybeObserver.java
@@ -42,11 +42,11 @@ public abstract class AbstractMaybeObserver<T> extends AbstractDisposable implem
     @Override
     public void onSuccess(T value) {
         whenNotCompleted(() -> {
-            hookOnSuccess();
+            hookOnSuccess(value);
             downstreamObserver.onSuccess(value);
         });
     }
 
-    protected abstract void hookOnSuccess();
+    protected abstract void hookOnSuccess(T value);
 
 }

--- a/resilience4j-rxjava3/src/main/java/io/github/resilience4j/rxjava3/bulkhead/operator/MaybeBulkhead.java
+++ b/resilience4j-rxjava3/src/main/java/io/github/resilience4j/rxjava3/bulkhead/operator/MaybeBulkhead.java
@@ -59,7 +59,7 @@ class MaybeBulkhead<T> extends Maybe<T> {
         }
 
         @Override
-        protected void hookOnSuccess() {
+        protected void hookOnSuccess(T value) {
             bulkhead.onComplete();
         }
 

--- a/resilience4j-rxjava3/src/main/java/io/github/resilience4j/rxjava3/circuitbreaker/operator/CompletableCircuitBreaker.java
+++ b/resilience4j-rxjava3/src/main/java/io/github/resilience4j/rxjava3/circuitbreaker/operator/CompletableCircuitBreaker.java
@@ -21,6 +21,7 @@ import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.CompletableObserver;
 import io.reactivex.rxjava3.internal.disposables.EmptyDisposable;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static io.github.resilience4j.circuitbreaker.CallNotPermittedException.createCallNotPermittedException;
@@ -56,7 +57,7 @@ class CompletableCircuitBreaker extends Completable {
 
         @Override
         protected void hookOnComplete() {
-            circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+            circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS, Optional.empty());
         }
 
         @Override

--- a/resilience4j-rxjava3/src/main/java/io/github/resilience4j/rxjava3/circuitbreaker/operator/FlowableCircuitBreaker.java
+++ b/resilience4j-rxjava3/src/main/java/io/github/resilience4j/rxjava3/circuitbreaker/operator/FlowableCircuitBreaker.java
@@ -23,6 +23,7 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static io.github.resilience4j.circuitbreaker.CallNotPermittedException.createCallNotPermittedException;
@@ -64,13 +65,13 @@ class FlowableCircuitBreaker<T> extends Flowable<T> {
 
         @Override
         public void hookOnComplete() {
-            circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+            circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS, Optional.empty());
         }
 
         @Override
         public void hookOnCancel() {
             if (eventWasEmitted.get()) {
-                circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+                circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS, Optional.empty());
             } else {
                 circuitBreaker.releasePermission();
             }

--- a/resilience4j-rxjava3/src/main/java/io/github/resilience4j/rxjava3/circuitbreaker/operator/MaybeCircuitBreaker.java
+++ b/resilience4j-rxjava3/src/main/java/io/github/resilience4j/rxjava3/circuitbreaker/operator/MaybeCircuitBreaker.java
@@ -21,6 +21,7 @@ import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.MaybeObserver;
 import io.reactivex.rxjava3.internal.disposables.EmptyDisposable;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static io.github.resilience4j.circuitbreaker.CallNotPermittedException.createCallNotPermittedException;
@@ -56,7 +57,7 @@ class MaybeCircuitBreaker<T> extends Maybe<T> {
 
         @Override
         protected void hookOnComplete() {
-            circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+            circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS, Optional.empty());
         }
 
         @Override
@@ -65,8 +66,8 @@ class MaybeCircuitBreaker<T> extends Maybe<T> {
         }
 
         @Override
-        protected void hookOnSuccess() {
-            circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+        protected void hookOnSuccess(T value) {
+            circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS, Optional.of(value));
         }
 
         @Override

--- a/resilience4j-rxjava3/src/main/java/io/github/resilience4j/rxjava3/circuitbreaker/operator/ObserverCircuitBreaker.java
+++ b/resilience4j-rxjava3/src/main/java/io/github/resilience4j/rxjava3/circuitbreaker/operator/ObserverCircuitBreaker.java
@@ -21,6 +21,7 @@ import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Observer;
 import io.reactivex.rxjava3.internal.disposables.EmptyDisposable;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static io.github.resilience4j.circuitbreaker.CallNotPermittedException.createCallNotPermittedException;
@@ -61,13 +62,13 @@ class ObserverCircuitBreaker<T> extends Observable<T> {
 
         @Override
         protected void hookOnComplete() {
-            circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+            circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS, Optional.empty());
         }
 
         @Override
         protected void hookOnCancel() {
             if (eventWasEmitted.get()) {
-                circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+                circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS, Optional.empty());
             } else {
                 circuitBreaker.releasePermission();
             }

--- a/resilience4j-rxjava3/src/main/java/io/github/resilience4j/rxjava3/circuitbreaker/operator/SingleCircuitBreaker.java
+++ b/resilience4j-rxjava3/src/main/java/io/github/resilience4j/rxjava3/circuitbreaker/operator/SingleCircuitBreaker.java
@@ -21,6 +21,7 @@ import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.core.SingleObserver;
 import io.reactivex.rxjava3.internal.disposables.EmptyDisposable;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static io.github.resilience4j.circuitbreaker.CallNotPermittedException.createCallNotPermittedException;
@@ -61,7 +62,7 @@ class SingleCircuitBreaker<T> extends Single<T> {
 
         @Override
         protected void hookOnSuccess() {
-            circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+            circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS, Optional.empty());
         }
 
         @Override

--- a/resilience4j-rxjava3/src/main/java/io/github/resilience4j/rxjava3/ratelimiter/operator/MaybeRateLimiter.java
+++ b/resilience4j-rxjava3/src/main/java/io/github/resilience4j/rxjava3/ratelimiter/operator/MaybeRateLimiter.java
@@ -68,7 +68,7 @@ class MaybeRateLimiter<T> extends Maybe<T> {
         }
 
         @Override
-        protected void hookOnSuccess() {
+        protected void hookOnSuccess(T value) {
             // NoOp
         }
 

--- a/resilience4j-rxjava3/src/test/java/io/github/resilience4j/rxjava3/circuitbreaker/operator/CompletableCircuitBreakerTest.java
+++ b/resilience4j-rxjava3/src/test/java/io/github/resilience4j/rxjava3/circuitbreaker/operator/CompletableCircuitBreakerTest.java
@@ -5,6 +5,7 @@ import io.reactivex.rxjava3.core.Completable;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -27,7 +28,7 @@ public class CompletableCircuitBreakerTest extends BaseCircuitBreakerTest {
             .test()
             .assertComplete();
 
-        then(circuitBreaker).should().onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should().onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }
@@ -44,7 +45,7 @@ public class CompletableCircuitBreakerTest extends BaseCircuitBreakerTest {
 
         then(circuitBreaker).should()
             .onError(anyLong(), any(TimeUnit.class), any(IOException.class));
-        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
     }
 
     @Test
@@ -57,7 +58,7 @@ public class CompletableCircuitBreakerTest extends BaseCircuitBreakerTest {
             .assertError(CallNotPermittedException.class)
             .assertNotComplete();
 
-        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }

--- a/resilience4j-rxjava3/src/test/java/io/github/resilience4j/rxjava3/circuitbreaker/operator/FlowableCircuitBreakerTest.java
+++ b/resilience4j-rxjava3/src/test/java/io/github/resilience4j/rxjava3/circuitbreaker/operator/FlowableCircuitBreakerTest.java
@@ -5,6 +5,7 @@ import io.reactivex.rxjava3.core.Flowable;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -12,6 +13,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 /**
  * Unit test for {@link FlowableCircuitBreaker}.
@@ -27,7 +29,8 @@ public class FlowableCircuitBreakerTest extends BaseCircuitBreakerTest {
             .test()
             .assertResult("Event 1", "Event 2");
 
-        then(circuitBreaker).should().onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(times(1)).onSuccess(anyLong(), any(TimeUnit.class), Optional.of("Event 1"));
+        then(circuitBreaker).should(times(1)).onSuccess(anyLong(), any(TimeUnit.class), Optional.of("Event 2"));
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }
@@ -44,7 +47,7 @@ public class FlowableCircuitBreakerTest extends BaseCircuitBreakerTest {
 
         then(circuitBreaker).should()
             .onError(anyLong(), any(TimeUnit.class), any(IOException.class));
-        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
     }
 
     @Test
@@ -57,7 +60,8 @@ public class FlowableCircuitBreakerTest extends BaseCircuitBreakerTest {
             .assertError(CallNotPermittedException.class)
             .assertNotComplete();
 
-        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(times(1)).onSuccess(anyLong(), any(TimeUnit.class), Optional.of("Event 1"));
+        then(circuitBreaker).should(times(1)).onSuccess(anyLong(), any(TimeUnit.class), Optional.of("Event 2"));
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }
@@ -75,7 +79,7 @@ public class FlowableCircuitBreakerTest extends BaseCircuitBreakerTest {
         then(circuitBreaker).should().releasePermission();
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
-        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
     }
 
     @Test
@@ -90,6 +94,6 @@ public class FlowableCircuitBreakerTest extends BaseCircuitBreakerTest {
         then(circuitBreaker).should(never()).releasePermission();
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
-        then(circuitBreaker).should().onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should().onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
     }
 }

--- a/resilience4j-rxjava3/src/test/java/io/github/resilience4j/rxjava3/circuitbreaker/operator/MaybeCircuitBreakerTest.java
+++ b/resilience4j-rxjava3/src/test/java/io/github/resilience4j/rxjava3/circuitbreaker/operator/MaybeCircuitBreakerTest.java
@@ -5,6 +5,7 @@ import io.reactivex.rxjava3.core.Maybe;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -27,7 +28,7 @@ public class MaybeCircuitBreakerTest extends BaseCircuitBreakerTest {
             .test()
             .assertResult(1);
 
-        then(circuitBreaker).should().onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should().onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }
@@ -44,7 +45,7 @@ public class MaybeCircuitBreakerTest extends BaseCircuitBreakerTest {
 
         then(circuitBreaker).should()
             .onError(anyLong(), any(TimeUnit.class), any(IOException.class));
-        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
     }
 
 
@@ -58,7 +59,7 @@ public class MaybeCircuitBreakerTest extends BaseCircuitBreakerTest {
             .assertError(CallNotPermittedException.class)
             .assertNotComplete();
 
-        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }
@@ -76,7 +77,7 @@ public class MaybeCircuitBreakerTest extends BaseCircuitBreakerTest {
         then(circuitBreaker).should().releasePermission();
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
-        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
     }
 
 }

--- a/resilience4j-rxjava3/src/test/java/io/github/resilience4j/rxjava3/circuitbreaker/operator/ObserverCircuitBreakerTest.java
+++ b/resilience4j-rxjava3/src/test/java/io/github/resilience4j/rxjava3/circuitbreaker/operator/ObserverCircuitBreakerTest.java
@@ -5,6 +5,7 @@ import io.reactivex.rxjava3.core.Observable;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -27,7 +28,7 @@ public class ObserverCircuitBreakerTest extends BaseCircuitBreakerTest {
             .test()
             .assertResult("Event 1", "Event 2");
 
-        then(circuitBreaker).should().onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should().onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }
@@ -44,7 +45,7 @@ public class ObserverCircuitBreakerTest extends BaseCircuitBreakerTest {
 
         then(circuitBreaker).should()
             .onError(anyLong(), any(TimeUnit.class), any(IOException.class));
-        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
     }
 
     @Test
@@ -57,7 +58,7 @@ public class ObserverCircuitBreakerTest extends BaseCircuitBreakerTest {
             .assertError(CallNotPermittedException.class)
             .assertNotComplete();
 
-        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }
@@ -75,6 +76,6 @@ public class ObserverCircuitBreakerTest extends BaseCircuitBreakerTest {
         then(circuitBreaker).should().releasePermission();
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
-        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
     }
 }

--- a/resilience4j-rxjava3/src/test/java/io/github/resilience4j/rxjava3/circuitbreaker/operator/SingleCircuitBreakerTest.java
+++ b/resilience4j-rxjava3/src/test/java/io/github/resilience4j/rxjava3/circuitbreaker/operator/SingleCircuitBreakerTest.java
@@ -5,6 +5,7 @@ import io.reactivex.rxjava3.core.Single;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -28,7 +29,7 @@ public class SingleCircuitBreakerTest extends BaseCircuitBreakerTest {
             .test()
             .assertResult(1);
 
-        then(circuitBreaker).should().onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should().onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }
@@ -45,7 +46,7 @@ public class SingleCircuitBreakerTest extends BaseCircuitBreakerTest {
             .assertResult("Hello World", "Hello World");
 
         then(helloWorldService).should(times(2)).returnHelloWorld();
-        then(circuitBreaker).should(times(2)).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(times(2)).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }
@@ -62,7 +63,7 @@ public class SingleCircuitBreakerTest extends BaseCircuitBreakerTest {
             .assertNotComplete();
 
         then(helloWorldService).should(never()).returnHelloWorld();
-        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }
@@ -79,7 +80,7 @@ public class SingleCircuitBreakerTest extends BaseCircuitBreakerTest {
 
         then(circuitBreaker).should()
             .onError(anyLong(), any(TimeUnit.class), any(IOException.class));
-        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
     }
 
     @Test
@@ -92,7 +93,7 @@ public class SingleCircuitBreakerTest extends BaseCircuitBreakerTest {
             .assertError(CallNotPermittedException.class)
             .assertNotComplete();
 
-        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
     }
@@ -110,6 +111,6 @@ public class SingleCircuitBreakerTest extends BaseCircuitBreakerTest {
         then(circuitBreaker).should().releasePermission();
         then(circuitBreaker).should(never())
             .onError(anyLong(), any(TimeUnit.class), any(Throwable.class));
-        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class));
+        then(circuitBreaker).should(never()).onSuccess(anyLong(), any(TimeUnit.class), any(Optional.class));
     }
 }

--- a/resilience4j-vertx/src/main/java/io/github/resilience4j/circuitbreaker/VertxCircuitBreaker.java
+++ b/resilience4j-vertx/src/main/java/io/github/resilience4j/circuitbreaker/VertxCircuitBreaker.java
@@ -20,6 +20,7 @@ package io.github.resilience4j.circuitbreaker;
 
 import io.vertx.core.Future;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
@@ -69,7 +70,7 @@ public interface VertxCircuitBreaker {
                                 .onError(durationInNanos, TimeUnit.NANOSECONDS, result.cause());
                             future.fail(result.cause());
                         } else {
-                            circuitBreaker.onSuccess(durationInNanos, TimeUnit.NANOSECONDS);
+                            circuitBreaker.onSuccess(durationInNanos, TimeUnit.NANOSECONDS, Optional.of(result));
                             future.complete(result.result());
                         }
                     });


### PR DESCRIPTION
This PR adds a CircuitBreaker record a failure predicate for a generic results not just exceptions.

The drawback with the current implementation of the circuit breaker is that it works with the assumption that a function fails when you have an exception, but the reality is that you can express a failure in several ways, for example using monads like Either or custom Result classes, where you carry the exception or whatever you consider an error in the result of the function itself.