### PR TITLE
Issue #866 add spring actuator rest endpoints for force open , disable, close specifc circuitbreaker

### DIFF
--- a/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/circuitbreaker/monitoring/endpoint/CircuitBreakerUpdateStateResponse.java
+++ b/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/circuitbreaker/monitoring/endpoint/CircuitBreakerUpdateStateResponse.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Mahmoud Romeh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.common.circuitbreaker.monitoring.endpoint;
+
+import java.util.Objects;
+
+/**
+ * change circuit breaker state response
+ */
+public class CircuitBreakerUpdateStateResponse {
+    private String circuitBreakerName;
+    private String currentState;
+    private String message;
+
+    public String getCircuitBreakerName() {
+        return circuitBreakerName;
+    }
+
+    public void setCircuitBreakerName(String circuitBreakerName) {
+        this.circuitBreakerName = circuitBreakerName;
+    }
+
+    public String getCurrentState() {
+        return currentState;
+    }
+
+    public void setCurrentState(String currentState) {
+        this.currentState = currentState;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CircuitBreakerUpdateStateResponse that = (CircuitBreakerUpdateStateResponse) o;
+        return circuitBreakerName.equals(that.circuitBreakerName) &&
+            currentState.equals(that.currentState) &&
+            message.equals(that.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(circuitBreakerName, currentState, message);
+    }
+
+    @Override
+    public String toString() {
+        return "CircuitBreakerUpdateStateResponse{" +
+            "circuitBreakerName='" + circuitBreakerName + '\'' +
+            ", currentState='" + currentState + '\'' +
+            ", message='" + message + '\'' +
+            '}';
+    }
+}

--- a/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/circuitbreaker/monitoring/endpoint/UpdateState.java
+++ b/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/circuitbreaker/monitoring/endpoint/UpdateState.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Mahmoud Romeh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.common.circuitbreaker.monitoring.endpoint;
+
+/**
+ * Update State of the circuit breaker through actuator spring endpoint enum.
+ */
+public enum UpdateState {
+    CLOSE, FORCE_OPEN, DISABLE;
+}

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/circuitbreaker/monitoring/endpoint/CircuitBreakerUpdateStateResponseTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/circuitbreaker/monitoring/endpoint/CircuitBreakerUpdateStateResponseTest.java
@@ -1,0 +1,63 @@
+package io.github.resilience4j.common.circuitbreaker.monitoring.endpoint;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * unit test for CircuitBreakerUpdateStateResponse DTO
+ */
+public class CircuitBreakerUpdateStateResponseTest {
+
+    @Test
+    public void testEquals() {
+        // Setup
+        CircuitBreakerUpdateStateResponse response1 = new CircuitBreakerUpdateStateResponse();
+        response1.setCircuitBreakerName("test2");
+        response1.setCurrentState("TESTState");
+        response1.setMessage("TestMessage");
+        CircuitBreakerUpdateStateResponse response2 = new CircuitBreakerUpdateStateResponse();
+        response2.setCircuitBreakerName("test2");
+        response2.setCurrentState("TESTState");
+        response2.setMessage("TestMessage");
+
+
+        // Verify the results
+        assertEquals(response1.getMessage(), response2.getMessage());
+        assertEquals(response1.getCircuitBreakerName(), response2.getCircuitBreakerName());
+        assertEquals(response1.getCurrentState(), response2.getCurrentState());
+        assertEquals(response1, response2);
+    }
+
+    @Test
+    public void testHashCode() {
+        // Setup
+        CircuitBreakerUpdateStateResponse response1 = new CircuitBreakerUpdateStateResponse();
+        response1.setCircuitBreakerName("test2");
+        response1.setCurrentState("TESTState");
+        response1.setMessage("TestMessage");
+        CircuitBreakerUpdateStateResponse response2 = new CircuitBreakerUpdateStateResponse();
+        response2.setCircuitBreakerName("test2");
+        response2.setCurrentState("TESTState");
+        response2.setMessage("TestMessage");
+
+        // Verify the results
+        assertEquals(response1.hashCode(), response2.hashCode());
+    }
+
+
+    @Test
+    public void testToString() {
+        // Setup
+        CircuitBreakerUpdateStateResponse response1 = new CircuitBreakerUpdateStateResponse();
+        response1.setCircuitBreakerName("test2");
+        response1.setCurrentState("TESTState");
+        response1.setMessage("TestMessage");
+        CircuitBreakerUpdateStateResponse response2 = new CircuitBreakerUpdateStateResponse();
+        response2.setCircuitBreakerName("test2");
+        response2.setCurrentState("TESTState");
+        response2.setMessage("TestMessage");
+        // Verify the results
+        assertEquals(response1.toString(), response2.toString());
+    }
+}

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/circuitbreaker/monitoring/endpoint/CircuitBreakerEndpoint.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/circuitbreaker/monitoring/endpoint/CircuitBreakerEndpoint.java
@@ -19,9 +19,14 @@ package io.github.resilience4j.circuitbreaker.monitoring.endpoint;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.common.circuitbreaker.monitoring.endpoint.CircuitBreakerEndpointResponse;
+import io.github.resilience4j.common.circuitbreaker.monitoring.endpoint.CircuitBreakerUpdateStateResponse;
+import io.github.resilience4j.common.circuitbreaker.monitoring.endpoint.UpdateState;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.boot.actuate.endpoint.annotation.Selector;
+import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
 
+import java.util.Arrays;
 import java.util.List;
 
 
@@ -39,5 +44,34 @@ public class CircuitBreakerEndpoint {
         List<String> circuitBreakers = circuitBreakerRegistry.getAllCircuitBreakers()
             .map(CircuitBreaker::getName).sorted().toJavaList();
         return new CircuitBreakerEndpointResponse(circuitBreakers);
+    }
+
+    @WriteOperation
+    public CircuitBreakerUpdateStateResponse updateCircuitBreakerState(@Selector String name, UpdateState updateState) {
+        final CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker(name);
+        final String message = "%s state has been changed successfully";
+        switch (updateState) {
+            case CLOSE:
+                circuitBreaker.transitionToClosedState();
+                return createCircuitBreakerUpdateStateResponse(name, circuitBreaker.getState().toString(), String.format(message, name));
+            case FORCE_OPEN:
+                circuitBreaker.transitionToForcedOpenState();
+                return createCircuitBreakerUpdateStateResponse(name, circuitBreaker.getState().toString(), String.format(message, name));
+            case DISABLE:
+                circuitBreaker.transitionToDisabledState();
+                return createCircuitBreakerUpdateStateResponse(name, circuitBreaker.getState().toString(), String.format(message, name));
+            default:
+                return createCircuitBreakerUpdateStateResponse(name, circuitBreaker.getState().toString(), "State change value is not supported please use only " + Arrays.toString(UpdateState.values()));
+        }
+
+    }
+
+    private CircuitBreakerUpdateStateResponse createCircuitBreakerUpdateStateResponse(String circuitBreakerName, String newState, String message) {
+        CircuitBreakerUpdateStateResponse circuitBreakerUpdateStateResponse = new CircuitBreakerUpdateStateResponse();
+        circuitBreakerUpdateStateResponse.setCircuitBreakerName(circuitBreakerName);
+        circuitBreakerUpdateStateResponse.setCurrentState(newState);
+        circuitBreakerUpdateStateResponse.setMessage(message);
+
+        return circuitBreakerUpdateStateResponse;
     }
 }


### PR DESCRIPTION
This PR is the one step of the requirements of enabling changing the state at runtime for specific circuit breaker , first part in that PR is provide actuator endpoint to disable , force open , and close specific circuit breaker instance 

Second PR is to provide state config property in circuit breaker configuration so it can be done via spring cloud config as well at runtime