### PR TITLE
#734 Modified CircuitBreaker to use clock to calculate duration

### DIFF
--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreaker.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreaker.java
@@ -71,13 +71,13 @@ public interface CircuitBreaker {
             final long start = circuitBreaker.getCurrentTimestamp();
             try {
                 T returnValue = supplier.apply();
-                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
-                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getTimestampUnit());
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onSuccess(duration, circuitBreaker.getTimestampUnit());
                 return returnValue;
             } catch (Exception exception) {
                 // Do not handle java.lang.Error
-                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
-                circuitBreaker.onError(durationInNanos, circuitBreaker.getTimestampUnit(), exception);
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onError(duration, circuitBreaker.getTimestampUnit(), exception);
                 throw exception;
             }
         };
@@ -107,21 +107,21 @@ public interface CircuitBreaker {
                 final long start = circuitBreaker.getCurrentTimestamp();
                 try {
                     supplier.get().whenComplete((result, throwable) -> {
-                        long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
+                        long duration = circuitBreaker.getCurrentTimestamp() - start;
                         if (throwable != null) {
                             if (throwable instanceof Exception) {
                                 circuitBreaker
-                                    .onError(durationInNanos, circuitBreaker.getTimestampUnit(), throwable);
+                                    .onError(duration, circuitBreaker.getTimestampUnit(), throwable);
                             }
                             promise.completeExceptionally(throwable);
                         } else {
-                            circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getTimestampUnit());
+                            circuitBreaker.onSuccess(duration, circuitBreaker.getTimestampUnit());
                             promise.complete(result);
                         }
                     });
                 } catch (Exception exception) {
-                    long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
-                    circuitBreaker.onError(durationInNanos, circuitBreaker.getTimestampUnit(), exception);
+                    long duration = circuitBreaker.getCurrentTimestamp() - start;
+                    circuitBreaker.onError(duration, circuitBreaker.getTimestampUnit(), exception);
                     promise.completeExceptionally(exception);
                 }
             }
@@ -144,12 +144,12 @@ public interface CircuitBreaker {
             final long start = circuitBreaker.getCurrentTimestamp();
             try {
                 runnable.run();
-                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
-                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getTimestampUnit());
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onSuccess(duration, circuitBreaker.getTimestampUnit());
             } catch (Exception exception) {
                 // Do not handle java.lang.Error
-                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
-                circuitBreaker.onError(durationInNanos, circuitBreaker.getTimestampUnit(), exception);
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onError(duration, circuitBreaker.getTimestampUnit(), exception);
                 throw exception;
             }
         };
@@ -169,13 +169,13 @@ public interface CircuitBreaker {
             final long start = circuitBreaker.getCurrentTimestamp();
             try {
                 T returnValue = callable.call();
-                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
-                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getTimestampUnit());
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onSuccess(duration, circuitBreaker.getTimestampUnit());
                 return returnValue;
             } catch (Exception exception) {
                 // Do not handle java.lang.Error
-                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
-                circuitBreaker.onError(durationInNanos, circuitBreaker.getTimestampUnit(), exception);
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onError(duration, circuitBreaker.getTimestampUnit(), exception);
                 throw exception;
             }
         };
@@ -195,13 +195,13 @@ public interface CircuitBreaker {
             final long start = circuitBreaker.getCurrentTimestamp();
             try {
                 T returnValue = supplier.get();
-                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
-                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getTimestampUnit());
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onSuccess(duration, circuitBreaker.getTimestampUnit());
                 return returnValue;
             } catch (Exception exception) {
                 // Do not handle java.lang.Error
-                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
-                circuitBreaker.onError(durationInNanos, circuitBreaker.getTimestampUnit(), exception);
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onError(duration, circuitBreaker.getTimestampUnit(), exception);
                 throw exception;
             }
         };
@@ -221,12 +221,12 @@ public interface CircuitBreaker {
             if (circuitBreaker.tryAcquirePermission()) {
                 final long start = circuitBreaker.getCurrentTimestamp();
                 Either<? extends Exception, T> result = supplier.get();
-                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
                 if (result.isRight()) {
-                    circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getTimestampUnit());
+                    circuitBreaker.onSuccess(duration, circuitBreaker.getTimestampUnit());
                 } else {
                     Exception exception = result.getLeft();
-                    circuitBreaker.onError(durationInNanos, circuitBreaker.getTimestampUnit(), exception);
+                    circuitBreaker.onError(duration, circuitBreaker.getTimestampUnit(), exception);
                 }
                 return Either.narrow(result);
             } else {
@@ -250,13 +250,13 @@ public interface CircuitBreaker {
             if (circuitBreaker.tryAcquirePermission()) {
                 final long start = circuitBreaker.getCurrentTimestamp();
                 Try<T> result = supplier.get();
-                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
                 if (result.isSuccess()) {
-                    circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getTimestampUnit());
+                    circuitBreaker.onSuccess(duration, circuitBreaker.getTimestampUnit());
                     return result;
                 } else {
                     circuitBreaker
-                        .onError(durationInNanos, circuitBreaker.getTimestampUnit(), result.getCause());
+                        .onError(duration, circuitBreaker.getTimestampUnit(), result.getCause());
                     return result;
                 }
             } else {
@@ -280,12 +280,12 @@ public interface CircuitBreaker {
             final long start = circuitBreaker.getCurrentTimestamp();
             try {
                 consumer.accept(t);
-                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
-                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getTimestampUnit());
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onSuccess(duration, circuitBreaker.getTimestampUnit());
             } catch (Exception exception) {
                 // Do not handle java.lang.Error
-                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
-                circuitBreaker.onError(durationInNanos, circuitBreaker.getTimestampUnit(), exception);
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onError(duration, circuitBreaker.getTimestampUnit(), exception);
                 throw exception;
             }
         };
@@ -306,12 +306,12 @@ public interface CircuitBreaker {
             final long start = circuitBreaker.getCurrentTimestamp();
             try {
                 consumer.accept(t);
-                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
-                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getTimestampUnit());
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onSuccess(duration, circuitBreaker.getTimestampUnit());
             } catch (Exception exception) {
                 // Do not handle java.lang.Error
-                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
-                circuitBreaker.onError(durationInNanos, circuitBreaker.getTimestampUnit(), exception);
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onError(duration, circuitBreaker.getTimestampUnit(), exception);
                 throw exception;
             }
         };
@@ -330,12 +330,12 @@ public interface CircuitBreaker {
             final long start = circuitBreaker.getCurrentTimestamp();
             try {
                 runnable.run();
-                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
-                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getTimestampUnit());
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onSuccess(duration, circuitBreaker.getTimestampUnit());
             } catch (Exception exception) {
                 // Do not handle java.lang.Error
-                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
-                circuitBreaker.onError(durationInNanos, circuitBreaker.getTimestampUnit(), exception);
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onError(duration, circuitBreaker.getTimestampUnit(), exception);
                 throw exception;
             }
         };
@@ -357,13 +357,13 @@ public interface CircuitBreaker {
             final long start = circuitBreaker.getCurrentTimestamp();
             try {
                 R returnValue = function.apply(t);
-                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
-                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getTimestampUnit());
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onSuccess(duration, circuitBreaker.getTimestampUnit());
                 return returnValue;
             } catch (Exception exception) {
                 // Do not handle java.lang.Error
-                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
-                circuitBreaker.onError(durationInNanos, circuitBreaker.getTimestampUnit(), exception);
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onError(duration, circuitBreaker.getTimestampUnit(), exception);
                 throw exception;
             }
         };
