### PR TITLE
feat(micronaut): add qualifier to correct multiple resolved types

### DIFF
--- a/resilience4j-micronaut/src/main/java/io/github/resilience4j/bulkhead/BulkHeadRegistryFactory.java
+++ b/resilience4j-micronaut/src/main/java/io/github/resilience4j/bulkhead/BulkHeadRegistryFactory.java
@@ -42,7 +42,7 @@ import java.util.stream.Collectors;
 public class BulkHeadRegistryFactory {
 
     @Bean
-    @Named("compositeBulkHeadCustomizer")
+    @BulkheadQualifier
     public CompositeCustomizer<BulkheadConfigCustomizer> composeBulkheadCustomizer(
         @Nullable List<BulkheadConfigCustomizer> configCustomizers
     ) {
@@ -54,9 +54,9 @@ public class BulkHeadRegistryFactory {
     @Requires(beans = BulkheadProperties.class)
     public BulkheadRegistry bulkheadRegistry(
         BulkheadConfigurationProperties bulkheadConfigurationProperties,
-        @Named("bulkheadEventConsumerRegistry") EventConsumerRegistry<BulkheadEvent> bulkheadEventConsumerRegistry,
-        @Named("bulkheadEventConsumer") RegistryEventConsumer<Bulkhead> bulkheadRegistryEventConsumer,
-        @Named("compositeBulkHeadCustomizer") CompositeCustomizer<BulkheadConfigCustomizer> compositeBulkheadCustomizer) {
+        @BulkheadQualifier EventConsumerRegistry<BulkheadEvent> bulkheadEventConsumerRegistry,
+        @BulkheadQualifier RegistryEventConsumer<Bulkhead> bulkheadRegistryEventConsumer,
+        @BulkheadQualifier CompositeCustomizer<BulkheadConfigCustomizer> compositeBulkheadCustomizer) {
         BulkheadRegistry bulkheadRegistry = createBulkheadRegistry(bulkheadConfigurationProperties,
             bulkheadRegistryEventConsumer, compositeBulkheadCustomizer);
         registerEventConsumer(bulkheadRegistry, bulkheadEventConsumerRegistry,
@@ -71,7 +71,7 @@ public class BulkHeadRegistryFactory {
 
     @Bean
     @Primary
-    @Named("bulkheadEventConsumer")
+    @BulkheadQualifier
     public RegistryEventConsumer<Bulkhead> bulkheadRegistryEventConsumer(
         Optional<List<RegistryEventConsumer<Bulkhead>>> optionalRegistryEventConsumers
     ) {
@@ -81,7 +81,7 @@ public class BulkHeadRegistryFactory {
     }
 
     @Bean
-    @Named("bulkheadEventConsumerRegistry")
+    @BulkheadQualifier
     public EventConsumerRegistry<BulkheadEvent> bulkheadEventsConsumerRegistry() {
         return new DefaultEventConsumerRegistry<>();
     }

--- a/resilience4j-micronaut/src/main/java/io/github/resilience4j/bulkhead/BulkheadQualifier.java
+++ b/resilience4j-micronaut/src/main/java/io/github/resilience4j/bulkhead/BulkheadQualifier.java
@@ -1,0 +1,10 @@
+package io.github.resilience4j.bulkhead;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BulkheadQualifier {
+}

--- a/resilience4j-micronaut/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadFactory.java
+++ b/resilience4j-micronaut/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadFactory.java
@@ -27,7 +27,7 @@ import static java.util.Optional.ofNullable;
 @Requires(property = "resilience4j.thread-pool-bulkhead.enabled")
 public class ThreadPoolBulkheadFactory {
     @Bean
-    @Named("compositeThreadPoolBulkHeadCustomizer")
+    @ThreadPoolBulkheadQualifier
     public CompositeCustomizer<ThreadPoolBulkheadConfigCustomizer> compositeThreadPoolBulkheadCustomizer(
         List<ThreadPoolBulkheadConfigCustomizer> customizers) {
         return new CompositeCustomizer<>(customizers);
@@ -37,9 +37,9 @@ public class ThreadPoolBulkheadFactory {
     @Requires(beans = ThreadPoolBulkheadConfigurationProperties.class)
     public ThreadPoolBulkheadRegistry threadPoolBulkheadRegistry(
         ThreadPoolBulkheadConfigurationProperties bulkheadConfigurationProperties,
-        @Named("threadPoolBulkheadEventConsumerRegistry") EventConsumerRegistry<BulkheadEvent> bulkheadEventConsumerRegistry,
-        @Named("threadPoolBulkheadEventConsumer") RegistryEventConsumer<ThreadPoolBulkhead> threadPoolBulkheadRegistryEventConsumer,
-        @Named("compositeThreadPoolBulkHeadCustomizer") CompositeCustomizer<ThreadPoolBulkheadConfigCustomizer> compositeThreadPoolBulkheadCustomizer) {
+        @ThreadPoolBulkheadQualifier EventConsumerRegistry<BulkheadEvent> bulkheadEventConsumerRegistry,
+        @ThreadPoolBulkheadQualifier RegistryEventConsumer<ThreadPoolBulkhead> threadPoolBulkheadRegistryEventConsumer,
+        @ThreadPoolBulkheadQualifier CompositeCustomizer<ThreadPoolBulkheadConfigCustomizer> compositeThreadPoolBulkheadCustomizer) {
 
         ThreadPoolBulkheadRegistry bulkheadRegistry = createBulkheadRegistry(
             bulkheadConfigurationProperties, threadPoolBulkheadRegistryEventConsumer,
@@ -54,7 +54,7 @@ public class ThreadPoolBulkheadFactory {
 
     @Bean
     @Primary
-    @Named("threadPoolBulkheadEventConsumer")
+    @ThreadPoolBulkheadQualifier
     public RegistryEventConsumer<ThreadPoolBulkhead> threadPoolBulkheadRegistryEventConsumer(
         Optional<List<RegistryEventConsumer<ThreadPoolBulkhead>>> optionalRegistryEventConsumers) {
         return new CompositeRegistryEventConsumer<>(
@@ -62,7 +62,7 @@ public class ThreadPoolBulkheadFactory {
     }
 
     @Bean
-    @Named("threadPoolBulkheadEventConsumerRegistry")
+    @ThreadPoolBulkheadQualifier
     public EventConsumerRegistry<BulkheadEvent> threadPoolBulkheadEventsConsumerRegistry() {
         return new DefaultEventConsumerRegistry<>();
     }

--- a/resilience4j-micronaut/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadQualifier.java
+++ b/resilience4j-micronaut/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadQualifier.java
@@ -1,0 +1,10 @@
+package io.github.resilience4j.bulkhead;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ThreadPoolBulkheadQualifier {
+}

--- a/resilience4j-micronaut/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerQualifier.java
+++ b/resilience4j-micronaut/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerQualifier.java
@@ -1,0 +1,10 @@
+package io.github.resilience4j.circuitbreaker;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CircuitBreakerQualifier {
+}

--- a/resilience4j-micronaut/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerRegistryFactory.java
+++ b/resilience4j-micronaut/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerRegistryFactory.java
@@ -29,7 +29,6 @@ import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Requires;
 
 import javax.annotation.Nullable;
-import javax.inject.Named;
 import javax.inject.Singleton;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,7 +40,7 @@ import java.util.stream.Collectors;
 @Requires(property = "resilience4j.circuitbreaker.enabled")
 public class CircuitBreakerRegistryFactory {
     @Bean
-    @Named("compositeCircuitBreakerCustomizer")
+    @CircuitBreakerQualifier
     public CompositeCustomizer<CircuitBreakerConfigCustomizer> compositeCircuitBreakerCustomizer(
         @Nullable List<CircuitBreakerConfigCustomizer> configCustomizer ) {
         return new CompositeCustomizer<>(configCustomizer);
@@ -51,9 +50,9 @@ public class CircuitBreakerRegistryFactory {
     @Requires(beans = CircuitBreakerProperties.class)
     public CircuitBreakerRegistry circuitBreakerRegistry(
         CircuitBreakerConfigurationProperties circuitBreakerConfigurationProperties,
-        EventConsumerRegistry<CircuitBreakerEvent> eventConsumerRegistry,
-        RegistryEventConsumer<CircuitBreaker> circuitBreakerRegistryEventConsumer,
-        @Named("compositeCircuitBreakerCustomizer") CompositeCustomizer<CircuitBreakerConfigCustomizer> compositeCircuitBreakerCustomizer) {
+        @CircuitBreakerQualifier EventConsumerRegistry<CircuitBreakerEvent> eventConsumerRegistry,
+        @CircuitBreakerQualifier RegistryEventConsumer<CircuitBreaker> circuitBreakerRegistryEventConsumer,
+        @CircuitBreakerQualifier CompositeCustomizer<CircuitBreakerConfigCustomizer> compositeCircuitBreakerCustomizer) {
         CircuitBreakerRegistry circuitBreakerRegistry = createCircuitBreakerRegistry(
             circuitBreakerConfigurationProperties, circuitBreakerRegistryEventConsumer,
             compositeCircuitBreakerCustomizer);
@@ -65,7 +64,8 @@ public class CircuitBreakerRegistryFactory {
 
     @Bean
     @Primary
-    public RegistryEventConsumer<CircuitBreaker> timeLimiterRegistryEventConsumer(
+    @CircuitBreakerQualifier
+    public RegistryEventConsumer<CircuitBreaker> circuitBreakerRegistryEventConsumer(
         Optional<List<RegistryEventConsumer<CircuitBreaker>>> optionalRegistryEventConsumers
     ) {
         return new CompositeRegistryEventConsumer<>(
@@ -74,7 +74,8 @@ public class CircuitBreakerRegistryFactory {
     }
 
     @Bean
-    public EventConsumerRegistry<CircuitBreakerEvent> timeLimiterEventsConsumerRegistry() {
+    @CircuitBreakerQualifier
+    public EventConsumerRegistry<CircuitBreakerEvent> circuitBreakerEventsConsumerRegistry() {
         return new DefaultEventConsumerRegistry<>();
     }
 
@@ -85,7 +86,7 @@ public class CircuitBreakerRegistryFactory {
      * @param circuitBreakerRegistry The circuit breaker registry.
      * @param customizerMap
      */
-    void initCircuitBreakerRegistry(CircuitBreakerConfigurationProperties circuitBreakerConfigurationProperties,
+    private void initCircuitBreakerRegistry(CircuitBreakerConfigurationProperties circuitBreakerConfigurationProperties,
                                     CircuitBreakerRegistry circuitBreakerRegistry,
                                     CompositeCustomizer<CircuitBreakerConfigCustomizer> customizerMap) {
         circuitBreakerConfigurationProperties.getInstances().forEach(

--- a/resilience4j-micronaut/src/main/java/io/github/resilience4j/ratelimiter/RateLimiterQualifier.java
+++ b/resilience4j-micronaut/src/main/java/io/github/resilience4j/ratelimiter/RateLimiterQualifier.java
@@ -1,0 +1,10 @@
+package io.github.resilience4j.ratelimiter;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RateLimiterQualifier {
+}

--- a/resilience4j-micronaut/src/main/java/io/github/resilience4j/ratelimiter/RateLimiterRegistryFactory.java
+++ b/resilience4j-micronaut/src/main/java/io/github/resilience4j/ratelimiter/RateLimiterRegistryFactory.java
@@ -42,7 +42,7 @@ import java.util.stream.Collectors;
 public class RateLimiterRegistryFactory {
 
     @Bean
-    @Named("compositeRateLimiterCustomizer")
+    @RateLimiterQualifier
     public CompositeCustomizer<RateLimiterConfigCustomizer> compositeRateLimiterCustomizer(
         @Nullable List<RateLimiterConfigCustomizer> configCustomizers) {
         return new CompositeCustomizer<>(configCustomizers);
@@ -50,9 +50,9 @@ public class RateLimiterRegistryFactory {
 
     @Singleton
     public RateLimiterRegistry rateLimiterRegistry(RateLimiterProperties rateLimiterProperties,
-                                                   EventConsumerRegistry<RateLimiterEvent> rateLimiterEventsConsumerRegistry,
-                                                   RegistryEventConsumer<RateLimiter> rateLimiterRegistryEventConsumer,
-                                                   @Named("compositeRateLimiterCustomizer") CompositeCustomizer<RateLimiterConfigCustomizer> compositeRateLimiterCustomizer) {
+                                                   @RateLimiterQualifier EventConsumerRegistry<RateLimiterEvent> rateLimiterEventsConsumerRegistry,
+                                                   @RateLimiterQualifier RegistryEventConsumer<RateLimiter> rateLimiterRegistryEventConsumer,
+                                                   @RateLimiterQualifier CompositeCustomizer<RateLimiterConfigCustomizer> compositeRateLimiterCustomizer) {
         RateLimiterRegistry rateLimiterRegistry = createRateLimiterRegistry(rateLimiterProperties, rateLimiterRegistryEventConsumer, compositeRateLimiterCustomizer);
         registerEventConsumer(rateLimiterRegistry, rateLimiterEventsConsumerRegistry,
             rateLimiterProperties);
@@ -66,12 +66,14 @@ public class RateLimiterRegistryFactory {
     }
 
     @Bean
+    @RateLimiterQualifier
     public EventConsumerRegistry<RateLimiterEvent> rateLimiterEventEventConsumerRegistry() {
         return new DefaultEventConsumerRegistry<>();
     }
 
     @Bean
     @Primary
+    @RateLimiterQualifier
     public RegistryEventConsumer<RateLimiter> rateLimiterRegistryEventConsumer(
         Optional<List<RegistryEventConsumer<RateLimiter>>> optionalRegistryEventConsumers
     ) {

--- a/resilience4j-micronaut/src/main/java/io/github/resilience4j/retry/RetryQualifier.java
+++ b/resilience4j-micronaut/src/main/java/io/github/resilience4j/retry/RetryQualifier.java
@@ -1,0 +1,10 @@
+package io.github.resilience4j.retry;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RetryQualifier {
+}

--- a/resilience4j-micronaut/src/main/java/io/github/resilience4j/retry/RetryRegistryFactory.java
+++ b/resilience4j-micronaut/src/main/java/io/github/resilience4j/retry/RetryRegistryFactory.java
@@ -42,7 +42,7 @@ import java.util.stream.Collectors;
 public class RetryRegistryFactory {
 
     @Bean
-    @Named("compositeRetryCustomizer")
+    @RetryQualifier
     public CompositeCustomizer<RetryConfigCustomizer> compositeTimeLimiterCustomizer(@Nullable List<RetryConfigCustomizer> configCustomizers) {
         return new CompositeCustomizer<>(configCustomizers);
     }
@@ -51,9 +51,9 @@ public class RetryRegistryFactory {
     @Requires(beans = RetryConfigurationProperties.class)
     public RetryRegistry createRetryRegistry(
         RetryConfigurationProperties retryConfigurationProperties,
-        EventConsumerRegistry<RetryEvent> retryEventConsumerRegistry,
-        RegistryEventConsumer<Retry> retryRegistryEventConsumer,
-        @Named("compositeRetryCustomizer") CompositeCustomizer<RetryConfigCustomizer> compositeRetryCustomizer) {
+        @RetryQualifier EventConsumerRegistry<RetryEvent> retryEventConsumerRegistry,
+        @RetryQualifier RegistryEventConsumer<Retry> retryRegistryEventConsumer,
+        @RetryQualifier CompositeCustomizer<RetryConfigCustomizer> compositeRetryCustomizer) {
         RetryRegistry retryRegistry = createRetryRegistry(retryConfigurationProperties,
             retryRegistryEventConsumer, compositeRetryCustomizer);
         registerEventConsumer(retryRegistry, retryEventConsumerRegistry,
@@ -67,13 +67,15 @@ public class RetryRegistryFactory {
 
 
     @Bean
-    public EventConsumerRegistry<RetryEvent> rateLimiterEventEventConsumerRegistry() {
+    @RetryQualifier
+    public EventConsumerRegistry<RetryEvent> retryEventEventConsumerRegistry() {
         return new DefaultEventConsumerRegistry<>();
     }
 
     @Bean
     @Primary
-    public RegistryEventConsumer<Retry> rateLimiterRegistryEventConsumer(
+    @RetryQualifier
+    public RegistryEventConsumer<Retry> retryRegistryEventConsumer(
         Optional<List<RegistryEventConsumer<Retry>>> optionalRegistryEventConsumers
     ) {
         return new CompositeRegistryEventConsumer<>(

--- a/resilience4j-micronaut/src/main/java/io/github/resilience4j/timelimiter/TimeLimiterQualifier.java
+++ b/resilience4j-micronaut/src/main/java/io/github/resilience4j/timelimiter/TimeLimiterQualifier.java
@@ -1,0 +1,10 @@
+package io.github.resilience4j.timelimiter;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TimeLimiterQualifier {
+}

--- a/resilience4j-micronaut/src/main/java/io/github/resilience4j/timelimiter/TimeLimiterRegistryFactory.java
+++ b/resilience4j-micronaut/src/main/java/io/github/resilience4j/timelimiter/TimeLimiterRegistryFactory.java
@@ -43,7 +43,7 @@ import java.util.stream.Collectors;
 public class TimeLimiterRegistryFactory {
 
     @Bean
-    @Named("compositeTimeLimiterCustomizer")
+    @TimeLimiterQualifier
     public CompositeCustomizer<TimeLimiterConfigCustomizer> compositeTimeLimiterCustomizer(@Nullable List<TimeLimiterConfigCustomizer> configCustomizers) {
         return new CompositeCustomizer<>(configCustomizers);
     }
@@ -52,9 +52,9 @@ public class TimeLimiterRegistryFactory {
     @Requires(beans = TimeLimiterConfigurationProperties.class)
     public TimeLimiterRegistry timeLimiterRegistry(
         TimeLimiterConfigurationProperties timeLimiterConfigurationProperties,
-        EventConsumerRegistry<TimeLimiterEvent> timeLimiterEventConsumerRegistry,
-        RegistryEventConsumer<TimeLimiter> timeLimiterRegistryEventConsumer,
-        @Named("compositeTimeLimiterCustomizer") CompositeCustomizer<TimeLimiterConfigCustomizer> compositeTimeLimiterCustomizer) {
+        @TimeLimiterQualifier EventConsumerRegistry<TimeLimiterEvent> timeLimiterEventConsumerRegistry,
+        @TimeLimiterQualifier RegistryEventConsumer<TimeLimiter> timeLimiterRegistryEventConsumer,
+        @TimeLimiterQualifier CompositeCustomizer<TimeLimiterConfigCustomizer> compositeTimeLimiterCustomizer) {
         TimeLimiterRegistry timeLimiterRegistry =
             createTimeLimiterRegistry(timeLimiterConfigurationProperties, timeLimiterRegistryEventConsumer,
                 compositeTimeLimiterCustomizer);
@@ -67,6 +67,7 @@ public class TimeLimiterRegistryFactory {
 
     @Bean
     @Primary
+    @TimeLimiterQualifier
     public RegistryEventConsumer<TimeLimiter> timeLimiterRegistryEventConsumer(
         Optional<List<RegistryEventConsumer<TimeLimiter>>> optionalRegistryEventConsumers
     ) {
@@ -76,6 +77,7 @@ public class TimeLimiterRegistryFactory {
     }
 
     @Bean
+    @TimeLimiterQualifier
     public EventConsumerRegistry<TimeLimiterEvent> timeLimiterEventsConsumerRegistry() {
         return new DefaultEventConsumerRegistry<>();
     }


### PR DESCRIPTION
ref: https://github.com/resilience4j/resilience4j/pull/967
ref: https://github.com/resilience4j/resilience4j-micronaut-demo/pull/2

while working on the example I was having a problem where multiple types where being resolved from the other implementations. Kind of strange, the types should be unique where this shouldn't happen. 

```
RegistryEventConsumer<Retry>
RegistryEventConsumer<TimeLimiter>
RegistryEventConsumer<Bulkhead>
RegistryEventConsumer<CircuitBreaker>
etc ...
``` 

```
Message: Multiple possible bean candidates found: [io.github.resilience4j.consumer.EventConsumerRegistry, io.github.resilience4j.consumer.EventConsumerRegistry, io.github.resilience4j.consumer.EventConsumerRegistry, io.github.resilience4j.consumer.EventConsumerRegistry, io.github.resilience4j.consumer.EventConsumerRegistry, io.github.resilience4j.consumer.EventConsumerRegistry]
Path Taken: new BackendCController([Service businessBService]) --> new $BusinessCServiceDefinition$Intercepted(BeanContext beanContext,Qualifier qualifier,[Interceptor[] interceptors]) --> new CircuitBreakerInterceptor(BeanContext beanContext,[CircuitBreakerRegistry circuitBreakerRegistry]) --> CircuitBreakerRegistry.circuitBreakerRegistry(CircuitBreakerConfigurationProperties circuitBreakerConfigurationProperties,[EventConsumerRegistry eventConsumerRegistry],RegistryEventConsumer circuitBreakerRegistryEventConsumer,CompositeCustomizer compositeCircuitBreakerCustomizer)


```