### PR TITLE
Issue #1062: Adding CircuitBreaker to CallNotPermittedException for inspection

### DIFF
--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CallNotPermittedException.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CallNotPermittedException.java
@@ -24,8 +24,11 @@ package io.github.resilience4j.circuitbreaker;
  */
 public class CallNotPermittedException extends RuntimeException {
 
-    private CallNotPermittedException(String message, boolean writableStackTrace) {
+    private final transient String causingCircuitBreakerName;
+
+    private CallNotPermittedException(CircuitBreaker circuitBreaker, String message, boolean writableStackTrace) {
         super(message, null, false, writableStackTrace);
+        this.causingCircuitBreakerName = circuitBreaker.getName();
     }
 
     /**
@@ -42,6 +45,15 @@ public class CallNotPermittedException extends RuntimeException {
             .format("CircuitBreaker '%s' is %s and does not permit further calls",
                 circuitBreaker.getName(), circuitBreaker.getState());
 
-        return new CallNotPermittedException(message, writableStackTraceEnabled);
+        return new CallNotPermittedException(circuitBreaker, message, writableStackTraceEnabled);
+    }
+
+    /**
+     * Returns the name of {@link CircuitBreaker} that caused this exception.
+     *
+     * @return the name of  {@link CircuitBreaker} that caused this exception.
+     */
+    public String getCausingCircuitBreakerName() {
+        return this.causingCircuitBreakerName;
     }
 }

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CallNotPermittedExceptionTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CallNotPermittedExceptionTest.java
@@ -11,15 +11,19 @@ public class CallNotPermittedExceptionTest {
     public void shouldReturnCorrectMessageWhenStateIsOpen() {
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
         circuitBreaker.transitionToOpenState();
-        assertThat(createCallNotPermittedException(circuitBreaker).getMessage())
+        final CallNotPermittedException callNotPermittedException = createCallNotPermittedException(circuitBreaker);
+        assertThat(callNotPermittedException.getMessage())
             .isEqualTo("CircuitBreaker 'testName' is OPEN and does not permit further calls");
+        assertThat(callNotPermittedException.getCausingCircuitBreakerName()).isEqualTo(circuitBreaker.getName());
     }
 
     @Test
     public void shouldReturnCorrectMessageWhenStateIsForcedOpen() {
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
         circuitBreaker.transitionToForcedOpenState();
-        assertThat(createCallNotPermittedException(circuitBreaker).getMessage()).isEqualTo(
+        final CallNotPermittedException callNotPermittedException = createCallNotPermittedException(circuitBreaker);
+        assertThat(callNotPermittedException.getMessage()).isEqualTo(
             "CircuitBreaker 'testName' is FORCED_OPEN and does not permit further calls");
+        assertThat(callNotPermittedException.getCausingCircuitBreakerName()).isEqualTo(circuitBreaker.getName());
     }
 }


### PR DESCRIPTION
Issue #1062: Adding CircuitBreaker to CallNotPermittedException for inspection

Raised a PR for adding the circuit breaker to the exception, otherwise one would have to parse the exception message which seems hacky. Instead of adding only the name passed the entire CircuitBreaker for any other inspection people might want to do.