@@ -385,13 +385,13 @@ public interface CircuitBreaker {
             final long start = circuitBreaker.getCurrentTimestamp();
             try {
                 R returnValue = function.apply(t);
-                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
-                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getTimestampUnit());
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onSuccess(duration, circuitBreaker.getTimestampUnit());
                 return returnValue;
             } catch (Exception exception) {
                 // Do not handle java.lang.Error
-                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
-                circuitBreaker.onError(durationInNanos, circuitBreaker.getTimestampUnit(), exception);
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onError(duration, circuitBreaker.getTimestampUnit(), exception);
                 throw exception;
             }
         };
@@ -488,8 +488,8 @@ public interface CircuitBreaker {
                 try {
                     return new CircuitBreakerFuture<>(circuitBreaker, supplier.get(), start);
                 } catch (Exception e) {
-                    long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
-                    circuitBreaker.onError(durationInNanos, circuitBreaker.getTimestampUnit(), e);
+                    long duration = circuitBreaker.getCurrentTimestamp() - start;
+                    circuitBreaker.onError(duration, circuitBreaker.getTimestampUnit(), e);
                     throw e;
                 }
             }

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreaker.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreaker.java
@@ -68,17 +68,16 @@ public interface CircuitBreaker {
         CheckedFunction0<T> supplier) {
         return () -> {
             circuitBreaker.acquirePermission();
-            long start = System.nanoTime();
+            final long start = circuitBreaker.getCurrentTime();
             try {
                 T returnValue = supplier.apply();
-
-                long durationInNanos = System.nanoTime() - start;
-                circuitBreaker.onSuccess(durationInNanos, TimeUnit.NANOSECONDS);
+                long durationInNanos = circuitBreaker.getCurrentTime() - start;
+                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getCurrentTimeUnit());
                 return returnValue;
             } catch (Exception exception) {
                 // Do not handle java.lang.Error
-                long durationInNanos = System.nanoTime() - start;
-                circuitBreaker.onError(durationInNanos, TimeUnit.NANOSECONDS, exception);
+                long durationInNanos = circuitBreaker.getCurrentTime() - start;
+                circuitBreaker.onError(durationInNanos, circuitBreaker.getCurrentTimeUnit(), exception);
                 throw exception;
             }
         };
@@ -105,24 +104,24 @@ public interface CircuitBreaker {
                     CallNotPermittedException.createCallNotPermittedException(circuitBreaker));
 
             } else {
-                final long start = System.nanoTime();
+                final long start = circuitBreaker.getCurrentTime();
                 try {
                     supplier.get().whenComplete((result, throwable) -> {
-                        long durationInNanos = System.nanoTime() - start;
+                        long durationInNanos = circuitBreaker.getCurrentTime() - start;
                         if (throwable != null) {
                             if (throwable instanceof Exception) {
                                 circuitBreaker
-                                    .onError(durationInNanos, TimeUnit.NANOSECONDS, throwable);
+                                    .onError(durationInNanos, circuitBreaker.getCurrentTimeUnit(), throwable);
                             }
                             promise.completeExceptionally(throwable);
                         } else {
-                            circuitBreaker.onSuccess(durationInNanos, TimeUnit.NANOSECONDS);
+                            circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getCurrentTimeUnit());
                             promise.complete(result);
                         }
                     });
                 } catch (Exception exception) {
-                    long durationInNanos = System.nanoTime() - start;
-                    circuitBreaker.onError(durationInNanos, TimeUnit.NANOSECONDS, exception);
+                    long durationInNanos = circuitBreaker.getCurrentTime() - start;
+                    circuitBreaker.onError(durationInNanos, circuitBreaker.getCurrentTimeUnit(), exception);
                     promise.completeExceptionally(exception);
                 }
             }
@@ -142,15 +141,15 @@ public interface CircuitBreaker {
         CheckedRunnable runnable) {
         return () -> {
             circuitBreaker.acquirePermission();
-            long start = System.nanoTime();
+            final long start = circuitBreaker.getCurrentTime();
             try {
                 runnable.run();
-                long durationInNanos = System.nanoTime() - start;
-                circuitBreaker.onSuccess(durationInNanos, TimeUnit.NANOSECONDS);
+                long durationInNanos = circuitBreaker.getCurrentTime() - start;
+                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getCurrentTimeUnit());
             } catch (Exception exception) {
                 // Do not handle java.lang.Error
-                long durationInNanos = System.nanoTime() - start;
-                circuitBreaker.onError(durationInNanos, TimeUnit.NANOSECONDS, exception);
+                long durationInNanos = circuitBreaker.getCurrentTime() - start;
+                circuitBreaker.onError(durationInNanos, circuitBreaker.getCurrentTimeUnit(), exception);
                 throw exception;
             }
         };
