### PR TITLE
#734 Added getCurrentTimestamp function to reactor circuitBreaker

### DIFF
--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/FluxCircuitBreakerTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/FluxCircuitBreakerTest.java
@@ -42,6 +42,8 @@ public class FluxCircuitBreakerTest {
     @Test
     public void shouldSubscribeToFluxJust() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
+        given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
+        given(circuitBreaker.getTimestampUnit()).willReturn(TimeUnit.NANOSECONDS);
 
         StepVerifier.create(
             Flux.just("Event 1", "Event 2")
@@ -58,6 +60,8 @@ public class FluxCircuitBreakerTest {
     @Test
     public void shouldPropagateError() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
+        given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
+        given(circuitBreaker.getTimestampUnit()).willReturn(TimeUnit.NANOSECONDS);
 
         StepVerifier.create(
             Flux.error(new IOException("BAM!"))
@@ -73,6 +77,8 @@ public class FluxCircuitBreakerTest {
     @Test
     public void shouldPropagateErrorWhenErrorNotOnSubscribe() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
+        given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
+        given(circuitBreaker.getTimestampUnit()).willReturn(TimeUnit.NANOSECONDS);
 
         StepVerifier.create(
             Flux.error(new IOException("BAM!"), true)
@@ -88,6 +94,8 @@ public class FluxCircuitBreakerTest {
     @Test
     public void shouldSubscribeToMonoJustTwice() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
+        given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
+        given(circuitBreaker.getTimestampUnit()).willReturn(TimeUnit.NANOSECONDS);
 
         StepVerifier.create(Flux.just("Event 1", "Event 2")
             .flatMap(value -> Mono.just("Bla " + value)
@@ -167,6 +175,8 @@ public class FluxCircuitBreakerTest {
     @Test
     public void shouldInvokeOnSuccessOnCancelWhenEventWasEmitted() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
+        given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
+        given(circuitBreaker.getTimestampUnit()).willReturn(TimeUnit.NANOSECONDS);
 
         StepVerifier.create(
             Flux.just("Event1", "Event2", "Event3")

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/MonoCircuitBreakerTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/MonoCircuitBreakerTest.java
@@ -50,6 +50,8 @@ public class MonoCircuitBreakerTest {
     public void shouldSubscribeToMonoJust() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
         given(helloWorldService.returnHelloWorld()).willReturn("Hello World");
+        given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
+        given(circuitBreaker.getTimestampUnit()).willReturn(TimeUnit.NANOSECONDS);
 
         StepVerifier.create(
             Mono.just(helloWorldService.returnHelloWorld())
@@ -67,6 +69,8 @@ public class MonoCircuitBreakerTest {
     public void shouldSubscribeToMonoFromCallable() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
         given(helloWorldService.returnHelloWorld()).willReturn("Hello World");
+        given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
+        given(circuitBreaker.getTimestampUnit()).willReturn(TimeUnit.NANOSECONDS);
 
         StepVerifier.create(
             Mono.fromCallable(() -> helloWorldService.returnHelloWorld())
@@ -84,6 +88,8 @@ public class MonoCircuitBreakerTest {
     public void shouldSubscribeToMonoFromCallableMultipleTimes() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
         given(helloWorldService.returnHelloWorld()).willReturn("Hello World");
+        given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
+        given(circuitBreaker.getTimestampUnit()).willReturn(TimeUnit.NANOSECONDS);
 
         StepVerifier.create(
             Mono.fromCallable(() -> helloWorldService.returnHelloWorld())
@@ -103,6 +109,8 @@ public class MonoCircuitBreakerTest {
     @Test
     public void emptyMonoShouldBeSuccessful() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
+        given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
+        given(circuitBreaker.getTimestampUnit()).willReturn(TimeUnit.NANOSECONDS);
 
         StepVerifier.create(
             Mono.empty()
@@ -117,6 +125,8 @@ public class MonoCircuitBreakerTest {
     @Test
     public void shouldPropagateError() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
+        given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
+        given(circuitBreaker.getTimestampUnit()).willReturn(TimeUnit.NANOSECONDS);
 
         StepVerifier.create(
             Mono.error(new IOException("BAM!"))


### PR DESCRIPTION
Issue: #734 
As part of #1063, Added `getCurrentTimestamp()` to get the current timestamp and removed System.nanoTime().

@RobWin Kindly review.