### PR TITLE
TimeLimiters decorateFutureSupplier method should also propagate TimeLimiters name on timeout

### DIFF
--- a/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/internal/TimeLimiterImpl.java
+++ b/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/internal/TimeLimiterImpl.java
@@ -189,7 +189,7 @@ public class TimeLimiterImpl implements TimeLimiter {
         }
     }
 
-    private static TimeoutException createdTimeoutExceptionWithName(String name) {
+    static TimeoutException createdTimeoutExceptionWithName(String name) {
         return new TimeoutException(String.format("TimeLimiter '%s' recorded a timeout exception." , name));
     }
 }

--- a/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/internal/TimeLimiterImpl.java
+++ b/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/internal/TimeLimiterImpl.java
@@ -49,6 +49,7 @@ public class TimeLimiterImpl implements TimeLimiter {
                 return result;
             } catch (TimeoutException e) {
                 TimeoutException timeoutException = createdTimeoutExceptionWithName(name);
+                timeoutException.setStackTrace(e.getStackTrace());
                 onError(timeoutException);
                 if (getTimeLimiterConfig().shouldCancelRunningFuture()) {
                     future.cancel(true);

--- a/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/internal/TimeLimiterImpl.java
+++ b/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/internal/TimeLimiterImpl.java
@@ -48,11 +48,12 @@ public class TimeLimiterImpl implements TimeLimiter {
                 onSuccess();
                 return result;
             } catch (TimeoutException e) {
-                onError(e);
+                TimeoutException timeoutException = createdTimeoutExceptionWithName(name);
+                onError(timeoutException);
                 if (getTimeLimiterConfig().shouldCancelRunningFuture()) {
                     future.cancel(true);
                 }
-                throw e;
+                throw timeoutException;
             } catch (ExecutionException e) {
                 Throwable t = e.getCause();
                 if (t == null) {
@@ -181,10 +182,13 @@ public class TimeLimiterImpl implements TimeLimiter {
             TimeUnit unit) {
             return scheduler.schedule(() -> {
                 if (future != null && !future.isDone()) {
-                    future.completeExceptionally(new TimeoutException(String.format("TimeLimiter '%s' recorded a timeout exception." , name)));
+                    future.completeExceptionally(createdTimeoutExceptionWithName(name));
                 }
             }, delay, unit);
         }
     }
 
+    private static TimeoutException createdTimeoutExceptionWithName(String name) {
+        return new TimeoutException(String.format("TimeLimiter '%s' recorded a timeout exception." , name));
+    }
 }


### PR DESCRIPTION
After a nice discussion with @RobWin in this issue: https://github.com/resilience4j/resilience4j/issues/1018, we decided to go with the decorateFutureSupplier method of a TimeLimiter, but we just realized that on a timeout the name of the timelimiter is not published. So unfortunately we get Errors like this in our error log:

`TimeoutException: null`

Formerly the error looked similar to this:

`TimeoutException: TimeLimiter 'FetchData' recorded a timeout exception.`

which is much more pleasant.

This PR should fix this issue.