@@ -167,16 +166,16 @@ public interface CircuitBreaker {
     static <T> Callable<T> decorateCallable(CircuitBreaker circuitBreaker, Callable<T> callable) {
         return () -> {
             circuitBreaker.acquirePermission();
-            long start = System.nanoTime();
+            final long start = circuitBreaker.getCurrentTime();
             try {
                 T returnValue = callable.call();
-                long durationInNanos = System.nanoTime() - start;
-                circuitBreaker.onSuccess(durationInNanos, TimeUnit.NANOSECONDS);
+                long durationInNanos = circuitBreaker.getCurrentTime() - start;
+                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getCurrentTimeUnit());
                 return returnValue;
             } catch (Exception exception) {
                 // Do not handle java.lang.Error
-                long durationInNanos = System.nanoTime() - start;
-                circuitBreaker.onError(durationInNanos, TimeUnit.NANOSECONDS, exception);
+                long durationInNanos = circuitBreaker.getCurrentTime() - start;
+                circuitBreaker.onError(durationInNanos, circuitBreaker.getCurrentTimeUnit(), exception);
                 throw exception;
             }
         };
@@ -193,16 +192,16 @@ public interface CircuitBreaker {
     static <T> Supplier<T> decorateSupplier(CircuitBreaker circuitBreaker, Supplier<T> supplier) {
         return () -> {
             circuitBreaker.acquirePermission();
-            long start = System.nanoTime();
+            final long start = circuitBreaker.getCurrentTime();
             try {
                 T returnValue = supplier.get();
-                long durationInNanos = System.nanoTime() - start;
-                circuitBreaker.onSuccess(durationInNanos, TimeUnit.NANOSECONDS);
+                long durationInNanos = circuitBreaker.getCurrentTime() - start;
+                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getCurrentTimeUnit());
                 return returnValue;
             } catch (Exception exception) {
                 // Do not handle java.lang.Error
-                long durationInNanos = System.nanoTime() - start;
-                circuitBreaker.onError(durationInNanos, TimeUnit.NANOSECONDS, exception);
+                long durationInNanos = circuitBreaker.getCurrentTime() - start;
+                circuitBreaker.onError(durationInNanos, circuitBreaker.getCurrentTimeUnit(), exception);
                 throw exception;
             }
         };
@@ -220,14 +219,14 @@ public interface CircuitBreaker {
         Supplier<Either<? extends Exception, T>> supplier) {
         return () -> {
             if (circuitBreaker.tryAcquirePermission()) {
-                long start = System.nanoTime();
+                final long start = circuitBreaker.getCurrentTime();
                 Either<? extends Exception, T> result = supplier.get();
-                long durationInNanos = System.nanoTime() - start;
+                long durationInNanos = circuitBreaker.getCurrentTime() - start;
                 if (result.isRight()) {
-                    circuitBreaker.onSuccess(durationInNanos, TimeUnit.NANOSECONDS);
+                    circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getCurrentTimeUnit());
                 } else {
                     Exception exception = result.getLeft();
-                    circuitBreaker.onError(durationInNanos, TimeUnit.NANOSECONDS, exception);
+                    circuitBreaker.onError(durationInNanos, circuitBreaker.getCurrentTimeUnit(), exception);
                 }
                 return Either.narrow(result);
             } else {
@@ -249,15 +248,15 @@ public interface CircuitBreaker {
         Supplier<Try<T>> supplier) {
         return () -> {
             if (circuitBreaker.tryAcquirePermission()) {
-                long start = System.nanoTime();
+                final long start = circuitBreaker.getCurrentTime();
                 Try<T> result = supplier.get();
-                long durationInNanos = System.nanoTime() - start;
+                long durationInNanos = circuitBreaker.getCurrentTime() - start;
                 if (result.isSuccess()) {
-                    circuitBreaker.onSuccess(durationInNanos, TimeUnit.NANOSECONDS);
+                    circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getCurrentTimeUnit());
                     return result;
                 } else {
                     circuitBreaker
-                        .onError(durationInNanos, TimeUnit.NANOSECONDS, result.getCause());
+                        .onError(durationInNanos, circuitBreaker.getCurrentTimeUnit(), result.getCause());
                     return result;
                 }
             } else {
@@ -278,15 +277,15 @@ public interface CircuitBreaker {
     static <T> Consumer<T> decorateConsumer(CircuitBreaker circuitBreaker, Consumer<T> consumer) {
         return (t) -> {
             circuitBreaker.acquirePermission();
-            long start = System.nanoTime();
+            final long start = circuitBreaker.getCurrentTime();
             try {
                 consumer.accept(t);
-                long durationInNanos = System.nanoTime() - start;
-                circuitBreaker.onSuccess(durationInNanos, TimeUnit.NANOSECONDS);
+                long durationInNanos = circuitBreaker.getCurrentTime() - start;
+                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getCurrentTimeUnit());
             } catch (Exception exception) {
                 // Do not handle java.lang.Error
-                long durationInNanos = System.nanoTime() - start;
-                circuitBreaker.onError(durationInNanos, TimeUnit.NANOSECONDS, exception);
+                long durationInNanos = circuitBreaker.getCurrentTime() - start;
+                circuitBreaker.onError(durationInNanos, circuitBreaker.getCurrentTimeUnit(), exception);
                 throw exception;
             }
         };
@@ -304,15 +303,15 @@ public interface CircuitBreaker {
         CheckedConsumer<T> consumer) {
         return (t) -> {
             circuitBreaker.acquirePermission();
-            long start = System.nanoTime();
+            final long start = circuitBreaker.getCurrentTime();
             try {
                 consumer.accept(t);
-                long durationInNanos = System.nanoTime() - start;
-                circuitBreaker.onSuccess(durationInNanos, TimeUnit.NANOSECONDS);
+                long durationInNanos = circuitBreaker.getCurrentTime() - start;
+                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getCurrentTimeUnit());
             } catch (Exception exception) {
                 // Do not handle java.lang.Error
-                long durationInNanos = System.nanoTime() - start;
-                circuitBreaker.onError(durationInNanos, TimeUnit.NANOSECONDS, exception);
+                long durationInNanos = circuitBreaker.getCurrentTime() - start;
+                circuitBreaker.onError(durationInNanos, circuitBreaker.getCurrentTimeUnit(), exception);
                 throw exception;
             }
         };
@@ -328,15 +327,15 @@ public interface CircuitBreaker {
     static Runnable decorateRunnable(CircuitBreaker circuitBreaker, Runnable runnable) {
         return () -> {
             circuitBreaker.acquirePermission();
-            long start = System.nanoTime();
+            final long start = circuitBreaker.getCurrentTime();
             try {
                 runnable.run();
-                long durationInNanos = System.nanoTime() - start;
-                circuitBreaker.onSuccess(durationInNanos, TimeUnit.NANOSECONDS);
+                long durationInNanos = circuitBreaker.getCurrentTime() - start;
+                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getCurrentTimeUnit());
             } catch (Exception exception) {
                 // Do not handle java.lang.Error
-                long durationInNanos = System.nanoTime() - start;
-                circuitBreaker.onError(durationInNanos, TimeUnit.NANOSECONDS, exception);
+                long durationInNanos = circuitBreaker.getCurrentTime() - start;
+                circuitBreaker.onError(durationInNanos, circuitBreaker.getCurrentTimeUnit(), exception);
                 throw exception;
             }
         };
@@ -355,16 +354,16 @@ public interface CircuitBreaker {
         Function<T, R> function) {
         return (T t) -> {
             circuitBreaker.acquirePermission();
-            long start = System.nanoTime();
+            final long start = circuitBreaker.getCurrentTime();
             try {
                 R returnValue = function.apply(t);
-                long durationInNanos = System.nanoTime() - start;
-                circuitBreaker.onSuccess(durationInNanos, TimeUnit.NANOSECONDS);
+                long durationInNanos = circuitBreaker.getCurrentTime() - start;
+                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getCurrentTimeUnit());
                 return returnValue;
             } catch (Exception exception) {
                 // Do not handle java.lang.Error
-                long durationInNanos = System.nanoTime() - start;
-                circuitBreaker.onError(durationInNanos, TimeUnit.NANOSECONDS, exception);
+                long durationInNanos = circuitBreaker.getCurrentTime() - start;
+                circuitBreaker.onError(durationInNanos, circuitBreaker.getCurrentTimeUnit(), exception);
                 throw exception;
             }
         };
@@ -383,16 +382,16 @@ public interface CircuitBreaker {
         CheckedFunction1<T, R> function) {
         return (T t) -> {
             circuitBreaker.acquirePermission();
-            long start = System.nanoTime();
+            final long start = circuitBreaker.getCurrentTime();
             try {
                 R returnValue = function.apply(t);
-                long durationInNanos = System.nanoTime() - start;
-                circuitBreaker.onSuccess(durationInNanos, TimeUnit.NANOSECONDS);
+                long durationInNanos = circuitBreaker.getCurrentTime() - start;
+                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getCurrentTimeUnit());
                 return returnValue;
             } catch (Exception exception) {
                 // Do not handle java.lang.Error
-                long durationInNanos = System.nanoTime() - start;
-                circuitBreaker.onError(durationInNanos, TimeUnit.NANOSECONDS, exception);
+                long durationInNanos = circuitBreaker.getCurrentTime() - start;
+                circuitBreaker.onError(durationInNanos, circuitBreaker.getCurrentTimeUnit(), exception);
                 throw exception;
             }
         };
@@ -485,12 +484,12 @@ public interface CircuitBreaker {
                     CallNotPermittedException.createCallNotPermittedException(circuitBreaker));
                 return promise;
             } else {
-                final long start = System.nanoTime();
+                final long start = circuitBreaker.getCurrentTime();
                 try {
                     return new CircuitBreakerFuture<>(circuitBreaker, supplier.get(), start);
                 } catch (Exception e) {
-                    long durationInNanos = System.nanoTime() - start;
-                    circuitBreaker.onError(durationInNanos, TimeUnit.NANOSECONDS, e);
+                    long durationInNanos = circuitBreaker.getCurrentTime() - start;
+                    circuitBreaker.onError(durationInNanos, circuitBreaker.getCurrentTimeUnit(), e);
                     throw e;
                 }
             }
@@ -664,6 +663,22 @@ public interface CircuitBreaker {
      * @return an EventPublisher
      */
     EventPublisher getEventPublisher();
+
+    /**
+     * Returns the current time with respect to the CircuitBreaker currentTimeFunction.
+     * Returns System.nanoTime() by default.
+     *
+     * @return current timestamp
+     */
+    long getCurrentTime();
+
+    /**
+     * Returns the timeUnit of current timestamp.
+     * Default is TimeUnit.NANOSECONDS.
+     *
+     * @return current timestamp
+     */
+    TimeUnit getCurrentTimeUnit();
 
     /**
      * Decorates and executes the decorated Supplier.
@@ -1122,7 +1137,7 @@ public interface CircuitBreaker {
         final private long start;
 
         CircuitBreakerFuture(CircuitBreaker circuitBreaker, Future<T> future) {
-            this(circuitBreaker, future, System.nanoTime());
+            this(circuitBreaker, future, circuitBreaker.getCurrentTime());
         }
 
         CircuitBreakerFuture(CircuitBreaker circuitBreaker, Future<T> future, long start) {
@@ -1152,14 +1167,14 @@ public interface CircuitBreaker {
             try {
                 T v = future.get();
                 onceToCircuitbreaker
-                    .applyOnce(cb -> cb.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS));
+                    .applyOnce(cb -> cb.onSuccess(cb.getCurrentTime() - start, cb.getCurrentTimeUnit()));
                 return v;
             } catch (CancellationException | InterruptedException e) {
                 onceToCircuitbreaker.applyOnce(cb -> cb.releasePermission());
                 throw e;
             } catch (Exception e) {
                 onceToCircuitbreaker.applyOnce(
-                    cb -> cb.onError(System.nanoTime() - start, TimeUnit.NANOSECONDS, e));
+                    cb -> cb.onError(cb.getCurrentTime() - start, cb.getCurrentTimeUnit(), e));
                 throw e;
             }
         }
@@ -1170,14 +1185,14 @@ public interface CircuitBreaker {
             try {
                 T v = future.get(timeout, unit);
                 onceToCircuitbreaker
-                    .applyOnce(cb -> cb.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS));
+                    .applyOnce(cb -> cb.onSuccess(cb.getCurrentTime() - start, cb.getCurrentTimeUnit()));
                 return v;
             } catch (CancellationException | InterruptedException e) {
                 onceToCircuitbreaker.applyOnce(cb -> cb.releasePermission());
                 throw e;
             } catch (Exception e) {
                 onceToCircuitbreaker.applyOnce(
-                    cb -> cb.onError(System.nanoTime() - start, TimeUnit.NANOSECONDS, e));
+                    cb -> cb.onError(cb.getCurrentTime() - start, cb.getCurrentTimeUnit(), e));
                 throw e;
             }
         }

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreaker.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreaker.java
@@ -68,16 +68,16 @@ public interface CircuitBreaker {
         CheckedFunction0<T> supplier) {
         return () -> {
             circuitBreaker.acquirePermission();
-            final long start = circuitBreaker.getCurrentTime();
+            final long start = circuitBreaker.getCurrentTimestamp();
             try {
                 T returnValue = supplier.apply();
-                long durationInNanos = circuitBreaker.getCurrentTime() - start;
-                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getCurrentTimeUnit());
+                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getTimestampUnit());
                 return returnValue;
             } catch (Exception exception) {
                 // Do not handle java.lang.Error
-                long durationInNanos = circuitBreaker.getCurrentTime() - start;
-                circuitBreaker.onError(durationInNanos, circuitBreaker.getCurrentTimeUnit(), exception);
+                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onError(durationInNanos, circuitBreaker.getTimestampUnit(), exception);
                 throw exception;
             }
         };
@@ -104,24 +104,24 @@ public interface CircuitBreaker {
                     CallNotPermittedException.createCallNotPermittedException(circuitBreaker));
 
             } else {
-                final long start = circuitBreaker.getCurrentTime();
+                final long start = circuitBreaker.getCurrentTimestamp();
                 try {
                     supplier.get().whenComplete((result, throwable) -> {
-                        long durationInNanos = circuitBreaker.getCurrentTime() - start;
+                        long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
                         if (throwable != null) {
                             if (throwable instanceof Exception) {
                                 circuitBreaker
-                                    .onError(durationInNanos, circuitBreaker.getCurrentTimeUnit(), throwable);
+                                    .onError(durationInNanos, circuitBreaker.getTimestampUnit(), throwable);
                             }
                             promise.completeExceptionally(throwable);
                         } else {
-                            circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getCurrentTimeUnit());
+                            circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getTimestampUnit());
                             promise.complete(result);
                         }
                     });
                 } catch (Exception exception) {
-                    long durationInNanos = circuitBreaker.getCurrentTime() - start;
-                    circuitBreaker.onError(durationInNanos, circuitBreaker.getCurrentTimeUnit(), exception);
+                    long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
+                    circuitBreaker.onError(durationInNanos, circuitBreaker.getTimestampUnit(), exception);
                     promise.completeExceptionally(exception);
                 }
             }
@@ -141,15 +141,15 @@ public interface CircuitBreaker {
         CheckedRunnable runnable) {
         return () -> {
             circuitBreaker.acquirePermission();
-            final long start = circuitBreaker.getCurrentTime();
+            final long start = circuitBreaker.getCurrentTimestamp();
             try {
                 runnable.run();
-                long durationInNanos = circuitBreaker.getCurrentTime() - start;
-                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getCurrentTimeUnit());
+                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getTimestampUnit());
             } catch (Exception exception) {
                 // Do not handle java.lang.Error
-                long durationInNanos = circuitBreaker.getCurrentTime() - start;
-                circuitBreaker.onError(durationInNanos, circuitBreaker.getCurrentTimeUnit(), exception);
+                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onError(durationInNanos, circuitBreaker.getTimestampUnit(), exception);
                 throw exception;
             }
         };
@@ -166,16 +166,16 @@ public interface CircuitBreaker {
     static <T> Callable<T> decorateCallable(CircuitBreaker circuitBreaker, Callable<T> callable) {
         return () -> {
             circuitBreaker.acquirePermission();
-            final long start = circuitBreaker.getCurrentTime();
+            final long start = circuitBreaker.getCurrentTimestamp();
             try {
                 T returnValue = callable.call();
-                long durationInNanos = circuitBreaker.getCurrentTime() - start;
-                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getCurrentTimeUnit());
+                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getTimestampUnit());
                 return returnValue;
             } catch (Exception exception) {
                 // Do not handle java.lang.Error
-                long durationInNanos = circuitBreaker.getCurrentTime() - start;
-                circuitBreaker.onError(durationInNanos, circuitBreaker.getCurrentTimeUnit(), exception);
+                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onError(durationInNanos, circuitBreaker.getTimestampUnit(), exception);
                 throw exception;
             }
         };
@@ -192,16 +192,16 @@ public interface CircuitBreaker {
     static <T> Supplier<T> decorateSupplier(CircuitBreaker circuitBreaker, Supplier<T> supplier) {
         return () -> {
             circuitBreaker.acquirePermission();
-            final long start = circuitBreaker.getCurrentTime();
+            final long start = circuitBreaker.getCurrentTimestamp();
             try {
                 T returnValue = supplier.get();
-                long durationInNanos = circuitBreaker.getCurrentTime() - start;
-                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getCurrentTimeUnit());
+                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getTimestampUnit());
                 return returnValue;
             } catch (Exception exception) {
                 // Do not handle java.lang.Error
-                long durationInNanos = circuitBreaker.getCurrentTime() - start;
-                circuitBreaker.onError(durationInNanos, circuitBreaker.getCurrentTimeUnit(), exception);
+                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onError(durationInNanos, circuitBreaker.getTimestampUnit(), exception);
                 throw exception;
             }
         };
@@ -219,14 +219,14 @@ public interface CircuitBreaker {
         Supplier<Either<? extends Exception, T>> supplier) {
         return () -> {
             if (circuitBreaker.tryAcquirePermission()) {
-                final long start = circuitBreaker.getCurrentTime();
+                final long start = circuitBreaker.getCurrentTimestamp();
                 Either<? extends Exception, T> result = supplier.get();
-                long durationInNanos = circuitBreaker.getCurrentTime() - start;
+                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
                 if (result.isRight()) {
-                    circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getCurrentTimeUnit());
+                    circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getTimestampUnit());
                 } else {
                     Exception exception = result.getLeft();
-                    circuitBreaker.onError(durationInNanos, circuitBreaker.getCurrentTimeUnit(), exception);
+                    circuitBreaker.onError(durationInNanos, circuitBreaker.getTimestampUnit(), exception);
                 }
                 return Either.narrow(result);
             } else {
@@ -248,15 +248,15 @@ public interface CircuitBreaker {
         Supplier<Try<T>> supplier) {
         return () -> {
             if (circuitBreaker.tryAcquirePermission()) {
-                final long start = circuitBreaker.getCurrentTime();
+                final long start = circuitBreaker.getCurrentTimestamp();
                 Try<T> result = supplier.get();
-                long durationInNanos = circuitBreaker.getCurrentTime() - start;
+                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
                 if (result.isSuccess()) {
-                    circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getCurrentTimeUnit());
+                    circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getTimestampUnit());
                     return result;
                 } else {
                     circuitBreaker
-                        .onError(durationInNanos, circuitBreaker.getCurrentTimeUnit(), result.getCause());
+                        .onError(durationInNanos, circuitBreaker.getTimestampUnit(), result.getCause());
                     return result;
                 }
             } else {
@@ -277,15 +277,15 @@ public interface CircuitBreaker {
     static <T> Consumer<T> decorateConsumer(CircuitBreaker circuitBreaker, Consumer<T> consumer) {
         return (t) -> {
             circuitBreaker.acquirePermission();
-            final long start = circuitBreaker.getCurrentTime();
+            final long start = circuitBreaker.getCurrentTimestamp();
             try {
                 consumer.accept(t);
-                long durationInNanos = circuitBreaker.getCurrentTime() - start;
-                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getCurrentTimeUnit());
+                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getTimestampUnit());
             } catch (Exception exception) {
                 // Do not handle java.lang.Error
-                long durationInNanos = circuitBreaker.getCurrentTime() - start;
-                circuitBreaker.onError(durationInNanos, circuitBreaker.getCurrentTimeUnit(), exception);
+                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onError(durationInNanos, circuitBreaker.getTimestampUnit(), exception);
                 throw exception;
             }
         };
@@ -303,15 +303,15 @@ public interface CircuitBreaker {
         CheckedConsumer<T> consumer) {
         return (t) -> {
             circuitBreaker.acquirePermission();
-            final long start = circuitBreaker.getCurrentTime();
+            final long start = circuitBreaker.getCurrentTimestamp();
             try {
                 consumer.accept(t);
-                long durationInNanos = circuitBreaker.getCurrentTime() - start;
-                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getCurrentTimeUnit());
+                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getTimestampUnit());
             } catch (Exception exception) {
                 // Do not handle java.lang.Error
-                long durationInNanos = circuitBreaker.getCurrentTime() - start;
-                circuitBreaker.onError(durationInNanos, circuitBreaker.getCurrentTimeUnit(), exception);
+                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onError(durationInNanos, circuitBreaker.getTimestampUnit(), exception);
                 throw exception;
             }
         };
@@ -327,15 +327,15 @@ public interface CircuitBreaker {
     static Runnable decorateRunnable(CircuitBreaker circuitBreaker, Runnable runnable) {
         return () -> {
             circuitBreaker.acquirePermission();
-            final long start = circuitBreaker.getCurrentTime();
+            final long start = circuitBreaker.getCurrentTimestamp();
             try {
                 runnable.run();
-                long durationInNanos = circuitBreaker.getCurrentTime() - start;
-                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getCurrentTimeUnit());
+                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getTimestampUnit());
             } catch (Exception exception) {
                 // Do not handle java.lang.Error
-                long durationInNanos = circuitBreaker.getCurrentTime() - start;
-                circuitBreaker.onError(durationInNanos, circuitBreaker.getCurrentTimeUnit(), exception);
+                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onError(durationInNanos, circuitBreaker.getTimestampUnit(), exception);
                 throw exception;
             }
         };
@@ -354,16 +354,16 @@ public interface CircuitBreaker {
         Function<T, R> function) {
         return (T t) -> {
             circuitBreaker.acquirePermission();
-            final long start = circuitBreaker.getCurrentTime();
+            final long start = circuitBreaker.getCurrentTimestamp();
             try {
                 R returnValue = function.apply(t);
-                long durationInNanos = circuitBreaker.getCurrentTime() - start;
-                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getCurrentTimeUnit());
+                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getTimestampUnit());
                 return returnValue;
             } catch (Exception exception) {
                 // Do not handle java.lang.Error
-                long durationInNanos = circuitBreaker.getCurrentTime() - start;
-                circuitBreaker.onError(durationInNanos, circuitBreaker.getCurrentTimeUnit(), exception);
+                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onError(durationInNanos, circuitBreaker.getTimestampUnit(), exception);
                 throw exception;
             }
         };
@@ -382,16 +382,16 @@ public interface CircuitBreaker {
         CheckedFunction1<T, R> function) {
         return (T t) -> {
             circuitBreaker.acquirePermission();
-            final long start = circuitBreaker.getCurrentTime();
+            final long start = circuitBreaker.getCurrentTimestamp();
             try {
                 R returnValue = function.apply(t);
-                long durationInNanos = circuitBreaker.getCurrentTime() - start;
-                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getCurrentTimeUnit());
+                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onSuccess(durationInNanos, circuitBreaker.getTimestampUnit());
                 return returnValue;
             } catch (Exception exception) {
                 // Do not handle java.lang.Error
-                long durationInNanos = circuitBreaker.getCurrentTime() - start;
-                circuitBreaker.onError(durationInNanos, circuitBreaker.getCurrentTimeUnit(), exception);
+                long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onError(durationInNanos, circuitBreaker.getTimestampUnit(), exception);
                 throw exception;
             }
         };
@@ -484,12 +484,12 @@ public interface CircuitBreaker {
                     CallNotPermittedException.createCallNotPermittedException(circuitBreaker));
                 return promise;
             } else {
-                final long start = circuitBreaker.getCurrentTime();
+                final long start = circuitBreaker.getCurrentTimestamp();
                 try {
                     return new CircuitBreakerFuture<>(circuitBreaker, supplier.get(), start);
                 } catch (Exception e) {
-                    long durationInNanos = circuitBreaker.getCurrentTime() - start;
-                    circuitBreaker.onError(durationInNanos, circuitBreaker.getCurrentTimeUnit(), e);
+                    long durationInNanos = circuitBreaker.getCurrentTimestamp() - start;
+                    circuitBreaker.onError(durationInNanos, circuitBreaker.getTimestampUnit(), e);
                     throw e;
                 }
             }
@@ -670,15 +670,15 @@ public interface CircuitBreaker {
      *
      * @return current timestamp
      */
-    long getCurrentTime();
+    long getCurrentTimestamp();
 
     /**
      * Returns the timeUnit of current timestamp.
      * Default is TimeUnit.NANOSECONDS.
      *
-     * @return current timestamp
+     * @return the timeUnit of current timestamp
      */
-    TimeUnit getCurrentTimeUnit();
+    TimeUnit getTimestampUnit();
 
     /**
      * Decorates and executes the decorated Supplier.
@@ -1137,7 +1137,7 @@ public interface CircuitBreaker {
         final private long start;
 
         CircuitBreakerFuture(CircuitBreaker circuitBreaker, Future<T> future) {
-            this(circuitBreaker, future, circuitBreaker.getCurrentTime());
+            this(circuitBreaker, future, circuitBreaker.getCurrentTimestamp());
         }
 
         CircuitBreakerFuture(CircuitBreaker circuitBreaker, Future<T> future, long start) {
@@ -1167,14 +1167,14 @@ public interface CircuitBreaker {
             try {
                 T v = future.get();
                 onceToCircuitbreaker
-                    .applyOnce(cb -> cb.onSuccess(cb.getCurrentTime() - start, cb.getCurrentTimeUnit()));
+                    .applyOnce(cb -> cb.onSuccess(cb.getCurrentTimestamp() - start, cb.getTimestampUnit()));
                 return v;
             } catch (CancellationException | InterruptedException e) {
                 onceToCircuitbreaker.applyOnce(cb -> cb.releasePermission());
                 throw e;
             } catch (Exception e) {
                 onceToCircuitbreaker.applyOnce(
-                    cb -> cb.onError(cb.getCurrentTime() - start, cb.getCurrentTimeUnit(), e));
+                    cb -> cb.onError(cb.getCurrentTimestamp() - start, cb.getTimestampUnit(), e));
                 throw e;
             }
         }
@@ -1185,14 +1185,14 @@ public interface CircuitBreaker {
             try {
                 T v = future.get(timeout, unit);
                 onceToCircuitbreaker
-                    .applyOnce(cb -> cb.onSuccess(cb.getCurrentTime() - start, cb.getCurrentTimeUnit()));
+                    .applyOnce(cb -> cb.onSuccess(cb.getCurrentTimestamp() - start, cb.getTimestampUnit()));
                 return v;
             } catch (CancellationException | InterruptedException e) {
                 onceToCircuitbreaker.applyOnce(cb -> cb.releasePermission());
                 throw e;
             } catch (Exception e) {
                 onceToCircuitbreaker.applyOnce(
-                    cb -> cb.onError(cb.getCurrentTime() - start, cb.getCurrentTimeUnit(), e));
+                    cb -> cb.onError(cb.getCurrentTimestamp() - start, cb.getTimestampUnit(), e));
                 throw e;
             }
         }

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfig.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfig.java
@@ -22,8 +22,11 @@ import io.github.resilience4j.core.IntervalFunction;
 import io.github.resilience4j.core.lang.Nullable;
 import io.github.resilience4j.core.predicate.PredicateCreator;
 
+import java.time.Clock;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 
@@ -44,10 +47,15 @@ public class CircuitBreakerConfig {
     public static final boolean DEFAULT_WRITABLE_STACK_TRACE_ENABLED = true;
     private static final Predicate<Throwable> DEFAULT_RECORD_EXCEPTION_PREDICATE = throwable -> true;
     private static final Predicate<Throwable> DEFAULT_IGNORE_EXCEPTION_PREDICATE = throwable -> false;
+    // The default Function to return current time
+    private static final Function<Clock, Long> DEFAULT_CURRENT_TIME_FUNCTION = clock -> System.nanoTime();
+    private static final TimeUnit DEFAULT_CURRENT_TIME_UNIT = TimeUnit.NANOSECONDS;
     // The default exception predicate counts all exceptions as failures.
     private Predicate<Throwable> recordExceptionPredicate = DEFAULT_RECORD_EXCEPTION_PREDICATE;
     // The default exception predicate ignores no exceptions.
     private Predicate<Throwable> ignoreExceptionPredicate = DEFAULT_IGNORE_EXCEPTION_PREDICATE;
+    private Function<Clock, Long> currentTimeFunction = DEFAULT_CURRENT_TIME_FUNCTION;
+    private TimeUnit currentTimeUnit = DEFAULT_CURRENT_TIME_UNIT;
 
     @SuppressWarnings("unchecked")
     private Class<? extends Throwable>[] recordExceptions = new Class[0];
@@ -135,6 +143,10 @@ public class CircuitBreakerConfig {
         return ignoreExceptionPredicate;
     }
 
+    public Function<Clock, Long> getCurrentTimeFunction() { return currentTimeFunction; }
+
+    public TimeUnit getCurrentTimeUnit() { return currentTimeUnit; }
+
     public boolean isAutomaticTransitionFromOpenToHalfOpenEnabled() {
         return automaticTransitionFromOpenToHalfOpenEnabled;
     }
@@ -212,6 +224,8 @@ public class CircuitBreakerConfig {
         private Predicate<Throwable> recordExceptionPredicate;
         @Nullable
         private Predicate<Throwable> ignoreExceptionPredicate;
+        private Function<Clock, Long> currentTimeFunction = DEFAULT_CURRENT_TIME_FUNCTION;
+        private TimeUnit currentTimeUnit = DEFAULT_CURRENT_TIME_UNIT;
 
         @SuppressWarnings("unchecked")
         private Class<? extends Throwable>[] recordExceptions = new Class[0];
@@ -247,6 +261,8 @@ public class CircuitBreakerConfig {
             this.recordExceptions = baseConfig.recordExceptions;
             this.recordExceptionPredicate = baseConfig.recordExceptionPredicate;
             this.ignoreExceptionPredicate = baseConfig.ignoreExceptionPredicate;
+            this.currentTimeFunction = baseConfig.currentTimeFunction;
+            this.currentTimeUnit = baseConfig.currentTimeUnit;
             this.automaticTransitionFromOpenToHalfOpenEnabled = baseConfig.automaticTransitionFromOpenToHalfOpenEnabled;
             this.slowCallRateThreshold = baseConfig.slowCallRateThreshold;
             this.slowCallDurationThreshold = baseConfig.slowCallDurationThreshold;
@@ -581,6 +597,21 @@ public class CircuitBreakerConfig {
             this.recordExceptionPredicate = predicate;
             return this;
         }
+        /**
+         * Configures a function that returns current timestamp for CircuitBreaker.
+         * Default implementation uses System.nanoTime() to compute current timestamp.
+         * Configure currentTimeFunction to provide different implementation to compute current timestamp.
+         * <p>
+         *
+         * @param currentTimeFunction function that computes current timestamp.
+         * @param timeUnit TimeUnit of timestamp returned by the function.
+         * @return the CircuitBreakerConfig.Builder
+         */
+        public Builder currentTimeFunction(Function<Clock, Long> currentTimeFunction, TimeUnit timeUnit) {
+            this.currentTimeUnit = timeUnit;
+            this.currentTimeFunction = currentTimeFunction;
+            return this;
+        }
 
         /**
          * Configures a Predicate which evaluates if an exception should be ignored and neither
@@ -695,6 +726,8 @@ public class CircuitBreakerConfig {
             config.writableStackTraceEnabled = writableStackTraceEnabled;
             config.recordExceptionPredicate = createRecordExceptionPredicate();
             config.ignoreExceptionPredicate = createIgnoreFailurePredicate();
+            config.currentTimeFunction = currentTimeFunction;
+            config.currentTimeUnit = currentTimeUnit;
             return config;
         }
 

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfig.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfig.java
@@ -48,14 +48,14 @@ public class CircuitBreakerConfig {
     private static final Predicate<Throwable> DEFAULT_RECORD_EXCEPTION_PREDICATE = throwable -> true;
     private static final Predicate<Throwable> DEFAULT_IGNORE_EXCEPTION_PREDICATE = throwable -> false;
     // The default Function to return current time
-    private static final Function<Clock, Long> DEFAULT_CURRENT_TIME_FUNCTION = clock -> System.nanoTime();
-    private static final TimeUnit DEFAULT_CURRENT_TIME_UNIT = TimeUnit.NANOSECONDS;
+    private static final Function<Clock, Long> DEFAULT_TIMESTAMP_FUNCTION = clock -> System.nanoTime();
+    private static final TimeUnit DEFAULT_TIMESTAMP_UNIT = TimeUnit.NANOSECONDS;
     // The default exception predicate counts all exceptions as failures.
     private Predicate<Throwable> recordExceptionPredicate = DEFAULT_RECORD_EXCEPTION_PREDICATE;
     // The default exception predicate ignores no exceptions.
     private Predicate<Throwable> ignoreExceptionPredicate = DEFAULT_IGNORE_EXCEPTION_PREDICATE;
-    private Function<Clock, Long> currentTimeFunction = DEFAULT_CURRENT_TIME_FUNCTION;
-    private TimeUnit currentTimeUnit = DEFAULT_CURRENT_TIME_UNIT;
+    private Function<Clock, Long> currentTimestampFunction = DEFAULT_TIMESTAMP_FUNCTION;
+    private TimeUnit timestampUnit = DEFAULT_TIMESTAMP_UNIT;
 
     @SuppressWarnings("unchecked")
     private Class<? extends Throwable>[] recordExceptions = new Class[0];
@@ -143,9 +143,9 @@ public class CircuitBreakerConfig {
         return ignoreExceptionPredicate;
     }
 
-    public Function<Clock, Long> getCurrentTimeFunction() { return currentTimeFunction; }
+    public Function<Clock, Long> getCurrentTimestampFunction() { return currentTimestampFunction; }
 
-    public TimeUnit getCurrentTimeUnit() { return currentTimeUnit; }
+    public TimeUnit getTimestampUnit() { return timestampUnit; }
 
     public boolean isAutomaticTransitionFromOpenToHalfOpenEnabled() {
         return automaticTransitionFromOpenToHalfOpenEnabled;
@@ -224,8 +224,8 @@ public class CircuitBreakerConfig {
         private Predicate<Throwable> recordExceptionPredicate;
         @Nullable
         private Predicate<Throwable> ignoreExceptionPredicate;
-        private Function<Clock, Long> currentTimeFunction = DEFAULT_CURRENT_TIME_FUNCTION;
-        private TimeUnit currentTimeUnit = DEFAULT_CURRENT_TIME_UNIT;
+        private Function<Clock, Long> currentTimestampFunction = DEFAULT_TIMESTAMP_FUNCTION;
+        private TimeUnit timestampUnit = DEFAULT_TIMESTAMP_UNIT;
 
         @SuppressWarnings("unchecked")
         private Class<? extends Throwable>[] recordExceptions = new Class[0];
@@ -261,8 +261,8 @@ public class CircuitBreakerConfig {
             this.recordExceptions = baseConfig.recordExceptions;
             this.recordExceptionPredicate = baseConfig.recordExceptionPredicate;
             this.ignoreExceptionPredicate = baseConfig.ignoreExceptionPredicate;
-            this.currentTimeFunction = baseConfig.currentTimeFunction;
-            this.currentTimeUnit = baseConfig.currentTimeUnit;
+            this.currentTimestampFunction = baseConfig.currentTimestampFunction;
+            this.timestampUnit = baseConfig.timestampUnit;
             this.automaticTransitionFromOpenToHalfOpenEnabled = baseConfig.automaticTransitionFromOpenToHalfOpenEnabled;
             this.slowCallRateThreshold = baseConfig.slowCallRateThreshold;
             this.slowCallDurationThreshold = baseConfig.slowCallDurationThreshold;
@@ -600,16 +600,16 @@ public class CircuitBreakerConfig {
         /**
          * Configures a function that returns current timestamp for CircuitBreaker.
          * Default implementation uses System.nanoTime() to compute current timestamp.
-         * Configure currentTimeFunction to provide different implementation to compute current timestamp.
+         * Configure currentTimestampFunction to provide different implementation to compute current timestamp.
          * <p>
          *
-         * @param currentTimeFunction function that computes current timestamp.
+         * @param currentTimestampFunction function that computes current timestamp.
          * @param timeUnit TimeUnit of timestamp returned by the function.
          * @return the CircuitBreakerConfig.Builder
          */
-        public Builder currentTimeFunction(Function<Clock, Long> currentTimeFunction, TimeUnit timeUnit) {
-            this.currentTimeUnit = timeUnit;
-            this.currentTimeFunction = currentTimeFunction;
+        public Builder currentTimestampFunction(Function<Clock, Long> currentTimestampFunction, TimeUnit timeUnit) {
+            this.timestampUnit = timeUnit;
+            this.currentTimestampFunction = currentTimestampFunction;
             return this;
         }
 
@@ -726,8 +726,8 @@ public class CircuitBreakerConfig {
             config.writableStackTraceEnabled = writableStackTraceEnabled;
             config.recordExceptionPredicate = createRecordExceptionPredicate();
             config.ignoreExceptionPredicate = createIgnoreFailurePredicate();
-            config.currentTimeFunction = currentTimeFunction;
-            config.currentTimeUnit = currentTimeUnit;
+            config.currentTimestampFunction = currentTimestampFunction;
+            config.timestampUnit = timestampUnit;
             return config;
         }
 

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachine.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachine.java
@@ -38,6 +38,7 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
@@ -60,6 +61,8 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
     private final CircuitBreakerEventProcessor eventProcessor;
     private final Clock clock;
     private final SchedulerFactory schedulerFactory;
+    private final Function<Clock, Long> currentTimeFunction;
+    private final TimeUnit currentTimeUnit;
 
     /**
      * Creates a circuitBreaker.
@@ -80,6 +83,8 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
         this.stateReference = new AtomicReference<>(new ClosedState());
         this.schedulerFactory = schedulerFactory;
         this.tags = Objects.requireNonNull(tags, "Tags must not be null");
+        this.currentTimeFunction = circuitBreakerConfig.getCurrentTimeFunction();
+        this.currentTimeUnit = circuitBreakerConfig.getCurrentTimeUnit();
     }
 
     /**
@@ -168,6 +173,16 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
         Supplier<CircuitBreakerConfig> circuitBreakerConfig,
         io.vavr.collection.Map<String, String> tags) {
         this(name, circuitBreakerConfig.get(), tags);
+    }
+
+    @Override
+    public long getCurrentTime() {
+        return this.currentTimeFunction.apply(clock);
+    }
+
+    @Override
+    public TimeUnit getCurrentTimeUnit() {
+        return currentTimeUnit;
     }
 
     @Override

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachine.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachine.java
@@ -61,8 +61,8 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
     private final CircuitBreakerEventProcessor eventProcessor;
     private final Clock clock;
     private final SchedulerFactory schedulerFactory;
-    private final Function<Clock, Long> currentTimeFunction;
-    private final TimeUnit currentTimeUnit;
+    private final Function<Clock, Long> currentTimestampFunction;
+    private final TimeUnit timestampUnit;
 
     /**
      * Creates a circuitBreaker.
@@ -83,8 +83,8 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
         this.stateReference = new AtomicReference<>(new ClosedState());
         this.schedulerFactory = schedulerFactory;
         this.tags = Objects.requireNonNull(tags, "Tags must not be null");
-        this.currentTimeFunction = circuitBreakerConfig.getCurrentTimeFunction();
-        this.currentTimeUnit = circuitBreakerConfig.getCurrentTimeUnit();
+        this.currentTimestampFunction = circuitBreakerConfig.getCurrentTimestampFunction();
+        this.timestampUnit = circuitBreakerConfig.getTimestampUnit();
     }
 
     /**
@@ -176,13 +176,13 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
     }
 
     @Override
-    public long getCurrentTime() {
-        return this.currentTimeFunction.apply(clock);
+    public long getCurrentTimestamp() {
+        return this.currentTimestampFunction.apply(clock);
     }
 
     @Override
-    public TimeUnit getCurrentTimeUnit() {
-        return currentTimeUnit;
+    public TimeUnit getTimestampUnit() {
+        return timestampUnit;
     }
 
     @Override

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfigTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfigTest.java
@@ -356,9 +356,9 @@ public class CircuitBreakerConfigTest {
         Instant instant = Instant.now();
         Clock fixedClock = Clock.fixed(instant, ZoneId.systemDefault());
         CircuitBreakerConfig circuitBreakerConfig = custom()
-            .currentTimeFunction(clock -> clock.instant().toEpochMilli(), TimeUnit.MILLISECONDS)
+            .currentTimestampFunction(clock -> clock.instant().toEpochMilli(), TimeUnit.MILLISECONDS)
             .build();
-        final Function<Clock, Long> currentTimeFunction = circuitBreakerConfig.getCurrentTimeFunction();
+        final Function<Clock, Long> currentTimeFunction = circuitBreakerConfig.getCurrentTimestampFunction();
         then(currentTimeFunction).isNotNull();
         then(currentTimeFunction.apply(fixedClock)).isEqualTo(instant.toEpochMilli());
     }

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfigTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfigTest.java
@@ -21,7 +21,12 @@ package io.github.resilience4j.circuitbreaker;
 import io.github.resilience4j.core.IntervalFunction;
 import org.junit.Test;
 
+import java.time.Clock;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import static io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.*;
@@ -344,6 +349,18 @@ public class CircuitBreakerConfigTest {
         for (int i = 0; i < 10; i++) {
             then(intervalFunction.apply(i)).isEqualTo(i);
         }
+    }
+
+    @Test
+    public void shouldCreateCurrentTimeFunction() {
+        Instant instant = Instant.now();
+        Clock fixedClock = Clock.fixed(instant, ZoneId.systemDefault());
+        CircuitBreakerConfig circuitBreakerConfig = custom()
+            .currentTimeFunction(clock -> clock.instant().toEpochMilli(), TimeUnit.MILLISECONDS)
+            .build();
+        final Function<Clock, Long> currentTimeFunction = circuitBreakerConfig.getCurrentTimeFunction();
+        then(currentTimeFunction).isNotNull();
+        then(currentTimeFunction.apply(fixedClock)).isEqualTo(instant.toEpochMilli());
     }
 
     @Test

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachineTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachineTest.java
@@ -72,7 +72,7 @@ public class CircuitBreakerStateMachineTest {
             .slidingWindow(20, 5, SlidingWindowType.TIME_BASED)
             .waitDurationInOpenState(Duration.ofSeconds(5))
             .ignoreExceptions(NumberFormatException.class)
-            .currentTimeFunction(clock -> clock.instant().toEpochMilli(), TimeUnit.MILLISECONDS)
+            .currentTimestampFunction(clock -> clock.instant().toEpochMilli(), TimeUnit.MILLISECONDS)
             .build(), mockClock);
     }
 

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachineTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachineTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import java.time.Duration;
 import java.time.ZoneId;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 import static io.github.resilience4j.circuitbreaker.CircuitBreaker.State.FORCED_OPEN;
 import static io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.SlidingWindowType;
@@ -68,9 +69,10 @@ public class CircuitBreakerStateMachineTest {
             .slowCallDurationThreshold(Duration.ofSeconds(4))
             .slowCallRateThreshold(50)
             .maxWaitDurationInHalfOpenState(Duration.ofSeconds(1))
-            .slidingWindow(5, 5, SlidingWindowType.TIME_BASED)
+            .slidingWindow(20, 5, SlidingWindowType.TIME_BASED)
             .waitDurationInOpenState(Duration.ofSeconds(5))
             .ignoreExceptions(NumberFormatException.class)
+            .currentTimeFunction(clock -> clock.instant().toEpochMilli(), TimeUnit.MILLISECONDS)
             .build(), mockClock);
     }
 
@@ -273,6 +275,47 @@ public class CircuitBreakerStateMachineTest {
         assertThat(circuitBreaker.getMetrics().getNumberOfSlowCalls()).isEqualTo(3);
         assertThat(circuitBreaker.getMetrics().getSlowCallRate()).isEqualTo(60.0f);
 
+    }
+
+    @Test
+    public void shouldOpenAfterSlowCallRateThresholdExceededUsingMockClock() {
+        // A ring buffer with size 5 is used in closed state
+        // Initially the CircuitBreaker is closed
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
+        assertThatMetricsAreReset();
+        Consumer<Integer> consumer = circuitBreaker.decorateConsumer(mockClock::advanceBySeconds);
+        // Call 1 is slow
+        consumer.accept(5);
+        assertThat(circuitBreaker.getMetrics().getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(circuitBreaker.getMetrics().getNumberOfSlowCalls()).isEqualTo(1);
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
+
+        // Call 2 is slow
+        consumer.accept(5);
+        assertThat(circuitBreaker.getMetrics().getNumberOfBufferedCalls()).isEqualTo(2);
+        assertThat(circuitBreaker.getMetrics().getNumberOfSlowCalls()).isEqualTo(2);
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
+
+        // Call 3 is fast
+        consumer.accept(1);
+        assertThat(circuitBreaker.getMetrics().getNumberOfBufferedCalls()).isEqualTo(3);
+        assertThat(circuitBreaker.getMetrics().getNumberOfSlowCalls()).isEqualTo(2);
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
+
+        // Call 4 is fast
+        consumer.accept(1);
+        assertThat(circuitBreaker.getMetrics().getNumberOfBufferedCalls()).isEqualTo(4);
+        assertThat(circuitBreaker.getMetrics().getNumberOfSlowCalls()).isEqualTo(2);
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
+
+        // Call 5 is slow
+        consumer.accept(5);
+        // The ring buffer is filled and the slow call rate is above 50%
+        assertThat(circuitBreaker.getState()).isEqualTo(
+            CircuitBreaker.State.OPEN); // Should create a CircuitBreakerOnStateTransitionEvent (6)
+        assertThat(circuitBreaker.getMetrics().getNumberOfBufferedCalls()).isEqualTo(5);
+        assertThat(circuitBreaker.getMetrics().getNumberOfSlowCalls()).isEqualTo(3);
+        assertThat(circuitBreaker.getMetrics().getSlowCallRate()).isEqualTo(60.0f);
     }
 
     @Test


### PR DESCRIPTION
As per #734 , `CircuitBreaker` now uses clock from `CircuitBreakerStateMachine` to calculate duration of the call so that clock can be easily mocked while writing unit test cases.

@RobWin Kindly review.