### PR TITLE
#734 Added getCurrentTime function to rxjava2 circuitBreaker

### DIFF
--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/CompletableCircuitBreaker.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/CompletableCircuitBreaker.java
@@ -21,8 +21,6 @@ import io.reactivex.Completable;
 import io.reactivex.CompletableObserver;
 import io.reactivex.internal.disposables.EmptyDisposable;
 
-import java.util.concurrent.TimeUnit;
-
 import static io.github.resilience4j.circuitbreaker.CallNotPermittedException.createCallNotPermittedException;
 
 class CompletableCircuitBreaker extends Completable {
@@ -51,17 +49,17 @@ class CompletableCircuitBreaker extends Completable {
 
         CircuitBreakerCompletableObserver(CompletableObserver downstreamObserver) {
             super(downstreamObserver);
-            this.start = System.nanoTime();
+            this.start = circuitBreaker.getCurrentTimestamp();
         }
 
         @Override
         protected void hookOnComplete() {
-            circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+            circuitBreaker.onSuccess(circuitBreaker.getCurrentTimestamp() - start, circuitBreaker.getTimestampUnit());
         }
 
         @Override
         protected void hookOnError(Throwable e) {
-            circuitBreaker.onError(System.nanoTime() - start, TimeUnit.NANOSECONDS, e);
+            circuitBreaker.onError(circuitBreaker.getCurrentTimestamp() - start, circuitBreaker.getTimestampUnit(), e);
         }
 
         @Override

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/FlowableCircuitBreaker.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/FlowableCircuitBreaker.java
@@ -23,7 +23,6 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 
 import static io.github.resilience4j.circuitbreaker.CallNotPermittedException.createCallNotPermittedException;
 import static java.util.Objects.requireNonNull;
@@ -54,23 +53,23 @@ class FlowableCircuitBreaker<T> extends Flowable<T> {
 
         CircuitBreakerSubscriber(Subscriber<? super T> downstreamSubscriber) {
             super(downstreamSubscriber);
-            this.start = System.nanoTime();
+            this.start = circuitBreaker.getCurrentTimestamp();
         }
 
         @Override
         public void hookOnError(Throwable t) {
-            circuitBreaker.onError(System.nanoTime() - start, TimeUnit.NANOSECONDS, t);
+            circuitBreaker.onError(circuitBreaker.getCurrentTimestamp() - start, circuitBreaker.getTimestampUnit(), t);
         }
 
         @Override
         public void hookOnComplete() {
-            circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+            circuitBreaker.onSuccess(circuitBreaker.getCurrentTimestamp() - start, circuitBreaker.getTimestampUnit());
         }
 
         @Override
         public void hookOnCancel() {
             if (eventWasEmitted.get()) {
-                circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+                circuitBreaker.onSuccess(circuitBreaker.getCurrentTimestamp() - start, circuitBreaker.getTimestampUnit());
             } else {
                 circuitBreaker.releasePermission();
             }

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/MaybeCircuitBreaker.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/MaybeCircuitBreaker.java
@@ -51,22 +51,22 @@ class MaybeCircuitBreaker<T> extends Maybe<T> {
 
         CircuitBreakerMaybeObserver(MaybeObserver<? super T> downstreamObserver) {
             super(downstreamObserver);
-            this.start = System.nanoTime();
+            this.start = circuitBreaker.getCurrentTimestamp();
         }
 
         @Override
         protected void hookOnComplete() {
-            circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+            circuitBreaker.onSuccess(circuitBreaker.getCurrentTimestamp() - start, circuitBreaker.getTimestampUnit());
         }
 
         @Override
         protected void hookOnError(Throwable e) {
-            circuitBreaker.onError(System.nanoTime() - start, TimeUnit.NANOSECONDS, e);
+            circuitBreaker.onError(circuitBreaker.getCurrentTimestamp() - start, circuitBreaker.getTimestampUnit(), e);
         }
 
         @Override
         protected void hookOnSuccess() {
-            circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+            circuitBreaker.onSuccess(circuitBreaker.getCurrentTimestamp() - start, circuitBreaker.getTimestampUnit());
         }
 
         @Override

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/ObserverCircuitBreaker.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/ObserverCircuitBreaker.java
@@ -21,8 +21,6 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.internal.disposables.EmptyDisposable;
 
-import java.util.concurrent.TimeUnit;
-
 import static io.github.resilience4j.circuitbreaker.CallNotPermittedException.createCallNotPermittedException;
 
 class ObserverCircuitBreaker<T> extends Observable<T> {
@@ -51,23 +49,23 @@ class ObserverCircuitBreaker<T> extends Observable<T> {
 
         CircuitBreakerObserver(Observer<? super T> downstreamObserver) {
             super(downstreamObserver);
-            this.start = System.nanoTime();
+            this.start = circuitBreaker.getCurrentTimestamp();
         }
 
         @Override
         protected void hookOnError(Throwable e) {
-            circuitBreaker.onError(System.nanoTime() - start, TimeUnit.NANOSECONDS, e);
+            circuitBreaker.onError(circuitBreaker.getCurrentTimestamp() - start, circuitBreaker.getTimestampUnit(), e);
         }
 
         @Override
         protected void hookOnComplete() {
-            circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+            circuitBreaker.onSuccess(circuitBreaker.getCurrentTimestamp() - start, circuitBreaker.getTimestampUnit());
         }
 
         @Override
         protected void hookOnCancel() {
             if (eventWasEmitted.get()) {
-                circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+                circuitBreaker.onSuccess(circuitBreaker.getCurrentTimestamp() - start, circuitBreaker.getTimestampUnit());
             } else {
                 circuitBreaker.releasePermission();
             }

--- a/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/SingleCircuitBreaker.java
+++ b/resilience4j-rxjava2/src/main/java/io/github/resilience4j/circuitbreaker/operator/SingleCircuitBreaker.java
@@ -21,8 +21,6 @@ import io.reactivex.Single;
 import io.reactivex.SingleObserver;
 import io.reactivex.internal.disposables.EmptyDisposable;
 
-import java.util.concurrent.TimeUnit;
-
 import static io.github.resilience4j.circuitbreaker.CallNotPermittedException.createCallNotPermittedException;
 
 class SingleCircuitBreaker<T> extends Single<T> {
@@ -51,17 +49,17 @@ class SingleCircuitBreaker<T> extends Single<T> {
 
         CircuitBreakerSingleObserver(SingleObserver<? super T> downstreamObserver) {
             super(downstreamObserver);
-            this.start = System.nanoTime();
+            this.start = circuitBreaker.getCurrentTimestamp();
         }
 
         @Override
         protected void hookOnError(Throwable e) {
-            circuitBreaker.onError(System.nanoTime() - start, TimeUnit.NANOSECONDS, e);
+            circuitBreaker.onError(circuitBreaker.getCurrentTimestamp() - start, circuitBreaker.getTimestampUnit(), e);
         }
 
         @Override
         protected void hookOnSuccess() {
-            circuitBreaker.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+            circuitBreaker.onSuccess(circuitBreaker.getCurrentTimestamp() - start, circuitBreaker.getTimestampUnit());
         }
 
         @Override

--- a/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/CompletableCircuitBreakerTest.java
+++ b/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/CompletableCircuitBreakerTest.java
@@ -21,6 +21,8 @@ public class CompletableCircuitBreakerTest extends BaseCircuitBreakerTest {
     @Test
     public void shouldSubscribeToCompletable() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
+        given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
+        given(circuitBreaker.getTimestampUnit()).willReturn(TimeUnit.NANOSECONDS);
 
         Completable.complete()
             .compose(CircuitBreakerOperator.of(circuitBreaker))
@@ -36,6 +38,8 @@ public class CompletableCircuitBreakerTest extends BaseCircuitBreakerTest {
     @Test
     public void shouldPropagateAndMarkError() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
+        given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
+        given(circuitBreaker.getTimestampUnit()).willReturn(TimeUnit.NANOSECONDS);
 
         Completable.error(new IOException("BAM!"))
             .compose(CircuitBreakerOperator.of(circuitBreaker))

--- a/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/FlowableCircuitBreakerTest.java
+++ b/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/FlowableCircuitBreakerTest.java
@@ -21,6 +21,8 @@ public class FlowableCircuitBreakerTest extends BaseCircuitBreakerTest {
     @Test
     public void shouldInvokeOnSuccess() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
+        given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
+        given(circuitBreaker.getTimestampUnit()).willReturn(TimeUnit.NANOSECONDS);
 
         Flowable.just("Event 1", "Event 2")
             .compose(CircuitBreakerOperator.of(circuitBreaker))
@@ -35,6 +37,8 @@ public class FlowableCircuitBreakerTest extends BaseCircuitBreakerTest {
     @Test
     public void shouldInvokeOnError() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
+        given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
+        given(circuitBreaker.getTimestampUnit()).willReturn(TimeUnit.NANOSECONDS);
 
         Flowable.error(new IOException("BAM!"))
             .compose(CircuitBreakerOperator.of(circuitBreaker))
@@ -83,6 +87,8 @@ public class FlowableCircuitBreakerTest extends BaseCircuitBreakerTest {
     @Test
     public void shouldInvokeOnSuccessOnCancelWhenOneEventWasEmitted() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
+        given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
+        given(circuitBreaker.getTimestampUnit()).willReturn(TimeUnit.NANOSECONDS);
 
         Flowable.just(1, 2, 3)
             .compose(CircuitBreakerOperator.of(circuitBreaker))

--- a/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/MaybeCircuitBreakerTest.java
+++ b/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/MaybeCircuitBreakerTest.java
@@ -21,6 +21,8 @@ public class MaybeCircuitBreakerTest extends BaseCircuitBreakerTest {
     @Test
     public void shouldSubscribeToMaybeJust() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
+        given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
+        given(circuitBreaker.getTimestampUnit()).willReturn(TimeUnit.NANOSECONDS);
 
         Maybe.just(1)
             .compose(CircuitBreakerOperator.of(circuitBreaker))
@@ -35,6 +37,8 @@ public class MaybeCircuitBreakerTest extends BaseCircuitBreakerTest {
     @Test
     public void shouldPropagateError() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
+        given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
+        given(circuitBreaker.getTimestampUnit()).willReturn(TimeUnit.NANOSECONDS);
 
         Maybe.error(new IOException("BAM!"))
             .compose(CircuitBreakerOperator.of(circuitBreaker))

--- a/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/ObserverCircuitBreakerTest.java
+++ b/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/ObserverCircuitBreakerTest.java
@@ -21,6 +21,8 @@ public class ObserverCircuitBreakerTest extends BaseCircuitBreakerTest {
     @Test
     public void shouldSubscribeToObservableJust() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
+        given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
+        given(circuitBreaker.getTimestampUnit()).willReturn(TimeUnit.NANOSECONDS);
 
         Observable.just("Event 1", "Event 2")
             .compose(CircuitBreakerOperator.of(circuitBreaker))
@@ -35,6 +37,8 @@ public class ObserverCircuitBreakerTest extends BaseCircuitBreakerTest {
     @Test
     public void shouldPropagateError() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
+        given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
+        given(circuitBreaker.getTimestampUnit()).willReturn(TimeUnit.NANOSECONDS);
 
         Observable.error(new IOException("BAM!"))
             .compose(CircuitBreakerOperator.of(circuitBreaker))

--- a/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/SingleCircuitBreakerTest.java
+++ b/resilience4j-rxjava2/src/test/java/io/github/resilience4j/circuitbreaker/operator/SingleCircuitBreakerTest.java
@@ -22,6 +22,8 @@ public class SingleCircuitBreakerTest extends BaseCircuitBreakerTest {
     @Test
     public void shouldSubscribeToSingleJust() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
+        given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
+        given(circuitBreaker.getTimestampUnit()).willReturn(TimeUnit.NANOSECONDS);
 
         Single.just(1)
             .compose(CircuitBreakerOperator.of(circuitBreaker))
@@ -37,6 +39,8 @@ public class SingleCircuitBreakerTest extends BaseCircuitBreakerTest {
     public void shouldSubscribeToMonoFromCallableMultipleTimes() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
         given(helloWorldService.returnHelloWorld()).willReturn("Hello World");
+        given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
+        given(circuitBreaker.getTimestampUnit()).willReturn(TimeUnit.NANOSECONDS);
 
         Single.fromCallable(() -> helloWorldService.returnHelloWorld())
             .compose(CircuitBreakerOperator.of(circuitBreaker))
@@ -71,6 +75,8 @@ public class SingleCircuitBreakerTest extends BaseCircuitBreakerTest {
     @Test
     public void shouldPropagateError() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
+        given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
+        given(circuitBreaker.getTimestampUnit()).willReturn(TimeUnit.NANOSECONDS);
 
         Single.error(new IOException("BAM!"))
             .compose(CircuitBreakerOperator.of(circuitBreaker))


### PR DESCRIPTION
Issue: #734 
Added getCurrentTimestamp() to get the current timestamp and removed System.nanoTime().

@RobWin 