### PR TITLE
Also make use of executeFutureSupplier method with TimeLimiter annotation

### DIFF
--- a/resilience4j-annotations/src/main/java/io/github/resilience4j/timelimiter/annotation/TimeLimiter.java
+++ b/resilience4j-annotations/src/main/java/io/github/resilience4j/timelimiter/annotation/TimeLimiter.java
@@ -46,4 +46,13 @@ public @interface TimeLimiter {
      */
     String fallbackMethod() default "";
 
+    /**
+     * In case blocking is true the annotated method is supposed to return the desired type
+     * instead of a concurrent type like CompletionStage.
+     * This is mainly useful for a servlet stack, where every request has a distinct thread
+     * and operations are usually blocking.
+     *
+     * @return true in case the operation should be blocking and false otherwise
+     */
+    boolean blocking() default false;
 }


### PR DESCRIPTION
Hi,

it would be nice to also make use of the `executeFutureSupplier` method by using the `Timelimiter` annotation. Also see https://github.com/resilience4j/resilience4j/issues/1018

This is just a draft and I'll add documentation for the changed in case you like them.