### PR TITLE
Phase-1 Remove vavr dependency for CircuitBreaker and retry module

### DIFF
--- a/resilience4j-all/build.gradle
+++ b/resilience4j-all/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     compile project(':resilience4j-retry')
     compile project(':resilience4j-cache')
     compile project(':resilience4j-timelimiter')
+    compile project(':resilience4j-vavr')
     testCompile project(':resilience4j-test')
 }
 ext.moduleName = 'io.github.resilience4j.all'

--- a/resilience4j-all/src/main/java/io/github/resilience4j/decorators/Decorators.java
+++ b/resilience4j-all/src/main/java/io/github/resilience4j/decorators/Decorators.java
@@ -5,12 +5,14 @@ import io.github.resilience4j.bulkhead.BulkheadFullException;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
 import io.github.resilience4j.cache.Cache;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.VavrCircuitBreaker;
 import io.github.resilience4j.core.CallableUtils;
 import io.github.resilience4j.core.CheckFunctionUtils;
 import io.github.resilience4j.core.CompletionStageUtils;
 import io.github.resilience4j.core.SupplierUtils;
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.VavrRetry;
 import io.github.resilience4j.timelimiter.TimeLimiter;
 import io.vavr.CheckedFunction0;
 import io.vavr.CheckedFunction1;
@@ -366,12 +368,12 @@ public interface Decorators {
 
 
         public DecorateCheckedSupplier<T> withCircuitBreaker(CircuitBreaker circuitBreaker) {
-            supplier = CircuitBreaker.decorateCheckedSupplier(circuitBreaker, supplier);
+            supplier = VavrCircuitBreaker.decorateCheckedSupplier(circuitBreaker, supplier);
             return this;
         }
 
         public DecorateCheckedSupplier<T> withRetry(Retry retryContext) {
-            supplier = Retry.decorateCheckedSupplier(retryContext, supplier);
+            supplier = VavrRetry.decorateCheckedSupplier(retryContext, supplier);
             return this;
         }
 
@@ -436,12 +438,12 @@ public interface Decorators {
         }
 
         public DecorateCheckedFunction<T, R> withCircuitBreaker(CircuitBreaker circuitBreaker) {
-            function = CircuitBreaker.decorateCheckedFunction(circuitBreaker, function);
+            function = VavrCircuitBreaker.decorateCheckedFunction(circuitBreaker, function);
             return this;
         }
 
         public DecorateCheckedFunction<T, R> withRetry(Retry retryContext) {
-            function = Retry.decorateCheckedFunction(retryContext, function);
+            function = VavrRetry.decorateCheckedFunction(retryContext, function);
             return this;
         }
 
@@ -484,12 +486,12 @@ public interface Decorators {
         }
 
         public DecorateCheckedRunnable withCircuitBreaker(CircuitBreaker circuitBreaker) {
-            runnable = CircuitBreaker.decorateCheckedRunnable(circuitBreaker, runnable);
+            runnable = VavrCircuitBreaker.decorateCheckedRunnable(circuitBreaker, runnable);
             return this;
         }
 
         public DecorateCheckedRunnable withRetry(Retry retryContext) {
-            runnable = Retry.decorateCheckedRunnable(retryContext, runnable);
+            runnable = VavrRetry.decorateCheckedRunnable(retryContext, runnable);
             return this;
         }
 

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/Bulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/Bulkhead.java
@@ -30,15 +30,17 @@ import io.vavr.CheckedConsumer;
 import io.vavr.CheckedFunction0;
 import io.vavr.CheckedFunction1;
 import io.vavr.CheckedRunnable;
-import io.vavr.collection.HashMap;
 import io.vavr.control.Either;
 import io.vavr.control.Try;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+
+import static java.util.Collections.emptyMap;
 
 /**
  * A Bulkhead instance is thread-safe can be used to decorate multiple requests.
@@ -362,7 +364,7 @@ public interface Bulkhead {
      * @return a Bulkhead instance
      */
     static Bulkhead of(String name, BulkheadConfig config) {
-        return of(name, config, HashMap.empty());
+        return of(name, config, emptyMap());
     }
 
     /**
@@ -373,8 +375,7 @@ public interface Bulkhead {
      * @param tags   tags added to the Bulkhead
      * @return a Bulkhead instance
      */
-    static Bulkhead of(String name, BulkheadConfig config,
-        io.vavr.collection.Map<String, String> tags) {
+    static Bulkhead of(String name, BulkheadConfig config, Map<String, String> tags) {
         return new SemaphoreBulkhead(name, config, tags);
     }
 
@@ -386,7 +387,7 @@ public interface Bulkhead {
      * @return a Bulkhead instance
      */
     static Bulkhead of(String name, Supplier<BulkheadConfig> bulkheadConfigSupplier) {
-        return of(name, bulkheadConfigSupplier, HashMap.empty());
+        return of(name, bulkheadConfigSupplier, emptyMap());
     }
 
     /**
@@ -397,8 +398,7 @@ public interface Bulkhead {
      * @param tags                   tags added to the Bulkhead
      * @return a Bulkhead instance
      */
-    static Bulkhead of(String name, Supplier<BulkheadConfig> bulkheadConfigSupplier,
-        io.vavr.collection.Map<String, String> tags) {
+    static Bulkhead of(String name, Supplier<BulkheadConfig> bulkheadConfigSupplier, Map<String, String> tags) {
         return new SemaphoreBulkhead(name, bulkheadConfigSupplier, tags);
     }
 
@@ -469,7 +469,7 @@ public interface Bulkhead {
      *
      * @return the tags assigned to this Retry in an unmodifiable map
      */
-    io.vavr.collection.Map<String, String> getTags();
+    Map<String, String> getTags();
 
     /**
      * Returns an EventPublisher which subscribes to the reactive stream of BulkheadEvent and can be

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/BulkheadRegistry.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/BulkheadRegistry.java
@@ -23,11 +23,11 @@ import io.github.resilience4j.bulkhead.internal.InMemoryBulkheadRegistry;
 import io.github.resilience4j.core.Registry;
 import io.github.resilience4j.core.RegistryStore;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
-import io.vavr.collection.Seq;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -55,8 +55,7 @@ public interface BulkheadRegistry extends Registry<Bulkhead, BulkheadConfig> {
      * @param tags           default tags to add to the registry
      * @return a BulkheadRegistry instance backed by a custom Bulkhead configuration
      */
-    static BulkheadRegistry of(BulkheadConfig bulkheadConfig,
-        io.vavr.collection.Map<String, String> tags) {
+    static BulkheadRegistry of(BulkheadConfig bulkheadConfig, Map<String, String> tags) {
         return new InMemoryBulkheadRegistry(bulkheadConfig, tags);
     }
 
@@ -107,8 +106,7 @@ public interface BulkheadRegistry extends Registry<Bulkhead, BulkheadConfig> {
      * @param tags    default tags to add to the registry
      * @return a RetryRegistry with a Map of shared Bulkhead configurations.
      */
-    static BulkheadRegistry of(Map<String, BulkheadConfig> configs,
-        io.vavr.collection.Map<String, String> tags) {
+    static BulkheadRegistry of(Map<String, BulkheadConfig> configs, Map<String, String> tags) {
         return new InMemoryBulkheadRegistry(configs, tags);
     }
 
@@ -137,8 +135,7 @@ public interface BulkheadRegistry extends Registry<Bulkhead, BulkheadConfig> {
      * registry event consumer.
      */
     static BulkheadRegistry of(Map<String, BulkheadConfig> configs,
-        RegistryEventConsumer<Bulkhead> registryEventConsumer,
-        io.vavr.collection.Map<String, String> tags) {
+        RegistryEventConsumer<Bulkhead> registryEventConsumer, Map<String, String> tags) {
         return new InMemoryBulkheadRegistry(configs, registryEventConsumer, tags);
     }
 
@@ -170,7 +167,7 @@ public interface BulkheadRegistry extends Registry<Bulkhead, BulkheadConfig> {
      *
      * @return all managed {@link Bulkhead} instances.
      */
-    Seq<Bulkhead> getAllBulkheads();
+    Set<Bulkhead> getAllBulkheads();
 
     /**
      * Returns a managed {@link Bulkhead} or creates a new one with default configuration.
@@ -191,7 +188,7 @@ public interface BulkheadRegistry extends Registry<Bulkhead, BulkheadConfig> {
      * @param tags tags to add to the bulkhead
      * @return The {@link Bulkhead}
      */
-    Bulkhead bulkhead(String name, io.vavr.collection.Map<String, String> tags);
+    Bulkhead bulkhead(String name, Map<String, String> tags);
 
     /**
      * Returns a managed {@link Bulkhead} or creates a new one with a custom BulkheadConfig
@@ -216,8 +213,7 @@ public interface BulkheadRegistry extends Registry<Bulkhead, BulkheadConfig> {
      * @param tags   tags added to the bulkhead
      * @return The {@link Bulkhead}
      */
-    Bulkhead bulkhead(String name, BulkheadConfig config,
-        io.vavr.collection.Map<String, String> tags);
+    Bulkhead bulkhead(String name, BulkheadConfig config, Map<String, String> tags);
 
     /**
      * Returns a managed {@link Bulkhead} or creates a new one with a custom Bulkhead
@@ -242,8 +238,7 @@ public interface BulkheadRegistry extends Registry<Bulkhead, BulkheadConfig> {
      * @param tags                   tags to add to the Bulkhead
      * @return The {@link Bulkhead}
      */
-    Bulkhead bulkhead(String name, Supplier<BulkheadConfig> bulkheadConfigSupplier,
-        io.vavr.collection.Map<String, String> tags);
+    Bulkhead bulkhead(String name, Supplier<BulkheadConfig> bulkheadConfigSupplier, Map<String, String> tags);
 
     /**
      * Returns a managed {@link Bulkhead} or creates a new one.
@@ -268,7 +263,7 @@ public interface BulkheadRegistry extends Registry<Bulkhead, BulkheadConfig> {
      * @param tags       tags to add to the Bulkhead
      * @return The {@link Bulkhead}
      */
-    Bulkhead bulkhead(String name, String configName, io.vavr.collection.Map<String, String> tags);
+    Bulkhead bulkhead(String name, String configName, Map<String, String> tags);
 
     /**
      * Returns a builder to create a custom BulkheadRegistry.
@@ -285,7 +280,7 @@ public interface BulkheadRegistry extends Registry<Bulkhead, BulkheadConfig> {
         private RegistryStore registryStore;
         private Map<String, BulkheadConfig> bulkheadConfigsMap;
         private List<RegistryEventConsumer<Bulkhead>> registryEventConsumers;
-        private io.vavr.collection.Map<String, String> tags;
+        private Map<String, String> tags;
 
         public Builder() {
             this.bulkheadConfigsMap = new java.util.HashMap<>();
@@ -344,7 +339,7 @@ public interface BulkheadRegistry extends Registry<Bulkhead, BulkheadConfig> {
          * @param tags default tags to add to the registry.
          * @return a {@link BulkheadRegistry.Builder}
          */
-        public Builder withTags(io.vavr.collection.Map<String, String> tags) {
+        public Builder withTags(Map<String, String> tags) {
             this.tags = tags;
             return this;
         }

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkhead.java
@@ -24,8 +24,8 @@ import io.github.resilience4j.bulkhead.event.BulkheadOnCallPermittedEvent;
 import io.github.resilience4j.bulkhead.event.BulkheadOnCallRejectedEvent;
 import io.github.resilience4j.bulkhead.internal.FixedThreadPoolBulkhead;
 import io.github.resilience4j.core.EventConsumer;
-import io.vavr.collection.Map;
 
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
@@ -111,8 +111,7 @@ public interface ThreadPoolBulkhead extends AutoCloseable {
      * @param config a custom BulkheadConfig configuration
      * @return a Bulkhead instance
      */
-    static ThreadPoolBulkhead of(String name, ThreadPoolBulkheadConfig config,
-        io.vavr.collection.Map<String, String> tags) {
+    static ThreadPoolBulkhead of(String name, ThreadPoolBulkheadConfig config, Map<String, String> tags) {
         return new FixedThreadPoolBulkhead(name, config, tags);
     }
 

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadRegistry.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadRegistry.java
@@ -23,13 +23,14 @@ import io.github.resilience4j.bulkhead.internal.InMemoryThreadPoolBulkheadRegist
 import io.github.resilience4j.core.Registry;
 import io.github.resilience4j.core.RegistryStore;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
-import io.vavr.collection.HashMap;
-import io.vavr.collection.Seq;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
+
+import static java.util.Collections.emptyMap;
 
 /**
  * The {@link ThreadPoolBulkheadRegistry} is a factory to create ThreadPoolBulkhead instances which
@@ -84,7 +85,7 @@ public interface ThreadPoolBulkheadRegistry extends
      * configuration
      */
     static ThreadPoolBulkheadRegistry ofDefaults() {
-        return ofDefaults(HashMap.empty());
+        return ofDefaults(emptyMap());
     }
 
     /**
@@ -96,7 +97,7 @@ public interface ThreadPoolBulkheadRegistry extends
      * @return a ThreadPoolBulkheadRegistry instance backed by a default ThreadPoolBulkhead
      * configuration
      */
-    static ThreadPoolBulkheadRegistry ofDefaults(io.vavr.collection.Map<String, String> tags) {
+    static ThreadPoolBulkheadRegistry ofDefaults(Map<String, String> tags) {
         return new InMemoryThreadPoolBulkheadRegistry(ThreadPoolBulkheadConfig.ofDefaults(), tags);
     }
 
@@ -107,7 +108,7 @@ public interface ThreadPoolBulkheadRegistry extends
      * @return a ThreadPoolBulkheadRegistry with a Map of shared ThreadPoolBulkhead configurations.
      */
     static ThreadPoolBulkheadRegistry of(Map<String, ThreadPoolBulkheadConfig> configs) {
-        return of(configs, HashMap.empty());
+        return of(configs, emptyMap());
     }
 
     /**
@@ -119,8 +120,7 @@ public interface ThreadPoolBulkheadRegistry extends
      * @param tags    default tags to add to the registry
      * @return a ThreadPoolBulkheadRegistry with a Map of shared ThreadPoolBulkhead configurations.
      */
-    static ThreadPoolBulkheadRegistry of(Map<String, ThreadPoolBulkheadConfig> configs,
-        io.vavr.collection.Map<String, String> tags) {
+    static ThreadPoolBulkheadRegistry of(Map<String, ThreadPoolBulkheadConfig> configs, Map<String, String> tags) {
         return new InMemoryThreadPoolBulkheadRegistry(configs, tags);
     }
 
@@ -135,7 +135,7 @@ public interface ThreadPoolBulkheadRegistry extends
      */
     static ThreadPoolBulkheadRegistry of(Map<String, ThreadPoolBulkheadConfig> configs,
         RegistryEventConsumer<ThreadPoolBulkhead> registryEventConsumer) {
-        return of(configs, registryEventConsumer, HashMap.empty());
+        return of(configs, registryEventConsumer, emptyMap());
     }
 
     /**
@@ -151,8 +151,7 @@ public interface ThreadPoolBulkheadRegistry extends
      * and a ThreadPoolBulkhead registry event consumer.
      */
     static ThreadPoolBulkheadRegistry of(Map<String, ThreadPoolBulkheadConfig> configs,
-        RegistryEventConsumer<ThreadPoolBulkhead> registryEventConsumer,
-        io.vavr.collection.Map<String, String> tags) {
+        RegistryEventConsumer<ThreadPoolBulkhead> registryEventConsumer, Map<String, String> tags) {
         return new InMemoryThreadPoolBulkheadRegistry(configs, registryEventConsumer, tags);
     }
 
@@ -167,7 +166,7 @@ public interface ThreadPoolBulkheadRegistry extends
      */
     static ThreadPoolBulkheadRegistry of(Map<String, ThreadPoolBulkheadConfig> configs,
         List<RegistryEventConsumer<ThreadPoolBulkhead>> registryEventConsumers) {
-        return of(configs, registryEventConsumers, HashMap.empty());
+        return of(configs, registryEventConsumers, emptyMap());
     }
 
     /**
@@ -183,8 +182,7 @@ public interface ThreadPoolBulkheadRegistry extends
      * and a list of ThreadPoolBulkhead registry event consumers.
      */
     static ThreadPoolBulkheadRegistry of(Map<String, ThreadPoolBulkheadConfig> configs,
-        List<RegistryEventConsumer<ThreadPoolBulkhead>> registryEventConsumers,
-        io.vavr.collection.Map<String, String> tags) {
+        List<RegistryEventConsumer<ThreadPoolBulkhead>> registryEventConsumers, Map<String, String> tags) {
         return new InMemoryThreadPoolBulkheadRegistry(configs, registryEventConsumers, tags);
     }
 
@@ -193,7 +191,7 @@ public interface ThreadPoolBulkheadRegistry extends
      *
      * @return all managed {@link ThreadPoolBulkhead} instances.
      */
-    Seq<ThreadPoolBulkhead> getAllBulkheads();
+    Set<ThreadPoolBulkhead> getAllBulkheads();
 
     /**
      * Returns a managed {@link ThreadPoolBulkhead} or creates a new one with default
@@ -212,7 +210,7 @@ public interface ThreadPoolBulkheadRegistry extends
      * @param tags Tags to add to the ThreadPoolBulkhead
      * @return The {@link ThreadPoolBulkhead}
      */
-    ThreadPoolBulkhead bulkhead(String name, io.vavr.collection.Map<String, String> tags);
+    ThreadPoolBulkhead bulkhead(String name, Map<String, String> tags);
 
     /**
      * Returns a managed {@link ThreadPoolBulkhead} or creates a new one with a custom
@@ -237,8 +235,7 @@ public interface ThreadPoolBulkheadRegistry extends
      * @param tags   tags to add to the ThreadPoolBulkhead
      * @return The {@link ThreadPoolBulkhead}
      */
-    ThreadPoolBulkhead bulkhead(String name, ThreadPoolBulkheadConfig config,
-        io.vavr.collection.Map<String, String> tags);
+    ThreadPoolBulkhead bulkhead(String name, ThreadPoolBulkheadConfig config, Map<String, String> tags);
 
     /**
      * Returns a managed {@link ThreadPoolBulkhead} or creates a new one with a custom
@@ -265,8 +262,7 @@ public interface ThreadPoolBulkheadRegistry extends
      * @return The {@link ThreadPoolBulkhead}
      */
     ThreadPoolBulkhead bulkhead(String name,
-        Supplier<ThreadPoolBulkheadConfig> bulkheadConfigSupplier,
-        io.vavr.collection.Map<String, String> tags);
+        Supplier<ThreadPoolBulkheadConfig> bulkheadConfigSupplier, Map<String, String> tags);
 
     /**
      * Returns a managed {@link ThreadPoolBulkhead} or creates a new one.
@@ -291,8 +287,7 @@ public interface ThreadPoolBulkheadRegistry extends
      * @param tags       tags to add to the ThreadPoolBulkhead
      * @return The {@link ThreadPoolBulkhead}
      */
-    ThreadPoolBulkhead bulkhead(String name, String configName,
-        io.vavr.collection.Map<String, String> tags);
+    ThreadPoolBulkhead bulkhead(String name, String configName, Map<String, String> tags);
 
     /**
      * Returns a builder to create a custom ThreadPoolBulkheadRegistry.
@@ -309,7 +304,7 @@ public interface ThreadPoolBulkheadRegistry extends
         private RegistryStore registryStore;
         private Map<String, ThreadPoolBulkheadConfig> threadPoolBulkheadConfigsMap;
         private List<RegistryEventConsumer<ThreadPoolBulkhead>> registryEventConsumers;
-        private io.vavr.collection.Map<String, String> tags;
+        private Map<String, String> tags;
 
         public Builder() {
             this.threadPoolBulkheadConfigsMap = new java.util.HashMap<>();
@@ -368,7 +363,7 @@ public interface ThreadPoolBulkheadRegistry extends
          * @param tags default tags to add to the registry.
          * @return a {@link ThreadPoolBulkheadRegistry.Builder}
          */
-        public Builder withTags(io.vavr.collection.Map<String, String> tags) {
+        public Builder withTags(Map<String, String> tags) {
             this.tags = tags;
             return this;
         }

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/FixedThreadPoolBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/FixedThreadPoolBulkhead.java
@@ -30,12 +30,12 @@ import io.github.resilience4j.bulkhead.event.BulkheadOnCallRejectedEvent;
 import io.github.resilience4j.core.EventConsumer;
 import io.github.resilience4j.core.EventProcessor;
 import io.github.resilience4j.core.lang.Nullable;
-import io.vavr.collection.HashMap;
-import io.vavr.collection.Map;
 
+import java.util.Map;
 import java.util.concurrent.*;
 import java.util.function.Supplier;
 
+import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -63,7 +63,7 @@ public class FixedThreadPoolBulkhead implements ThreadPoolBulkhead {
      * @param bulkheadConfig custom bulkhead configuration
      */
     public FixedThreadPoolBulkhead(String name, @Nullable ThreadPoolBulkheadConfig bulkheadConfig) {
-        this(name, bulkheadConfig, HashMap.empty());
+        this(name, bulkheadConfig, emptyMap());
     }
 
     /**
@@ -95,7 +95,7 @@ public class FixedThreadPoolBulkhead implements ThreadPoolBulkhead {
      * @param name the name of this bulkhead
      */
     public FixedThreadPoolBulkhead(String name) {
-        this(name, ThreadPoolBulkheadConfig.ofDefaults(), HashMap.empty());
+        this(name, ThreadPoolBulkheadConfig.ofDefaults(), emptyMap());
     }
 
     /**
@@ -114,7 +114,7 @@ public class FixedThreadPoolBulkhead implements ThreadPoolBulkhead {
      * @param configSupplier BulkheadConfig supplier
      */
     public FixedThreadPoolBulkhead(String name, Supplier<ThreadPoolBulkheadConfig> configSupplier) {
-        this(name, configSupplier.get(), HashMap.empty());
+        this(name, configSupplier.get(), emptyMap());
     }
 
     /**

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/InMemoryBulkheadRegistry.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/InMemoryBulkheadRegistry.java
@@ -26,15 +26,12 @@ import io.github.resilience4j.core.RegistryStore;
 import io.github.resilience4j.core.registry.AbstractRegistry;
 import io.github.resilience4j.core.registry.InMemoryRegistryStore;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
-import io.vavr.collection.Array;
 import io.vavr.collection.HashMap;
-import io.vavr.collection.Seq;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Supplier;
+
+import static java.util.Collections.emptyMap;
 
 /**
  * Bulkhead instance manager; Constructs/returns bulkhead instances.
@@ -49,16 +46,12 @@ public final class InMemoryBulkheadRegistry extends
         this(BulkheadConfig.ofDefaults());
     }
 
-    public InMemoryBulkheadRegistry(io.vavr.collection.Map<String, String> tags) {
-        this(BulkheadConfig.ofDefaults(), tags);
-    }
 
     public InMemoryBulkheadRegistry(Map<String, BulkheadConfig> configs) {
-        this(configs, HashMap.empty());
+        this(configs, emptyMap());
     }
 
-    public InMemoryBulkheadRegistry(Map<String, BulkheadConfig> configs,
-        io.vavr.collection.Map<String, String> tags) {
+    public InMemoryBulkheadRegistry(Map<String, BulkheadConfig> configs, Map<String, String> tags) {
         this(configs.getOrDefault(DEFAULT_CONFIG, BulkheadConfig.ofDefaults()), tags);
         this.configurations.putAll(configs);
     }
@@ -66,12 +59,12 @@ public final class InMemoryBulkheadRegistry extends
     public InMemoryBulkheadRegistry(
         Map<String, BulkheadConfig> configs,
         RegistryEventConsumer<Bulkhead> registryEventConsumer) {
-        this(configs, registryEventConsumer, HashMap.empty());
+        this(configs, registryEventConsumer, emptyMap());
     }
 
     public InMemoryBulkheadRegistry(
         Map<String, BulkheadConfig> configs, RegistryEventConsumer<Bulkhead> registryEventConsumer,
-        io.vavr.collection.Map<String, String> tags) {
+        Map<String, String> tags) {
         this(configs.getOrDefault(DEFAULT_CONFIG, BulkheadConfig.ofDefaults()),
             registryEventConsumer, tags);
         this.configurations.putAll(configs);
@@ -80,13 +73,12 @@ public final class InMemoryBulkheadRegistry extends
     public InMemoryBulkheadRegistry(
         Map<String, BulkheadConfig> configs,
         List<RegistryEventConsumer<Bulkhead>> registryEventConsumers) {
-        this(configs, registryEventConsumers, HashMap.empty());
+        this(configs, registryEventConsumers, emptyMap());
     }
 
     public InMemoryBulkheadRegistry(
         Map<String, BulkheadConfig> configs,
-        List<RegistryEventConsumer<Bulkhead>> registryEventConsumers,
-        io.vavr.collection.Map<String, String> tags) {
+        List<RegistryEventConsumer<Bulkhead>> registryEventConsumers, Map<String, String> tags) {
         this(configs.getOrDefault(DEFAULT_CONFIG, BulkheadConfig.ofDefaults()),
             registryEventConsumers, tags);
         this.configurations.putAll(configs);
@@ -101,8 +93,7 @@ public final class InMemoryBulkheadRegistry extends
         super(defaultConfig);
     }
 
-    public InMemoryBulkheadRegistry(BulkheadConfig defaultConfig,
-        io.vavr.collection.Map<String, String> tags) {
+    public InMemoryBulkheadRegistry(BulkheadConfig defaultConfig, Map<String, String> tags) {
         super(defaultConfig, tags);
     }
 
@@ -112,8 +103,7 @@ public final class InMemoryBulkheadRegistry extends
     }
 
     public InMemoryBulkheadRegistry(BulkheadConfig defaultConfig,
-        List<RegistryEventConsumer<Bulkhead>> registryEventConsumers,
-        io.vavr.collection.Map<String, String> tags) {
+        List<RegistryEventConsumer<Bulkhead>> registryEventConsumers, Map<String, String> tags) {
         super(defaultConfig, registryEventConsumers, tags);
     }
 
@@ -123,16 +113,15 @@ public final class InMemoryBulkheadRegistry extends
     }
 
     public InMemoryBulkheadRegistry(BulkheadConfig defaultConfig,
-        RegistryEventConsumer<Bulkhead> registryEventConsumer,
-        io.vavr.collection.Map<String, String> tags) {
+        RegistryEventConsumer<Bulkhead> registryEventConsumer, Map<String, String> tags) {
         super(defaultConfig, registryEventConsumer, tags);
     }
 
     public InMemoryBulkheadRegistry(Map<String, BulkheadConfig> configs,
                                           List<RegistryEventConsumer<Bulkhead>> registryEventConsumers,
-                                          io.vavr.collection.Map<String, String> tags, RegistryStore<Bulkhead> registryStore) {
+                                          Map<String, String> tags, RegistryStore<Bulkhead> registryStore) {
         super(configs.getOrDefault(DEFAULT_CONFIG, BulkheadConfig.ofDefaults()),
-            registryEventConsumers, Optional.ofNullable(tags).orElse(HashMap.empty()),
+            registryEventConsumers, Optional.ofNullable(tags).orElse(emptyMap()),
             Optional.ofNullable(registryStore).orElse(new InMemoryRegistryStore<>()));
         this.configurations.putAll(configs);
     }
@@ -141,8 +130,8 @@ public final class InMemoryBulkheadRegistry extends
      * {@inheritDoc}
      */
     @Override
-    public Seq<Bulkhead> getAllBulkheads() {
-        return Array.ofAll(entryMap.values());
+    public Set<Bulkhead> getAllBulkheads() {
+        return new HashSet<>(entryMap.values());
     }
 
     /**
@@ -150,14 +139,14 @@ public final class InMemoryBulkheadRegistry extends
      */
     @Override
     public Bulkhead bulkhead(String name) {
-        return bulkhead(name, HashMap.empty());
+        return bulkhead(name, emptyMap());
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public Bulkhead bulkhead(String name, io.vavr.collection.Map<String, String> tags) {
+    public Bulkhead bulkhead(String name, Map<String, String> tags) {
         return bulkhead(name, getDefaultConfig(), getAllTags(tags));
     }
 
@@ -166,15 +155,14 @@ public final class InMemoryBulkheadRegistry extends
      */
     @Override
     public Bulkhead bulkhead(String name, BulkheadConfig config) {
-        return bulkhead(name, config, HashMap.empty());
+        return bulkhead(name, config, emptyMap());
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public Bulkhead bulkhead(String name, BulkheadConfig config,
-        io.vavr.collection.Map<String, String> tags) {
+    public Bulkhead bulkhead(String name, BulkheadConfig config, Map<String, String> tags) {
         return computeIfAbsent(name, () -> Bulkhead
             .of(name, Objects.requireNonNull(config, CONFIG_MUST_NOT_BE_NULL), getAllTags(tags)));
     }
@@ -184,15 +172,14 @@ public final class InMemoryBulkheadRegistry extends
      */
     @Override
     public Bulkhead bulkhead(String name, Supplier<BulkheadConfig> bulkheadConfigSupplier) {
-        return bulkhead(name, bulkheadConfigSupplier, HashMap.empty());
+        return bulkhead(name, bulkheadConfigSupplier, emptyMap());
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public Bulkhead bulkhead(String name, Supplier<BulkheadConfig> bulkheadConfigSupplier,
-        io.vavr.collection.Map<String, String> tags) {
+    public Bulkhead bulkhead(String name, Supplier<BulkheadConfig> bulkheadConfigSupplier, Map<String, String> tags) {
         return computeIfAbsent(name, () -> Bulkhead.of(name, Objects.requireNonNull(
             Objects.requireNonNull(bulkheadConfigSupplier, SUPPLIER_MUST_NOT_BE_NULL).get(),
             CONFIG_MUST_NOT_BE_NULL), getAllTags(tags)));
@@ -203,15 +190,14 @@ public final class InMemoryBulkheadRegistry extends
      */
     @Override
     public Bulkhead bulkhead(String name, String configName) {
-        return bulkhead(name, configName, HashMap.empty());
+        return bulkhead(name, configName, emptyMap());
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public Bulkhead bulkhead(String name, String configName,
-        io.vavr.collection.Map<String, String> tags) {
+    public Bulkhead bulkhead(String name, String configName, Map<String, String> tags) {
         return computeIfAbsent(name, () -> Bulkhead.of(name, getConfiguration(configName)
             .orElseThrow(() -> new ConfigurationNotFoundException(configName)), getAllTags(tags)));
     }

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/InMemoryThreadPoolBulkheadRegistry.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/InMemoryThreadPoolBulkheadRegistry.java
@@ -26,15 +26,11 @@ import io.github.resilience4j.core.RegistryStore;
 import io.github.resilience4j.core.registry.AbstractRegistry;
 import io.github.resilience4j.core.registry.InMemoryRegistryStore;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
-import io.vavr.collection.Array;
-import io.vavr.collection.HashMap;
-import io.vavr.collection.Seq;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Supplier;
+
+import static java.util.Collections.emptyMap;
 
 /**
  * Thread pool Bulkhead instance manager; Constructs/returns thread pool bulkhead instances.
@@ -47,19 +43,14 @@ public final class InMemoryThreadPoolBulkheadRegistry extends
      * The constructor with default default.
      */
     public InMemoryThreadPoolBulkheadRegistry() {
-        this(HashMap.empty());
-    }
-
-    public InMemoryThreadPoolBulkheadRegistry(io.vavr.collection.Map<String, String> tags) {
-        this(ThreadPoolBulkheadConfig.ofDefaults(), tags);
+        this(emptyMap());
     }
 
     public InMemoryThreadPoolBulkheadRegistry(Map<String, ThreadPoolBulkheadConfig> configs) {
-        this(configs, HashMap.empty());
+        this(configs, emptyMap());
     }
 
-    public InMemoryThreadPoolBulkheadRegistry(Map<String, ThreadPoolBulkheadConfig> configs,
-        io.vavr.collection.Map<String, String> tags) {
+    public InMemoryThreadPoolBulkheadRegistry(Map<String, ThreadPoolBulkheadConfig> configs, Map<String, String> tags) {
         this(configs.getOrDefault(DEFAULT_CONFIG, ThreadPoolBulkheadConfig.ofDefaults()), tags);
         this.configurations.putAll(configs);
     }
@@ -67,13 +58,12 @@ public final class InMemoryThreadPoolBulkheadRegistry extends
     public InMemoryThreadPoolBulkheadRegistry(
         Map<String, ThreadPoolBulkheadConfig> configs,
         RegistryEventConsumer<ThreadPoolBulkhead> registryEventConsumer) {
-        this(configs, registryEventConsumer, HashMap.empty());
+        this(configs, registryEventConsumer, emptyMap());
     }
 
     public InMemoryThreadPoolBulkheadRegistry(
         Map<String, ThreadPoolBulkheadConfig> configs,
-        RegistryEventConsumer<ThreadPoolBulkhead> registryEventConsumer,
-        io.vavr.collection.Map<String, String> tags) {
+        RegistryEventConsumer<ThreadPoolBulkhead> registryEventConsumer, Map<String, String> tags) {
         this(configs.getOrDefault(DEFAULT_CONFIG, ThreadPoolBulkheadConfig.ofDefaults()),
             registryEventConsumer, tags);
         this.configurations.putAll(configs);
@@ -82,13 +72,12 @@ public final class InMemoryThreadPoolBulkheadRegistry extends
     public InMemoryThreadPoolBulkheadRegistry(
         Map<String, ThreadPoolBulkheadConfig> configs,
         List<RegistryEventConsumer<ThreadPoolBulkhead>> registryEventConsumers) {
-        this(configs, registryEventConsumers, HashMap.empty());
+        this(configs, registryEventConsumers, emptyMap());
     }
 
     public InMemoryThreadPoolBulkheadRegistry(
         Map<String, ThreadPoolBulkheadConfig> configs,
-        List<RegistryEventConsumer<ThreadPoolBulkhead>> registryEventConsumers,
-        io.vavr.collection.Map<String, String> tags) {
+        List<RegistryEventConsumer<ThreadPoolBulkhead>> registryEventConsumers, Map<String, String> tags) {
         this(configs.getOrDefault(DEFAULT_CONFIG, ThreadPoolBulkheadConfig.ofDefaults()),
             registryEventConsumers, tags);
         this.configurations.putAll(configs);
@@ -103,8 +92,7 @@ public final class InMemoryThreadPoolBulkheadRegistry extends
         super(defaultConfig);
     }
 
-    public InMemoryThreadPoolBulkheadRegistry(ThreadPoolBulkheadConfig defaultConfig,
-        io.vavr.collection.Map<String, String> tags) {
+    public InMemoryThreadPoolBulkheadRegistry(ThreadPoolBulkheadConfig defaultConfig, Map<String, String> tags) {
         super(defaultConfig, tags);
     }
 
@@ -116,8 +104,7 @@ public final class InMemoryThreadPoolBulkheadRegistry extends
 
     public InMemoryThreadPoolBulkheadRegistry(
         ThreadPoolBulkheadConfig defaultConfig,
-        RegistryEventConsumer<ThreadPoolBulkhead> registryEventConsumer,
-        io.vavr.collection.Map<String, String> tags) {
+        RegistryEventConsumer<ThreadPoolBulkhead> registryEventConsumer, Map<String, String> tags) {
         super(defaultConfig, registryEventConsumer, tags);
     }
 
@@ -129,16 +116,15 @@ public final class InMemoryThreadPoolBulkheadRegistry extends
 
     public InMemoryThreadPoolBulkheadRegistry(
         ThreadPoolBulkheadConfig defaultConfig,
-        List<RegistryEventConsumer<ThreadPoolBulkhead>> registryEventConsumers,
-        io.vavr.collection.Map<String, String> tags) {
+        List<RegistryEventConsumer<ThreadPoolBulkhead>> registryEventConsumers, Map<String, String> tags) {
         super(defaultConfig, registryEventConsumers, tags);
     }
 
     public InMemoryThreadPoolBulkheadRegistry(Map<String, ThreadPoolBulkheadConfig> configs,
                                           List<RegistryEventConsumer<ThreadPoolBulkhead>> registryEventConsumers,
-                                          io.vavr.collection.Map<String, String> tags, RegistryStore<ThreadPoolBulkhead> registryStore) {
+                                          Map<String, String> tags, RegistryStore<ThreadPoolBulkhead> registryStore) {
         super(configs.getOrDefault(DEFAULT_CONFIG, ThreadPoolBulkheadConfig.ofDefaults()),
-            registryEventConsumers, Optional.ofNullable(tags).orElse(HashMap.empty()),
+            registryEventConsumers, Optional.ofNullable(tags).orElse(emptyMap()),
             Optional.ofNullable(registryStore).orElse(new InMemoryRegistryStore<>()));
         this.configurations.putAll(configs);
     }
@@ -147,8 +133,8 @@ public final class InMemoryThreadPoolBulkheadRegistry extends
      * {@inheritDoc}
      */
     @Override
-    public Seq<ThreadPoolBulkhead> getAllBulkheads() {
-        return Array.ofAll(entryMap.values());
+    public Set<ThreadPoolBulkhead> getAllBulkheads() {
+        return new HashSet<>(entryMap.values());
     }
 
     /**
@@ -156,14 +142,14 @@ public final class InMemoryThreadPoolBulkheadRegistry extends
      */
     @Override
     public ThreadPoolBulkhead bulkhead(String name) {
-        return bulkhead(name, HashMap.empty());
+        return bulkhead(name, emptyMap());
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public ThreadPoolBulkhead bulkhead(String name, io.vavr.collection.Map<String, String> tags) {
+    public ThreadPoolBulkhead bulkhead(String name, Map<String, String> tags) {
         return bulkhead(name, getDefaultConfig(), tags);
     }
 
@@ -172,15 +158,14 @@ public final class InMemoryThreadPoolBulkheadRegistry extends
      */
     @Override
     public ThreadPoolBulkhead bulkhead(String name, ThreadPoolBulkheadConfig config) {
-        return bulkhead(name, config, HashMap.empty());
+        return bulkhead(name, config, emptyMap());
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public ThreadPoolBulkhead bulkhead(String name, ThreadPoolBulkheadConfig config,
-        io.vavr.collection.Map<String, String> tags) {
+    public ThreadPoolBulkhead bulkhead(String name, ThreadPoolBulkheadConfig config, Map<String, String> tags) {
         return computeIfAbsent(name, () -> ThreadPoolBulkhead
             .of(name, Objects.requireNonNull(config, CONFIG_MUST_NOT_BE_NULL), getAllTags(tags)));
     }
@@ -191,7 +176,7 @@ public final class InMemoryThreadPoolBulkheadRegistry extends
     @Override
     public ThreadPoolBulkhead bulkhead(String name,
         Supplier<ThreadPoolBulkheadConfig> bulkheadConfigSupplier) {
-        return bulkhead(name, bulkheadConfigSupplier, HashMap.empty());
+        return bulkhead(name, bulkheadConfigSupplier, emptyMap());
     }
 
     /**
@@ -199,8 +184,7 @@ public final class InMemoryThreadPoolBulkheadRegistry extends
      */
     @Override
     public ThreadPoolBulkhead bulkhead(String name,
-        Supplier<ThreadPoolBulkheadConfig> bulkheadConfigSupplier,
-        io.vavr.collection.Map<String, String> tags) {
+        Supplier<ThreadPoolBulkheadConfig> bulkheadConfigSupplier, Map<String, String> tags) {
         return computeIfAbsent(name, () -> ThreadPoolBulkhead.of(name, Objects.requireNonNull(
             Objects.requireNonNull(bulkheadConfigSupplier, SUPPLIER_MUST_NOT_BE_NULL).get(),
             CONFIG_MUST_NOT_BE_NULL), getAllTags(tags)));
@@ -211,15 +195,14 @@ public final class InMemoryThreadPoolBulkheadRegistry extends
      */
     @Override
     public ThreadPoolBulkhead bulkhead(String name, String configName) {
-        return bulkhead(name, configName, HashMap.empty());
+        return bulkhead(name, configName, emptyMap());
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public ThreadPoolBulkhead bulkhead(String name, String configName,
-        io.vavr.collection.Map<String, String> tags) {
+    public ThreadPoolBulkhead bulkhead(String name, String configName, Map<String, String> tags) {
         return computeIfAbsent(name, () -> ThreadPoolBulkhead.of(name, getConfiguration(configName)
             .orElseThrow(() -> new ConfigurationNotFoundException(configName)), getAllTags(tags)));
     }

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkhead.java
@@ -30,13 +30,13 @@ import io.github.resilience4j.core.EventConsumer;
 import io.github.resilience4j.core.EventProcessor;
 import io.github.resilience4j.core.exception.AcquirePermissionCancelledException;
 import io.github.resilience4j.core.lang.Nullable;
-import io.vavr.collection.HashMap;
-import io.vavr.collection.Map;
 
+import java.util.Map;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -65,7 +65,7 @@ public class SemaphoreBulkhead implements Bulkhead {
      * @param bulkheadConfig custom bulkhead configuration
      */
     public SemaphoreBulkhead(String name, @Nullable BulkheadConfig bulkheadConfig) {
-        this(name, bulkheadConfig, HashMap.empty());
+        this(name, bulkheadConfig, emptyMap());
     }
 
     /**
@@ -93,7 +93,7 @@ public class SemaphoreBulkhead implements Bulkhead {
      * @param name the name of this bulkhead
      */
     public SemaphoreBulkhead(String name) {
-        this(name, BulkheadConfig.ofDefaults(), HashMap.empty());
+        this(name, BulkheadConfig.ofDefaults(), emptyMap());
     }
 
     /**
@@ -103,7 +103,7 @@ public class SemaphoreBulkhead implements Bulkhead {
      * @param configSupplier BulkheadConfig supplier
      */
     public SemaphoreBulkhead(String name, Supplier<BulkheadConfig> configSupplier) {
-        this(name, configSupplier.get(), HashMap.empty());
+        this(name, configSupplier.get(), emptyMap());
     }
 
     /**

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/BulkheadRegistryTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/BulkheadRegistryTest.java
@@ -21,7 +21,6 @@ package io.github.resilience4j.bulkhead;
 import io.github.resilience4j.core.EventProcessor;
 import io.github.resilience4j.core.Registry;
 import io.github.resilience4j.core.registry.*;
-import io.vavr.Tuple;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
@@ -55,9 +54,9 @@ public class BulkheadRegistryTest {
 
     @Test
     public void shouldInitRegistryTags() {
-        BulkheadRegistry registry = BulkheadRegistry.of(config,io.vavr.collection.HashMap.of("Tag1Key","Tag1Value"));
+        BulkheadRegistry registry = BulkheadRegistry.of(config,Map.of("Tag1Key","Tag1Value"));
         assertThat(registry.getTags()).isNotEmpty();
-        assertThat(registry.getTags()).containsOnly(Tuple.of("Tag1Key","Tag1Value"));
+        assertThat(registry.getTags()).containsOnly(Map.entry("Tag1Key","Tag1Value"));
     }
 
     @Test
@@ -108,35 +107,31 @@ public class BulkheadRegistryTest {
         BulkheadConfig bulkheadConfig = BulkheadConfig.ofDefaults();
         Map<String, BulkheadConfig> bulkheadConfigs = Collections
             .singletonMap("default", bulkheadConfig);
-        io.vavr.collection.Map<String, String> bulkheadTags = io.vavr.collection.HashMap
-            .of("key1", "value1", "key2", "value2");
+        Map<String, String> bulkheadTags = Map.of("key1", "value1", "key2", "value2");
         BulkheadRegistry bulkheadRegistry = BulkheadRegistry.of(bulkheadConfigs, bulkheadTags);
         Bulkhead bulkhead = bulkheadRegistry.bulkhead("testName");
 
-        assertThat(bulkhead.getTags()).containsOnlyElementsOf(bulkheadTags);
+        assertThat(bulkhead.getTags()).containsAllEntriesOf(bulkheadTags);
     }
 
     @Test
     public void tagsAddedToInstance() {
-        io.vavr.collection.Map<String, String> bulkheadTags = io.vavr.collection.HashMap
-            .of("key1", "value1", "key2", "value2");
+        Map<String, String> bulkheadTags = Map.of("key1", "value1", "key2", "value2");
         Bulkhead bulkhead = registry.bulkhead("testName", bulkheadTags);
 
-        assertThat(bulkhead.getTags()).containsOnlyElementsOf(bulkheadTags);
+        assertThat(bulkhead.getTags()).containsAllEntriesOf(bulkheadTags);
     }
 
     @Test
     public void tagsOfRetriesShouldNotBeMixed() {
         BulkheadConfig config = BulkheadConfig.ofDefaults();
-        io.vavr.collection.Map<String, String> bulkheadTags = io.vavr.collection.HashMap
-            .of("key1", "value1", "key2", "value2");
+        Map<String, String> bulkheadTags = Map.of("key1", "value1", "key2", "value2");
         Bulkhead bulkhead = registry.bulkhead("testName", config, bulkheadTags);
-        io.vavr.collection.Map<String, String> bulkheadTags2 = io.vavr.collection.HashMap
-            .of("key3", "value3", "key4", "value4");
+        Map<String, String> bulkheadTags2 = Map.of("key3", "value3", "key4", "value4");
         Bulkhead bulkhead2 = registry.bulkhead("otherTestName", config, bulkheadTags2);
 
-        Assertions.assertThat(bulkhead.getTags()).containsOnlyElementsOf(bulkheadTags);
-        Assertions.assertThat(bulkhead2.getTags()).containsOnlyElementsOf(bulkheadTags2);
+        Assertions.assertThat(bulkhead.getTags()).containsAllEntriesOf(bulkheadTags);
+        Assertions.assertThat(bulkhead2.getTags()).containsAllEntriesOf(bulkheadTags2);
     }
 
     @Test
@@ -144,16 +139,13 @@ public class BulkheadRegistryTest {
         BulkheadConfig bulkheadConfig = BulkheadConfig.ofDefaults();
         Map<String, BulkheadConfig> bulkheadConfigs = Collections
             .singletonMap("default", bulkheadConfig);
-        io.vavr.collection.Map<String, String> registryTags = io.vavr.collection.HashMap
-            .of("key1", "value1", "key2", "value2");
-        io.vavr.collection.Map<String, String> instanceTags = io.vavr.collection.HashMap
-            .of("key1", "value3", "key4", "value4");
+        Map<String, String> registryTags = Map.of("key1", "value1", "key2", "value2");
+        Map<String, String> instanceTags = Map.of("key1", "value3", "key4", "value4");
         BulkheadRegistry bulkheadRegistry = BulkheadRegistry.of(bulkheadConfigs, registryTags);
         Bulkhead retry = bulkheadRegistry.bulkhead("testName", bulkheadConfig, instanceTags);
 
-        io.vavr.collection.Map<String, String> expectedTags = io.vavr.collection.HashMap
-            .of("key1", "value3", "key2", "value2", "key4", "value4");
-        Assertions.assertThat(retry.getTags()).containsOnlyElementsOf(expectedTags);
+        Map<String, String> expectedTags = Map.of("key1", "value3", "key2", "value2", "key4", "value4");
+        Assertions.assertThat(retry.getTags()).containsAllEntriesOf(expectedTags);
     }
 
     @Test
@@ -345,7 +337,7 @@ public class BulkheadRegistryTest {
 
     @Test
     public void testCreateUsingBuilderWithRegistryTags() {
-        io.vavr.collection.Map<String, String> bulkheadTags = io.vavr.collection.HashMap
+        Map<String, String> bulkheadTags = Map
             .of("key1", "value1", "key2", "value2");
         BulkheadRegistry bulkheadRegistry = BulkheadRegistry.custom()
             .withBulkheadConfig(BulkheadConfig.ofDefaults())
@@ -353,7 +345,7 @@ public class BulkheadRegistryTest {
             .build();
         Bulkhead bulkhead = bulkheadRegistry.bulkhead("testName");
 
-        assertThat(bulkhead.getTags()).containsOnlyElementsOf(bulkheadTags);
+        assertThat(bulkhead.getTags()).containsAllEntriesOf(bulkheadTags);
     }
 
     @Test

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadRegistryTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadRegistryTest.java
@@ -91,7 +91,7 @@ public class ThreadPoolBulkheadRegistryTest {
 //	public void tagsOfRegistryAddedToInstance() {
 //		ThreadPoolBulkhead retryConfig = ThreadPoolBulkhead.ofDefaults();
 //		Map<String, RetryConfig> retryConfigs = Collections.singletonMap("default", retryConfig);
-//		io.vavr.collection.Map<String, String> retryTags = io.vavr.collection.HashMap.of("key1","value1", "key2", "value2");
+//		Map<String, String> retryTags = Map.of("key1","value1", "key2", "value2");
 //		RetryRegistry retryRegistry = RetryRegistry.of(retryConfigs, retryTags);
 //		Retry retry = retryRegistry.retry("testName");
 //
@@ -106,25 +106,22 @@ public class ThreadPoolBulkheadRegistryTest {
 
     @Test
     public void tagsAddedToInstance() {
-        io.vavr.collection.Map<String, String> bulkheadTags = io.vavr.collection.HashMap
-            .of("key1", "value1", "key2", "value2");
+        Map<String, String> bulkheadTags = Map.of("key1", "value1", "key2", "value2");
         ThreadPoolBulkhead bulkhead = registry.bulkhead("testName", bulkheadTags);
 
-        assertThat(bulkhead.getTags()).containsOnlyElementsOf(bulkheadTags);
+        assertThat(bulkhead.getTags()).containsAllEntriesOf(bulkheadTags);
     }
 
     @Test
     public void tagsOfRetriesShouldNotBeMixed() {
         ThreadPoolBulkheadConfig config = ThreadPoolBulkheadConfig.ofDefaults();
-        io.vavr.collection.Map<String, String> bulkheadTags = io.vavr.collection.HashMap
-            .of("key1", "value1", "key2", "value2");
+        Map<String, String> bulkheadTags = Map.of("key1", "value1", "key2", "value2");
         ThreadPoolBulkhead bulkhead = registry.bulkhead("testName", config, bulkheadTags);
-        io.vavr.collection.Map<String, String> bulkheadTags2 = io.vavr.collection.HashMap
-            .of("key3", "value3", "key4", "value4");
+        Map<String, String> bulkheadTags2 = Map.of("key3", "value3", "key4", "value4");
         ThreadPoolBulkhead bulkhead2 = registry.bulkhead("otherTestName", config, bulkheadTags2);
 
-        assertThat(bulkhead.getTags()).containsOnlyElementsOf(bulkheadTags);
-        assertThat(bulkhead2.getTags()).containsOnlyElementsOf(bulkheadTags2);
+        assertThat(bulkhead.getTags()).containsAllEntriesOf(bulkheadTags);
+        assertThat(bulkhead2.getTags()).containsAllEntriesOf(bulkheadTags2);
     }
 
     @Test
@@ -132,18 +129,15 @@ public class ThreadPoolBulkheadRegistryTest {
         ThreadPoolBulkheadConfig bulkheadConfig = ThreadPoolBulkheadConfig.ofDefaults();
         Map<String, ThreadPoolBulkheadConfig> bulkheadConfigs = Collections
             .singletonMap("default", bulkheadConfig);
-        io.vavr.collection.Map<String, String> registryTags = io.vavr.collection.HashMap
-            .of("key1", "value1", "key2", "value2");
-        io.vavr.collection.Map<String, String> instanceTags = io.vavr.collection.HashMap
-            .of("key1", "value3", "key4", "value4");
+        Map<String, String> registryTags = Map.of("key1", "value1", "key2", "value2");
+        Map<String, String> instanceTags = Map.of("key1", "value3", "key4", "value4");
         ThreadPoolBulkheadRegistry bulkheadRegistry = ThreadPoolBulkheadRegistry
             .of(bulkheadConfigs, registryTags);
         ThreadPoolBulkhead bulkhead = bulkheadRegistry
             .bulkhead("testName", bulkheadConfig, instanceTags);
 
-        io.vavr.collection.Map<String, String> expectedTags = io.vavr.collection.HashMap
-            .of("key1", "value3", "key2", "value2", "key4", "value4");
-        assertThat(bulkhead.getTags()).containsOnlyElementsOf(expectedTags);
+        Map<String, String> expectedTags = Map.of("key1", "value3", "key2", "value2", "key4", "value4");
+        assertThat(bulkhead.getTags()).containsAllEntriesOf(expectedTags);
     }
 
     @Test
@@ -352,15 +346,14 @@ public class ThreadPoolBulkheadRegistryTest {
 
     @Test
     public void testCreateUsingBuilderWithRegistryTags() {
-        io.vavr.collection.Map<String, String> threadPoolBulkheadTags = io.vavr.collection.HashMap
-            .of("key1", "value1", "key2", "value2");
+        Map<String, String> threadPoolBulkheadTags = Map.of("key1", "value1", "key2", "value2");
         ThreadPoolBulkheadRegistry threadPoolBulkheadRegistry = ThreadPoolBulkheadRegistry.custom()
             .withThreadPoolBulkheadConfig(ThreadPoolBulkheadConfig.ofDefaults())
             .withTags(threadPoolBulkheadTags)
             .build();
         ThreadPoolBulkhead threadPoolBulkhead = threadPoolBulkheadRegistry.bulkhead("testName");
 
-        assertThat(threadPoolBulkhead.getTags()).containsOnlyElementsOf(threadPoolBulkheadTags);
+        assertThat(threadPoolBulkhead.getTags()).containsAllEntriesOf(threadPoolBulkheadTags);
     }
 
     @Test

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/internal/FixedThreadPoolBulkheadTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/internal/FixedThreadPoolBulkheadTest.java
@@ -124,7 +124,7 @@ public class FixedThreadPoolBulkheadTest {
         configs.put("default", defaultConfig);
         final InMemoryThreadPoolBulkheadRegistry inMemoryThreadPoolBulkheadRegistry =
             new InMemoryThreadPoolBulkheadRegistry(configs, registryEventConsumers,
-                io.vavr.collection.HashMap.of("Tag1", "Tag1Value"), new InMemoryRegistryStore());
+                Map.of("Tag1", "Tag1Value"), new InMemoryRegistryStore());
 
         AssertionsForClassTypes.assertThat(inMemoryThreadPoolBulkheadRegistry).isNotNull();
         AssertionsForClassTypes.assertThat(inMemoryThreadPoolBulkheadRegistry.getDefaultConfig()).isEqualTo(defaultConfig);

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkheadTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkheadTest.java
@@ -533,7 +533,7 @@ public class SemaphoreBulkheadTest {
         configs.put("default", defaultConfig);
         final InMemoryBulkheadRegistry inMemoryBulkheadRegistry =
             new InMemoryBulkheadRegistry(configs, registryEventConsumers,
-                io.vavr.collection.HashMap.of("Tag1", "Tag1Value"), new InMemoryRegistryStore());
+                Map.of("Tag1", "Tag1Value"), new InMemoryRegistryStore());
 
         AssertionsForClassTypes.assertThat(inMemoryBulkheadRegistry).isNotNull();
         AssertionsForClassTypes.assertThat(inMemoryBulkheadRegistry.getDefaultConfig()).isEqualTo(defaultConfig);

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreaker.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreaker.java
@@ -22,9 +22,6 @@ import io.github.resilience4j.circuitbreaker.event.*;
 import io.github.resilience4j.circuitbreaker.internal.CircuitBreakerStateMachine;
 import io.github.resilience4j.core.EventConsumer;
 import io.github.resilience4j.core.functions.OnceConsumer;
-import io.vavr.*;
-import io.vavr.control.Either;
-import io.vavr.control.Try;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -55,34 +52,6 @@ import java.util.stream.Collectors;
  * If the failure rate is below or equal to the threshold, the state changes back to CLOSED.
  */
 public interface CircuitBreaker {
-
-    /**
-     * Returns a supplier which is decorated by a CircuitBreaker.
-     *
-     * @param circuitBreaker the CircuitBreaker
-     * @param supplier       the original supplier
-     * @param <T>            the type of results supplied by this supplier
-     * @return a supplier which is decorated by a CircuitBreaker.
-     */
-    static <T> CheckedFunction0<T> decorateCheckedSupplier(CircuitBreaker circuitBreaker,
-        CheckedFunction0<T> supplier) {
-        return () -> {
-            circuitBreaker.acquirePermission();
-            final long start = circuitBreaker.getCurrentTimestamp();
-            try {
-                T returnValue = supplier.apply();
-                long duration = circuitBreaker.getCurrentTimestamp() - start;
-                circuitBreaker.onSuccess(duration, circuitBreaker.getTimestampUnit());
-                return returnValue;
-            } catch (Exception exception) {
-                // Do not handle java.lang.Error
-                long duration = circuitBreaker.getCurrentTimestamp() - start;
-                circuitBreaker.onError(duration, circuitBreaker.getTimestampUnit(), exception);
-                throw exception;
-            }
-        };
-    }
-
     /**
      * Returns a supplier which is decorated by a CircuitBreaker.
      *
@@ -127,31 +96,6 @@ public interface CircuitBreaker {
             }
 
             return promise;
-        };
-    }
-
-    /**
-     * Returns a runnable which is decorated by a CircuitBreaker.
-     *
-     * @param circuitBreaker the CircuitBreaker
-     * @param runnable       the original runnable
-     * @return a runnable which is decorated by a CircuitBreaker.
-     */
-    static CheckedRunnable decorateCheckedRunnable(CircuitBreaker circuitBreaker,
-        CheckedRunnable runnable) {
-        return () -> {
-            circuitBreaker.acquirePermission();
-            final long start = circuitBreaker.getCurrentTimestamp();
-            try {
-                runnable.run();
-                long duration = circuitBreaker.getCurrentTimestamp() - start;
-                circuitBreaker.onSuccess(duration, circuitBreaker.getTimestampUnit());
-            } catch (Exception exception) {
-                // Do not handle java.lang.Error
-                long duration = circuitBreaker.getCurrentTimestamp() - start;
-                circuitBreaker.onError(duration, circuitBreaker.getTimestampUnit(), exception);
-                throw exception;
-            }
         };
     }
 
@@ -208,65 +152,6 @@ public interface CircuitBreaker {
     }
 
     /**
-     * Returns a supplier which is decorated by a CircuitBreaker.
-     *
-     * @param circuitBreaker the CircuitBreaker
-     * @param supplier       the original supplier
-     * @param <T>            the type of results supplied by this supplier
-     * @return a supplier which is decorated by a CircuitBreaker.
-     */
-    static <T> Supplier<Either<Exception, T>> decorateEitherSupplier(CircuitBreaker circuitBreaker,
-        Supplier<Either<? extends Exception, T>> supplier) {
-        return () -> {
-            if (circuitBreaker.tryAcquirePermission()) {
-                final long start = circuitBreaker.getCurrentTimestamp();
-                Either<? extends Exception, T> result = supplier.get();
-                long duration = circuitBreaker.getCurrentTimestamp() - start;
-                if (result.isRight()) {
-                    circuitBreaker.onSuccess(duration, circuitBreaker.getTimestampUnit());
-                } else {
-                    Exception exception = result.getLeft();
-                    circuitBreaker.onError(duration, circuitBreaker.getTimestampUnit(), exception);
-                }
-                return Either.narrow(result);
-            } else {
-                return Either.left(
-                    CallNotPermittedException.createCallNotPermittedException(circuitBreaker));
-            }
-        };
-    }
-
-    /**
-     * Returns a supplier which is decorated by a CircuitBreaker.
-     *
-     * @param circuitBreaker the CircuitBreaker
-     * @param supplier       the original function
-     * @param <T>            the type of results supplied by this supplier
-     * @return a retryable function
-     */
-    static <T> Supplier<Try<T>> decorateTrySupplier(CircuitBreaker circuitBreaker,
-        Supplier<Try<T>> supplier) {
-        return () -> {
-            if (circuitBreaker.tryAcquirePermission()) {
-                final long start = circuitBreaker.getCurrentTimestamp();
-                Try<T> result = supplier.get();
-                long duration = circuitBreaker.getCurrentTimestamp() - start;
-                if (result.isSuccess()) {
-                    circuitBreaker.onSuccess(duration, circuitBreaker.getTimestampUnit());
-                    return result;
-                } else {
-                    circuitBreaker
-                        .onError(duration, circuitBreaker.getTimestampUnit(), result.getCause());
-                    return result;
-                }
-            } else {
-                return Try.failure(
-                    CallNotPermittedException.createCallNotPermittedException(circuitBreaker));
-            }
-        };
-    }
-
-    /**
      * Returns a consumer which is decorated by a CircuitBreaker.
      *
      * @param circuitBreaker the CircuitBreaker
@@ -275,32 +160,6 @@ public interface CircuitBreaker {
      * @return a consumer which is decorated by a CircuitBreaker.
      */
     static <T> Consumer<T> decorateConsumer(CircuitBreaker circuitBreaker, Consumer<T> consumer) {
-        return (t) -> {
-            circuitBreaker.acquirePermission();
-            final long start = circuitBreaker.getCurrentTimestamp();
-            try {
-                consumer.accept(t);
-                long duration = circuitBreaker.getCurrentTimestamp() - start;
-                circuitBreaker.onSuccess(duration, circuitBreaker.getTimestampUnit());
-            } catch (Exception exception) {
-                // Do not handle java.lang.Error
-                long duration = circuitBreaker.getCurrentTimestamp() - start;
-                circuitBreaker.onError(duration, circuitBreaker.getTimestampUnit(), exception);
-                throw exception;
-            }
-        };
-    }
-
-    /**
-     * Returns a consumer which is decorated by a CircuitBreaker.
-     *
-     * @param circuitBreaker the CircuitBreaker
-     * @param consumer       the original consumer
-     * @param <T>            the type of the input to the consumer
-     * @return a consumer which is decorated by a CircuitBreaker.
-     */
-    static <T> CheckedConsumer<T> decorateCheckedConsumer(CircuitBreaker circuitBreaker,
-        CheckedConsumer<T> consumer) {
         return (t) -> {
             circuitBreaker.acquirePermission();
             final long start = circuitBreaker.getCurrentTimestamp();
@@ -370,34 +229,6 @@ public interface CircuitBreaker {
     }
 
     /**
-     * Returns a function which is decorated by a CircuitBreaker.
-     *
-     * @param circuitBreaker the CircuitBreaker
-     * @param function       the original function
-     * @param <T>            the type of the input to the function
-     * @param <R>            the type of the result of the function
-     * @return a function which is decorated by a CircuitBreaker.
-     */
-    static <T, R> CheckedFunction1<T, R> decorateCheckedFunction(CircuitBreaker circuitBreaker,
-        CheckedFunction1<T, R> function) {
-        return (T t) -> {
-            circuitBreaker.acquirePermission();
-            final long start = circuitBreaker.getCurrentTimestamp();
-            try {
-                R returnValue = function.apply(t);
-                long duration = circuitBreaker.getCurrentTimestamp() - start;
-                circuitBreaker.onSuccess(duration, circuitBreaker.getTimestampUnit());
-                return returnValue;
-            } catch (Exception exception) {
-                // Do not handle java.lang.Error
-                long duration = circuitBreaker.getCurrentTimestamp() - start;
-                circuitBreaker.onError(duration, circuitBreaker.getTimestampUnit(), exception);
-                throw exception;
-            }
-        };
-    }
-
-    /**
      * Creates a CircuitBreaker with a default CircuitBreaker configuration.
      *
      * @param name the name of the CircuitBreaker
@@ -430,8 +261,7 @@ public interface CircuitBreaker {
      * @param tags                 tags added to the Retry
      * @return a CircuitBreaker with a custom CircuitBreaker configuration.
      */
-    static CircuitBreaker of(String name, CircuitBreakerConfig circuitBreakerConfig,
-        io.vavr.collection.Map<String, String> tags) {
+    static CircuitBreaker of(String name, CircuitBreakerConfig circuitBreakerConfig, Map<String, String> tags) {
         return new CircuitBreakerStateMachine(name, circuitBreakerConfig, tags);
     }
 
@@ -460,8 +290,7 @@ public interface CircuitBreaker {
      * @return a CircuitBreaker with a custom CircuitBreaker configuration.
      */
     static CircuitBreaker of(String name,
-        Supplier<CircuitBreakerConfig> circuitBreakerConfigSupplier,
-        io.vavr.collection.Map<String, String> tags) {
+        Supplier<CircuitBreakerConfig> circuitBreakerConfigSupplier, Map<String, String> tags) {
         return new CircuitBreakerStateMachine(name, circuitBreakerConfigSupplier, tags);
     }
 
@@ -655,7 +484,7 @@ public interface CircuitBreaker {
      *
      * @return the tags assigned to this Retry in an unmodifiable map
      */
-    io.vavr.collection.Map<String, String> getTags();
+    Map<String, String> getTags();
 
     /**
      * Returns an EventPublisher which can be used to register event consumers.
@@ -700,52 +529,6 @@ public interface CircuitBreaker {
      */
     default <T> Supplier<T> decorateSupplier(Supplier<T> supplier) {
         return decorateSupplier(this, supplier);
-    }
-
-    /**
-     * Decorates and executes the decorated Supplier.
-     *
-     * @param supplier the original Supplier
-     * @param <T>      the type of results supplied by this supplier
-     * @return the result of the decorated Supplier.
-     */
-    default <T> Either<Exception, T> executeEitherSupplier(
-        Supplier<Either<? extends Exception, T>> supplier) {
-        return decorateEitherSupplier(this, supplier).get();
-    }
-
-    /**
-     * Returns a supplier which is decorated by a CircuitBreaker.
-     *
-     * @param supplier the original supplier
-     * @param <T>      the type of results supplied by this supplier
-     * @return a supplier which is decorated by a CircuitBreaker.
-     */
-    default <T> Supplier<Try<T>> decorateTrySupplier(Supplier<Try<T>> supplier) {
-        return decorateTrySupplier(this, supplier);
-    }
-
-    /**
-     * Decorates and executes the decorated Supplier.
-     *
-     * @param supplier the original Supplier
-     * @param <T>      the type of results supplied by this supplier
-     * @return the result of the decorated Supplier.
-     */
-    default <T> Try<T> executeTrySupplier(Supplier<Try<T>> supplier) {
-        return decorateTrySupplier(this, supplier).get();
-    }
-
-    /**
-     * Returns a supplier which is decorated by a CircuitBreaker.
-     *
-     * @param supplier the original supplier
-     * @param <T>      the type of results supplied by this supplier
-     * @return a supplier which is decorated by a CircuitBreaker.
-     */
-    default <T> Supplier<Either<Exception, T>> decorateEitherSupplier(
-        Supplier<Either<? extends Exception, T>> supplier) {
-        return decorateEitherSupplier(this, supplier);
     }
 
     /**
@@ -814,48 +597,6 @@ public interface CircuitBreaker {
     }
 
     /**
-     * Decorates and executes the decorated Supplier.
-     *
-     * @param checkedSupplier the original Supplier
-     * @param <T>             the type of results supplied by this supplier
-     * @return the result of the decorated Supplier.
-     * @throws Throwable if something goes wrong applying this function to the given arguments
-     */
-    default <T> T executeCheckedSupplier(CheckedFunction0<T> checkedSupplier) throws Throwable {
-        return decorateCheckedSupplier(this, checkedSupplier).apply();
-    }
-
-    /**
-     * Returns a supplier which is decorated by a CircuitBreaker.
-     *
-     * @param checkedSupplier the original supplier
-     * @param <T>             the type of results supplied by this supplier
-     * @return a supplier which is decorated by a CircuitBreaker.
-     */
-    default <T> CheckedFunction0<T> decorateCheckedSupplier(CheckedFunction0<T> checkedSupplier) {
-        return decorateCheckedSupplier(this, checkedSupplier);
-    }
-
-    /**
-     * Returns a runnable which is decorated by a CircuitBreaker.
-     *
-     * @param runnable the original runnable
-     * @return a runnable which is decorated by a CircuitBreaker.
-     */
-    default CheckedRunnable decorateCheckedRunnable(CheckedRunnable runnable) {
-        return decorateCheckedRunnable(this, runnable);
-    }
-
-    /**
-     * Decorates and executes the decorated Runnable.
-     *
-     * @param runnable the original runnable
-     */
-    default void executeCheckedRunnable(CheckedRunnable runnable) throws Throwable {
-        decorateCheckedRunnable(this, runnable).run();
-    }
-
-    /**
      * Returns a consumer which is decorated by a CircuitBreaker.
      *
      * @param consumer the original consumer
@@ -864,17 +605,6 @@ public interface CircuitBreaker {
      */
     default <T> Consumer<T> decorateConsumer(Consumer<T> consumer) {
         return decorateConsumer(this, consumer);
-    }
-
-    /**
-     * Returns a consumer which is decorated by a CircuitBreaker.
-     *
-     * @param consumer the original consumer
-     * @param <T>      the type of the input to the consumer
-     * @return a consumer which is decorated by a CircuitBreaker.
-     */
-    default <T> CheckedConsumer<T> decorateCheckedConsumer(CheckedConsumer<T> consumer) {
-        return decorateCheckedConsumer(this, consumer);
     }
 
     /**
@@ -984,9 +714,9 @@ public interface CircuitBreaker {
         METRICS_ONLY_TO_FORCED_OPEN(State.METRICS_ONLY, State.FORCED_OPEN),
         METRICS_ONLY_TO_DISABLED(State.METRICS_ONLY, State.DISABLED);
 
-        private static final Map<Tuple2<State, State>, StateTransition> STATE_TRANSITION_MAP = Arrays
+        private static final Map<Map.Entry<State, State>, StateTransition> STATE_TRANSITION_MAP = Arrays
             .stream(StateTransition.values())
-            .collect(Collectors.toMap(v -> Tuple.of(v.fromState, v.toState), Function.identity()));
+            .collect(Collectors.toMap(v -> Map.entry(v.fromState, v.toState), Function.identity()));
         private final State fromState;
         private final State toState;
 
@@ -998,7 +728,7 @@ public interface CircuitBreaker {
         public static StateTransition transitionBetween(String name, State fromState,
             State toState) {
             final StateTransition stateTransition = STATE_TRANSITION_MAP
-                .get(Tuple.of(fromState, toState));
+                .get(Map.entry(fromState, toState));
             if (stateTransition == null) {
                 throw new IllegalStateTransitionException(name, fromState, toState);
             }

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerRegistry.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerRegistry.java
@@ -23,13 +23,14 @@ import io.github.resilience4j.circuitbreaker.internal.InMemoryCircuitBreakerRegi
 import io.github.resilience4j.core.Registry;
 import io.github.resilience4j.core.RegistryStore;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
-import io.vavr.collection.HashMap;
-import io.vavr.collection.Seq;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
+
+import static java.util.Collections.emptyMap;
 
 /**
  * The {@link CircuitBreakerRegistry} is a factory to create CircuitBreaker instances which stores
@@ -82,7 +83,7 @@ public interface CircuitBreakerRegistry extends Registry<CircuitBreaker, Circuit
      * @return a CircuitBreakerRegistry with a Map of shared CircuitBreaker configurations.
      */
     static CircuitBreakerRegistry of(Map<String, CircuitBreakerConfig> configs) {
-        return of(configs, HashMap.empty());
+        return of(configs, emptyMap());
     }
 
     /**
@@ -94,8 +95,7 @@ public interface CircuitBreakerRegistry extends Registry<CircuitBreaker, Circuit
      * @param tags    default tags to add to the registry
      * @return a CircuitBreakerRegistry with a Map of shared CircuitBreaker configurations.
      */
-    static CircuitBreakerRegistry of(Map<String, CircuitBreakerConfig> configs,
-        io.vavr.collection.Map<String, String> tags) {
+    static CircuitBreakerRegistry of(Map<String, CircuitBreakerConfig> configs, Map<String, String> tags) {
         return new InMemoryCircuitBreakerRegistry(configs, tags);
     }
 
@@ -124,8 +124,7 @@ public interface CircuitBreakerRegistry extends Registry<CircuitBreaker, Circuit
      * CircuitBreaker registry event consumer.
      */
     static CircuitBreakerRegistry of(Map<String, CircuitBreakerConfig> configs,
-        RegistryEventConsumer<CircuitBreaker> registryEventConsumer,
-        io.vavr.collection.Map<String, String> tags) {
+        RegistryEventConsumer<CircuitBreaker> registryEventConsumer, Map<String, String> tags) {
         return new InMemoryCircuitBreakerRegistry(configs, registryEventConsumer, tags);
     }
 
@@ -158,7 +157,7 @@ public interface CircuitBreakerRegistry extends Registry<CircuitBreaker, Circuit
      *
      * @return all managed {@link CircuitBreaker} instances.
      */
-    Seq<CircuitBreaker> getAllCircuitBreakers();
+    Set<CircuitBreaker> getAllCircuitBreakers();
 
     /**
      * Returns a managed {@link CircuitBreaker} or creates a new one with the default CircuitBreaker
@@ -181,7 +180,7 @@ public interface CircuitBreakerRegistry extends Registry<CircuitBreaker, Circuit
      * @param tags tags added to the CircuitBreaker
      * @return The {@link CircuitBreaker}
      */
-    CircuitBreaker circuitBreaker(String name, io.vavr.collection.Map<String, String> tags);
+    CircuitBreaker circuitBreaker(String name, Map<String, String> tags);
 
     /**
      * Returns a managed {@link CircuitBreaker} or creates a new one with a custom CircuitBreaker
@@ -206,8 +205,7 @@ public interface CircuitBreakerRegistry extends Registry<CircuitBreaker, Circuit
      * @param tags   tags added to the CircuitBreaker
      * @return The {@link CircuitBreaker}
      */
-    CircuitBreaker circuitBreaker(String name, CircuitBreakerConfig config,
-        io.vavr.collection.Map<String, String> tags);
+    CircuitBreaker circuitBreaker(String name, CircuitBreakerConfig config, Map<String, String> tags);
 
     /**
      * Returns a managed {@link CircuitBreaker} or creates a new one.
@@ -232,8 +230,7 @@ public interface CircuitBreakerRegistry extends Registry<CircuitBreaker, Circuit
      * @param tags       tags added to the CircuitBreaker
      * @return The {@link CircuitBreaker}
      */
-    CircuitBreaker circuitBreaker(String name, String configName,
-        io.vavr.collection.Map<String, String> tags);
+    CircuitBreaker circuitBreaker(String name, String configName, Map<String, String> tags);
 
     /**
      * Returns a managed {@link CircuitBreaker} or creates a new one with a custom CircuitBreaker
@@ -260,8 +257,7 @@ public interface CircuitBreakerRegistry extends Registry<CircuitBreaker, Circuit
      * @return The {@link CircuitBreaker}
      */
     CircuitBreaker circuitBreaker(String name,
-        Supplier<CircuitBreakerConfig> circuitBreakerConfigSupplier,
-        io.vavr.collection.Map<String, String> tags);
+        Supplier<CircuitBreakerConfig> circuitBreakerConfigSupplier, Map<String, String> tags);
 
     /**
      * Returns a builder to create a custom CircuitBreakerRegistry.
@@ -278,7 +274,7 @@ public interface CircuitBreakerRegistry extends Registry<CircuitBreaker, Circuit
         private RegistryStore registryStore;
         private Map<String, CircuitBreakerConfig> circuitBreakerConfigsMap;
         private List<RegistryEventConsumer<CircuitBreaker>> registryEventConsumers;
-        private io.vavr.collection.Map<String, String> tags;
+        private Map<String, String> tags;
 
         public Builder() {
             this.circuitBreakerConfigsMap = new java.util.HashMap<>();
@@ -337,7 +333,7 @@ public interface CircuitBreakerRegistry extends Registry<CircuitBreaker, Circuit
          * @param tags default tags to add to the registry.
          * @return a {@link CircuitBreakerRegistry.Builder}
          */
-        public Builder withTags(io.vavr.collection.Map<String, String> tags) {
+        public Builder withTags(Map<String, String> tags) {
             this.tags = tags;
             return this;
         }

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachine.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachine.java
@@ -25,14 +25,13 @@ import io.github.resilience4j.circuitbreaker.event.*;
 import io.github.resilience4j.core.EventConsumer;
 import io.github.resilience4j.core.EventProcessor;
 import io.github.resilience4j.core.lang.Nullable;
-import io.vavr.collection.HashMap;
-import io.vavr.collection.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -46,6 +45,7 @@ import static io.github.resilience4j.circuitbreaker.CircuitBreaker.State.*;
 import static io.github.resilience4j.circuitbreaker.internal.CircuitBreakerMetrics.Result;
 import static io.github.resilience4j.circuitbreaker.internal.CircuitBreakerMetrics.Result.BELOW_THRESHOLDS;
 import static java.time.temporal.ChronoUnit.MILLIS;
+import static java.util.Collections.emptyMap;
 
 /**
  * A CircuitBreaker finite state machine.
@@ -73,8 +73,7 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
      * @param schedulerFactory     A SchedulerFactory which can be mocked in tests.
      */
     private CircuitBreakerStateMachine(String name, CircuitBreakerConfig circuitBreakerConfig,
-        Clock clock, SchedulerFactory schedulerFactory,
-        io.vavr.collection.Map<String, String> tags) {
+        Clock clock, SchedulerFactory schedulerFactory, Map<String, String> tags) {
         this.name = name;
         this.circuitBreakerConfig = Objects
             .requireNonNull(circuitBreakerConfig, "Config must not be null");
@@ -96,7 +95,7 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
      */
     public CircuitBreakerStateMachine(String name, CircuitBreakerConfig circuitBreakerConfig,
         SchedulerFactory schedulerFactory) {
-        this(name, circuitBreakerConfig, Clock.systemUTC(), schedulerFactory, HashMap.empty());
+        this(name, circuitBreakerConfig, Clock.systemUTC(), schedulerFactory, emptyMap());
     }
 
     /**
@@ -107,7 +106,7 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
      */
     public CircuitBreakerStateMachine(String name, CircuitBreakerConfig circuitBreakerConfig,
         Clock clock) {
-        this(name, circuitBreakerConfig, clock, SchedulerFactory.getInstance(), HashMap.empty());
+        this(name, circuitBreakerConfig, clock, SchedulerFactory.getInstance(), emptyMap());
     }
 
     /**
@@ -117,7 +116,7 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
      * @param circuitBreakerConfig The CircuitBreaker configuration.
      */
     public CircuitBreakerStateMachine(String name, CircuitBreakerConfig circuitBreakerConfig,
-        Clock clock, io.vavr.collection.Map<String, String> tags) {
+        Clock clock, Map<String, String> tags) {
         this(name, circuitBreakerConfig, clock, SchedulerFactory.getInstance(), tags);
     }
 
@@ -139,7 +138,7 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
      * @param tags                 Tags to add to the CircuitBreaker.
      */
     public CircuitBreakerStateMachine(String name, CircuitBreakerConfig circuitBreakerConfig,
-        io.vavr.collection.Map<String, String> tags) {
+        Map<String, String> tags) {
         this(name, circuitBreakerConfig, Clock.systemUTC(), tags);
     }
 
@@ -171,7 +170,7 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
      */
     public CircuitBreakerStateMachine(String name,
         Supplier<CircuitBreakerConfig> circuitBreakerConfig,
-        io.vavr.collection.Map<String, String> tags) {
+        Map<String, String> tags) {
         this(name, circuitBreakerConfig.get(), tags);
     }
 

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/InMemoryCircuitBreakerRegistry.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/InMemoryCircuitBreakerRegistry.java
@@ -26,15 +26,11 @@ import io.github.resilience4j.core.RegistryStore;
 import io.github.resilience4j.core.registry.AbstractRegistry;
 import io.github.resilience4j.core.registry.InMemoryRegistryStore;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
-import io.vavr.collection.Array;
-import io.vavr.collection.HashMap;
-import io.vavr.collection.Seq;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Supplier;
+
+import static java.util.Collections.emptyMap;
 
 /**
  * Backend circuitBreaker manager. Constructs backend circuitBreakers according to configuration
@@ -47,19 +43,15 @@ public final class InMemoryCircuitBreakerRegistry extends
      * The constructor with default default.
      */
     public InMemoryCircuitBreakerRegistry() {
-        this(HashMap.empty());
-    }
-
-    public InMemoryCircuitBreakerRegistry(io.vavr.collection.Map<String, String> tags) {
-        this(CircuitBreakerConfig.ofDefaults(), tags);
+        this(emptyMap());
     }
 
     public InMemoryCircuitBreakerRegistry(Map<String, CircuitBreakerConfig> configs) {
-        this(configs, HashMap.empty());
+        this(configs, emptyMap());
     }
 
     public InMemoryCircuitBreakerRegistry(Map<String, CircuitBreakerConfig> configs,
-        io.vavr.collection.Map<String, String> tags) {
+        Map<String, String> tags) {
         this(configs.getOrDefault(DEFAULT_CONFIG, CircuitBreakerConfig.ofDefaults()), tags);
         this.configurations.putAll(configs);
     }
@@ -72,8 +64,7 @@ public final class InMemoryCircuitBreakerRegistry extends
     }
 
     public InMemoryCircuitBreakerRegistry(Map<String, CircuitBreakerConfig> configs,
-        RegistryEventConsumer<CircuitBreaker> registryEventConsumer,
-        io.vavr.collection.Map<String, String> tags) {
+        RegistryEventConsumer<CircuitBreaker> registryEventConsumer, Map<String, String> tags) {
         this(configs.getOrDefault(DEFAULT_CONFIG, CircuitBreakerConfig.ofDefaults()),
             registryEventConsumer, tags);
         this.configurations.putAll(configs);
@@ -81,9 +72,9 @@ public final class InMemoryCircuitBreakerRegistry extends
 
     public InMemoryCircuitBreakerRegistry(Map<String, CircuitBreakerConfig> configs,
                                           List<RegistryEventConsumer<CircuitBreaker>> registryEventConsumers,
-                                          io.vavr.collection.Map<String, String> tags, RegistryStore<CircuitBreaker> registryStore) {
+                                          Map<String, String> tags, RegistryStore<CircuitBreaker> registryStore) {
         super(configs.getOrDefault(DEFAULT_CONFIG, CircuitBreakerConfig.ofDefaults()),
-            registryEventConsumers, Optional.ofNullable(tags).orElse(HashMap.empty()),
+            registryEventConsumers, Optional.ofNullable(tags).orElse(emptyMap()),
             Optional.ofNullable(registryStore).orElse(new InMemoryRegistryStore<>()));
         this.configurations.putAll(configs);
     }
@@ -111,7 +102,7 @@ public final class InMemoryCircuitBreakerRegistry extends
      * @param tags          The tags to add to the CircuitBreaker
      */
     public InMemoryCircuitBreakerRegistry(CircuitBreakerConfig defaultConfig,
-        io.vavr.collection.Map<String, String> tags) {
+        Map<String, String> tags) {
         super(defaultConfig, tags);
     }
 
@@ -122,7 +113,7 @@ public final class InMemoryCircuitBreakerRegistry extends
 
     public InMemoryCircuitBreakerRegistry(CircuitBreakerConfig defaultConfig,
         RegistryEventConsumer<CircuitBreaker> registryEventConsumer,
-        io.vavr.collection.Map<String, String> tags) {
+        Map<String, String> tags) {
         super(defaultConfig, registryEventConsumer, tags);
     }
 
@@ -135,8 +126,8 @@ public final class InMemoryCircuitBreakerRegistry extends
      * {@inheritDoc}
      */
     @Override
-    public Seq<CircuitBreaker> getAllCircuitBreakers() {
-        return Array.ofAll(entryMap.values());
+    public Set<CircuitBreaker> getAllCircuitBreakers() {
+        return new HashSet<>(entryMap.values());
     }
 
     /**
@@ -148,7 +139,7 @@ public final class InMemoryCircuitBreakerRegistry extends
     }
 
     @Override
-    public CircuitBreaker circuitBreaker(String name, io.vavr.collection.Map<String, String> tags) {
+    public CircuitBreaker circuitBreaker(String name, Map<String, String> tags) {
         return circuitBreaker(name, getDefaultConfig(), tags);
     }
 
@@ -157,12 +148,12 @@ public final class InMemoryCircuitBreakerRegistry extends
      */
     @Override
     public CircuitBreaker circuitBreaker(String name, CircuitBreakerConfig config) {
-        return circuitBreaker(name, config, HashMap.empty());
+        return circuitBreaker(name, config, emptyMap());
     }
 
     @Override
     public CircuitBreaker circuitBreaker(String name, CircuitBreakerConfig config,
-        io.vavr.collection.Map<String, String> tags) {
+        Map<String, String> tags) {
         return computeIfAbsent(name, () -> CircuitBreaker
             .of(name, Objects.requireNonNull(config, CONFIG_MUST_NOT_BE_NULL), getAllTags(tags)));
     }
@@ -172,12 +163,11 @@ public final class InMemoryCircuitBreakerRegistry extends
      */
     @Override
     public CircuitBreaker circuitBreaker(String name, String configName) {
-        return circuitBreaker(name, configName, HashMap.empty());
+        return circuitBreaker(name, configName, emptyMap());
     }
 
     @Override
-    public CircuitBreaker circuitBreaker(String name, String configName,
-        io.vavr.collection.Map<String, String> tags) {
+    public CircuitBreaker circuitBreaker(String name, String configName, Map<String, String> tags) {
         return computeIfAbsent(name, () -> CircuitBreaker.of(name, getConfiguration(configName)
             .orElseThrow(() -> new ConfigurationNotFoundException(configName)), getAllTags(tags)));
     }
@@ -188,13 +178,12 @@ public final class InMemoryCircuitBreakerRegistry extends
     @Override
     public CircuitBreaker circuitBreaker(String name,
         Supplier<CircuitBreakerConfig> circuitBreakerConfigSupplier) {
-        return circuitBreaker(name, circuitBreakerConfigSupplier, HashMap.empty());
+        return circuitBreaker(name, circuitBreakerConfigSupplier, emptyMap());
     }
 
     @Override
     public CircuitBreaker circuitBreaker(String name,
-        Supplier<CircuitBreakerConfig> circuitBreakerConfigSupplier,
-        io.vavr.collection.Map<String, String> tags) {
+        Supplier<CircuitBreakerConfig> circuitBreakerConfigSupplier, Map<String, String> tags) {
         return computeIfAbsent(name, () -> CircuitBreaker.of(name, Objects.requireNonNull(
             Objects.requireNonNull(circuitBreakerConfigSupplier, SUPPLIER_MUST_NOT_BE_NULL).get(),
             CONFIG_MUST_NOT_BE_NULL), getAllTags(tags)));

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/SchedulerFactory.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/SchedulerFactory.java
@@ -1,28 +1,27 @@
 package io.github.resilience4j.circuitbreaker.internal;
 
-import io.vavr.Lazy;
-
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
 public class SchedulerFactory {
 
-    private static Lazy<SchedulerFactory> lazyInstance = Lazy.of(SchedulerFactory::new);
-    private Lazy<ScheduledExecutorService> lazyScheduler = Lazy
-        .of(() -> Executors.newSingleThreadScheduledExecutor(threadTask -> {
-            Thread thread = new Thread(threadTask, "CircuitBreakerAutoTransitionThread");
-            thread.setDaemon(true);
-            return thread;
-        }));
+    private static class SchedulerFactoryInstance {
+        private static final SchedulerFactory lazyInstance =  new SchedulerFactory();
+        private static final ScheduledExecutorService lazyScheduler = Executors.newSingleThreadScheduledExecutor(threadTask -> {
+                Thread thread = new Thread(threadTask, "CircuitBreakerAutoTransitionThread");
+                thread.setDaemon(true);
+                return thread;
+            });
+    }
 
     private SchedulerFactory() {
     }
 
     public static SchedulerFactory getInstance() {
-        return lazyInstance.get();
+        return SchedulerFactoryInstance.lazyInstance;
     }
 
     public ScheduledExecutorService getScheduler() {
-        return lazyScheduler.get();
+        return SchedulerFactoryInstance.lazyScheduler;
     }
 }

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerTest.java
@@ -20,11 +20,6 @@ package io.github.resilience4j.circuitbreaker;
 
 import io.github.resilience4j.test.HelloWorldException;
 import io.github.resilience4j.test.HelloWorldService;
-import io.vavr.CheckedConsumer;
-import io.vavr.CheckedFunction0;
-import io.vavr.CheckedFunction1;
-import io.vavr.CheckedRunnable;
-import io.vavr.control.Either;
 import io.vavr.control.Try;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,7 +37,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 
 public class CircuitBreakerTest {
 
@@ -87,7 +83,6 @@ public class CircuitBreakerTest {
         then(helloWorldService).should().returnHelloWorld();
     }
 
-
     @Test
     public void shouldDecorateSupplierAndReturnWithException() {
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
@@ -105,47 +100,6 @@ public class CircuitBreakerTest {
         assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
         assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(0);
         then(helloWorldService).should().returnHelloWorld();
-    }
-
-    @Test
-    public void shouldDecorateCheckedSupplierAndReturnWithSuccess() throws Throwable {
-        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
-        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
-        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
-        given(helloWorldService.returnHelloWorldWithException()).willReturn("Hello world");
-        CheckedFunction0<String> checkedSupplier = circuitBreaker
-            .decorateCheckedSupplier(helloWorldService::returnHelloWorldWithException);
-
-        String result = checkedSupplier.apply();
-
-        assertThat(result).isEqualTo("Hello world");
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(0);
-        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
-        then(helloWorldService).should().returnHelloWorldWithException();
-    }
-
-
-    @Test
-    public void shouldDecorateCheckedSupplierAndReturnWithException() throws Throwable {
-        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
-        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
-        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
-        given(helloWorldService.returnHelloWorldWithException())
-            .willThrow(new RuntimeException("BAM!"));
-        CheckedFunction0<String> checkedSupplier = circuitBreaker
-            .decorateCheckedSupplier(helloWorldService::returnHelloWorldWithException);
-
-        Try<String> result = Try.of(checkedSupplier);
-
-        assertThat(result.isFailure()).isTrue();
-        assertThat(result.failed().get()).isInstanceOf(RuntimeException.class);
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(0);
-        then(helloWorldService).should().returnHelloWorldWithException();
     }
 
     @Test
@@ -206,42 +160,6 @@ public class CircuitBreakerTest {
     }
 
     @Test
-    public void shouldDecorateCheckedRunnableAndReturnWithSuccess() throws Throwable {
-        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
-        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
-        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
-        CheckedRunnable checkedRunnable = circuitBreaker
-            .decorateCheckedRunnable(helloWorldService::sayHelloWorldWithException);
-
-        checkedRunnable.run();
-
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(0);
-        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
-        then(helloWorldService).should().sayHelloWorldWithException();
-    }
-
-    @Test
-    public void shouldDecorateCheckedRunnableAndReturnWithException() throws Throwable {
-        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
-        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
-        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
-        CheckedRunnable checkedRunnable = circuitBreaker.decorateCheckedRunnable(() -> {
-            throw new RuntimeException("BAM!");
-        });
-
-        Try<Void> result = Try.run(checkedRunnable);
-
-        assertThat(result.isFailure()).isTrue();
-        assertThat(result.failed().get()).isInstanceOf(RuntimeException.class);
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(0);
-    }
-
-    @Test
     public void shouldDecorateRunnableAndReturnWithSuccess() throws Throwable {
         CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
         CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
@@ -271,7 +189,6 @@ public class CircuitBreakerTest {
         assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
         then(helloWorldService).should().sayHelloWorld();
     }
-
 
     @Test
     public void shouldDecorateRunnableAndReturnWithException() throws Throwable {
@@ -329,44 +246,6 @@ public class CircuitBreakerTest {
     }
 
     @Test
-    public void shouldDecorateCheckedConsumerAndReturnWithSuccess() throws Throwable {
-        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
-        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
-        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
-        CheckedConsumer<String> checkedConsumer = circuitBreaker
-            .decorateCheckedConsumer(helloWorldService::sayHelloWorldWithNameWithException);
-
-        checkedConsumer.accept("Tom");
-
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(0);
-        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
-        then(helloWorldService).should().sayHelloWorldWithNameWithException("Tom");
-    }
-
-    @Test
-    public void shouldDecorateCheckedConsumerAndReturnWithException() throws Throwable {
-        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
-        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
-        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        int numberOfBufferedCallsBefore = metrics.getNumberOfBufferedCalls();
-        CheckedConsumer<String> checkedConsumer = circuitBreaker
-            .decorateCheckedConsumer((value) -> {
-                throw new RuntimeException("BAM!");
-            });
-
-        Try<Void> result = Try.run(() -> checkedConsumer.accept("Tom"));
-
-        assertThat(result.isFailure()).isTrue();
-        assertThat(result.failed().get()).isInstanceOf(RuntimeException.class);
-        assertThat(numberOfBufferedCallsBefore).isEqualTo(0);
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(0);
-    }
-
-    @Test
     public void shouldDecorateFunctionAndReturnWithSuccess() throws Throwable {
         CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
         CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
@@ -403,199 +282,6 @@ public class CircuitBreakerTest {
         assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
         assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
         assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(0);
-    }
-
-    @Test
-    public void shouldDecorateCheckedFunctionAndReturnWithSuccess() throws Throwable {
-        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
-        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
-        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
-        given(helloWorldService.returnHelloWorldWithNameWithException("Tom"))
-            .willReturn("Hello world Tom");
-        CheckedFunction1<String, String> function = CircuitBreaker
-            .decorateCheckedFunction(circuitBreaker,
-                helloWorldService::returnHelloWorldWithNameWithException);
-
-        String result = function.apply("Tom");
-
-        assertThat(result).isEqualTo("Hello world Tom");
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(0);
-        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
-        then(helloWorldService).should().returnHelloWorldWithNameWithException("Tom");
-    }
-
-
-    @Test
-    public void shouldDecorateCheckedFunctionAndReturnWithException() throws Throwable {
-        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
-        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
-        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
-        given(helloWorldService.returnHelloWorldWithNameWithException("Tom"))
-            .willThrow(new RuntimeException("BAM!"));
-        CheckedFunction1<String, String> function = CircuitBreaker
-            .decorateCheckedFunction(circuitBreaker,
-                helloWorldService::returnHelloWorldWithNameWithException);
-
-        Try<String> result = Try.of(() -> function.apply("Tom"));
-
-        assertThat(result.isFailure()).isTrue();
-        assertThat(result.failed().get()).isInstanceOf(RuntimeException.class);
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(0);
-    }
-
-    @Test
-    public void shouldReturnFailureWithCircuitBreakerOpenException() {
-        // Given
-        CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
-            .slidingWindowSize(2)
-            .permittedNumberOfCallsInHalfOpenState(2)
-            .failureRateThreshold(50)
-            .waitDurationInOpenState(Duration.ofMillis(1000))
-            .build();
-        CircuitBreaker circuitBreaker = CircuitBreaker.of("testName", circuitBreakerConfig);
-        CheckedRunnable checkedRunnable = circuitBreaker.decorateCheckedRunnable(() -> {
-            throw new RuntimeException("BAM!");
-        });
-
-        // When
-        circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new RuntimeException());
-        circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new RuntimeException());
-
-        // Then
-        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.OPEN);
-        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(2);
-        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(2);
-
-        // When
-        Try result = Try.run(checkedRunnable);
-
-        // Then
-        assertThat(result.isFailure()).isTrue();
-        assertThat(result.failed().get()).isInstanceOf(CallNotPermittedException.class);
-    }
-
-    @Test
-    public void shouldReturnFailureWithRuntimeException() {
-        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
-        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
-        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
-        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(0);
-        CheckedRunnable checkedRunnable = circuitBreaker.decorateCheckedRunnable(() -> {
-            throw new RuntimeException("BAM!");
-        });
-
-        Try result = Try.run(checkedRunnable);
-
-        assertThat(result.isFailure()).isTrue();
-        assertThat(result.failed().get()).isInstanceOf(RuntimeException.class);
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
-    }
-
-    @Test
-    public void shouldNotRecordIOExceptionAsAFailure() {
-        // tag::shouldNotRecordIOExceptionAsAFailure[]
-        CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
-            .slidingWindowSize(2)
-            .permittedNumberOfCallsInHalfOpenState(2)
-            .waitDurationInOpenState(Duration.ofMillis(1000))
-            .ignoreExceptions(IOException.class)
-            .build();
-        CircuitBreaker circuitBreaker = CircuitBreaker.of("testName", circuitBreakerConfig);
-        // Simulate a failure attempt
-        circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new HelloWorldException());
-        // CircuitBreaker is still CLOSED, because 1 failure is allowed
-        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
-        CheckedRunnable checkedRunnable = circuitBreaker.decorateCheckedRunnable(() -> {
-            throw new SocketTimeoutException("BAM!");
-        });
-
-        Try result = Try.run(checkedRunnable);
-
-        assertThat(result.isFailure()).isTrue();
-        // CircuitBreaker is still CLOSED, because SocketTimeoutException has not been recorded as a failure
-        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
-        assertThat(result.failed().get()).isInstanceOf(IOException.class);
-        // end::shouldNotRecordIOExceptionAsAFailure[]
-        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
-    }
-
-    @Test
-    public void shouldInvokeRecoverFunction() {
-        // tag::shouldInvokeRecoverFunction[]
-        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
-        // When I decorate my function and invoke the decorated function
-        CheckedFunction0<String> checkedSupplier = circuitBreaker.decorateCheckedSupplier(() -> {
-            throw new RuntimeException("BAM!");
-        });
-
-        Try<String> result = Try.of(checkedSupplier)
-            .recover(throwable -> "Hello Recovery");
-
-        // Then the function should be a success, because the exception could be recovered
-        assertThat(result.isSuccess()).isTrue();
-        // and the result must match the result of the recovery function.
-        assertThat(result.get()).isEqualTo("Hello Recovery");
-        // end::shouldInvokeRecoverFunction[]
-    }
-
-    @Test
-    public void shouldInvokeMap() {
-        // tag::shouldInvokeMap[]
-        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
-        // When I decorate my function
-        CheckedFunction0<String> decoratedSupplier = CircuitBreaker
-            .decorateCheckedSupplier(circuitBreaker,
-                () -> "This can be any method which returns: 'Hello");
-
-        // and chain an other function with map
-        Try<String> result = Try.of(decoratedSupplier)
-            .map(value -> value + " world'");
-
-        // Then the Try Monad returns a Success<String>, if all functions ran successfully.
-        assertThat(result.isSuccess()).isTrue();
-        assertThat(result.get()).isEqualTo("This can be any method which returns: 'Hello world'");
-        // end::shouldInvokeMap[]
-    }
-
-    @Test
-    public void shouldThrowCircuitBreakerOpenException() {
-        // tag::shouldThrowCircuitBreakerOpenException[]
-        CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
-            .slidingWindowSize(2)
-            .waitDurationInOpenState(Duration.ofMillis(1000))
-            .build();
-        CircuitBreaker circuitBreaker = CircuitBreaker.of("testName", circuitBreakerConfig);
-        // Simulate a failure attempt
-        circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new RuntimeException());
-        // CircuitBreaker is still CLOSED, because 1 failure is allowed
-        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
-        // Simulate a failure attempt
-        circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new RuntimeException());
-        // CircuitBreaker is OPEN, because the failure rate is above 50%
-        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.OPEN);
-
-        // When I decorate my function and invoke the decorated function
-        Try<String> result = Try.of(circuitBreaker.decorateCheckedSupplier(() -> "Hello"))
-            .map(value -> value + " world");
-
-        // Then the call fails, because CircuitBreaker is OPEN
-        assertThat(result.isFailure()).isTrue();
-        // Exception is CallNotPermittedException
-        assertThat(result.failed().get()).isInstanceOf(CallNotPermittedException.class);
-        // end::shouldThrowCircuitBreakerOpenException[]
-        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(2);
-        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(2);
     }
 
     @Test
@@ -740,32 +426,6 @@ public class CircuitBreakerTest {
     }
 
     @Test
-    public void shouldChainDecoratedFunctions() {
-        // tag::shouldChainDecoratedFunctions[]
-        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
-        CircuitBreaker anotherCircuitBreaker = CircuitBreaker.ofDefaults("anotherTestName");
-        // When I create a Supplier and a Function which are decorated by different CircuitBreakers
-        CheckedFunction0<String> decoratedSupplier = CircuitBreaker
-            .decorateCheckedSupplier(circuitBreaker, () -> "Hello");
-        CheckedFunction1<String, String> decoratedFunction = CircuitBreaker
-            .decorateCheckedFunction(anotherCircuitBreaker, (input) -> input + " world");
-
-        // and I chain a function with map
-        Try<String> result = Try.of(decoratedSupplier)
-            .mapTry(decoratedFunction);
-
-        assertThat(result.isSuccess()).isTrue();
-        assertThat(result.get()).isEqualTo("Hello world");
-        // end::shouldChainDecoratedFunctions[]
-        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(0);
-        CircuitBreaker.Metrics metrics2 = anotherCircuitBreaker.getMetrics();
-        assertThat(metrics2.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics2.getNumberOfFailedCalls()).isEqualTo(0);
-    }
-
-    @Test
     public void testCreateWithNullConfig() {
         assertThatThrownBy(() -> CircuitBreaker.of("test", (CircuitBreakerConfig) null))
             .isInstanceOf(NullPointerException.class).hasMessage("Config must not be null");
@@ -785,108 +445,6 @@ public class CircuitBreakerTest {
         assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(0);
         then(helloWorldService).should().returnHelloWorld();
 
-    }
-
-    @Test
-    public void shouldExecuteTrySupplierAndReturnWithSuccess() {
-        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
-        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
-        given(helloWorldService.returnTry()).willReturn(Try.success("Hello world"));
-
-        Try<String> result = circuitBreaker.executeTrySupplier(helloWorldService::returnTry);
-
-        assertThat(result).contains("Hello world");
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(0);
-        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
-        then(helloWorldService).should().returnTry();
-    }
-
-    @Test
-    public void shouldExecuteEitherSupplierAndReturnWithSuccess() {
-        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
-        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
-        given(helloWorldService.returnEither()).willReturn(Either.right("Hello world"));
-
-        Either<Exception, String> result = circuitBreaker
-            .executeEitherSupplier(helloWorldService::returnEither);
-
-        assertThat(result).contains("Hello world");
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(0);
-        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
-        then(helloWorldService).should().returnEither();
-    }
-
-    @Test
-    public void shouldExecuteTrySupplierAndReturnWithFailure() {
-        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
-        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
-        given(helloWorldService.returnTry()).willReturn(Try.failure(new RuntimeException("BAM!")));
-
-        Try<String> result = circuitBreaker.executeTrySupplier(helloWorldService::returnTry);
-
-        assertThat(result.isFailure()).isTrue();
-        assertThat(result.failed().get()).isInstanceOf(RuntimeException.class);
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(0);
-        then(helloWorldService).should().returnTry();
-    }
-
-    @Test
-    public void shouldExecuteTrySupplierAndReturnWithCallNotPermittedException() {
-        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
-        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
-        circuitBreaker.transitionToOpenState();
-
-        Try<String> result = circuitBreaker.executeTrySupplier(helloWorldService::returnTry);
-
-        assertThat(result.isFailure()).isTrue();
-        assertThat(result.failed().get()).isInstanceOf(CallNotPermittedException.class);
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
-        assertThat(metrics.getNumberOfNotPermittedCalls()).isEqualTo(1);
-        then(helloWorldService).should(never()).returnTry();
-    }
-
-
-    @Test
-    public void shouldExecuteEitherSupplierAndReturnWithFailure() {
-        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
-        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
-        given(helloWorldService.returnEither()).willReturn(Either.left(new HelloWorldException()));
-
-        Either<Exception, String> result = circuitBreaker
-            .executeEitherSupplier(helloWorldService::returnEither);
-
-        assertThat(result.isLeft()).isTrue();
-        assertThat(result.getLeft()).isInstanceOf(RuntimeException.class);
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(0);
-        then(helloWorldService).should().returnEither();
-    }
-
-    @Test
-    public void shouldExecuteEitherSupplierAndReturnWithCallNotPermittedException() {
-        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
-        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
-        circuitBreaker.transitionToOpenState();
-
-        Either<Exception, String> result = circuitBreaker
-            .executeEitherSupplier(helloWorldService::returnEither);
-
-        assertThat(result.isLeft()).isTrue();
-        assertThat(result.getLeft()).isInstanceOf(CallNotPermittedException.class);
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
-        assertThat(metrics.getNumberOfNotPermittedCalls()).isEqualTo(1);
-        then(helloWorldService).should(never()).returnEither();
     }
 
     @Test

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/InMemoryCircuitBreakerRegistryTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/InMemoryCircuitBreakerRegistryTest.java
@@ -4,11 +4,7 @@ import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.core.ConfigurationNotFoundException;
-import io.github.resilience4j.core.registry.EntryAddedEvent;
-import io.github.resilience4j.core.registry.EntryRemovedEvent;
-import io.github.resilience4j.core.registry.EntryReplacedEvent;
-import io.github.resilience4j.core.registry.InMemoryRegistryStore;
-import io.github.resilience4j.core.registry.RegistryEventConsumer;
+import io.github.resilience4j.core.registry.*;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -115,7 +111,7 @@ public class InMemoryCircuitBreakerRegistryTest {
         configs.put("default", defaultConfig);
         final InMemoryCircuitBreakerRegistry inMemoryCircuitBreakerRegistry =
             new InMemoryCircuitBreakerRegistry(configs, registryEventConsumers,
-                io.vavr.collection.HashMap.of("Tag1", "Tag1Value"), new InMemoryRegistryStore());
+                Map.of("Tag1", "Tag1Value"), new InMemoryRegistryStore());
 
         assertThat(inMemoryCircuitBreakerRegistry).isNotNull();
         assertThat(inMemoryCircuitBreakerRegistry.getDefaultConfig()).isEqualTo(defaultConfig);

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/Registry.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/Registry.java
@@ -22,8 +22,8 @@ import io.github.resilience4j.core.registry.EntryAddedEvent;
 import io.github.resilience4j.core.registry.EntryRemovedEvent;
 import io.github.resilience4j.core.registry.EntryReplacedEvent;
 import io.github.resilience4j.core.registry.RegistryEvent;
-import io.vavr.collection.Map;
 
+import java.util.Map;
 import java.util.Optional;
 
 /**

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/functions/CheckedConsumer.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/functions/CheckedConsumer.java
@@ -1,0 +1,29 @@
+/*
+ *
+ *  Copyright 2020 krnSaurabh
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.core.functions;
+
+import java.util.function.Consumer;
+
+/**
+ * A {@link Consumer}-like interface which allows throwing checked exceptions.
+ */
+@FunctionalInterface
+public interface CheckedConsumer<T, E extends Exception> {
+    void accept(T t) throws E;
+} 

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/registry/AbstractRegistry.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/registry/AbstractRegistry.java
@@ -22,8 +22,6 @@ import io.github.resilience4j.core.EventConsumer;
 import io.github.resilience4j.core.EventProcessor;
 import io.github.resilience4j.core.Registry;
 import io.github.resilience4j.core.RegistryStore;
-import io.vavr.collection.HashMap;
-import io.vavr.collection.Map;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -54,7 +52,7 @@ public class AbstractRegistry<E, C> implements Registry<E, C> {
     private final RegistryEventProcessor eventProcessor;
 
     public AbstractRegistry(C defaultConfig) {
-        this(defaultConfig, HashMap.empty());
+        this(defaultConfig, Collections.emptyMap());
     }
 
     public AbstractRegistry(C defaultConfig, Map<String, String> registryTags) {
@@ -62,7 +60,7 @@ public class AbstractRegistry<E, C> implements Registry<E, C> {
     }
 
     public AbstractRegistry(C defaultConfig, RegistryEventConsumer<E> registryEventConsumer) {
-        this(defaultConfig, registryEventConsumer, HashMap.empty());
+        this(defaultConfig, registryEventConsumer, Collections.emptyMap());
     }
 
     public AbstractRegistry(C defaultConfig, RegistryEventConsumer<E> registryEventConsumer,
@@ -73,7 +71,7 @@ public class AbstractRegistry<E, C> implements Registry<E, C> {
 
     public AbstractRegistry(C defaultConfig,
         List<RegistryEventConsumer<E>> registryEventConsumers) {
-        this(defaultConfig, registryEventConsumers, HashMap.empty());
+        this(defaultConfig, registryEventConsumers, Collections.emptyMap());
     }
 
     public AbstractRegistry(C defaultConfig, List<RegistryEventConsumer<E>> registryEventConsumers,
@@ -163,8 +161,10 @@ public class AbstractRegistry<E, C> implements Registry<E, C> {
      * @param tags Tags of the instance.
      * @return Map containing all tags
      */
-    protected io.vavr.collection.Map<String, String> getAllTags(io.vavr.collection.Map<String, String> tags) {
-        return Objects.requireNonNull(tags, TAGS_MUST_NOT_BE_NULL).merge(registryTags);
+    protected Map<String, String> getAllTags(Map<String, String> tags) {
+        final HashMap<String, String> allTags = new HashMap<>(Objects.requireNonNull(registryTags, TAGS_MUST_NOT_BE_NULL));
+        allTags.putAll(tags);
+        return allTags;
     }
 
     private class RegistryEventProcessor extends EventProcessor<RegistryEvent> implements

--- a/resilience4j-core/src/test/java/io/github/resilience4j/core/registry/AbstractRegistryTest.java
+++ b/resilience4j-core/src/test/java/io/github/resilience4j/core/registry/AbstractRegistryTest.java
@@ -1,12 +1,11 @@
 package io.github.resilience4j.core.registry;
 
 import io.github.resilience4j.core.RegistryStore;
-import io.vavr.Tuple;
-import io.vavr.collection.Map;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static io.github.resilience4j.core.registry.RegistryEvent.Type;
@@ -19,9 +18,9 @@ public class AbstractRegistryTest {
 
     @Test
     public void shouldInitRegistryTags(){
-        TestRegistry testRegistry = new TestRegistry(io.vavr.collection.HashMap.of("Tag1","Tag1Value"));
+        TestRegistry testRegistry = new TestRegistry(Map.of("Tag1","Tag1Value"));
         assertThat(testRegistry.getTags()).isNotEmpty();
-        assertThat(testRegistry.getTags()).containsOnly(Tuple.of("Tag1","Tag1Value"));
+        assertThat(testRegistry.getTags()).containsOnly(Map.entry("Tag1","Tag1Value"));
     }
 
 
@@ -198,12 +197,12 @@ public class AbstractRegistryTest {
         List<RegistryEventConsumer<String>> registryEventConsumers = new ArrayList<>();
         registryEventConsumers.add(registryEventConsumer);
         TestRegistry testRegistry  = new TestRegistry(
-            registryEventConsumers, io.vavr.collection.HashMap.of("Tag1","Tag1Value"), new InMemoryRegistryStore());
+            registryEventConsumers, Map.of("Tag1","Tag1Value"), new InMemoryRegistryStore());
 
         assertEquals("Wrong Value", "default", testRegistry.getDefaultConfig());
         assertThat(testRegistry.getDefaultConfig()).isEqualTo("default");
         assertThat(testRegistry.getTags()).isNotEmpty();
-        assertThat(testRegistry.getTags()).containsOnly(Tuple.of("Tag1","Tag1Value"));
+        assertThat(testRegistry.getTags()).containsOnly(Map.entry("Tag1","Tag1Value"));
 
         String addedEntry1 = testRegistry.computeIfAbsent("name", () -> "entry1");
         assertThat(addedEntry1).isEqualTo("entry1");

--- a/resilience4j-feign/build.gradle
+++ b/resilience4j-feign/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     compile project(':resilience4j-circuitbreaker')
     compile project(':resilience4j-ratelimiter')
     compile project(':resilience4j-bulkhead')
+    compile project(':resilience4j-vavr')
     testCompile(libraries.feign_wiremock)
     testCompile(libraries.feign)
 }

--- a/resilience4j-feign/src/main/java/io/github/resilience4j/feign/FeignDecorators.java
+++ b/resilience4j-feign/src/main/java/io/github/resilience4j/feign/FeignDecorators.java
@@ -20,8 +20,10 @@ import feign.InvocationHandlerFactory.MethodHandler;
 import feign.Target;
 import io.github.resilience4j.bulkhead.Bulkhead;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.VavrCircuitBreaker;
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.VavrRetry;
 import io.vavr.CheckedFunction1;
 
 import java.lang.reflect.Method;
@@ -89,7 +91,7 @@ public class FeignDecorators implements FeignDecorator {
          */
         public Builder withRetry(Retry retry) {
             decorators
-                .add((fn, m, mh, t) -> Retry.decorateCheckedFunction(retry, fn));
+                .add((fn, m, mh, t) -> VavrRetry.decorateCheckedFunction(retry, fn));
             return this;
         }
 
@@ -101,7 +103,7 @@ public class FeignDecorators implements FeignDecorator {
          */
         public Builder withCircuitBreaker(CircuitBreaker circuitBreaker) {
             decorators
-                .add((fn, m, mh, t) -> CircuitBreaker.decorateCheckedFunction(circuitBreaker, fn));
+                .add((fn, m, mh, t) -> VavrCircuitBreaker.decorateCheckedFunction(circuitBreaker, fn));
             return this;
         }
 

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/bulkhead/BulkheadRegistry.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/bulkhead/BulkheadRegistry.kt
@@ -20,8 +20,6 @@ package io.github.resilience4j.kotlin.bulkhead
 
 import io.github.resilience4j.bulkhead.BulkheadConfig
 import io.github.resilience4j.bulkhead.BulkheadRegistry
-import io.vavr.Tuple2 as VavrTuple2
-import io.vavr.collection.HashMap as VavrHashMap
 
 /**
  * Creates new custom [BulkheadRegistry].
@@ -137,7 +135,7 @@ inline fun BulkheadRegistry.Builder.addBulkheadConfig(
  * @param tags default tags to add to the registry.
  */
 fun BulkheadRegistry.Builder.withTags(tags: Map<String, String>) {
-    withTags(VavrHashMap.ofAll(tags))
+    withTags(tags)
 }
 
 /**
@@ -148,5 +146,5 @@ fun BulkheadRegistry.Builder.withTags(tags: Map<String, String>) {
  * @param tags default tags to add to the registry.
  */
 fun BulkheadRegistry.Builder.withTags(vararg tags: Pair<String, String>) {
-    withTags(VavrHashMap.ofEntries(tags.map { VavrTuple2(it.first, it.second) }))
+    withTags(HashMap(tags.toMap()))
 }

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/bulkhead/ThreadPoolBulkheadRegistry.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/bulkhead/ThreadPoolBulkheadRegistry.kt
@@ -20,8 +20,6 @@ package io.github.resilience4j.kotlin.bulkhead
 
 import io.github.resilience4j.bulkhead.ThreadPoolBulkheadConfig
 import io.github.resilience4j.bulkhead.ThreadPoolBulkheadRegistry
-import io.vavr.Tuple2 as VavrTuple2
-import io.vavr.collection.HashMap as VavrHashMap
 
 /**
  * Creates new custom [ThreadPoolBulkheadRegistry].
@@ -141,7 +139,7 @@ inline fun ThreadPoolBulkheadRegistry.Builder.addThreadPoolBulkheadConfig(
  * @param tags default tags to add to the registry.
  */
 fun ThreadPoolBulkheadRegistry.Builder.withTags(tags: Map<String, String>) {
-    withTags(VavrHashMap.ofAll(tags))
+    withTags(tags)
 }
 
 /**
@@ -152,5 +150,5 @@ fun ThreadPoolBulkheadRegistry.Builder.withTags(tags: Map<String, String>) {
  * @param tags default tags to add to the registry.
  */
 fun ThreadPoolBulkheadRegistry.Builder.withTags(vararg tags: Pair<String, String>) {
-    withTags(VavrHashMap.ofEntries(tags.map { VavrTuple2(it.first, it.second) }))
+    withTags(HashMap(tags.toMap()))
 }

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/CircuitBreakerRegistry.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/CircuitBreakerRegistry.kt
@@ -20,8 +20,6 @@ package io.github.resilience4j.kotlin.circuitbreaker
 
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
-import io.vavr.Tuple2 as VavrTuple2
-import io.vavr.collection.HashMap as VavrHashMap
 
 /**
  * Creates new custom [CircuitBreakerRegistry].
@@ -137,7 +135,7 @@ inline fun CircuitBreakerRegistry.Builder.addCircuitBreakerConfig(
  * @param tags default tags to add to the registry.
  */
 fun CircuitBreakerRegistry.Builder.withTags(tags: Map<String, String>) {
-    withTags(VavrHashMap.ofAll(tags))
+    withTags(tags)
 }
 
 /**
@@ -148,5 +146,5 @@ fun CircuitBreakerRegistry.Builder.withTags(tags: Map<String, String>) {
  * @param tags default tags to add to the registry.
  */
 fun CircuitBreakerRegistry.Builder.withTags(vararg tags: Pair<String, String>) {
-    withTags(VavrHashMap.ofEntries(tags.map { VavrTuple2(it.first, it.second) }))
+    withTags(HashMap(tags.toMap()))
 }

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/ratelimiter/RateLimiterRegistry.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/ratelimiter/RateLimiterRegistry.kt
@@ -20,8 +20,6 @@ package io.github.resilience4j.kotlin.ratelimiter
 
 import io.github.resilience4j.ratelimiter.RateLimiterConfig
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry
-import io.vavr.Tuple2 as VavrTuple2
-import io.vavr.collection.HashMap as VavrHashMap
 
 /**
  * Creates new custom [RateLimiterRegistry].
@@ -141,7 +139,7 @@ inline fun RateLimiterRegistry.Builder.addRateLimiterConfig(
  * @param tags default tags to add to the registry.
  */
 fun RateLimiterRegistry.Builder.withTags(tags: Map<String, String>) {
-    withTags(VavrHashMap.ofAll(tags))
+    withTags(tags)
 }
 
 /**
@@ -152,5 +150,5 @@ fun RateLimiterRegistry.Builder.withTags(tags: Map<String, String>) {
  * @param tags default tags to add to the registry.
  */
 fun RateLimiterRegistry.Builder.withTags(vararg tags: Pair<String, String>) {
-    withTags(VavrHashMap.ofEntries(tags.map { VavrTuple2(it.first, it.second) }))
+    withTags(HashMap(tags.toMap()))
 }

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/retry/RetryRegistry.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/retry/RetryRegistry.kt
@@ -20,8 +20,6 @@ package io.github.resilience4j.kotlin.retry
 
 import io.github.resilience4j.retry.RetryConfig
 import io.github.resilience4j.retry.RetryRegistry
-import io.vavr.Tuple2 as VavrTuple2
-import io.vavr.collection.HashMap as VavrHashMap
 
 /**
  * Creates new custom [RetryRegistry].
@@ -226,7 +224,7 @@ inline fun RetryRegistry.Builder.addRetryConfig(
  * @param tags default tags to add to the registry.
  */
 fun RetryRegistry.Builder.withTags(tags: Map<String, String>) {
-    withTags(VavrHashMap.ofAll(tags))
+    withTags(tags)
 }
 
 /**
@@ -237,5 +235,5 @@ fun RetryRegistry.Builder.withTags(tags: Map<String, String>) {
  * @param tags default tags to add to the registry.
  */
 fun RetryRegistry.Builder.withTags(vararg tags: Pair<String, String>) {
-    withTags(VavrHashMap.ofEntries(tags.map { VavrTuple2(it.first, it.second) }))
+    withTags(HashMap(tags.toMap()))
 }

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractBulkheadMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractBulkheadMetrics.java
@@ -42,7 +42,7 @@ abstract class AbstractBulkheadMetrics extends AbstractMetrics {
     }
 
     protected void addMetrics(MeterRegistry meterRegistry, Bulkhead bulkhead) {
-        List<Tag> customTags = mapToTagsList(bulkhead.getTags().toJavaMap());
+        List<Tag> customTags = mapToTagsList(bulkhead.getTags());
         registerMetrics(meterRegistry, bulkhead, customTags);
     }
 

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractCircuitBreakerMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractCircuitBreakerMetrics.java
@@ -45,8 +45,7 @@ abstract class AbstractCircuitBreakerMetrics extends AbstractMetrics {
     }
 
     protected void addMetrics(MeterRegistry meterRegistry, CircuitBreaker circuitBreaker) {
-        List<Tag> customTags = mapToTagsList(circuitBreaker.getTags()
-            .toJavaMap());
+        List<Tag> customTags = mapToTagsList(circuitBreaker.getTags());
         registerMetrics(meterRegistry, circuitBreaker, customTags);
     }
 

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractRateLimiterMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractRateLimiterMetrics.java
@@ -42,8 +42,7 @@ abstract class AbstractRateLimiterMetrics extends AbstractMetrics {
     }
 
     protected void addMetrics(MeterRegistry meterRegistry, RateLimiter rateLimiter) {
-        List<Tag> customTags = mapToTagsList(rateLimiter.getTags()
-            .toJavaMap());
+        List<Tag> customTags = mapToTagsList(rateLimiter.getTags());
         registerMetrics(meterRegistry, rateLimiter, customTags);
     }
 

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractRetryMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractRetryMetrics.java
@@ -42,8 +42,7 @@ abstract class AbstractRetryMetrics extends AbstractMetrics {
     }
 
     protected void addMetrics(MeterRegistry meterRegistry, Retry retry) {
-        List<Tag> customTags = mapToTagsList(retry.getTags()
-            .toJavaMap());
+        List<Tag> customTags = mapToTagsList(retry.getTags());
         registerMetrics(meterRegistry, retry, customTags);
     }
 

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractThreadPoolBulkheadMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractThreadPoolBulkheadMetrics.java
@@ -42,7 +42,7 @@ abstract class AbstractThreadPoolBulkheadMetrics extends AbstractMetrics {
     }
 
     protected void addMetrics(MeterRegistry meterRegistry, ThreadPoolBulkhead bulkhead) {
-        List<Tag> customTags = mapToTagsList(bulkhead.getTags().toJavaMap());
+        List<Tag> customTags = mapToTagsList(bulkhead.getTags());
         registerMetrics(meterRegistry, bulkhead, customTags);
     }
 

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractTimeLimiterMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractTimeLimiterMetrics.java
@@ -46,7 +46,7 @@ abstract class AbstractTimeLimiterMetrics extends AbstractMetrics {
     }
 
     protected void addMetrics(MeterRegistry meterRegistry, TimeLimiter timeLimiter) {
-        List<Tag> customTags = mapToTagsList(timeLimiter.getTags().toJavaMap());
+        List<Tag> customTags = mapToTagsList(timeLimiter.getTags());
         registerMetrics(meterRegistry, timeLimiter, customTags);
     }
 

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedBulkheadMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedBulkheadMetricsTest.java
@@ -137,7 +137,7 @@ public class TaggedBulkheadMetricsTest {
 
     @Test
     public void customTagsShouldBeAdded() {
-        Bulkhead bulkheadC = bulkheadRegistry.bulkhead("backendC", io.vavr.collection.HashMap.of("key1", "value1"));
+        Bulkhead bulkheadC = bulkheadRegistry.bulkhead("backendC", Map.of("key1", "value1"));
         // record some basic stats
         bulkheadC.tryAcquirePermission();
         bulkheadC.tryAcquirePermission();

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetricsTest.java
@@ -89,7 +89,7 @@ public class TaggedCircuitBreakerMetricsTest {
 
     @Test
     public void shouldAddCustomTags() {
-        CircuitBreaker circuitBreakerF = circuitBreakerRegistry.circuitBreaker("backendF", io.vavr.collection.HashMap.of("key1", "value1"));
+        CircuitBreaker circuitBreakerF = circuitBreakerRegistry.circuitBreaker("backendF", Map.of("key1", "value1"));
         circuitBreakerF.onSuccess(0, TimeUnit.NANOSECONDS);
         assertThat(taggedCircuitBreakerMetrics.meterIdMap).containsKeys("backendA", "backendF");
         assertThat(taggedCircuitBreakerMetrics.meterIdMap.get("backendF")).hasSize(16);

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRateLimiterMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRateLimiterMetricsTest.java
@@ -28,9 +28,9 @@ import org.junit.Test;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByNamesTag;
 import static io.github.resilience4j.micrometer.tagged.RateLimiterMetricNames.DEFAULT_AVAILABLE_PERMISSIONS_METRIC_NAME;
 import static io.github.resilience4j.micrometer.tagged.RateLimiterMetricNames.DEFAULT_WAITING_THREADS_METRIC_NAME;
-import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByNamesTag;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TaggedRateLimiterMetricsTest {
@@ -73,7 +73,7 @@ public class TaggedRateLimiterMetricsTest {
 
     @Test
     public void shouldAddCustomTags() {
-        RateLimiter newRateLimiter = rateLimiterRegistry.rateLimiter("backendF", io.vavr.collection.HashMap.of("key1", "value1"));
+        RateLimiter newRateLimiter = rateLimiterRegistry.rateLimiter("backendF", Map.of("key1", "value1"));
         assertThat(taggedRateLimiterMetrics.meterIdMap).containsKeys("backendA", "backendF");
         assertThat(taggedRateLimiterMetrics.meterIdMap.get("backendA")).hasSize(2);
         assertThat(taggedRateLimiterMetrics.meterIdMap.get("backendF")).hasSize(2);

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRetryMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRetryMetricsTest.java
@@ -28,8 +28,8 @@ import org.junit.Test;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static io.github.resilience4j.micrometer.tagged.RetryMetricNames.DEFAULT_RETRY_CALLS;
 import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByKindAndNameTags;
+import static io.github.resilience4j.micrometer.tagged.RetryMetricNames.DEFAULT_RETRY_CALLS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TaggedRetryMetricsTest {
@@ -76,7 +76,7 @@ public class TaggedRetryMetricsTest {
 
     @Test
     public void shouldAddCustomTags() {
-        retryRegistry.retry("backendF", io.vavr.collection.HashMap.of("key1", "value1"));
+        retryRegistry.retry("backendF", Map.of("key1", "value1"));
         assertThat(taggedRetryMetrics.meterIdMap).containsKeys("backendA", "backendF");
         assertThat(taggedRetryMetrics.meterIdMap.get("backendA")).hasSize(4);
         assertThat(taggedRetryMetrics.meterIdMap.get("backendF")).hasSize(4);

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedThreadPoolBulkheadMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedThreadPoolBulkheadMetricsTest.java
@@ -76,7 +76,7 @@ public class TaggedThreadPoolBulkheadMetricsTest {
 
     @Test
     public void shouldAddCustomTags() {
-        bulkheadRegistry.bulkhead("backendF", io.vavr.collection.HashMap.of("key1", "value1"));
+        bulkheadRegistry.bulkhead("backendF", Map.of("key1", "value1"));
         assertThat(taggedBulkheadMetrics.meterIdMap).containsKeys("backendA", "backendF");
         assertThat(taggedBulkheadMetrics.meterIdMap.get("backendA")).hasSize(5);
         assertThat(taggedBulkheadMetrics.meterIdMap.get("backendF")).hasSize(5);

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedTimeLimiterMetricsPublisherTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedTimeLimiterMetricsPublisherTest.java
@@ -27,10 +27,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
@@ -76,7 +73,7 @@ public class TaggedTimeLimiterMetricsPublisherTest {
 
     @Test
     public void shouldAddCustomTags() {
-        TimeLimiter timeLimiterF = timeLimiterRegistry.timeLimiter("backendF", io.vavr.collection.HashMap.of("key1", "value1"));
+        TimeLimiter timeLimiterF = timeLimiterRegistry.timeLimiter("backendF", Map.of("key1", "value1"));
         timeLimiterF.onSuccess();
         assertThat(taggedTimeLimiterMetricsPublisher.meterIdMap).containsKeys("backendA", "backendF");
         assertThat(taggedTimeLimiterMetricsPublisher.meterIdMap.get("backendF")).hasSize(3);

--- a/resilience4j-prometheus/src/main/java/io/github/resilience4j/prometheus/collectors/CircuitBreakerMetricsCollector.java
+++ b/resilience4j-prometheus/src/main/java/io/github/resilience4j/prometheus/collectors/CircuitBreakerMetricsCollector.java
@@ -19,7 +19,9 @@ import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker.Metrics;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.prometheus.AbstractCircuitBreakerMetrics;
+import org.w3c.dom.stylesheets.LinkStyle;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -86,7 +88,7 @@ public class CircuitBreakerMetricsCollector extends AbstractCircuitBreakerMetric
         List<MetricFamilySamples> samples = Collections
             .list(collectorRegistry.metricFamilySamples());
         samples
-            .addAll(collectGaugeSamples(circuitBreakerRegistry.getAllCircuitBreakers().asJava()));
+            .addAll(collectGaugeSamples(new ArrayList<>(circuitBreakerRegistry.getAllCircuitBreakers())));
         return samples;
     }
 

--- a/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/RateLimiter.java
+++ b/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/RateLimiter.java
@@ -27,12 +27,11 @@ import io.github.resilience4j.ratelimiter.internal.AtomicRateLimiter;
 import io.vavr.CheckedFunction0;
 import io.vavr.CheckedFunction1;
 import io.vavr.CheckedRunnable;
-import io.vavr.collection.HashMap;
-import io.vavr.collection.Map;
 import io.vavr.control.Either;
 import io.vavr.control.Try;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -40,6 +39,8 @@ import java.util.concurrent.Future;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+
+import static java.util.Collections.emptyMap;
 
 /**
  * A RateLimiter instance is thread-safe can be used to decorate multiple requests.
@@ -58,7 +59,7 @@ public interface RateLimiter {
      * @return The {@link RateLimiter}
      */
     static RateLimiter of(String name, RateLimiterConfig rateLimiterConfig) {
-        return of(name, rateLimiterConfig, HashMap.empty());
+        return of(name, rateLimiterConfig, emptyMap());
     }
 
     /**
@@ -82,7 +83,7 @@ public interface RateLimiter {
      * @return The {@link RateLimiter}
      */
     static RateLimiter of(String name, Supplier<RateLimiterConfig> rateLimiterConfigSupplier) {
-        return of(name, rateLimiterConfigSupplier.get(), HashMap.empty());
+        return of(name, rateLimiterConfigSupplier.get(), emptyMap());
     }
 
     /**

--- a/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/RateLimiterRegistry.java
+++ b/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/RateLimiterRegistry.java
@@ -22,11 +22,11 @@ import io.github.resilience4j.core.Registry;
 import io.github.resilience4j.core.RegistryStore;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
 import io.github.resilience4j.ratelimiter.internal.InMemoryRateLimiterRegistry;
-import io.vavr.collection.Seq;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -101,8 +101,7 @@ public interface RateLimiterRegistry extends Registry<RateLimiter, RateLimiterCo
      * @param tags    default tags to add to the registry
      * @return a ThreadPoolBulkheadRegistry with a Map of shared RateLimiter configurations.
      */
-    static RateLimiterRegistry of(Map<String, RateLimiterConfig> configs,
-        io.vavr.collection.Map<String, String> tags) {
+    static RateLimiterRegistry of(Map<String, RateLimiterConfig> configs, Map<String, String> tags) {
         return new InMemoryRateLimiterRegistry(configs, tags);
     }
 
@@ -131,8 +130,7 @@ public interface RateLimiterRegistry extends Registry<RateLimiter, RateLimiterCo
      * RateLimiter registry event consumer.
      */
     static RateLimiterRegistry of(Map<String, RateLimiterConfig> configs,
-        RegistryEventConsumer<RateLimiter> registryEventConsumer,
-        io.vavr.collection.Map<String, String> tags) {
+        RegistryEventConsumer<RateLimiter> registryEventConsumer, Map<String, String> tags) {
         return new InMemoryRateLimiterRegistry(configs, registryEventConsumer, tags);
     }
 
@@ -155,7 +153,7 @@ public interface RateLimiterRegistry extends Registry<RateLimiter, RateLimiterCo
      *
      * @return all managed {@link RateLimiter} instances.
      */
-    Seq<RateLimiter> getAllRateLimiters();
+    Set<RateLimiter> getAllRateLimiters();
 
     /**
      * Returns a managed {@link RateLimiter} or creates a new one with the default RateLimiter
@@ -178,7 +176,7 @@ public interface RateLimiterRegistry extends Registry<RateLimiter, RateLimiterCo
      * @param tags tags added to the RateLimiter
      * @return The {@link RateLimiter}
      */
-    RateLimiter rateLimiter(String name, io.vavr.collection.Map<String, String> tags);
+    RateLimiter rateLimiter(String name, Map<String, String> tags);
 
     /**
      * Returns a managed {@link RateLimiter} or creates a new one with a custom RateLimiter
@@ -203,8 +201,7 @@ public interface RateLimiterRegistry extends Registry<RateLimiter, RateLimiterCo
      * @param tags              tags added to the RateLimiter
      * @return The {@link RateLimiter}
      */
-    RateLimiter rateLimiter(String name, RateLimiterConfig rateLimiterConfig,
-        io.vavr.collection.Map<String, String> tags);
+    RateLimiter rateLimiter(String name, RateLimiterConfig rateLimiterConfig, Map<String, String> tags);
 
     /**
      * Returns a managed {@link RateLimiterConfig} or creates a new one with a custom
@@ -229,8 +226,7 @@ public interface RateLimiterRegistry extends Registry<RateLimiter, RateLimiterCo
      * @param tags                      tags added to the RateLimiter
      * @return The {@link RateLimiterConfig}
      */
-    RateLimiter rateLimiter(String name, Supplier<RateLimiterConfig> rateLimiterConfigSupplier,
-        io.vavr.collection.Map<String, String> tags);
+    RateLimiter rateLimiter(String name, Supplier<RateLimiterConfig> rateLimiterConfigSupplier, Map<String, String> tags);
 
     /**
      * Returns a managed {@link RateLimiter} or creates a new one.
@@ -250,8 +246,7 @@ public interface RateLimiterRegistry extends Registry<RateLimiter, RateLimiterCo
      * @param configName the name of the shared configuration
      * @return The {@link RateLimiter}
      */
-    RateLimiter rateLimiter(String name, String configName,
-        io.vavr.collection.Map<String, String> tags);
+    RateLimiter rateLimiter(String name, String configName, Map<String, String> tags);
 
     /**
      * Returns a builder to create a custom RateLimiterRegistry.
@@ -268,7 +263,7 @@ public interface RateLimiterRegistry extends Registry<RateLimiter, RateLimiterCo
         private RegistryStore registryStore;
         private Map<String, RateLimiterConfig> rateLimiterConfigsMap;
         private List<RegistryEventConsumer<RateLimiter>> registryEventConsumers;
-        private io.vavr.collection.Map<String, String> tags;
+        private Map<String, String> tags;
 
         public Builder() {
             this.rateLimiterConfigsMap = new java.util.HashMap<>();
@@ -327,7 +322,7 @@ public interface RateLimiterRegistry extends Registry<RateLimiter, RateLimiterCo
          * @param tags default tags to add to the registry.
          * @return a {@link RateLimiterRegistry.Builder}
          */
-        public Builder withTags(io.vavr.collection.Map<String, String> tags) {
+        public Builder withTags(Map<String, String> tags) {
             this.tags = tags;
             return this;
         }

--- a/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/internal/AtomicRateLimiter.java
+++ b/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/internal/AtomicRateLimiter.java
@@ -22,10 +22,10 @@ import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
 import io.github.resilience4j.ratelimiter.event.RateLimiterOnFailureEvent;
 import io.github.resilience4j.ratelimiter.event.RateLimiterOnSuccessEvent;
-import io.vavr.collection.HashMap;
-import io.vavr.collection.Map;
 
 import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.UnaryOperator;
@@ -33,6 +33,7 @@ import java.util.function.UnaryOperator;
 import static java.lang.Long.min;
 import static java.lang.System.nanoTime;
 import static java.lang.Thread.currentThread;
+import static java.util.Collections.emptyMap;
 import static java.util.concurrent.locks.LockSupport.parkNanos;
 
 /**
@@ -56,7 +57,7 @@ public class AtomicRateLimiter implements RateLimiter {
     private final RateLimiterEventProcessor eventProcessor;
 
     public AtomicRateLimiter(String name, RateLimiterConfig rateLimiterConfig) {
-        this(name, rateLimiterConfig, HashMap.empty());
+        this(name, rateLimiterConfig, emptyMap());
     }
 
     public AtomicRateLimiter(String name, RateLimiterConfig rateLimiterConfig,

--- a/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/internal/InMemoryRateLimiterRegistry.java
+++ b/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/internal/InMemoryRateLimiterRegistry.java
@@ -26,15 +26,11 @@ import io.github.resilience4j.core.registry.RegistryEventConsumer;
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
-import io.vavr.collection.Array;
-import io.vavr.collection.HashMap;
-import io.vavr.collection.Seq;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Supplier;
+
+import static java.util.Collections.emptyMap;
 
 /**
  * Backend RateLimiter manager. Constructs backend RateLimiters according to configuration values.
@@ -49,28 +45,22 @@ public class InMemoryRateLimiterRegistry extends
         this(RateLimiterConfig.ofDefaults());
     }
 
-    public InMemoryRateLimiterRegistry(io.vavr.collection.Map<String, String> tags) {
-        this(RateLimiterConfig.ofDefaults(), tags);
-    }
-
     public InMemoryRateLimiterRegistry(Map<String, RateLimiterConfig> configs) {
-        this(configs, HashMap.empty());
+        this(configs, emptyMap());
     }
 
-    public InMemoryRateLimiterRegistry(Map<String, RateLimiterConfig> configs,
-        io.vavr.collection.Map<String, String> tags) {
+    public InMemoryRateLimiterRegistry(Map<String, RateLimiterConfig> configs, Map<String, String> tags) {
         this(configs.getOrDefault(DEFAULT_CONFIG, RateLimiterConfig.ofDefaults()), tags);
         this.configurations.putAll(configs);
     }
 
     public InMemoryRateLimiterRegistry(Map<String, RateLimiterConfig> configs,
         RegistryEventConsumer<RateLimiter> registryEventConsumer) {
-        this(configs, registryEventConsumer, HashMap.empty());
+        this(configs, registryEventConsumer, emptyMap());
     }
 
     public InMemoryRateLimiterRegistry(Map<String, RateLimiterConfig> configs,
-        RegistryEventConsumer<RateLimiter> registryEventConsumer,
-        io.vavr.collection.Map<String, String> tags) {
+        RegistryEventConsumer<RateLimiter> registryEventConsumer, Map<String, String> tags) {
         this(configs.getOrDefault(DEFAULT_CONFIG, RateLimiterConfig.ofDefaults()),
             registryEventConsumer, tags);
         this.configurations.putAll(configs);
@@ -78,12 +68,11 @@ public class InMemoryRateLimiterRegistry extends
 
     public InMemoryRateLimiterRegistry(Map<String, RateLimiterConfig> configs,
         List<RegistryEventConsumer<RateLimiter>> registryEventConsumers) {
-        this(configs, registryEventConsumers, HashMap.empty());
+        this(configs, registryEventConsumers, emptyMap());
     }
 
     public InMemoryRateLimiterRegistry(Map<String, RateLimiterConfig> configs,
-        List<RegistryEventConsumer<RateLimiter>> registryEventConsumers,
-        io.vavr.collection.Map<String, String> tags) {
+        List<RegistryEventConsumer<RateLimiter>> registryEventConsumers, Map<String, String> tags) {
         this(configs.getOrDefault(DEFAULT_CONFIG, RateLimiterConfig.ofDefaults()),
             registryEventConsumers, tags);
         this.configurations.putAll(configs);
@@ -98,8 +87,7 @@ public class InMemoryRateLimiterRegistry extends
         super(defaultConfig);
     }
 
-    public InMemoryRateLimiterRegistry(RateLimiterConfig defaultConfig,
-        io.vavr.collection.Map<String, String> tags) {
+    public InMemoryRateLimiterRegistry(RateLimiterConfig defaultConfig, Map<String, String> tags) {
         super(defaultConfig, tags);
     }
 
@@ -109,8 +97,7 @@ public class InMemoryRateLimiterRegistry extends
     }
 
     public InMemoryRateLimiterRegistry(RateLimiterConfig defaultConfig,
-        RegistryEventConsumer<RateLimiter> registryEventConsumer,
-        io.vavr.collection.Map<String, String> tags) {
+        RegistryEventConsumer<RateLimiter> registryEventConsumer, Map<String, String> tags) {
         super(defaultConfig, registryEventConsumer, tags);
     }
 
@@ -120,16 +107,15 @@ public class InMemoryRateLimiterRegistry extends
     }
 
     public InMemoryRateLimiterRegistry(RateLimiterConfig defaultConfig,
-        List<RegistryEventConsumer<RateLimiter>> registryEventConsumers,
-        io.vavr.collection.Map<String, String> tags) {
+        List<RegistryEventConsumer<RateLimiter>> registryEventConsumers, Map<String, String> tags) {
         super(defaultConfig, registryEventConsumers, tags);
     }
 
     public InMemoryRateLimiterRegistry(Map<String, RateLimiterConfig> configs,
                                           List<RegistryEventConsumer<RateLimiter>> registryEventConsumers,
-                                          io.vavr.collection.Map<String, String> tags, RegistryStore<RateLimiter> registryStore) {
+                                          Map<String, String> tags, RegistryStore<RateLimiter> registryStore) {
         super(configs.getOrDefault(DEFAULT_CONFIG, RateLimiterConfig.ofDefaults()),
-            registryEventConsumers, Optional.ofNullable(tags).orElse(HashMap.empty()),
+            registryEventConsumers, Optional.ofNullable(tags).orElse(emptyMap()),
             Optional.ofNullable(registryStore).orElse(new InMemoryRegistryStore<>()));
         this.configurations.putAll(configs);
     }
@@ -138,8 +124,8 @@ public class InMemoryRateLimiterRegistry extends
      * {@inheritDoc}
      */
     @Override
-    public Seq<RateLimiter> getAllRateLimiters() {
-        return Array.ofAll(entryMap.values());
+    public Set<RateLimiter> getAllRateLimiters() {
+        return new HashSet<>(entryMap.values());
     }
 
     /**
@@ -154,7 +140,7 @@ public class InMemoryRateLimiterRegistry extends
      * {@inheritDoc}
      */
     @Override
-    public RateLimiter rateLimiter(String name, io.vavr.collection.Map<String, String> tags) {
+    public RateLimiter rateLimiter(String name, Map<String, String> tags) {
         return rateLimiter(name, getDefaultConfig(), tags);
     }
 
@@ -163,15 +149,14 @@ public class InMemoryRateLimiterRegistry extends
      */
     @Override
     public RateLimiter rateLimiter(final String name, final RateLimiterConfig config) {
-        return rateLimiter(name, config, HashMap.empty());
+        return rateLimiter(name, config, emptyMap());
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public RateLimiter rateLimiter(String name, RateLimiterConfig config,
-        io.vavr.collection.Map<String, String> tags) {
+    public RateLimiter rateLimiter(String name, RateLimiterConfig config, Map<String, String> tags) {
         return computeIfAbsent(name, () -> new AtomicRateLimiter(name,
             Objects.requireNonNull(config, CONFIG_MUST_NOT_BE_NULL), getAllTags(tags)));
     }
@@ -182,7 +167,7 @@ public class InMemoryRateLimiterRegistry extends
     @Override
     public RateLimiter rateLimiter(final String name,
         final Supplier<RateLimiterConfig> rateLimiterConfigSupplier) {
-        return rateLimiter(name, rateLimiterConfigSupplier, HashMap.empty());
+        return rateLimiter(name, rateLimiterConfigSupplier, emptyMap());
     }
 
     /**
@@ -190,8 +175,7 @@ public class InMemoryRateLimiterRegistry extends
      */
     @Override
     public RateLimiter rateLimiter(String name,
-        Supplier<RateLimiterConfig> rateLimiterConfigSupplier,
-        io.vavr.collection.Map<String, String> tags) {
+        Supplier<RateLimiterConfig> rateLimiterConfigSupplier, Map<String, String> tags) {
         return computeIfAbsent(name, () -> new AtomicRateLimiter(name, Objects.requireNonNull(
             Objects.requireNonNull(rateLimiterConfigSupplier, SUPPLIER_MUST_NOT_BE_NULL).get(),
             CONFIG_MUST_NOT_BE_NULL), getAllTags(tags)));
@@ -202,15 +186,14 @@ public class InMemoryRateLimiterRegistry extends
      */
     @Override
     public RateLimiter rateLimiter(String name, String configName) {
-        return rateLimiter(name, configName, HashMap.empty());
+        return rateLimiter(name, configName, emptyMap());
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public RateLimiter rateLimiter(String name, String configName,
-        io.vavr.collection.Map<String, String> tags) {
+    public RateLimiter rateLimiter(String name, String configName, Map<String, String> tags) {
         return computeIfAbsent(name, () -> RateLimiter.of(name, getConfiguration(configName)
             .orElseThrow(() -> new ConfigurationNotFoundException(configName)), getAllTags(tags)));
     }

--- a/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/internal/SemaphoreBasedRateLimiter.java
+++ b/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/internal/SemaphoreBasedRateLimiter.java
@@ -23,17 +23,17 @@ import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
 import io.github.resilience4j.ratelimiter.event.RateLimiterOnFailureEvent;
 import io.github.resilience4j.ratelimiter.event.RateLimiterOnSuccessEvent;
-import io.vavr.collection.HashMap;
-import io.vavr.collection.Map;
 import io.vavr.control.Option;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 
@@ -61,7 +61,7 @@ public class SemaphoreBasedRateLimiter implements RateLimiter {
      * @param rateLimiterConfig The RateLimiter configuration.
      */
     public SemaphoreBasedRateLimiter(final String name, final RateLimiterConfig rateLimiterConfig) {
-        this(name, rateLimiterConfig, HashMap.empty());
+        this(name, rateLimiterConfig, emptyMap());
     }
 
     /**
@@ -71,8 +71,7 @@ public class SemaphoreBasedRateLimiter implements RateLimiter {
      * @param rateLimiterConfig The RateLimiter configuration.
      * @param tags              tags to assign to the RateLimiter
      */
-    public SemaphoreBasedRateLimiter(final String name, final RateLimiterConfig rateLimiterConfig,
-        Map<String, String> tags) {
+    public SemaphoreBasedRateLimiter(final String name, final RateLimiterConfig rateLimiterConfig, Map<String, String> tags) {
         this(name, rateLimiterConfig, null, tags);
     }
 
@@ -85,7 +84,7 @@ public class SemaphoreBasedRateLimiter implements RateLimiter {
      */
     public SemaphoreBasedRateLimiter(String name, RateLimiterConfig rateLimiterConfig,
         @Nullable ScheduledExecutorService scheduler) {
-        this(name, rateLimiterConfig, scheduler, HashMap.empty());
+        this(name, rateLimiterConfig, scheduler, emptyMap());
     }
 
     /**

--- a/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/RateLimiterRegistryTest.java
+++ b/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/RateLimiterRegistryTest.java
@@ -4,7 +4,6 @@ import io.github.resilience4j.core.ConfigurationNotFoundException;
 import io.github.resilience4j.core.EventProcessor;
 import io.github.resilience4j.core.Registry;
 import io.github.resilience4j.core.registry.*;
-import io.vavr.Tuple;
 import org.junit.Test;
 
 import java.time.Duration;
@@ -29,9 +28,9 @@ public class RateLimiterRegistryTest {
     public void shouldInitRegistryTags() {
         Map<String, RateLimiterConfig> configs = new HashMap<>();
         configs.put("custom", RateLimiterConfig.ofDefaults());
-        RateLimiterRegistry registry = RateLimiterRegistry.of(configs,io.vavr.collection.HashMap.of("Tag1Key","Tag1Value"));
+        RateLimiterRegistry registry = RateLimiterRegistry.of(configs, Map.of("Tag1Key","Tag1Value"));
         assertThat(registry.getTags()).isNotEmpty();
-        assertThat(registry.getTags()).containsOnly(Tuple.of("Tag1Key","Tag1Value"));
+        assertThat(registry.getTags()).containsOnly(Map.entry("Tag1Key","Tag1Value"));
     }
 
     @Test
@@ -148,40 +147,36 @@ public class RateLimiterRegistryTest {
         RateLimiterConfig rateLimiterConfig = RateLimiterConfig.ofDefaults();
         Map<String, RateLimiterConfig> ratelimiterConfigs = Collections
             .singletonMap("default", rateLimiterConfig);
-        io.vavr.collection.Map<String, String> rateLimiterTags = io.vavr.collection.HashMap
-            .of("key1", "value1", "key2", "value2");
+        Map<String, String> rateLimiterTags = Map.of("key1", "value1", "key2", "value2");
         RateLimiterRegistry rateLimiterRegistry = RateLimiterRegistry
             .of(ratelimiterConfigs, rateLimiterTags);
         RateLimiter rateLimiter = rateLimiterRegistry.rateLimiter("testName");
 
-        assertThat(rateLimiter.getTags()).containsOnlyElementsOf(rateLimiterTags);
+        assertThat(rateLimiter.getTags()).containsAllEntriesOf(rateLimiterTags);
     }
 
     @Test
     public void tagsAddedToInstance() {
         RateLimiterRegistry rateLimiterRegistry = RateLimiterRegistry.ofDefaults();
-        io.vavr.collection.Map<String, String> retryTags = io.vavr.collection.HashMap
-            .of("key1", "value1", "key2", "value2");
+        Map<String, String> retryTags = Map.of("key1", "value1", "key2", "value2");
         RateLimiter rateLimiter = rateLimiterRegistry.rateLimiter("testName", retryTags);
 
-        assertThat(rateLimiter.getTags()).containsOnlyElementsOf(retryTags);
+        assertThat(rateLimiter.getTags()).containsAllEntriesOf(retryTags);
     }
 
     @Test
     public void tagsOfRetriesShouldNotBeMixed() {
         RateLimiterRegistry rateLimiterRegistry = RateLimiterRegistry.ofDefaults();
         RateLimiterConfig rateLimiterConfig = RateLimiterConfig.ofDefaults();
-        io.vavr.collection.Map<String, String> rateLimiterTags = io.vavr.collection.HashMap
-            .of("key1", "value1", "key2", "value2");
+        Map<String, String> rateLimiterTags = Map.of("key1", "value1", "key2", "value2");
         RateLimiter rateLimiter = rateLimiterRegistry
             .rateLimiter("testName", rateLimiterConfig, rateLimiterTags);
-        io.vavr.collection.Map<String, String> rateLimiterTags2 = io.vavr.collection.HashMap
-            .of("key3", "value3", "key4", "value4");
+        Map<String, String> rateLimiterTags2 = Map.of("key3", "value3", "key4", "value4");
         RateLimiter rateLimiter2 = rateLimiterRegistry
             .rateLimiter("otherTestName", rateLimiterConfig, rateLimiterTags2);
 
-        assertThat(rateLimiter.getTags()).containsOnlyElementsOf(rateLimiterTags);
-        assertThat(rateLimiter2.getTags()).containsOnlyElementsOf(rateLimiterTags2);
+        assertThat(rateLimiter.getTags()).containsAllEntriesOf(rateLimiterTags);
+        assertThat(rateLimiter2.getTags()).containsAllEntriesOf(rateLimiterTags2);
     }
 
     @Test
@@ -189,18 +184,15 @@ public class RateLimiterRegistryTest {
         RateLimiterConfig rateLimiterConfig = RateLimiterConfig.ofDefaults();
         Map<String, RateLimiterConfig> rateLimiterConfigs = Collections
             .singletonMap("default", rateLimiterConfig);
-        io.vavr.collection.Map<String, String> registryTags = io.vavr.collection.HashMap
-            .of("key1", "value1", "key2", "value2");
-        io.vavr.collection.Map<String, String> instanceTags = io.vavr.collection.HashMap
-            .of("key1", "value3", "key4", "value4");
+        Map<String, String> registryTags = Map.of("key1", "value1", "key2", "value2");
+        Map<String, String> instanceTags = Map.of("key1", "value3", "key4", "value4");
         RateLimiterRegistry rateLimiterRegistry = RateLimiterRegistry
             .of(rateLimiterConfigs, registryTags);
         RateLimiter rateLimiter = rateLimiterRegistry
             .rateLimiter("testName", rateLimiterConfig, instanceTags);
 
-        io.vavr.collection.Map<String, String> expectedTags = io.vavr.collection.HashMap
-            .of("key1", "value3", "key2", "value2", "key4", "value4");
-        assertThat(rateLimiter.getTags()).containsOnlyElementsOf(expectedTags);
+        Map<String, String> expectedTags = Map.of("key1", "value3", "key2", "value2", "key4", "value4");
+        assertThat(rateLimiter.getTags()).containsAllEntriesOf(expectedTags);
     }
 
     private static class NoOpRateLimiterEventConsumer implements
@@ -312,15 +304,14 @@ public class RateLimiterRegistryTest {
 
     @Test
     public void testCreateUsingBuilderWithRegistryTags() {
-        io.vavr.collection.Map<String, String> rateLimiterTags = io.vavr.collection.HashMap
-            .of("key1", "value1", "key2", "value2");
+        Map<String, String> rateLimiterTags = Map.of("key1", "value1", "key2", "value2");
         RateLimiterRegistry rateLimiterRegistry = RateLimiterRegistry.custom()
             .withRateLimiterConfig(RateLimiterConfig.ofDefaults())
             .withTags(rateLimiterTags)
             .build();
         RateLimiter rateLimiter = rateLimiterRegistry.rateLimiter("testName");
 
-        assertThat(rateLimiter.getTags()).containsOnlyElementsOf(rateLimiterTags);
+        assertThat(rateLimiter.getTags()).containsAllEntriesOf(rateLimiterTags);
     }
 
     @Test

--- a/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/InMemoryRateLimiterRegistryTest.java
+++ b/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/InMemoryRateLimiterRegistryTest.java
@@ -142,10 +142,10 @@ public class InMemoryRateLimiterRegistryTest {
     @Test
     public void rateLimiterGetAllRateLimiters() {
         RateLimiterRegistry registry = new InMemoryRateLimiterRegistry(config);
-        registry.rateLimiter("foo");
+        final RateLimiter rateLimiter = registry.rateLimiter("foo");
 
         assertThat(registry.getAllRateLimiters().size()).isEqualTo(1);
-        assertThat(registry.getAllRateLimiters().get(0).getName()).isEqualTo("foo");
+        assertThat(registry.getAllRateLimiters()).contains(rateLimiter);
     }
 
     @Test
@@ -158,7 +158,7 @@ public class InMemoryRateLimiterRegistryTest {
         configs.put("default", defaultConfig);
         final InMemoryRateLimiterRegistry inMemoryRateLimiterRegistry =
             new InMemoryRateLimiterRegistry(configs, registryEventConsumers,
-                io.vavr.collection.HashMap.of("Tag1", "Tag1Value"), new InMemoryRegistryStore());
+                Map.of("Tag1", "Tag1Value"), new InMemoryRegistryStore());
 
         AssertionsForClassTypes.assertThat(inMemoryRateLimiterRegistry).isNotNull();
         AssertionsForClassTypes.assertThat(inMemoryRateLimiterRegistry.getDefaultConfig()).isEqualTo(defaultConfig);

--- a/resilience4j-ratpack/build.gradle
+++ b/resilience4j-ratpack/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     compile project(':resilience4j-consumer')
     compile project(':resilience4j-reactor')
     compile project(':resilience4j-timelimiter')
+    compile project(':resilience4j-vavr')
     compile(libraries.reactor)
     compileOnly(libraries.ratpack_metrics)
     compileOnly project(':resilience4j-prometheus')

--- a/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/circuitbreaker/CircuitBreakerMethodInterceptor.java
+++ b/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/circuitbreaker/CircuitBreakerMethodInterceptor.java
@@ -17,6 +17,7 @@ package io.github.resilience4j.ratpack.circuitbreaker;
 
 import com.google.inject.Inject;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.circuitbreaker.VavrCircuitBreaker;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.core.lang.Nullable;
 import io.github.resilience4j.ratpack.internal.AbstractMethodInterceptor;
@@ -173,8 +174,7 @@ public class CircuitBreakerMethodInterceptor extends AbstractMethodInterceptor {
         io.github.resilience4j.circuitbreaker.CircuitBreaker breaker,
         RecoveryFunction<?> recoveryFunction) throws Throwable {
         try {
-            return io.github.resilience4j.circuitbreaker.CircuitBreaker
-                .decorateCheckedSupplier(breaker, invocation::proceed).apply();
+            return VavrCircuitBreaker.decorateCheckedSupplier(breaker, invocation::proceed).apply();
         } catch (Throwable throwable) {
             return recoveryFunction.apply(throwable);
         }

--- a/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/retry/RetryMethodInterceptor.java
+++ b/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/retry/RetryMethodInterceptor.java
@@ -21,6 +21,7 @@ import io.github.resilience4j.ratpack.internal.AbstractMethodInterceptor;
 import io.github.resilience4j.ratpack.recovery.DefaultRecoveryFunction;
 import io.github.resilience4j.ratpack.recovery.RecoveryFunction;
 import io.github.resilience4j.retry.RetryRegistry;
+import io.github.resilience4j.retry.VavrRetry;
 import io.github.resilience4j.retry.annotation.Retry;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
@@ -155,7 +156,7 @@ public class RetryMethodInterceptor extends AbstractMethodInterceptor {
         io.github.resilience4j.retry.Retry retry, RecoveryFunction<?> recoveryFunction)
         throws Throwable {
         try {
-            return io.github.resilience4j.retry.Retry
+            return VavrRetry
                 .decorateCheckedSupplier(retry, invocation::proceed).apply();
         } catch (Throwable t) {
             return recoveryFunction.apply(t);

--- a/resilience4j-ratpack/src/test/groovy/io/github/resilience4j/ratpack/retry/monitoring/endpoint/RetryChainSpec.groovy
+++ b/resilience4j-ratpack/src/test/groovy/io/github/resilience4j/ratpack/retry/monitoring/endpoint/RetryChainSpec.groovy
@@ -19,8 +19,8 @@ package io.github.resilience4j.ratpack.retry.monitoring.endpoint
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.github.resilience4j.common.retry.monitoring.endpoint.RetryEventsEndpointResponse
 import io.github.resilience4j.ratpack.Resilience4jModule
-import io.github.resilience4j.retry.Retry
 import io.github.resilience4j.retry.RetryRegistry
+import io.github.resilience4j.retry.VavrRetry
 import io.github.resilience4j.retry.event.RetryEvent
 import io.vavr.CheckedFunction0
 import io.vavr.control.Try
@@ -88,7 +88,7 @@ class RetryChainSpec extends Specification {
         when: "we get all retry events"
         ['test1', 'test2'].each {
             def r = retryRegistry.retry(it)
-            Try.of(Retry.decorateCheckedSupplier(r, {
+            Try.of(VavrRetry.decorateCheckedSupplier(r, {
                 throw new Exception('derek olk'); 'unreachable'
             } as CheckedFunction0<String>)).recover { "recovered" }.get()
         }
@@ -158,7 +158,7 @@ class RetryChainSpec extends Specification {
         def retryRegistry = app.server.registry.get().get(RetryRegistry)
         ['test1', 'test2'].each {
             def r = retryRegistry.retry(it)
-            Try.of(Retry.decorateCheckedSupplier(r, {
+            Try.of(VavrRetry.decorateCheckedSupplier(r, {
                 throw new Exception('derek olk'); 'unreachable'
             } as CheckedFunction0<String>)).recover { "recovered" }.get()
         }
@@ -229,7 +229,7 @@ class RetryChainSpec extends Specification {
         def retryRegistry = app.server.registry.get().get(RetryRegistry)
         ['test1', 'test2'].each {
             def r = retryRegistry.retry(it)
-            Try.of(Retry.decorateCheckedSupplier(r, {
+            Try.of(VavrRetry.decorateCheckedSupplier(r, {
                 throw new Exception('derek olk'); 'unreachable'
             } as CheckedFunction0<String>)).recover { "recovered" }.get()
         }

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/IntervalFunction.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/IntervalFunction.java
@@ -1,12 +1,11 @@
 package io.github.resilience4j.retry;
 
-import io.vavr.collection.Stream;
-
 import java.time.Duration;
 import java.util.function.Function;
 
 import static io.github.resilience4j.retry.IntervalFunctionCompanion.*;
 import static java.util.Objects.requireNonNull;
+
 
 /**
  * Use io.github.resilience4j.core.IntervalFunction instead, this class kept for backwards
@@ -30,7 +29,15 @@ public interface IntervalFunction extends io.github.resilience4j.core.IntervalFu
 
         return (attempt) -> {
             checkAttempt(attempt);
-            return Stream.iterate(intervalMillis, backoffFunction).get(attempt - 1);
+            if (attempt == 1) {
+                return intervalMillis;
+            } else {
+                long currentIntervalMillis = intervalMillis;
+                for(int i = 1; i < attempt; i++) {
+                    currentIntervalMillis = backoffFunction.apply(currentIntervalMillis);
+                }
+                return currentIntervalMillis;
+            }
         };
     }
 

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/Retry.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/Retry.java
@@ -21,14 +21,9 @@ package io.github.resilience4j.retry;
 import io.github.resilience4j.core.EventConsumer;
 import io.github.resilience4j.retry.event.*;
 import io.github.resilience4j.retry.internal.RetryImpl;
-import io.vavr.CheckedFunction0;
-import io.vavr.CheckedFunction1;
-import io.vavr.CheckedRunnable;
-import io.vavr.collection.HashMap;
-import io.vavr.collection.Map;
-import io.vavr.control.Either;
-import io.vavr.control.Try;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.*;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -46,7 +41,7 @@ public interface Retry {
      * @return a Retry with a custom Retry configuration.
      */
     static Retry of(String name, RetryConfig retryConfig) {
-        return of(name, retryConfig, HashMap.empty());
+        return of(name, retryConfig, Collections.emptyMap());
     }
 
     /**
@@ -69,7 +64,7 @@ public interface Retry {
      * @return a Retry with a custom Retry configuration.
      */
     static Retry of(String name, Supplier<RetryConfig> retryConfigSupplier) {
-        return of(name, retryConfigSupplier.get(), HashMap.empty());
+        return of(name, retryConfigSupplier.get(), Collections.emptyMap());
     }
 
     /**
@@ -92,7 +87,7 @@ public interface Retry {
      * @return a Retry with default configuration
      */
     static Retry ofDefaults(String name) {
-        return of(name, RetryConfig.ofDefaults(), HashMap.empty());
+        return of(name, RetryConfig.ofDefaults(), Collections.emptyMap());
     }
 
     /**
@@ -128,83 +123,6 @@ public interface Retry {
      * @param <T>      the type of results supplied by this supplier
      * @return a retryable function
      */
-    static <T> CheckedFunction0<T> decorateCheckedSupplier(Retry retry,
-                                                           CheckedFunction0<T> supplier) {
-        return () -> {
-            Retry.Context<T> context = retry.context();
-            do {
-                try {
-                    T result = supplier.apply();
-                    final boolean validationOfResult = context.onResult(result);
-                    if (!validationOfResult) {
-                        context.onComplete();
-                        return result;
-                    }
-                } catch (Exception exception) {
-                    context.onError(exception);
-                }
-            } while (true);
-        };
-    }
-
-    /**
-     * Creates a retryable runnable.
-     *
-     * @param retry    the retry context
-     * @param runnable the original runnable
-     * @return a retryable runnable
-     */
-    static CheckedRunnable decorateCheckedRunnable(Retry retry, CheckedRunnable runnable) {
-        return () -> {
-            Retry.Context context = retry.context();
-            do {
-                try {
-                    runnable.run();
-                    context.onComplete();
-                    break;
-                } catch (Exception exception) {
-                    context.onError(exception);
-                }
-            } while (true);
-        };
-    }
-
-    /**
-     * Creates a retryable function.
-     *
-     * @param retry    the retry context
-     * @param function the original function
-     * @param <T>      the type of the input to the function
-     * @param <R>      the result type of the function
-     * @return a retryable function
-     */
-    static <T, R> CheckedFunction1<T, R> decorateCheckedFunction(Retry retry,
-                                                                 CheckedFunction1<T, R> function) {
-        return (T t) -> {
-            Retry.Context<R> context = retry.context();
-            do {
-                try {
-                    R result = function.apply(t);
-                    final boolean validationOfResult = context.onResult(result);
-                    if (!validationOfResult) {
-                        context.onComplete();
-                        return result;
-                    }
-                } catch (Exception exception) {
-                    context.onError(exception);
-                }
-            } while (true);
-        };
-    }
-
-    /**
-     * Creates a retryable supplier.
-     *
-     * @param retry    the retry context
-     * @param supplier the original function
-     * @param <T>      the type of results supplied by this supplier
-     * @return a retryable function
-     */
     static <T> Supplier<T> decorateSupplier(Retry retry, Supplier<T> supplier) {
         return () -> {
             Retry.Context<T> context = retry.context();
@@ -218,73 +136,6 @@ public interface Retry {
                     }
                 } catch (RuntimeException runtimeException) {
                     context.onRuntimeError(runtimeException);
-                }
-            } while (true);
-        };
-    }
-
-    /**
-     * Creates a retryable supplier.
-     *
-     * @param retry    the retry context
-     * @param supplier the original function
-     * @param <T>      the type of results supplied by this supplier
-     * @return a retryable function
-     */
-    static <E extends Exception, T> Supplier<Either<E, T>> decorateEitherSupplier(Retry retry,
-                                                                                  Supplier<Either<E, T>> supplier) {
-        return () -> {
-            Retry.Context<T> context = retry.context();
-            do {
-                Either<E, T> result = supplier.get();
-                if (result.isRight()) {
-                    final boolean validationOfResult = context.onResult(result.get());
-                    if (!validationOfResult) {
-                        context.onComplete();
-                        return result;
-                    }
-                } else {
-                    E exception = result.getLeft();
-                    try {
-                        context.onError(result.getLeft());
-                    } catch (Exception e) {
-                        return Either.left(exception);
-                    }
-                }
-            } while (true);
-        };
-    }
-
-    /**
-     * Creates a retryable supplier.
-     *
-     * @param retry    the retry context
-     * @param supplier the original function
-     * @param <T>      the type of results supplied by this supplier
-     * @return a retryable function
-     */
-    static <T> Supplier<Try<T>> decorateTrySupplier(Retry retry, Supplier<Try<T>> supplier) {
-        return () -> {
-            Retry.Context<T> context = retry.context();
-            do {
-                Try<T> result = supplier.get();
-                if (result.isSuccess()) {
-                    final boolean validationOfResult = context.onResult(result.get());
-                    if (!validationOfResult) {
-                        context.onComplete();
-                        return result;
-                    }
-                } else {
-                    Throwable cause = result.getCause();
-                    if (cause instanceof Exception) {
-                        try {
-                            context.onError((Exception) result.getCause());
-                        } catch (Exception e) {
-                            return result;
-                        }
-                    } else {
-                        return result;
-                    }
                 }
             } while (true);
         };
@@ -410,47 +261,12 @@ public interface Retry {
     /**
      * Decorates and executes the decorated Supplier.
      *
-     * @param checkedSupplier the original Supplier
-     * @param <T>             the type of results supplied by this supplier
-     * @return the result of the decorated Supplier.
-     * @throws Throwable if something goes wrong applying this function to the given arguments
-     */
-    default <T> T executeCheckedSupplier(CheckedFunction0<T> checkedSupplier) throws Throwable {
-        return decorateCheckedSupplier(this, checkedSupplier).apply();
-    }
-
-    /**
-     * Decorates and executes the decorated Supplier.
-     *
      * @param supplier the original Supplier
      * @param <T>      the type of results supplied by this supplier
      * @return the result of the decorated Supplier.
      */
     default <T> T executeSupplier(Supplier<T> supplier) {
         return decorateSupplier(this, supplier).get();
-    }
-
-    /**
-     * Decorates and executes the decorated Supplier.
-     *
-     * @param supplier the original Supplier
-     * @param <T>      the type of results supplied by this supplier
-     * @return the result of the decorated Supplier.
-     */
-    default <E extends Exception, T> Either<E, T> executeEitherSupplier(
-        Supplier<Either<E, T>> supplier) {
-        return decorateEitherSupplier(this, supplier).get();
-    }
-
-    /**
-     * Decorates and executes the decorated Supplier.
-     *
-     * @param supplier the original Supplier
-     * @param <T>      the type of results supplied by this supplier
-     * @return the result of the decorated Supplier.
-     */
-    default <T> Try<T> executeTrySupplier(Supplier<Try<T>> supplier) {
-        return decorateTrySupplier(this, supplier).get();
     }
 
     /**

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/RetryRegistry.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/RetryRegistry.java
@@ -20,12 +20,8 @@ import io.github.resilience4j.core.Registry;
 import io.github.resilience4j.core.RegistryStore;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
 import io.github.resilience4j.retry.internal.InMemoryRetryRegistry;
-import io.vavr.collection.HashMap;
-import io.vavr.collection.Seq;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Supplier;
 
 /**
@@ -88,7 +84,7 @@ public interface RetryRegistry extends Registry<Retry, RetryConfig> {
      * @return a RetryRegistry with a Map of shared Retry configurations.
      */
     static RetryRegistry of(Map<String, RetryConfig> configs) {
-        return of(configs, HashMap.empty());
+        return of(configs, Collections.emptyMap());
     }
 
     /**
@@ -101,7 +97,7 @@ public interface RetryRegistry extends Registry<Retry, RetryConfig> {
      * @return a RetryRegistry with a Map of shared Retry configurations.
      */
     static RetryRegistry of(Map<String, RetryConfig> configs,
-        io.vavr.collection.Map<String, String> tags) {
+        Map<String, String> tags) {
         return new InMemoryRetryRegistry(configs, tags);
     }
 
@@ -131,7 +127,7 @@ public interface RetryRegistry extends Registry<Retry, RetryConfig> {
      */
     static RetryRegistry of(Map<String, RetryConfig> configs,
         RegistryEventConsumer<Retry> registryEventConsumer,
-        io.vavr.collection.Map<String, String> tags) {
+        Map<String, String> tags) {
         return new InMemoryRetryRegistry(configs, registryEventConsumer, tags);
     }
 
@@ -154,7 +150,7 @@ public interface RetryRegistry extends Registry<Retry, RetryConfig> {
      *
      * @return all managed {@link Retry} instances.
      */
-    Seq<Retry> getAllRetries();
+    Set<Retry> getAllRetries();
 
     /**
      * Returns a managed {@link Retry} or creates a new one with the default Retry configuration.
@@ -175,7 +171,7 @@ public interface RetryRegistry extends Registry<Retry, RetryConfig> {
      * @param tags tags added to the Retry
      * @return The {@link Retry}
      */
-    Retry retry(String name, io.vavr.collection.Map<String, String> tags);
+    Retry retry(String name, Map<String, String> tags);
 
     /**
      * Returns a managed {@link Retry} or creates a new one with a custom Retry configuration.
@@ -198,7 +194,7 @@ public interface RetryRegistry extends Registry<Retry, RetryConfig> {
      * @param tags   tags added to the Retry
      * @return The {@link Retry}
      */
-    Retry retry(String name, RetryConfig config, io.vavr.collection.Map<String, String> tags);
+    Retry retry(String name, RetryConfig config, Map<String, String> tags);
 
     /**
      * Returns a managed {@link Retry} or creates a new one with a custom Retry configuration.
@@ -222,7 +218,7 @@ public interface RetryRegistry extends Registry<Retry, RetryConfig> {
      * @return The {@link Retry}
      */
     Retry retry(String name, Supplier<RetryConfig> retryConfigSupplier,
-        io.vavr.collection.Map<String, String> tags);
+        Map<String, String> tags);
 
     /**
      * Returns a managed {@link Retry} or creates a new one.
@@ -247,7 +243,7 @@ public interface RetryRegistry extends Registry<Retry, RetryConfig> {
      * @param tags       tags added to the Retry
      * @return The {@link Retry}
      */
-    Retry retry(String name, String configName, io.vavr.collection.Map<String, String> tags);
+    Retry retry(String name, String configName, Map<String, String> tags);
 
     /**
      * Returns a builder to create a custom RetryRegistry.
@@ -264,7 +260,7 @@ public interface RetryRegistry extends Registry<Retry, RetryConfig> {
         private RegistryStore registryStore;
         private Map<String, RetryConfig> retryConfigsMap;
         private List<RegistryEventConsumer<Retry>> registryEventConsumers;
-        private io.vavr.collection.Map<String, String> tags;
+        private Map<String, String> tags;
 
         public Builder() {
             this.retryConfigsMap = new java.util.HashMap<>();
@@ -323,7 +319,7 @@ public interface RetryRegistry extends Registry<Retry, RetryConfig> {
          * @param tags default tags to add to the registry.
          * @return a {@link RetryRegistry.Builder}
          */
-        public Builder withTags(io.vavr.collection.Map<String, String> tags) {
+        public Builder withTags(Map<String, String> tags) {
             this.tags = tags;
             return this;
         }

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/internal/InMemoryRetryRegistry.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/internal/InMemoryRetryRegistry.java
@@ -23,14 +23,8 @@ import io.github.resilience4j.core.registry.RegistryEventConsumer;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.retry.RetryRegistry;
-import io.vavr.collection.Array;
-import io.vavr.collection.HashMap;
-import io.vavr.collection.Seq;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Supplier;
 
 /**
@@ -46,28 +40,26 @@ public final class InMemoryRetryRegistry extends AbstractRegistry<Retry, RetryCo
         this(RetryConfig.ofDefaults());
     }
 
-    public InMemoryRetryRegistry(io.vavr.collection.Map<String, String> tags) {
+    /*public InMemoryRetryRegistry(Map<String, String> tags) {
         this(RetryConfig.ofDefaults(), tags);
-    }
+    }*/
 
     public InMemoryRetryRegistry(Map<String, RetryConfig> configs) {
-        this(configs, HashMap.empty());
+        this(configs, Collections.emptyMap());
     }
 
-    public InMemoryRetryRegistry(Map<String, RetryConfig> configs,
-        io.vavr.collection.Map<String, String> tags) {
+    public InMemoryRetryRegistry(Map<String, RetryConfig> configs, Map<String, String> tags) {
         this(configs.getOrDefault(DEFAULT_CONFIG, RetryConfig.ofDefaults()), tags);
         this.configurations.putAll(configs);
     }
 
     public InMemoryRetryRegistry(Map<String, RetryConfig> configs,
         RegistryEventConsumer<Retry> registryEventConsumer) {
-        this(configs, registryEventConsumer, HashMap.empty());
+        this(configs, registryEventConsumer, Collections.emptyMap());
     }
 
     public InMemoryRetryRegistry(Map<String, RetryConfig> configs,
-        RegistryEventConsumer<Retry> registryEventConsumer,
-        io.vavr.collection.Map<String, String> tags) {
+        RegistryEventConsumer<Retry> registryEventConsumer, Map<String, String> tags) {
         this(configs.getOrDefault(DEFAULT_CONFIG, RetryConfig.ofDefaults()), registryEventConsumer,
             tags);
         this.configurations.putAll(configs);
@@ -75,12 +67,11 @@ public final class InMemoryRetryRegistry extends AbstractRegistry<Retry, RetryCo
 
     public InMemoryRetryRegistry(Map<String, RetryConfig> configs,
         List<RegistryEventConsumer<Retry>> registryEventConsumers) {
-        this(configs, registryEventConsumers, HashMap.empty());
+        this(configs, registryEventConsumers, Collections.emptyMap());
     }
 
     public InMemoryRetryRegistry(Map<String, RetryConfig> configs,
-        List<RegistryEventConsumer<Retry>> registryEventConsumers,
-        io.vavr.collection.Map<String, String> tags) {
+        List<RegistryEventConsumer<Retry>> registryEventConsumers, Map<String, String> tags) {
         this(configs.getOrDefault(DEFAULT_CONFIG, RetryConfig.ofDefaults()),
             registryEventConsumers, tags);
         this.configurations.putAll(configs);
@@ -88,9 +79,9 @@ public final class InMemoryRetryRegistry extends AbstractRegistry<Retry, RetryCo
 
     public InMemoryRetryRegistry(Map<String, RetryConfig> configs,
                                           List<RegistryEventConsumer<Retry>> registryEventConsumers,
-                                          io.vavr.collection.Map<String, String> tags, RegistryStore<Retry> registryStore) {
+                                          Map<String, String> tags, RegistryStore<Retry> registryStore) {
         super(configs.getOrDefault(DEFAULT_CONFIG, RetryConfig.ofDefaults()),
-            registryEventConsumers, Optional.ofNullable(tags).orElse(HashMap.empty()),
+            registryEventConsumers, Optional.ofNullable(tags).orElse(Collections.emptyMap()),
             Optional.ofNullable(registryStore).orElse(new InMemoryRegistryStore<>()));
         this.configurations.putAll(configs);
     }
@@ -101,33 +92,30 @@ public final class InMemoryRetryRegistry extends AbstractRegistry<Retry, RetryCo
      * @param defaultConfig The default config.
      */
     public InMemoryRetryRegistry(RetryConfig defaultConfig) {
-        this(defaultConfig, HashMap.empty());
+        this(defaultConfig, Collections.emptyMap());
     }
 
-    public InMemoryRetryRegistry(RetryConfig defaultConfig,
-        io.vavr.collection.Map<String, String> tags) {
+    public InMemoryRetryRegistry(RetryConfig defaultConfig, Map<String, String> tags) {
         super(defaultConfig, tags);
     }
 
     public InMemoryRetryRegistry(RetryConfig defaultConfig,
         RegistryEventConsumer<Retry> registryEventConsumer) {
-        this(defaultConfig, registryEventConsumer, HashMap.empty());
+        this(defaultConfig, registryEventConsumer, Collections.emptyMap());
     }
 
     public InMemoryRetryRegistry(RetryConfig defaultConfig,
-        RegistryEventConsumer<Retry> registryEventConsumer,
-        io.vavr.collection.Map<String, String> tags) {
+        RegistryEventConsumer<Retry> registryEventConsumer, Map<String, String> tags) {
         super(defaultConfig, registryEventConsumer, tags);
     }
 
     public InMemoryRetryRegistry(RetryConfig defaultConfig,
         List<RegistryEventConsumer<Retry>> registryEventConsumers) {
-        this(defaultConfig, registryEventConsumers, HashMap.empty());
+        this(defaultConfig, registryEventConsumers, Collections.emptyMap());
     }
 
     public InMemoryRetryRegistry(RetryConfig defaultConfig,
-        List<RegistryEventConsumer<Retry>> registryEventConsumers,
-        io.vavr.collection.Map<String, String> tags) {
+        List<RegistryEventConsumer<Retry>> registryEventConsumers, Map<String, String> tags) {
         super(defaultConfig, registryEventConsumers, tags);
     }
 
@@ -135,8 +123,8 @@ public final class InMemoryRetryRegistry extends AbstractRegistry<Retry, RetryCo
      * {@inheritDoc}
      */
     @Override
-    public Seq<Retry> getAllRetries() {
-        return Array.ofAll(entryMap.values());
+    public Set<Retry> getAllRetries() {
+        return new HashSet<>(entryMap.values());
     }
 
     /**
@@ -151,7 +139,7 @@ public final class InMemoryRetryRegistry extends AbstractRegistry<Retry, RetryCo
      * {@inheritDoc}
      */
     @Override
-    public Retry retry(String name, io.vavr.collection.Map<String, String> tags) {
+    public Retry retry(String name, Map<String, String> tags) {
         return retry(name, getDefaultConfig(), tags);
     }
 
@@ -160,12 +148,11 @@ public final class InMemoryRetryRegistry extends AbstractRegistry<Retry, RetryCo
      */
     @Override
     public Retry retry(String name, RetryConfig config) {
-        return retry(name, config, HashMap.empty());
+        return retry(name, config, Collections.emptyMap());
     }
 
     @Override
-    public Retry retry(String name, RetryConfig config,
-        io.vavr.collection.Map<String, String> tags) {
+    public Retry retry(String name, RetryConfig config, Map<String, String> tags) {
         return computeIfAbsent(name, () -> Retry
             .of(name, Objects.requireNonNull(config, CONFIG_MUST_NOT_BE_NULL), getAllTags(tags)));
     }
@@ -175,12 +162,11 @@ public final class InMemoryRetryRegistry extends AbstractRegistry<Retry, RetryCo
      */
     @Override
     public Retry retry(String name, Supplier<RetryConfig> retryConfigSupplier) {
-        return retry(name, retryConfigSupplier, HashMap.empty());
+        return retry(name, retryConfigSupplier, Collections.emptyMap());
     }
 
     @Override
-    public Retry retry(String name, Supplier<RetryConfig> retryConfigSupplier,
-        io.vavr.collection.Map<String, String> tags) {
+    public Retry retry(String name, Supplier<RetryConfig> retryConfigSupplier, Map<String, String> tags) {
         return computeIfAbsent(name, () -> Retry.of(name, Objects.requireNonNull(
             Objects.requireNonNull(retryConfigSupplier, SUPPLIER_MUST_NOT_BE_NULL).get(),
             CONFIG_MUST_NOT_BE_NULL), getAllTags(tags)));
@@ -191,12 +177,11 @@ public final class InMemoryRetryRegistry extends AbstractRegistry<Retry, RetryCo
      */
     @Override
     public Retry retry(String name, String configName) {
-        return retry(name, configName, HashMap.empty());
+        return retry(name, configName, Collections.emptyMap());
     }
 
     @Override
-    public Retry retry(String name, String configName,
-        io.vavr.collection.Map<String, String> tags) {
+    public Retry retry(String name, String configName, Map<String, String> tags) {
         return computeIfAbsent(name, () -> Retry.of(name, getConfiguration(configName)
             .orElseThrow(() -> new ConfigurationNotFoundException(configName)), getAllTags(tags)));
     }

--- a/resilience4j-retry/src/test/java/io/github/resilience4j/retry/RetryRegistryTest.java
+++ b/resilience4j-retry/src/test/java/io/github/resilience4j/retry/RetryRegistryTest.java
@@ -19,7 +19,6 @@ import io.github.resilience4j.core.ConfigurationNotFoundException;
 import io.github.resilience4j.core.EventProcessor;
 import io.github.resilience4j.core.Registry;
 import io.github.resilience4j.core.registry.*;
-import io.vavr.Tuple;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -55,9 +54,9 @@ public class RetryRegistryTest {
     public void shouldInitRegistryTags() {
         RetryConfig retryConfig = RetryConfig.ofDefaults();
         Map<String, RetryConfig> retryConfigs = Collections.singletonMap("default", retryConfig);
-        RetryRegistry registry = RetryRegistry.of(retryConfigs,new NoOpRetryEventConsumer(),io.vavr.collection.HashMap.of("Tag1Key","Tag1Value"));
+        RetryRegistry registry = RetryRegistry.of(retryConfigs,new NoOpRetryEventConsumer(), Map.of("Tag1Key","Tag1Value"));
         assertThat(registry.getTags()).isNotEmpty();
-        assertThat(registry.getTags()).containsOnly(Tuple.of("Tag1Key","Tag1Value"));
+        assertThat(registry.getTags()).containsOnly(Map.entry("Tag1Key","Tag1Value"));
     }
 
     @Test
@@ -96,51 +95,44 @@ public class RetryRegistryTest {
     public void tagsOfRegistryAddedToInstance() {
         RetryConfig retryConfig = RetryConfig.ofDefaults();
         Map<String, RetryConfig> retryConfigs = Collections.singletonMap("default", retryConfig);
-        io.vavr.collection.Map<String, String> retryTags = io.vavr.collection.HashMap
-            .of("key1", "value1", "key2", "value2");
+        Map<String, String> retryTags = Map.of("key1", "value1", "key2", "value2");
         RetryRegistry retryRegistry = RetryRegistry.of(retryConfigs, retryTags);
         Retry retry = retryRegistry.retry("testName");
 
-        assertThat(retry.getTags()).containsOnlyElementsOf(retryTags);
+        assertThat(retry.getTags()).containsAllEntriesOf(retryTags);
     }
 
     @Test
     public void tagsAddedToInstance() {
-        io.vavr.collection.Map<String, String> retryTags = io.vavr.collection.HashMap
-            .of("key1", "value1", "key2", "value2");
+        Map<String, String> retryTags = Map.of("key1", "value1", "key2", "value2");
         Retry retry = retryRegistry.retry("testName", retryTags);
 
-        assertThat(retry.getTags()).containsOnlyElementsOf(retryTags);
+        assertThat(retry.getTags()).containsAllEntriesOf(retryTags);
     }
 
     @Test
     public void tagsOfRetriesShouldNotBeMixed() {
         RetryConfig config = RetryConfig.ofDefaults();
-        io.vavr.collection.Map<String, String> retryTags = io.vavr.collection.HashMap
-            .of("key1", "value1", "key2", "value2");
+        Map<String, String> retryTags = Map.of("key1", "value1", "key2", "value2");
         Retry retry = retryRegistry.retry("testName", config, retryTags);
-        io.vavr.collection.Map<String, String> retryTags2 = io.vavr.collection.HashMap
-            .of("key3", "value3", "key4", "value4");
+        Map<String, String> retryTags2 = Map.of("key3", "value3", "key4", "value4");
         Retry retry2 = retryRegistry.retry("otherTestName", config, retryTags2);
 
-        assertThat(retry.getTags()).containsOnlyElementsOf(retryTags);
-        assertThat(retry2.getTags()).containsOnlyElementsOf(retryTags2);
+        assertThat(retry.getTags()).containsAllEntriesOf(retryTags);
+        assertThat(retry2.getTags()).containsAllEntriesOf(retryTags2);
     }
 
     @Test
     public void tagsOfInstanceTagsShouldOverrideRegistryTags() {
         RetryConfig retryConfig = RetryConfig.ofDefaults();
         Map<String, RetryConfig> retryConfigs = Collections.singletonMap("default", retryConfig);
-        io.vavr.collection.Map<String, String> registryTags = io.vavr.collection.HashMap
-            .of("key1", "value1", "key2", "value2");
-        io.vavr.collection.Map<String, String> instanceTags = io.vavr.collection.HashMap
-            .of("key1", "value3", "key4", "value4");
+        Map<String, String> registryTags = Map.of("key1", "value1", "key2", "value2");
+        Map<String, String> instanceTags = Map.of("key1", "value3", "key4", "value4");
         RetryRegistry retryRegistry = RetryRegistry.of(retryConfigs, registryTags);
         Retry retry = retryRegistry.retry("testName", retryConfig, instanceTags);
 
-        io.vavr.collection.Map<String, String> expectedTags = io.vavr.collection.HashMap
-            .of("key1", "value3", "key2", "value2", "key4", "value4");
-        assertThat(retry.getTags()).containsOnlyElementsOf(expectedTags);
+        Map<String, String> expectedTags = Map.of("key1", "value3", "key2", "value2", "key4", "value4");
+        assertThat(retry.getTags()).containsAllEntriesOf(expectedTags);
     }
 
     @Test
@@ -368,15 +360,14 @@ public class RetryRegistryTest {
 
     @Test
     public void testCreateUsingBuilderWithRegistryTags() {
-        io.vavr.collection.Map<String, String> retryTags = io.vavr.collection.HashMap
-            .of("key1", "value1", "key2", "value2");
+        Map<String, String> retryTags = Map.of("key1", "value1", "key2", "value2");
         RetryRegistry retryRegistry = RetryRegistry.custom()
             .withRetryConfig(RetryConfig.ofDefaults())
             .withTags(retryTags)
             .build();
         Retry retry = retryRegistry.retry("testName");
 
-        assertThat(retry.getTags()).containsOnlyElementsOf(retryTags);
+        assertThat(retry.getTags()).containsAllEntriesOf(retryTags);
     }
 
     @Test

--- a/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/InMemoryRetryRegistryTest.java
+++ b/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/InMemoryRetryRegistryTest.java
@@ -42,7 +42,7 @@ public class InMemoryRetryRegistryTest {
         configs.put("default", defaultConfig);
         final InMemoryRetryRegistry inMemoryRetryRegistry =
             new InMemoryRetryRegistry(configs, registryEventConsumers,
-                io.vavr.collection.HashMap.of("Tag1", "Tag1Value"), new InMemoryRegistryStore());
+                Map.of("Tag1", "Tag1Value"), new InMemoryRegistryStore());
 
         assertThat(inMemoryRetryRegistry).isNotNull();
         assertThat(inMemoryRetryRegistry.getDefaultConfig()).isEqualTo(defaultConfig);

--- a/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/RunnableRetryTest.java
+++ b/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/RunnableRetryTest.java
@@ -18,20 +18,14 @@
  */
 package io.github.resilience4j.retry.internal;
 
-import io.github.resilience4j.core.IntervalFunction;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.test.HelloWorldException;
 import io.github.resilience4j.test.HelloWorldService;
-import io.vavr.CheckedRunnable;
-import io.vavr.Predicates;
 import io.vavr.control.Try;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.time.Duration;
-
-import static io.vavr.API.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
@@ -82,76 +76,5 @@ public class RunnableRetryTest {
 
         then(helloWorldService).should().sayHelloWorld();
         assertThat(sleptTime).isEqualTo(0);
-    }
-
-    @Test
-    public void shouldReturnAfterThreeAttempts() {
-        willThrow(new HelloWorldException()).given(helloWorldService).sayHelloWorld();
-        Retry retry = Retry.ofDefaults("id");
-        CheckedRunnable retryableRunnable = Retry
-            .decorateCheckedRunnable(retry, helloWorldService::sayHelloWorld);
-
-        Try<Void> result = Try.run(retryableRunnable);
-
-        then(helloWorldService).should(times(3)).sayHelloWorld();
-        assertThat(result.isFailure()).isTrue();
-        assertThat(result.failed().get()).isInstanceOf(HelloWorldException.class);
-        assertThat(sleptTime).isEqualTo(RetryConfig.DEFAULT_WAIT_DURATION * 2);
-    }
-
-    @Test
-    public void shouldReturnAfterOneAttempt() {
-        willThrow(new HelloWorldException()).given(helloWorldService).sayHelloWorld();
-        RetryConfig config = RetryConfig.custom().maxAttempts(1).build();
-        Retry retry = Retry.of("id", config);
-        CheckedRunnable retryableRunnable = Retry
-            .decorateCheckedRunnable(retry, helloWorldService::sayHelloWorld);
-
-        Try<Void> result = Try.run(retryableRunnable);
-
-        then(helloWorldService).should().sayHelloWorld();
-        assertThat(result.isFailure()).isTrue();
-        assertThat(result.failed().get()).isInstanceOf(HelloWorldException.class);
-        assertThat(sleptTime).isEqualTo(0);
-    }
-
-    @Test
-    public void shouldReturnAfterOneAttemptAndIgnoreException() {
-        willThrow(new HelloWorldException()).given(helloWorldService).sayHelloWorld();
-        RetryConfig config = RetryConfig.custom()
-            .retryOnException(throwable -> Match(throwable).of(
-                Case($(Predicates.instanceOf(HelloWorldException.class)), false),
-                Case($(), true)))
-            .build();
-        Retry retry = Retry.of("id", config);
-        CheckedRunnable retryableRunnable = Retry
-            .decorateCheckedRunnable(retry, helloWorldService::sayHelloWorld);
-
-        Try<Void> result = Try.run(retryableRunnable);
-
-        // because the exception should be rethrown immediately
-        then(helloWorldService).should().sayHelloWorld();
-        assertThat(result.isFailure()).isTrue();
-        assertThat(result.failed().get()).isInstanceOf(HelloWorldException.class);
-        assertThat(sleptTime).isEqualTo(0);
-    }
-
-    @Test
-    public void shouldTakeIntoAccountBackoffFunction() {
-        willThrow(new HelloWorldException()).given(helloWorldService).sayHelloWorld();
-        RetryConfig config = RetryConfig
-            .custom()
-            .intervalFunction(IntervalFunction.of(Duration.ofMillis(500), x -> x * x))
-            .build();
-        Retry retry = Retry.of("id", config);
-        CheckedRunnable retryableRunnable = Retry
-            .decorateCheckedRunnable(retry, helloWorldService::sayHelloWorld);
-
-        Try.run(retryableRunnable);
-
-        then(helloWorldService).should(times(3)).sayHelloWorld();
-        assertThat(sleptTime).isEqualTo(
-            RetryConfig.DEFAULT_WAIT_DURATION +
-                RetryConfig.DEFAULT_WAIT_DURATION * RetryConfig.DEFAULT_WAIT_DURATION);
     }
 }

--- a/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/SupplierRetryTest.java
+++ b/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/SupplierRetryTest.java
@@ -18,16 +18,11 @@
  */
 package io.github.resilience4j.retry.internal;
 
-import io.github.resilience4j.core.IntervalFunction;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.test.AsyncHelloWorldService;
 import io.github.resilience4j.test.HelloWorldException;
 import io.github.resilience4j.test.HelloWorldService;
-import io.vavr.API;
-import io.vavr.CheckedFunction0;
-import io.vavr.Predicates;
-import io.vavr.control.Either;
 import io.vavr.control.Try;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,7 +34,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Supplier;
 
 import static io.github.resilience4j.retry.utils.AsyncUtils.awaitResult;
-import static io.vavr.API.$;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -107,7 +101,6 @@ public class SupplierRetryTest {
         assertThat(sleptTime).isEqualTo(0);
     }
 
-
     private <T> Supplier<T> decorateSupplierWithOnSuccess(Retry retry, Supplier<T> supplier) {
         return () -> {
             Retry.Context<T> context = retry.context();
@@ -126,7 +119,6 @@ public class SupplierRetryTest {
         };
     }
 
-
     @Test
     public void shouldRetryWithResult() {
         given(helloWorldService.returnHelloWorld()).willReturn("Hello world");
@@ -141,122 +133,6 @@ public class SupplierRetryTest {
 
         then(helloWorldService).should(times(2)).returnHelloWorld();
         assertThat(result).isEqualTo("Hello world");
-    }
-
-    @Test
-    public void shouldNotRetryDecoratedTry() {
-        given(helloWorldService.returnTry()).willReturn(Try.success("Hello world"));
-        final RetryConfig tryAgain = RetryConfig.<String>custom()
-            .maxAttempts(2).build();
-        Retry retry = Retry.of("id", tryAgain);
-
-        Try<String> result = retry.executeTrySupplier(helloWorldService::returnTry);
-
-        then(helloWorldService).should().returnTry();
-        assertThat(result.get()).isEqualTo("Hello world");
-    }
-
-    @Test
-    public void shouldNotRetryDecoratedEither() {
-        given(helloWorldService.returnEither()).willReturn(Either.right("Hello world"));
-        final RetryConfig tryAgain = RetryConfig.<String>custom()
-            .maxAttempts(2).build();
-        Retry retry = Retry.of("id", tryAgain);
-
-        Either<HelloWorldException, String> result = retry
-            .executeEitherSupplier(helloWorldService::returnEither);
-
-        then(helloWorldService).should().returnEither();
-        assertThat(result.get()).isEqualTo("Hello world");
-    }
-
-    @Test
-    public void shouldRetryDecoratedTry() {
-        given(helloWorldService.returnTry()).willReturn(Try.success("Hello world"));
-        final RetryConfig tryAgain = RetryConfig.<String>custom()
-            .retryOnResult(s -> s.contains("Hello world"))
-            .maxAttempts(2).build();
-        Retry retry = Retry.of("id", tryAgain);
-
-        Try<String> result = retry.executeTrySupplier(helloWorldService::returnTry);
-
-        then(helloWorldService).should(times(2)).returnTry();
-        assertThat(result.get()).isEqualTo("Hello world");
-    }
-
-    @Test
-    public void shouldRetryDecoratedEither() {
-        given(helloWorldService.returnEither()).willReturn(Either.right("Hello world"));
-        final RetryConfig tryAgain = RetryConfig.<String>custom()
-            .retryOnResult(s -> s.contains("Hello world"))
-            .maxAttempts(2).build();
-        Retry retry = Retry.of("id", tryAgain);
-
-        Either<HelloWorldException, String> result = retry
-            .executeEitherSupplier(helloWorldService::returnEither);
-
-        then(helloWorldService).should(times(2)).returnEither();
-        assertThat(result.get()).isEqualTo("Hello world");
-    }
-
-    @Test
-    public void shouldFailToRetryDecoratedTry() {
-        given(helloWorldService.returnTry()).willReturn(Try.failure(new HelloWorldException()));
-        final RetryConfig tryAgain = RetryConfig.<String>custom()
-            .maxAttempts(2).build();
-        Retry retry = Retry.of("id", tryAgain);
-
-        Try<String> result = retry.executeTrySupplier(helloWorldService::returnTry);
-
-        then(helloWorldService).should(times(2)).returnTry();
-        assertThat(result.isFailure()).isTrue();
-        assertThat(result.getCause()).isInstanceOf(HelloWorldException.class);
-    }
-
-    @Test
-    public void shouldFailToRetryDecoratedEither() {
-        given(helloWorldService.returnEither()).willReturn(Either.left(new HelloWorldException()));
-        final RetryConfig tryAgain = RetryConfig.<String>custom()
-            .maxAttempts(2).build();
-        Retry retry = Retry.of("id", tryAgain);
-
-        Either<HelloWorldException, String> result = retry
-            .executeEitherSupplier(helloWorldService::returnEither);
-
-        then(helloWorldService).should(times(2)).returnEither();
-        assertThat(result.isLeft()).isTrue();
-        assertThat(result.getLeft()).isInstanceOf(HelloWorldException.class);
-    }
-
-    @Test
-    public void shouldIgnoreExceptionOfDecoratedTry() {
-        given(helloWorldService.returnTry()).willReturn(Try.failure(new HelloWorldException()));
-        final RetryConfig tryAgain = RetryConfig.<String>custom()
-            .ignoreExceptions(HelloWorldException.class)
-            .maxAttempts(2).build();
-        Retry retry = Retry.of("id", tryAgain);
-
-        Try<String> result = retry.executeTrySupplier(helloWorldService::returnTry);
-
-        then(helloWorldService).should().returnTry();
-        assertThat(result.isFailure()).isTrue();
-        assertThat(result.getCause()).isInstanceOf(HelloWorldException.class);
-    }
-
-    @Test
-    public void shouldIgnoreExceptionOfDecoratedEither() {
-        given(helloWorldService.returnEither()).willReturn(Either.left(new HelloWorldException()));
-        final RetryConfig tryAgain = RetryConfig.<String>custom()
-            .ignoreExceptions(HelloWorldException.class)
-            .maxAttempts(2).build();
-        Retry retry = Retry.of("id", tryAgain);
-
-        Either<HelloWorldException, String> result = retry
-            .executeEitherSupplier(helloWorldService::returnEither);
-
-        then(helloWorldService).should().returnEither();
-        assertThat(result.isLeft()).isTrue();
-        assertThat(result.getLeft()).isInstanceOf(HelloWorldException.class);
     }
 
     @Test
@@ -374,129 +250,6 @@ public class SupplierRetryTest {
         then(helloWorldService).should(times(2)).returnHelloWorld();
         assertThat(result).isEqualTo("Hello world");
         assertThat(sleptTime).isEqualTo(RetryConfig.DEFAULT_WAIT_DURATION);
-    }
-
-    @Test
-    public void shouldReturnSuccessfullyAfterSecondAttempt() {
-        given(helloWorldService.returnHelloWorld())
-            .willThrow(new HelloWorldException())
-            .willReturn("Hello world");
-        Retry retry = Retry.ofDefaults("id");
-        CheckedFunction0<String> retryableSupplier = Retry
-            .decorateCheckedSupplier(retry, helloWorldService::returnHelloWorld);
-
-        Try<String> result = Try.of(retryableSupplier);
-
-        then(helloWorldService).should(times(2)).returnHelloWorld();
-        assertThat(result.get()).isEqualTo("Hello world");
-        assertThat(sleptTime).isEqualTo(RetryConfig.DEFAULT_WAIT_DURATION);
-    }
-
-    @Test
-    public void shouldReturnAfterThreeAttempts() {
-        given(helloWorldService.returnHelloWorld()).willThrow(new HelloWorldException());
-        Retry retry = Retry.ofDefaults("id");
-        CheckedFunction0<String> retryableSupplier = Retry
-            .decorateCheckedSupplier(retry, helloWorldService::returnHelloWorld);
-
-        Try<String> result = Try.of(retryableSupplier);
-
-        then(helloWorldService).should(times(3)).returnHelloWorld();
-        assertThat(result.isFailure()).isTrue();
-        assertThat(result.failed().get()).isInstanceOf(HelloWorldException.class);
-        assertThat(sleptTime).isEqualTo(RetryConfig.DEFAULT_WAIT_DURATION * 2);
-    }
-
-    @Test
-    public void shouldReturnAfterOneAttempt() {
-        given(helloWorldService.returnHelloWorld()).willThrow(new HelloWorldException());
-        RetryConfig config = RetryConfig.custom().maxAttempts(1).build();
-        Retry retry = Retry.of("id", config);
-        CheckedFunction0<String> retryableSupplier = Retry
-            .decorateCheckedSupplier(retry, helloWorldService::returnHelloWorld);
-
-        Try<String> result = Try.of(retryableSupplier);
-
-        then(helloWorldService).should().returnHelloWorld();
-        assertThat(result.isFailure()).isTrue();
-        assertThat(result.failed().get()).isInstanceOf(HelloWorldException.class);
-        assertThat(sleptTime).isEqualTo(0);
-    }
-
-    @Test
-    public void shouldReturnAfterOneAttemptAndIgnoreException() {
-        given(helloWorldService.returnHelloWorld()).willThrow(new HelloWorldException());
-        RetryConfig config = RetryConfig.custom()
-            .retryOnException(throwable -> API.Match(throwable).of(
-                API.Case($(Predicates.instanceOf(HelloWorldException.class)), false),
-                API.Case($(), true)))
-            .build();
-        Retry retry = Retry.of("id", config);
-        CheckedFunction0<String> retryableSupplier = Retry
-            .decorateCheckedSupplier(retry, helloWorldService::returnHelloWorld);
-
-        Try<String> result = Try.of(retryableSupplier);
-
-        // Because the exception should be rethrown immediately.
-        then(helloWorldService).should().returnHelloWorld();
-        assertThat(result.isFailure()).isTrue();
-        assertThat(result.failed().get()).isInstanceOf(HelloWorldException.class);
-        assertThat(sleptTime).isEqualTo(0);
-    }
-
-    @Test
-    public void shouldReturnAfterThreeAttemptsAndRecover() {
-        given(helloWorldService.returnHelloWorld()).willThrow(new HelloWorldException());
-        Retry retry = Retry.ofDefaults("id");
-        CheckedFunction0<String> retryableSupplier = Retry
-            .decorateCheckedSupplier(retry, helloWorldService::returnHelloWorld);
-
-        Try<String> result = Try.of(retryableSupplier)
-            .recover((throwable) -> "Hello world from recovery function");
-        assertThat(retry.getMetrics().getNumberOfFailedCallsWithRetryAttempt()).isEqualTo(1);
-
-        then(helloWorldService).should(times(3)).returnHelloWorld();
-        assertThat(result.get()).isEqualTo("Hello world from recovery function");
-        assertThat(sleptTime).isEqualTo(RetryConfig.DEFAULT_WAIT_DURATION * 2);
-    }
-
-    @Test
-    public void shouldReturnAfterThreeAttemptsAndRecoverWithResult() {
-        given(helloWorldService.returnHelloWorld())
-            .willThrow(new HelloWorldException())
-            .willReturn("Hello world")
-            .willThrow(new HelloWorldException());
-        final RetryConfig tryAgain = RetryConfig.<String>custom()
-            .retryOnResult(s -> s.contains("Hello world"))
-            .maxAttempts(3).build();
-        Retry retry = Retry.of("id", tryAgain);
-        CheckedFunction0<String> retryableSupplier = Retry
-            .decorateCheckedSupplier(retry, helloWorldService::returnHelloWorld);
-
-        Try<String> result = Try.of(retryableSupplier)
-            .recover((throwable) -> "Hello world from recovery function");
-
-        then(helloWorldService).should(times(3)).returnHelloWorld();
-        assertThat(result.get()).isEqualTo("Hello world from recovery function");
-        assertThat(sleptTime).isEqualTo(RetryConfig.DEFAULT_WAIT_DURATION * 2);
-    }
-
-    @Test
-    public void shouldTakeIntoAccountBackoffFunction() {
-        given(helloWorldService.returnHelloWorld()).willThrow(new HelloWorldException());
-        RetryConfig config = RetryConfig.custom()
-            .intervalFunction(IntervalFunction.ofExponentialBackoff(500, 2.0))
-            .build();
-        Retry retry = Retry.of("id", config);
-        CheckedFunction0<String> retryableSupplier = Retry
-            .decorateCheckedSupplier(retry, helloWorldService::returnHelloWorld);
-
-        Try.of(retryableSupplier);
-
-        then(helloWorldService).should(times(3)).returnHelloWorld();
-        assertThat(sleptTime).isEqualTo(
-            RetryConfig.DEFAULT_WAIT_DURATION +
-                RetryConfig.DEFAULT_WAIT_DURATION * 2);
     }
 
     @Test

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/bulkhead/monitoring/endpoint/BulkheadEndpoint.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/bulkhead/monitoring/endpoint/BulkheadEndpoint.java
@@ -24,6 +24,8 @@ import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 
 /**
@@ -43,11 +45,12 @@ public class BulkheadEndpoint {
 
     @ReadOperation
     public BulkheadEndpointResponse getAllBulkheads() {
-        List<String> bulkheads = bulkheadRegistry.getAllBulkheads()
-            .map(Bulkhead::getName)
-            .appendAll(threadPoolBulkheadRegistry
-                .getAllBulkheads()
-                .map(ThreadPoolBulkhead::getName)).sorted().toJavaList();
+        List<String> bulkheads = Stream.concat(bulkheadRegistry.getAllBulkheads().stream()
+            .map(Bulkhead::getName),
+            threadPoolBulkheadRegistry
+                .getAllBulkheads().stream()
+                .map(ThreadPoolBulkhead::getName))
+            .sorted().collect(Collectors.toList());
         return new BulkheadEndpointResponse(bulkheads);
     }
 }

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/circuitbreaker/monitoring/endpoint/CircuitBreakerEndpoint.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/circuitbreaker/monitoring/endpoint/CircuitBreakerEndpoint.java
@@ -28,6 +28,7 @@ import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 
 @Endpoint(id = "circuitbreakers")
@@ -41,8 +42,8 @@ public class CircuitBreakerEndpoint {
 
     @ReadOperation
     public CircuitBreakerEndpointResponse getAllCircuitBreakers() {
-        List<String> circuitBreakers = circuitBreakerRegistry.getAllCircuitBreakers()
-            .map(CircuitBreaker::getName).sorted().toJavaList();
+        List<String> circuitBreakers = circuitBreakerRegistry.getAllCircuitBreakers().stream()
+            .map(CircuitBreaker::getName).sorted().collect(Collectors.toList());
         return new CircuitBreakerEndpointResponse(circuitBreakers);
     }
 

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/circuitbreaker/monitoring/health/CircuitBreakersHealthIndicator.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/circuitbreaker/monitoring/health/CircuitBreakersHealthIndicator.java
@@ -20,7 +20,10 @@ import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.circuitbreaker.configure.CircuitBreakerConfigurationProperties;
-import org.springframework.boot.actuate.health.*;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.boot.actuate.health.StatusAggregator;
 
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -102,7 +105,7 @@ public class CircuitBreakersHealthIndicator implements HealthIndicator {
 
     @Override
     public Health health() {
-        Map<String, Health> healths = circuitBreakerRegistry.getAllCircuitBreakers().toJavaStream()
+        Map<String, Health> healths = circuitBreakerRegistry.getAllCircuitBreakers().stream()
             .filter(this::isRegisterHealthIndicator)
             .collect(Collectors.toMap(CircuitBreaker::getName,
                 this::mapBackendMonitorState));

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/ratelimiter/monitoring/endpoint/RateLimiterEndpoint.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/ratelimiter/monitoring/endpoint/RateLimiterEndpoint.java
@@ -22,6 +22,7 @@ import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Endpoint(id = "ratelimiters")
 public class RateLimiterEndpoint {
@@ -34,8 +35,8 @@ public class RateLimiterEndpoint {
 
     @ReadOperation
     public RateLimiterEndpointResponse getAllRateLimiters() {
-        List<String> names = rateLimiterRegistry.getAllRateLimiters()
-            .map(RateLimiter::getName).sorted().toJavaList();
+        List<String> names = rateLimiterRegistry.getAllRateLimiters().stream()
+            .map(RateLimiter::getName).sorted().collect(Collectors.toList());
         return new RateLimiterEndpointResponse(names);
     }
 }

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/ratelimiter/monitoring/health/RateLimitersHealthIndicator.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/ratelimiter/monitoring/health/RateLimitersHealthIndicator.java
@@ -50,7 +50,7 @@ public class RateLimitersHealthIndicator implements HealthIndicator {
 
     @Override
     public Health health() {
-        Map<String, Health> healths = rateLimiterRegistry.getAllRateLimiters().toJavaStream()
+        Map<String, Health> healths = rateLimiterRegistry.getAllRateLimiters().stream()
             .filter(this::isRegisterHealthIndicator)
             .collect(Collectors.toMap(RateLimiter::getName, this::mapRateLimiterHealth));
 

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/retry/monitoring/endpoint/RetryEndpoint.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/retry/monitoring/endpoint/RetryEndpoint.java
@@ -23,6 +23,7 @@ import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 
 /**
@@ -39,8 +40,8 @@ public class RetryEndpoint {
 
     @ReadOperation
     public RetryEndpointResponse getAllRetries() {
-        List<String> retries = retryRegistry.getAllRetries()
-            .map(Retry::getName).sorted().toJavaList();
+        List<String> retries = retryRegistry.getAllRetries().stream()
+            .map(Retry::getName).sorted().collect(Collectors.toList());
         return new RetryEndpointResponse(retries);
     }
 }

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/timelimiter/monitoring/endpoint/TimeLimiterEndpoint.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/timelimiter/monitoring/endpoint/TimeLimiterEndpoint.java
@@ -23,6 +23,7 @@ import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Endpoint(id = "timelimiters")
 public class TimeLimiterEndpoint {
@@ -34,8 +35,8 @@ public class TimeLimiterEndpoint {
 
     @ReadOperation
     public TimeLimiterEndpointResponse getAllTimeLimiters() {
-        List<String> timeLimiters = timeLimiterRegistry.getAllTimeLimiters()
-                .map(TimeLimiter::getName).sorted().toJavaList();
+        List<String> timeLimiters = timeLimiterRegistry.getAllTimeLimiters().stream()
+                .map(TimeLimiter::getName).sorted().collect(Collectors.toList());
         return new TimeLimiterEndpointResponse(timeLimiters);
     }
 

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerAutoConfigurationTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerAutoConfigurationTest.java
@@ -39,6 +39,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -322,12 +323,12 @@ public class CircuitBreakerAutoConfigurationTest {
     @Test
     public void shouldDefineWaitIntervalFunctionInOpenStateForCircuitBreakerAutoConfiguration() {
         //when
-        final CircuitBreaker backendC = circuitBreakerRegistry.getAllCircuitBreakers()
+        final Optional<CircuitBreaker> backendC = circuitBreakerRegistry.getAllCircuitBreakers().stream()
             .filter(circuitBreaker -> circuitBreaker.getName().equalsIgnoreCase("backendC"))
-            .get();
+            .findAny();
         //then
-        assertThat(backendC).isNotNull();
-        CircuitBreakerConfig backendConfig = backendC.getCircuitBreakerConfig();
+        assertThat(backendC.isPresent()).isTrue();
+        CircuitBreakerConfig backendConfig = backendC.get().getCircuitBreakerConfig();
 
         assertThat(backendConfig.getWaitIntervalFunctionInOpenState()).isNotNull();
         assertThat(backendConfig.getWaitIntervalFunctionInOpenState().apply(1)).isEqualTo(1000);

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/circuitbreaker/monitoring/health/CircuitBreakersHealthIndicatorTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/circuitbreaker/monitoring/health/CircuitBreakersHealthIndicatorTest.java
@@ -4,14 +4,13 @@ import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.circuitbreaker.configure.CircuitBreakerConfigurationProperties;
-import io.vavr.collection.Array;
 import org.junit.Test;
-import org.springframework.boot.actuate.health.*;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.SimpleStatusAggregator;
+import org.springframework.boot.actuate.health.Status;
 
 import java.util.AbstractMap.SimpleEntry;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 import static io.github.resilience4j.circuitbreaker.CircuitBreaker.State.*;
 import static org.assertj.core.api.BDDAssertions.then;
@@ -47,7 +46,7 @@ public class CircuitBreakersHealthIndicatorTest {
         when(metrics.getNumberOfSlowCalls()).thenReturn(20);
         when(metrics.getNumberOfNotPermittedCalls()).thenReturn(0L);
 
-        when(registry.getAllCircuitBreakers()).thenReturn(Array.of(circuitBreaker));
+        when(registry.getAllCircuitBreakers()).thenReturn(Set.of(circuitBreaker));
         when(circuitBreaker.getName()).thenReturn("test");
         when(circuitBreakerProperties.findCircuitBreakerProperties("test"))
             .thenReturn(Optional.of(instanceProperties));
@@ -96,7 +95,7 @@ public class CircuitBreakersHealthIndicatorTest {
         CircuitBreaker.Metrics metrics = mock(CircuitBreaker.Metrics.class);
 
         // when
-        when(registry.getAllCircuitBreakers()).thenReturn(Array.ofAll(expectedStateToCircuitBreaker.values()));
+        when(registry.getAllCircuitBreakers()).thenReturn(new HashSet<>(expectedStateToCircuitBreaker.values()));
         boolean allowHealthIndicatorToFail = true;
         expectedStateToCircuitBreaker.forEach(
             (state, circuitBreaker) -> setCircuitBreakerWhen(state, circuitBreaker, config, metrics, instanceProperties, circuitBreakerProperties, allowHealthIndicatorToFail));
@@ -136,7 +135,7 @@ public class CircuitBreakersHealthIndicatorTest {
         CircuitBreaker.Metrics metrics = mock(CircuitBreaker.Metrics.class);
 
         // when
-        when(registry.getAllCircuitBreakers()).thenReturn(Array.ofAll(expectedStateToCircuitBreaker.values()));
+        when(registry.getAllCircuitBreakers()).thenReturn(new HashSet<>(expectedStateToCircuitBreaker.values()));
         boolean allowHealthIndicatorToFail = false;  // do not allow health indicator to fail
         expectedStateToCircuitBreaker.forEach(
             (state, circuitBreaker) -> setCircuitBreakerWhen(state, circuitBreaker, config, metrics, instanceProperties, circuitBreakerProperties, allowHealthIndicatorToFail));

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/ratelimiter/monitoring/health/RateLimitersHealthIndicatorTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/ratelimiter/monitoring/health/RateLimitersHealthIndicatorTest.java
@@ -4,7 +4,6 @@ import io.github.resilience4j.ratelimiter.RateLimiterConfig;
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
 import io.github.resilience4j.ratelimiter.configure.RateLimiterConfigurationProperties;
 import io.github.resilience4j.ratelimiter.internal.AtomicRateLimiter;
-import io.vavr.collection.Array;
 import org.junit.Test;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.SimpleStatusAggregator;
@@ -13,6 +12,7 @@ import org.springframework.boot.actuate.health.Status;
 import java.time.Duration;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.mockito.Mockito.mock;
@@ -46,7 +46,7 @@ public class RateLimitersHealthIndicatorTest {
         when(instanceProperties.getAllowHealthIndicatorToFail()).thenReturn(true);
         when(rateLimiter.getMetrics()).thenReturn(metrics);
         when(rateLimiter.getDetailedMetrics()).thenReturn(metrics);
-        when(rateLimiterRegistry.getAllRateLimiters()).thenReturn(Array.of(rateLimiter));
+        when(rateLimiterRegistry.getAllRateLimiters()).thenReturn(Set.of(rateLimiter));
 
         when(config.getTimeoutDuration()).thenReturn(Duration.ofNanos(30L));
 
@@ -99,7 +99,7 @@ public class RateLimitersHealthIndicatorTest {
         when(instanceProperties.getAllowHealthIndicatorToFail()).thenReturn(allowHealthIndicatorToFail);
         when(rateLimiter.getMetrics()).thenReturn(metrics);
         when(rateLimiter.getDetailedMetrics()).thenReturn(metrics);
-        when(rateLimiterRegistry.getAllRateLimiters()).thenReturn(Array.of(rateLimiter));
+        when(rateLimiterRegistry.getAllRateLimiters()).thenReturn(Set.of(rateLimiter));
 
         when(config.getTimeoutDuration()).thenReturn(Duration.ofNanos(30L));
 

--- a/resilience4j-spring/build.gradle
+++ b/resilience4j-spring/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     compile project(':resilience4j-annotations')
     compile project(':resilience4j-consumer')
+    compile project(':resilience4j-vavr')
     compile project(':resilience4j-framework-common')
 
     compileOnly(libraries.aspectj)

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/bulkhead/configure/BulkheadConfiguration.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/bulkhead/configure/BulkheadConfiguration.java
@@ -104,7 +104,7 @@ public class BulkheadConfiguration {
             .entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey,
                 entry -> bulkheadConfigurationProperties.createBulkheadConfig(entry.getValue(),
                     compositeBulkheadCustomizer, entry.getKey())));
-        return BulkheadRegistry.of(configs, bulkheadRegistryEventConsumer, bulkheadConfigurationProperties.getTags());
+        return BulkheadRegistry.of(configs, bulkheadRegistryEventConsumer, Map.copyOf(bulkheadConfigurationProperties.getTags()));
     }
 
     /**

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/bulkhead/configure/BulkheadConfiguration.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/bulkhead/configure/BulkheadConfiguration.java
@@ -104,8 +104,7 @@ public class BulkheadConfiguration {
             .entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey,
                 entry -> bulkheadConfigurationProperties.createBulkheadConfig(entry.getValue(),
                     compositeBulkheadCustomizer, entry.getKey())));
-        return BulkheadRegistry.of(configs, bulkheadRegistryEventConsumer,
-            io.vavr.collection.HashMap.ofAll(bulkheadConfigurationProperties.getTags()));
+        return BulkheadRegistry.of(configs, bulkheadRegistryEventConsumer, bulkheadConfigurationProperties.getTags());
     }
 
     /**

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/bulkhead/configure/threadpool/ThreadPoolBulkheadConfiguration.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/bulkhead/configure/threadpool/ThreadPoolBulkheadConfiguration.java
@@ -102,8 +102,7 @@ public class ThreadPoolBulkheadConfiguration {
                 entry -> threadPoolBulkheadConfigurationProperties
                     .createThreadPoolBulkheadConfig(entry.getValue(),
                         compositeThreadPoolBulkheadCustomizer, entry.getKey())));
-        return ThreadPoolBulkheadRegistry.of(configs, threadPoolBulkheadRegistryEventConsumer,
-            io.vavr.collection.HashMap.ofAll(threadPoolBulkheadConfigurationProperties.getTags()));
+        return ThreadPoolBulkheadRegistry.of(configs, threadPoolBulkheadRegistryEventConsumer, threadPoolBulkheadConfigurationProperties.getTags());
     }
 
     /**

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/bulkhead/configure/threadpool/ThreadPoolBulkheadConfiguration.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/bulkhead/configure/threadpool/ThreadPoolBulkheadConfiguration.java
@@ -102,7 +102,7 @@ public class ThreadPoolBulkheadConfiguration {
                 entry -> threadPoolBulkheadConfigurationProperties
                     .createThreadPoolBulkheadConfig(entry.getValue(),
                         compositeThreadPoolBulkheadCustomizer, entry.getKey())));
-        return ThreadPoolBulkheadRegistry.of(configs, threadPoolBulkheadRegistryEventConsumer, threadPoolBulkheadConfigurationProperties.getTags());
+        return ThreadPoolBulkheadRegistry.of(configs, threadPoolBulkheadRegistryEventConsumer, Map.copyOf(threadPoolBulkheadConfigurationProperties.getTags()));
     }
 
     /**

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/circuitbreaker/configure/CircuitBreakerAspect.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/circuitbreaker/configure/CircuitBreakerAspect.java
@@ -16,6 +16,7 @@
 package io.github.resilience4j.circuitbreaker.configure;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.circuitbreaker.VavrCircuitBreaker;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.core.lang.Nullable;
 import io.github.resilience4j.fallback.FallbackDecorators;
@@ -185,7 +186,7 @@ public class CircuitBreakerAspect implements Ordered {
      */
     private Object defaultHandling(ProceedingJoinPoint proceedingJoinPoint,
         io.github.resilience4j.circuitbreaker.CircuitBreaker circuitBreaker) throws Throwable {
-        return circuitBreaker.executeCheckedSupplier(proceedingJoinPoint::proceed);
+        return VavrCircuitBreaker.executeCheckedSupplier(circuitBreaker, proceedingJoinPoint::proceed);
     }
 
     @Override

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/circuitbreaker/configure/CircuitBreakerConfiguration.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/circuitbreaker/configure/CircuitBreakerConfiguration.java
@@ -142,7 +142,7 @@ public class CircuitBreakerConfiguration {
                     .createCircuitBreakerConfig(entry.getKey(), entry.getValue(),
                         customizerMap)));
 
-        return CircuitBreakerRegistry.of(configs, circuitBreakerRegistryEventConsumer, circuitBreakerProperties.getTags());
+        return CircuitBreakerRegistry.of(configs, circuitBreakerRegistryEventConsumer, Map.copyOf(circuitBreakerProperties.getTags()));
     }
 
     /**

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/circuitbreaker/configure/CircuitBreakerConfiguration.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/circuitbreaker/configure/CircuitBreakerConfiguration.java
@@ -142,8 +142,7 @@ public class CircuitBreakerConfiguration {
                     .createCircuitBreakerConfig(entry.getKey(), entry.getValue(),
                         customizerMap)));
 
-        return CircuitBreakerRegistry.of(configs, circuitBreakerRegistryEventConsumer,
-            io.vavr.collection.HashMap.ofAll(circuitBreakerProperties.getTags()));
+        return CircuitBreakerRegistry.of(configs, circuitBreakerRegistryEventConsumer, circuitBreakerProperties.getTags());
     }
 
     /**

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/ratelimiter/configure/RateLimiterConfiguration.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/ratelimiter/configure/RateLimiterConfiguration.java
@@ -104,7 +104,7 @@ public class RateLimiterConfiguration {
                         entry.getKey())));
 
         return RateLimiterRegistry.of(configs, rateLimiterRegistryEventConsumer,
-            io.vavr.collection.HashMap.ofAll(rateLimiterConfigurationProperties.getTags()));
+            rateLimiterConfigurationProperties.getTags());
     }
 
     /**

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/ratelimiter/configure/RateLimiterConfiguration.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/ratelimiter/configure/RateLimiterConfiguration.java
@@ -104,7 +104,7 @@ public class RateLimiterConfiguration {
                         entry.getKey())));
 
         return RateLimiterRegistry.of(configs, rateLimiterRegistryEventConsumer,
-            rateLimiterConfigurationProperties.getTags());
+            Map.copyOf(rateLimiterConfigurationProperties.getTags()));
     }
 
     /**

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/retry/configure/RetryAspect.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/retry/configure/RetryAspect.java
@@ -19,6 +19,7 @@ import io.github.resilience4j.core.lang.Nullable;
 import io.github.resilience4j.fallback.FallbackDecorators;
 import io.github.resilience4j.fallback.FallbackMethod;
 import io.github.resilience4j.retry.RetryRegistry;
+import io.github.resilience4j.retry.VavrRetry;
 import io.github.resilience4j.retry.annotation.Retry;
 import io.github.resilience4j.spelresolver.SpelResolver;
 import io.github.resilience4j.utils.AnnotationExtractor;
@@ -177,7 +178,7 @@ public class RetryAspect implements Ordered, AutoCloseable {
      */
     private Object handleDefaultJoinPoint(ProceedingJoinPoint proceedingJoinPoint,
         io.github.resilience4j.retry.Retry retry) throws Throwable {
-        return retry.executeCheckedSupplier(proceedingJoinPoint::proceed);
+        return VavrRetry.executeCheckedSupplier(retry, proceedingJoinPoint::proceed);
     }
 
     /**

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/retry/configure/RetryConfiguration.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/retry/configure/RetryConfiguration.java
@@ -103,8 +103,7 @@ public class RetryConfiguration {
                     .createRetryConfig(entry.getValue(), compositeRetryCustomizer,
                         entry.getKey())));
 
-        return RetryRegistry.of(configs, retryRegistryEventConsumer,
-            io.vavr.collection.HashMap.ofAll(retryConfigurationProperties.getTags()));
+        return RetryRegistry.of(configs, retryRegistryEventConsumer, retryConfigurationProperties.getTags());
     }
 
     /**

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/retry/configure/RetryConfiguration.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/retry/configure/RetryConfiguration.java
@@ -103,7 +103,7 @@ public class RetryConfiguration {
                     .createRetryConfig(entry.getValue(), compositeRetryCustomizer,
                         entry.getKey())));
 
-        return RetryRegistry.of(configs, retryRegistryEventConsumer, retryConfigurationProperties.getTags());
+        return RetryRegistry.of(configs, retryRegistryEventConsumer, Map.copyOf(retryConfigurationProperties.getTags()));
     }
 
     /**

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/timelimiter/configure/TimeLimiterConfiguration.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/timelimiter/configure/TimeLimiterConfiguration.java
@@ -131,8 +131,7 @@ public class TimeLimiterConfiguration {
                         entry -> timeLimiterConfigurationProperties.createTimeLimiterConfig(
                             entry.getKey(), entry.getValue(), compositeTimeLimiterCustomizer)));
 
-        return TimeLimiterRegistry.of(configs, timeLimiterRegistryEventConsumer,
-            HashMap.ofAll(timeLimiterConfigurationProperties.getTags()));
+        return TimeLimiterRegistry.of(configs, timeLimiterRegistryEventConsumer, timeLimiterConfigurationProperties.getTags());
     }
 
     /**

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/timelimiter/configure/TimeLimiterConfiguration.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/timelimiter/configure/TimeLimiterConfiguration.java
@@ -31,7 +31,6 @@ import io.github.resilience4j.timelimiter.event.TimeLimiterEvent;
 import io.github.resilience4j.utils.AspectJOnClasspathCondition;
 import io.github.resilience4j.utils.ReactorOnClasspathCondition;
 import io.github.resilience4j.utils.RxJava2OnClasspathCondition;
-import io.vavr.collection.HashMap;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -131,7 +130,7 @@ public class TimeLimiterConfiguration {
                         entry -> timeLimiterConfigurationProperties.createTimeLimiterConfig(
                             entry.getKey(), entry.getValue(), compositeTimeLimiterCustomizer)));
 
-        return TimeLimiterRegistry.of(configs, timeLimiterRegistryEventConsumer, timeLimiterConfigurationProperties.getTags());
+        return TimeLimiterRegistry.of(configs, timeLimiterRegistryEventConsumer, Map.copyOf(timeLimiterConfigurationProperties.getTags()));
     }
 
     /**

--- a/resilience4j-spring/src/test/java/io/github/resilience4j/bulkhead/configure/BulkheadAspectSpelResolverTest.java
+++ b/resilience4j-spring/src/test/java/io/github/resilience4j/bulkhead/configure/BulkheadAspectSpelResolverTest.java
@@ -39,8 +39,8 @@ public class BulkheadAspectSpelResolverTest {
 
     @Test
     public void testSpel() {
-        assertThat(registry.getAllBulkheads().exists(it -> it.getName().equals("SPEL_BACKEND"))).isFalse();
+        assertThat(registry.getAllBulkheads().stream().filter(it -> it.getName().equals("SPEL_BACKEND")).findAny().isPresent()).isFalse();
         assertThat(testDummyService.spelSync("SPEL_BACKEND")).isEqualTo("recovered");
-        assertThat(registry.getAllBulkheads().exists(it -> it.getName().equals("SPEL_BACKEND"))).isTrue();
+        assertThat(registry.getAllBulkheads().stream().filter(it -> it.getName().equals("SPEL_BACKEND")).findAny().isPresent()).isTrue();
     }
 }

--- a/resilience4j-spring/src/test/java/io/github/resilience4j/circuitbreaker/configure/CircuitBreakerAspectSpelResolverTest.java
+++ b/resilience4j-spring/src/test/java/io/github/resilience4j/circuitbreaker/configure/CircuitBreakerAspectSpelResolverTest.java
@@ -39,8 +39,8 @@ public class CircuitBreakerAspectSpelResolverTest {
 
     @Test
     public void testSpel() {
-        assertThat(registry.getAllCircuitBreakers().exists(it -> it.getName().equals("SPEL_BACKEND"))).isFalse();
+        assertThat(registry.getAllCircuitBreakers().stream().filter(it -> it.getName().equals("SPEL_BACKEND")).findAny().isPresent()).isFalse();
         assertThat(testDummyService.spelSync("SPEL_BACKEND")).isEqualTo("recovered");
-        assertThat(registry.getAllCircuitBreakers().exists(it -> it.getName().equals("SPEL_BACKEND"))).isTrue();
+        assertThat(registry.getAllCircuitBreakers().stream().filter(it -> it.getName().equals("SPEL_BACKEND")).findAny().isPresent()).isTrue();
     }
 }

--- a/resilience4j-spring/src/test/java/io/github/resilience4j/ratelimiter/configure/RateLimiterAspectSpelResolverTest.java
+++ b/resilience4j-spring/src/test/java/io/github/resilience4j/ratelimiter/configure/RateLimiterAspectSpelResolverTest.java
@@ -39,8 +39,8 @@ public class RateLimiterAspectSpelResolverTest {
 
     @Test
     public void testSpel() {
-        assertThat(registry.getAllRateLimiters().exists(it -> it.getName().equals("SPEL_BACKEND"))).isFalse();
+        assertThat(registry.getAllRateLimiters().stream().filter(it -> it.getName().equals("SPEL_BACKEND")).findAny().isPresent()).isFalse();
         assertThat(testDummyService.spelSync("SPEL_BACKEND")).isEqualTo("recovered");
-        assertThat(registry.getAllRateLimiters().exists(it -> it.getName().equals("SPEL_BACKEND"))).isTrue();
+        assertThat(registry.getAllRateLimiters().stream().filter(it -> it.getName().equals("SPEL_BACKEND")).findAny().isPresent()).isTrue();
     }
 }

--- a/resilience4j-spring/src/test/java/io/github/resilience4j/retry/configure/RetryAspectSpelResolverTest.java
+++ b/resilience4j-spring/src/test/java/io/github/resilience4j/retry/configure/RetryAspectSpelResolverTest.java
@@ -39,8 +39,8 @@ public class RetryAspectSpelResolverTest {
 
     @Test
     public void testSpel() {
-        assertThat(registry.getAllRetries().exists(it -> it.getName().equals("SPEL_BACKEND"))).isFalse();
+        assertThat(registry.getAllRetries().stream().filter(it -> it.getName().equals("SPEL_BACKEND")).findAny().isPresent()).isFalse();
         assertThat(testDummyService.spelSync("SPEL_BACKEND")).isEqualTo("recovered");
-        assertThat(registry.getAllRetries().exists(it -> it.getName().equals("SPEL_BACKEND"))).isTrue();
+        assertThat(registry.getAllRetries().stream().filter(it -> it.getName().equals("SPEL_BACKEND")).findAny().isPresent()).isTrue();
     }
 }

--- a/resilience4j-spring/src/test/java/io/github/resilience4j/timelimiter/configure/TimeLimiterAspectSpelResolverTest.java
+++ b/resilience4j-spring/src/test/java/io/github/resilience4j/timelimiter/configure/TimeLimiterAspectSpelResolverTest.java
@@ -39,8 +39,8 @@ public class TimeLimiterAspectSpelResolverTest {
 
     @Test
     public void testSpel() {
-        assertThat(registry.getAllTimeLimiters().exists(it -> it.getName().equals("SPEL_BACKEND"))).isFalse();
+        assertThat(registry.getAllTimeLimiters().stream().filter(it -> it.getName().equals("SPEL_BACKEND")).findAny().isPresent()).isFalse();
         assertThat(testDummyService.spelMono("SPEL_BACKEND").block()).isEqualTo("SPEL_BACKEND");
-        assertThat(registry.getAllTimeLimiters().exists(it -> it.getName().equals("SPEL_BACKEND"))).isTrue();
+        assertThat(registry.getAllTimeLimiters().stream().filter(it -> it.getName().equals("SPEL_BACKEND")).findAny().isPresent()).isTrue();
     }
 }

--- a/resilience4j-test/build.gradle
+++ b/resilience4j-test/build.gradle
@@ -1,4 +1,6 @@
 artifactoryPublish.skip = true
 sonarqube.skipProject = true
-
+dependencies {
+    compile ( libraries.vavr )
+}
 ext.moduleName = 'io.github.resilience4j.test'

--- a/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/TimeLimiter.java
+++ b/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/TimeLimiter.java
@@ -8,6 +8,7 @@ import io.github.resilience4j.timelimiter.event.TimeLimiterOnTimeoutEvent;
 import io.github.resilience4j.timelimiter.internal.TimeLimiterImpl;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Future;
@@ -72,8 +73,7 @@ public interface TimeLimiter {
      * @param tags                 tags added to the Retry
      * @return a TimeLimiter with a custom TimeLimiter configuration.
      */
-    static TimeLimiter of(String name, TimeLimiterConfig timeLimiterConfig,
-        io.vavr.collection.Map<String, String> tags) {
+    static TimeLimiter of(String name, TimeLimiterConfig timeLimiterConfig, Map<String, String> tags) {
         return new TimeLimiterImpl(name, timeLimiterConfig, tags);
     }
 
@@ -126,7 +126,7 @@ public interface TimeLimiter {
      *
      * @return the tags assigned to this TimeLimiter in an unmodifiable map
      */
-    io.vavr.collection.Map<String, String> getTags();
+    Map<String, String> getTags();
 
     /**
      * Get the TimeLimiterConfig of this TimeLimiter decorator.

--- a/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/TimeLimiterRegistry.java
+++ b/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/TimeLimiterRegistry.java
@@ -21,10 +21,10 @@ package io.github.resilience4j.timelimiter;
 import io.github.resilience4j.core.Registry;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
 import io.github.resilience4j.timelimiter.internal.InMemoryTimeLimiterRegistry;
-import io.vavr.collection.Seq;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -99,8 +99,7 @@ public interface TimeLimiterRegistry extends Registry<TimeLimiter, TimeLimiterCo
      * @param tags    default tags to add to the registry
      * @return a TimeLimiterRegistry with a Map of shared TimeLimiter configurations.
      */
-    static TimeLimiterRegistry of(Map<String, TimeLimiterConfig> configs,
-        io.vavr.collection.Map<String, String> tags) {
+    static TimeLimiterRegistry of(Map<String, TimeLimiterConfig> configs, Map<String, String> tags) {
         return new InMemoryTimeLimiterRegistry(configs, tags);
     }
 
@@ -129,8 +128,7 @@ public interface TimeLimiterRegistry extends Registry<TimeLimiter, TimeLimiterCo
      * TimeLimiter registry event consumer.
      */
     static TimeLimiterRegistry of(Map<String, TimeLimiterConfig> configs,
-        RegistryEventConsumer<TimeLimiter> registryEventConsumer,
-        io.vavr.collection.Map<String, String> tags) {
+        RegistryEventConsumer<TimeLimiter> registryEventConsumer, Map<String, String> tags) {
         return new InMemoryTimeLimiterRegistry(configs, registryEventConsumer, tags);
     }
 
@@ -153,7 +151,7 @@ public interface TimeLimiterRegistry extends Registry<TimeLimiter, TimeLimiterCo
      *
      * @return all managed {@link TimeLimiter} instances.
      */
-    Seq<TimeLimiter> getAllTimeLimiters();
+    Set<TimeLimiter> getAllTimeLimiters();
 
     /**
      * Returns a managed {@link TimeLimiter} or creates a new one with the default TimeLimiter
@@ -176,7 +174,7 @@ public interface TimeLimiterRegistry extends Registry<TimeLimiter, TimeLimiterCo
      * @param tags tags added to the TimeLimiter
      * @return The {@link TimeLimiter}
      */
-    TimeLimiter timeLimiter(String name, io.vavr.collection.Map<String, String> tags);
+    TimeLimiter timeLimiter(String name, Map<String, String> tags);
 
     /**
      * Returns a managed {@link TimeLimiter} or creates a new one with a custom TimeLimiter
@@ -201,8 +199,7 @@ public interface TimeLimiterRegistry extends Registry<TimeLimiter, TimeLimiterCo
      * @param tags              tags added to the TimeLimiter
      * @return The {@link TimeLimiter}
      */
-    TimeLimiter timeLimiter(String name, TimeLimiterConfig timeLimiterConfig,
-        io.vavr.collection.Map<String, String> tags);
+    TimeLimiter timeLimiter(String name, TimeLimiterConfig timeLimiterConfig, Map<String, String> tags);
 
     /**
      * Returns a managed {@link TimeLimiterConfig} or creates a new one with a custom
@@ -228,8 +225,7 @@ public interface TimeLimiterRegistry extends Registry<TimeLimiter, TimeLimiterCo
      * @return The {@link TimeLimiter}
      */
     TimeLimiter timeLimiter(String name,
-        Supplier<TimeLimiterConfig> timeLimiterConfigSupplier,
-        io.vavr.collection.Map<String, String> tags);
+        Supplier<TimeLimiterConfig> timeLimiterConfigSupplier, Map<String, String> tags);
 
     /**
      * Returns a managed {@link TimeLimiter} or creates a new one.
@@ -254,7 +250,6 @@ public interface TimeLimiterRegistry extends Registry<TimeLimiter, TimeLimiterCo
      * @param tags       tags added to the TimeLimiter
      * @return The {@link TimeLimiter}
      */
-    TimeLimiter timeLimiter(String name, String configName,
-        io.vavr.collection.Map<String, String> tags);
+    TimeLimiter timeLimiter(String name, String configName, Map<String, String> tags);
 
 }

--- a/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/internal/InMemoryTimeLimiterRegistry.java
+++ b/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/internal/InMemoryTimeLimiterRegistry.java
@@ -24,14 +24,11 @@ import io.github.resilience4j.core.registry.RegistryEventConsumer;
 import io.github.resilience4j.timelimiter.TimeLimiter;
 import io.github.resilience4j.timelimiter.TimeLimiterConfig;
 import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
-import io.vavr.collection.Array;
-import io.vavr.collection.HashMap;
-import io.vavr.collection.Seq;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.Supplier;
+
+import static java.util.Collections.emptyMap;
 
 /**
  * Backend TimeLimiter manager. Constructs backend TimeLimiters according to configuration values.
@@ -43,11 +40,7 @@ public class InMemoryTimeLimiterRegistry extends
      * The constructor with default default.
      */
     public InMemoryTimeLimiterRegistry() {
-        this(TimeLimiterConfig.ofDefaults(), HashMap.empty());
-    }
-
-    public InMemoryTimeLimiterRegistry(io.vavr.collection.Map<String, String> tags) {
-        this(TimeLimiterConfig.ofDefaults(), tags);
+        this(TimeLimiterConfig.ofDefaults(), emptyMap());
     }
 
     public InMemoryTimeLimiterRegistry(Map<String, TimeLimiterConfig> configs) {
@@ -55,8 +48,7 @@ public class InMemoryTimeLimiterRegistry extends
         this.configurations.putAll(configs);
     }
 
-    public InMemoryTimeLimiterRegistry(Map<String, TimeLimiterConfig> configs,
-        io.vavr.collection.Map<String, String> tags) {
+    public InMemoryTimeLimiterRegistry(Map<String, TimeLimiterConfig> configs, Map<String, String> tags) {
         this(configs.getOrDefault(DEFAULT_CONFIG, TimeLimiterConfig.ofDefaults()), tags);
         this.configurations.putAll(configs);
     }
@@ -69,8 +61,7 @@ public class InMemoryTimeLimiterRegistry extends
     }
 
     public InMemoryTimeLimiterRegistry(Map<String, TimeLimiterConfig> configs,
-        RegistryEventConsumer<TimeLimiter> registryEventConsumer,
-        io.vavr.collection.Map<String, String> tags) {
+        RegistryEventConsumer<TimeLimiter> registryEventConsumer, Map<String, String> tags) {
         this(configs.getOrDefault(DEFAULT_CONFIG, TimeLimiterConfig.ofDefaults()), registryEventConsumer,
             tags);
         this.configurations.putAll(configs);
@@ -84,8 +75,7 @@ public class InMemoryTimeLimiterRegistry extends
     }
 
     public InMemoryTimeLimiterRegistry(Map<String, TimeLimiterConfig> configs,
-        List<RegistryEventConsumer<TimeLimiter>> registryEventConsumers,
-        io.vavr.collection.Map<String, String> tags) {
+        List<RegistryEventConsumer<TimeLimiter>> registryEventConsumers, Map<String, String> tags) {
         this(configs.getOrDefault(DEFAULT_CONFIG, TimeLimiterConfig.ofDefaults()),
             registryEventConsumers, tags);
         this.configurations.putAll(configs);
@@ -100,8 +90,7 @@ public class InMemoryTimeLimiterRegistry extends
         super(defaultConfig);
     }
 
-    public InMemoryTimeLimiterRegistry(TimeLimiterConfig defaultConfig,
-        io.vavr.collection.Map<String, String> tags) {
+    public InMemoryTimeLimiterRegistry(TimeLimiterConfig defaultConfig, Map<String, String> tags) {
         super(defaultConfig, tags);
     }
 
@@ -111,8 +100,7 @@ public class InMemoryTimeLimiterRegistry extends
     }
 
     public InMemoryTimeLimiterRegistry(TimeLimiterConfig defaultConfig,
-        RegistryEventConsumer<TimeLimiter> registryEventConsumer,
-        io.vavr.collection.Map<String, String> tags) {
+        RegistryEventConsumer<TimeLimiter> registryEventConsumer, Map<String, String> tags) {
         super(defaultConfig, registryEventConsumer, tags);
     }
 
@@ -122,8 +110,7 @@ public class InMemoryTimeLimiterRegistry extends
     }
 
     public InMemoryTimeLimiterRegistry(TimeLimiterConfig defaultConfig,
-        List<RegistryEventConsumer<TimeLimiter>> registryEventConsumers,
-        io.vavr.collection.Map<String, String> tags) {
+        List<RegistryEventConsumer<TimeLimiter>> registryEventConsumers, Map<String, String> tags) {
         super(defaultConfig, registryEventConsumers, tags);
     }
 
@@ -131,8 +118,8 @@ public class InMemoryTimeLimiterRegistry extends
      * {@inheritDoc}
      */
     @Override
-    public Seq<TimeLimiter> getAllTimeLimiters() {
-        return Array.ofAll(entryMap.values());
+    public Set<TimeLimiter> getAllTimeLimiters() {
+        return new HashSet<>(entryMap.values());
     }
 
     /**
@@ -140,12 +127,11 @@ public class InMemoryTimeLimiterRegistry extends
      */
     @Override
     public TimeLimiter timeLimiter(final String name) {
-        return timeLimiter(name, getDefaultConfig(), HashMap.empty());
+        return timeLimiter(name, getDefaultConfig(), emptyMap());
     }
 
     @Override
-    public TimeLimiter timeLimiter(String name,
-        io.vavr.collection.Map<String, String> tags) {
+    public TimeLimiter timeLimiter(String name, Map<String, String> tags) {
         return timeLimiter(name, getDefaultConfig(), tags);
     }
 
@@ -154,13 +140,12 @@ public class InMemoryTimeLimiterRegistry extends
      */
     @Override
     public TimeLimiter timeLimiter(final String name, final TimeLimiterConfig config) {
-        return timeLimiter(name, config, HashMap.empty());
+        return timeLimiter(name, config, emptyMap());
     }
 
     @Override
     public TimeLimiter timeLimiter(String name,
-        TimeLimiterConfig timeLimiterConfig,
-        io.vavr.collection.Map<String, String> tags) {
+        TimeLimiterConfig timeLimiterConfig, Map<String, String> tags) {
         return computeIfAbsent(name, () -> TimeLimiter.of(name,
             Objects.requireNonNull(timeLimiterConfig, CONFIG_MUST_NOT_BE_NULL), getAllTags(tags)));
     }
@@ -171,13 +156,12 @@ public class InMemoryTimeLimiterRegistry extends
     @Override
     public TimeLimiter timeLimiter(final String name,
         final Supplier<TimeLimiterConfig> timeLimiterConfigSupplier) {
-        return timeLimiter(name, timeLimiterConfigSupplier, HashMap.empty());
+        return timeLimiter(name, timeLimiterConfigSupplier, emptyMap());
     }
 
     @Override
     public TimeLimiter timeLimiter(String name,
-        Supplier<TimeLimiterConfig> timeLimiterConfigSupplier,
-        io.vavr.collection.Map<String, String> tags) {
+        Supplier<TimeLimiterConfig> timeLimiterConfigSupplier, Map<String, String> tags) {
         return computeIfAbsent(name, () -> TimeLimiter.of(name, Objects.requireNonNull(
             Objects.requireNonNull(timeLimiterConfigSupplier, SUPPLIER_MUST_NOT_BE_NULL).get(),
             CONFIG_MUST_NOT_BE_NULL), getAllTags(tags)));
@@ -188,12 +172,11 @@ public class InMemoryTimeLimiterRegistry extends
      */
     @Override
     public TimeLimiter timeLimiter(String name, String configName) {
-        return timeLimiter(name, configName, HashMap.empty());
+        return timeLimiter(name, configName, emptyMap());
     }
 
     @Override
-    public TimeLimiter timeLimiter(String name, String configName,
-        io.vavr.collection.Map<String, String> tags) {
+    public TimeLimiter timeLimiter(String name, String configName, Map<String, String> tags) {
         TimeLimiterConfig config = getConfiguration(configName)
             .orElseThrow(() -> new ConfigurationNotFoundException(configName));
         return timeLimiter(name, config, tags);

--- a/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/internal/TimeLimiterImpl.java
+++ b/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/internal/TimeLimiterImpl.java
@@ -6,14 +6,15 @@ import io.github.resilience4j.timelimiter.event.TimeLimiterEvent;
 import io.github.resilience4j.timelimiter.event.TimeLimiterOnErrorEvent;
 import io.github.resilience4j.timelimiter.event.TimeLimiterOnSuccessEvent;
 import io.github.resilience4j.timelimiter.event.TimeLimiterOnTimeoutEvent;
-import io.vavr.collection.HashMap;
-import io.vavr.collection.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.*;
 import java.util.function.Supplier;
+
+import static java.util.Collections.emptyMap;
 
 public class TimeLimiterImpl implements TimeLimiter {
 
@@ -25,12 +26,11 @@ public class TimeLimiterImpl implements TimeLimiter {
     private final TimeLimiterEventProcessor eventProcessor;
 
     public TimeLimiterImpl(String name, TimeLimiterConfig timeLimiterConfig) {
-        this(name, timeLimiterConfig, HashMap.empty());
+        this(name, timeLimiterConfig, emptyMap());
 
     }
 
-    public TimeLimiterImpl(String name, TimeLimiterConfig timeLimiterConfig,
-        io.vavr.collection.Map<String, String> tags) {
+    public TimeLimiterImpl(String name, TimeLimiterConfig timeLimiterConfig, Map<String, String> tags) {
         this.name = name;
         this.tags = Objects.requireNonNull(tags, "Tags must not be null");
         this.timeLimiterConfig = timeLimiterConfig;

--- a/resilience4j-timelimiter/src/test/java/io/github/resilience4j/timelimiter/TimeLimiterRegistryTest.java
+++ b/resilience4j-timelimiter/src/test/java/io/github/resilience4j/timelimiter/TimeLimiterRegistryTest.java
@@ -7,7 +7,6 @@ import io.github.resilience4j.core.registry.EntryAddedEvent;
 import io.github.resilience4j.core.registry.EntryRemovedEvent;
 import io.github.resilience4j.core.registry.EntryReplacedEvent;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
-import io.vavr.Tuple;
 import org.junit.Test;
 
 import java.time.Duration;
@@ -46,9 +45,9 @@ public class TimeLimiterRegistryTest {
         TimeLimiterConfig timeLimiterConfig = TimeLimiterConfig.ofDefaults();
         Map<String, TimeLimiterConfig> timeLimiterConfigs = Collections
             .singletonMap("default", timeLimiterConfig);
-        TimeLimiterRegistry registry = TimeLimiterRegistry.of(timeLimiterConfigs, new NoOpTimeLimiterEventConsumer(),io.vavr.collection.HashMap.of("Tag1Key","Tag1Value"));
+        TimeLimiterRegistry registry = TimeLimiterRegistry.of(timeLimiterConfigs, new NoOpTimeLimiterEventConsumer(), Map.of("Tag1Key","Tag1Value"));
         assertThat(registry.getTags()).isNotEmpty();
-        assertThat(registry.getTags()).containsOnly(Tuple.of("Tag1Key","Tag1Value"));
+        assertThat(registry.getTags()).containsOnly(Map.entry("Tag1Key","Tag1Value"));
     }
 
     @Test
@@ -63,41 +62,37 @@ public class TimeLimiterRegistryTest {
         TimeLimiterConfig timeLimiterConfig = TimeLimiterConfig.ofDefaults();
         Map<String, TimeLimiterConfig> timeLimiterConfigs = Collections
             .singletonMap("default", timeLimiterConfig);
-        io.vavr.collection.Map<String, String> timeLimiterTags = io.vavr.collection.HashMap
-            .of("key1", "value1", "key2", "value2");
+        Map<String, String> timeLimiterTags = Map.of("key1", "value1", "key2", "value2");
         TimeLimiterRegistry timeLimiterRegistry = TimeLimiterRegistry
             .of(timeLimiterConfigs, timeLimiterTags);
         TimeLimiter TimeLimiter = timeLimiterRegistry.timeLimiter("testName");
 
-        assertThat(TimeLimiter.getTags()).containsOnlyElementsOf(timeLimiterTags);
+        assertThat(TimeLimiter.getTags()).containsAllEntriesOf(timeLimiterTags);
     }
 
     @Test
     public void tagsAddedToInstance() {
         TimeLimiterRegistry timeLimiterRegistry = TimeLimiterRegistry.ofDefaults();
-        io.vavr.collection.Map<String, String> timeLimiterTags = io.vavr.collection.HashMap
-            .of("key1", "value1", "key2", "value2");
+        Map<String, String> timeLimiterTags = Map.of("key1", "value1", "key2", "value2");
         TimeLimiter TimeLimiter = timeLimiterRegistry
             .timeLimiter("testName", timeLimiterTags);
 
-        assertThat(TimeLimiter.getTags()).containsOnlyElementsOf(timeLimiterTags);
+        assertThat(TimeLimiter.getTags()).containsAllEntriesOf(timeLimiterTags);
     }
 
     @Test
     public void tagsOfTimeLimitersShouldNotBeMixed() {
         TimeLimiterRegistry timeLimiterRegistry = TimeLimiterRegistry.ofDefaults();
         TimeLimiterConfig timeLimiterConfig = TimeLimiterConfig.ofDefaults();
-        io.vavr.collection.Map<String, String> timeLimiterTags = io.vavr.collection.HashMap
-            .of("key1", "value1", "key2", "value2");
+        Map<String, String> timeLimiterTags = Map.of("key1", "value1", "key2", "value2");
         TimeLimiter TimeLimiter = timeLimiterRegistry
             .timeLimiter("testName", timeLimiterConfig, timeLimiterTags);
-        io.vavr.collection.Map<String, String> timeLimiterTags2 = io.vavr.collection.HashMap
-            .of("key3", "value3", "key4", "value4");
+        Map<String, String> timeLimiterTags2 = Map.of("key3", "value3", "key4", "value4");
         TimeLimiter TimeLimiter2 = timeLimiterRegistry
             .timeLimiter("otherTestName", timeLimiterConfig, timeLimiterTags2);
 
-        assertThat(TimeLimiter.getTags()).containsOnlyElementsOf(timeLimiterTags);
-        assertThat(TimeLimiter2.getTags()).containsOnlyElementsOf(timeLimiterTags2);
+        assertThat(TimeLimiter.getTags()).containsAllEntriesOf(timeLimiterTags);
+        assertThat(TimeLimiter2.getTags()).containsAllEntriesOf(timeLimiterTags2);
     }
 
     @Test
@@ -105,18 +100,15 @@ public class TimeLimiterRegistryTest {
         TimeLimiterConfig timeLimiterConfig = TimeLimiterConfig.ofDefaults();
         Map<String, TimeLimiterConfig> timeLimiterConfigs = Collections
             .singletonMap("default", timeLimiterConfig);
-        io.vavr.collection.Map<String, String> timeLimiterTags = io.vavr.collection.HashMap
-            .of("key1", "value1", "key2", "value2");
-        io.vavr.collection.Map<String, String> instanceTags = io.vavr.collection.HashMap
-            .of("key1", "value3", "key4", "value4");
+        Map<String, String> timeLimiterTags = Map.of("key1", "value1", "key2", "value2");
+        Map<String, String> instanceTags = Map.of("key1", "value3", "key4", "value4");
         TimeLimiterRegistry timeLimiterRegistry = TimeLimiterRegistry
             .of(timeLimiterConfigs, timeLimiterTags);
         TimeLimiter timeLimiter = timeLimiterRegistry
             .timeLimiter("testName", timeLimiterConfig, instanceTags);
 
-        io.vavr.collection.Map<String, String> expectedTags = io.vavr.collection.HashMap
-            .of("key1", "value3", "key2", "value2", "key4", "value4");
-        assertThat(timeLimiter.getTags()).containsOnlyElementsOf(expectedTags);
+        Map<String, String> expectedTags = Map.of("key1", "value3", "key2", "value2", "key4", "value4");
+        assertThat(timeLimiter.getTags()).containsAllEntriesOf(expectedTags);
     }
 
     @Test

--- a/resilience4j-timelimiter/src/test/java/io/github/resilience4j/timelimiter/internal/InMemoryTimeLimiterRegistryTest.java
+++ b/resilience4j-timelimiter/src/test/java/io/github/resilience4j/timelimiter/internal/InMemoryTimeLimiterRegistryTest.java
@@ -132,10 +132,10 @@ public class InMemoryTimeLimiterRegistryTest {
     public void timeLimiterGetAllTimeLimiters() {
         TimeLimiterRegistry registry = new InMemoryTimeLimiterRegistry(config);
 
-        registry.timeLimiter("foo");
+        final TimeLimiter timeLimiter = registry.timeLimiter("foo");
 
         then(registry.getAllTimeLimiters().size()).isEqualTo(1);
-        then(registry.getAllTimeLimiters().get(0).getName()).isEqualTo("foo");
+        then(registry.getAllTimeLimiters()).contains(timeLimiter);
     }
 
 }

--- a/resilience4j-vavr/build.gradle
+++ b/resilience4j-vavr/build.gradle
@@ -1,0 +1,10 @@
+dependencies {
+    compile project(':resilience4j-retry')
+    compile project(':resilience4j-circuitbreaker')
+    compile ( libraries.vavr )
+    testCompile project(':resilience4j-test')
+    testCompile project(':resilience4j-rxjava2')
+    testCompile(libraries.rxjava2)
+}
+
+ext.moduleName = 'io.github.resilience4j.vavr'

--- a/resilience4j-vavr/src/main/java/io/github/resilience4j/circuitbreaker/VavrCircuitBreaker.java
+++ b/resilience4j-vavr/src/main/java/io/github/resilience4j/circuitbreaker/VavrCircuitBreaker.java
@@ -1,0 +1,239 @@
+/*
+ *
+ *  Copyright 2020: KrnSaurabh
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.circuitbreaker;
+
+import io.vavr.CheckedConsumer;
+import io.vavr.CheckedFunction0;
+import io.vavr.CheckedFunction1;
+import io.vavr.CheckedRunnable;
+import io.vavr.control.Either;
+import io.vavr.control.Try;
+
+import java.util.function.Supplier;
+
+public interface VavrCircuitBreaker {
+    /**
+     * Returns a supplier which is decorated by a CircuitBreaker.
+     *
+     * @param circuitBreaker the CircuitBreaker
+     * @param supplier       the original supplier
+     * @param <T>            the type of results supplied by this supplier
+     * @return a supplier which is decorated by a CircuitBreaker.
+     */
+    static <T> CheckedFunction0<T> decorateCheckedSupplier(CircuitBreaker circuitBreaker,
+                                                           CheckedFunction0<T> supplier) {
+        return () -> {
+            circuitBreaker.acquirePermission();
+            final long start = circuitBreaker.getCurrentTimestamp();
+            try {
+                T returnValue = supplier.apply();
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onSuccess(duration, circuitBreaker.getTimestampUnit());
+                return returnValue;
+            } catch (Exception exception) {
+                // Do not handle java.lang.Error
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onError(duration, circuitBreaker.getTimestampUnit(), exception);
+                throw exception;
+            }
+        };
+    }
+
+    /**
+     * Returns a runnable which is decorated by a CircuitBreaker.
+     *
+     * @param circuitBreaker the CircuitBreaker
+     * @param runnable       the original runnable
+     * @return a runnable which is decorated by a CircuitBreaker.
+     */
+    static CheckedRunnable decorateCheckedRunnable(CircuitBreaker circuitBreaker,
+                                                   CheckedRunnable runnable) {
+        return () -> {
+            circuitBreaker.acquirePermission();
+            final long start = circuitBreaker.getCurrentTimestamp();
+            try {
+                runnable.run();
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onSuccess(duration, circuitBreaker.getTimestampUnit());
+            } catch (Exception exception) {
+                // Do not handle java.lang.Error
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onError(duration, circuitBreaker.getTimestampUnit(), exception);
+                throw exception;
+            }
+        };
+    }
+
+    /**
+     * Returns a supplier which is decorated by a CircuitBreaker.
+     *
+     * @param circuitBreaker the CircuitBreaker
+     * @param supplier       the original supplier
+     * @param <T>            the type of results supplied by this supplier
+     * @return a supplier which is decorated by a CircuitBreaker.
+     */
+    static <T> Supplier<Either<Exception, T>> decorateEitherSupplier(CircuitBreaker circuitBreaker,
+                                                                     Supplier<Either<? extends Exception, T>> supplier) {
+        return () -> {
+            if (circuitBreaker.tryAcquirePermission()) {
+                final long start = circuitBreaker.getCurrentTimestamp();
+                Either<? extends Exception, T> result = supplier.get();
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                if (result.isRight()) {
+                    circuitBreaker.onSuccess(duration, circuitBreaker.getTimestampUnit());
+                } else {
+                    Exception exception = result.getLeft();
+                    circuitBreaker.onError(duration, circuitBreaker.getTimestampUnit(), exception);
+                }
+                return Either.narrow(result);
+            } else {
+                return Either.left(
+                    CallNotPermittedException.createCallNotPermittedException(circuitBreaker));
+            }
+        };
+    }
+
+    /**
+     * Returns a supplier which is decorated by a CircuitBreaker.
+     *
+     * @param circuitBreaker the CircuitBreaker
+     * @param supplier       the original function
+     * @param <T>            the type of results supplied by this supplier
+     * @return a retryable function
+     */
+    static <T> Supplier<Try<T>> decorateTrySupplier(CircuitBreaker circuitBreaker,
+                                                    Supplier<Try<T>> supplier) {
+        return () -> {
+            if (circuitBreaker.tryAcquirePermission()) {
+                final long start = circuitBreaker.getCurrentTimestamp();
+                Try<T> result = supplier.get();
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                if (result.isSuccess()) {
+                    circuitBreaker.onSuccess(duration, circuitBreaker.getTimestampUnit());
+                    return result;
+                } else {
+                    circuitBreaker
+                        .onError(duration, circuitBreaker.getTimestampUnit(), result.getCause());
+                    return result;
+                }
+            } else {
+                return Try.failure(
+                    CallNotPermittedException.createCallNotPermittedException(circuitBreaker));
+            }
+        };
+    }
+
+    /**
+     * Returns a consumer which is decorated by a CircuitBreaker.
+     *
+     * @param circuitBreaker the CircuitBreaker
+     * @param consumer       the original consumer
+     * @param <T>            the type of the input to the consumer
+     * @return a consumer which is decorated by a CircuitBreaker.
+     */
+    static <T> CheckedConsumer<T> decorateCheckedConsumer(CircuitBreaker circuitBreaker,
+                                                          CheckedConsumer<T> consumer) {
+        return (t) -> {
+            circuitBreaker.acquirePermission();
+            final long start = circuitBreaker.getCurrentTimestamp();
+            try {
+                consumer.accept(t);
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onSuccess(duration, circuitBreaker.getTimestampUnit());
+            } catch (Exception exception) {
+                // Do not handle java.lang.Error
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onError(duration, circuitBreaker.getTimestampUnit(), exception);
+                throw exception;
+            }
+        };
+    }
+
+    /**
+     * Returns a function which is decorated by a CircuitBreaker.
+     *
+     * @param circuitBreaker the CircuitBreaker
+     * @param function       the original function
+     * @param <T>            the type of the input to the function
+     * @param <R>            the type of the result of the function
+     * @return a function which is decorated by a CircuitBreaker.
+     */
+    static <T, R> CheckedFunction1<T, R> decorateCheckedFunction(CircuitBreaker circuitBreaker,
+                                                                 CheckedFunction1<T, R> function) {
+        return (T t) -> {
+            circuitBreaker.acquirePermission();
+            final long start = circuitBreaker.getCurrentTimestamp();
+            try {
+                R returnValue = function.apply(t);
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onSuccess(duration, circuitBreaker.getTimestampUnit());
+                return returnValue;
+            } catch (Exception exception) {
+                // Do not handle java.lang.Error
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onError(duration, circuitBreaker.getTimestampUnit(), exception);
+                throw exception;
+            }
+        };
+    }
+
+    /**
+     * Decorates and executes the decorated Supplier.
+     *
+     * @param supplier the original Supplier
+     * @param <T>      the type of results supplied by this supplier
+     * @return the result of the decorated Supplier.
+     */
+    static <T> Either<Exception, T> executeEitherSupplier(CircuitBreaker circuitBreaker,
+        Supplier<Either<? extends Exception, T>> supplier) {
+        return decorateEitherSupplier(circuitBreaker, supplier).get();
+    }
+
+    /**
+     * Decorates and executes the decorated Supplier.
+     *
+     * @param supplier the original Supplier
+     * @param <T>      the type of results supplied by this supplier
+     * @return the result of the decorated Supplier.
+     */
+    static <T> Try<T> executeTrySupplier(CircuitBreaker circuitBreaker, Supplier<Try<T>> supplier) {
+        return decorateTrySupplier(circuitBreaker, supplier).get();
+    }
+
+    /**
+     * Decorates and executes the decorated Supplier.
+     *
+     * @param checkedSupplier the original Supplier
+     * @param <T>             the type of results supplied by this supplier
+     * @return the result of the decorated Supplier.
+     * @throws Throwable if something goes wrong applying this function to the given arguments
+     */
+    static <T> T executeCheckedSupplier(CircuitBreaker circuitBreaker, CheckedFunction0<T> checkedSupplier) throws Throwable {
+        return decorateCheckedSupplier(circuitBreaker, checkedSupplier).apply();
+    }
+
+    /**
+     * Decorates and executes the decorated Runnable.
+     *
+     * @param runnable the original runnable
+     */
+    static void executeCheckedRunnable(CircuitBreaker circuitBreaker, CheckedRunnable runnable) throws Throwable {
+        decorateCheckedRunnable(circuitBreaker, runnable).run();
+    }
+}

--- a/resilience4j-vavr/src/main/java/io/github/resilience4j/retry/VavrRetry.java
+++ b/resilience4j-vavr/src/main/java/io/github/resilience4j/retry/VavrRetry.java
@@ -1,0 +1,207 @@
+/*
+ *
+ *  Copyright 2020: KrnSaurabh
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.retry;
+
+import io.vavr.CheckedFunction0;
+import io.vavr.CheckedFunction1;
+import io.vavr.CheckedRunnable;
+import io.vavr.control.Either;
+import io.vavr.control.Try;
+
+import java.util.function.Supplier;
+
+public interface VavrRetry {
+    /**
+     * Creates a retryable supplier.
+     *
+     * @param retry    the retry context
+     * @param supplier the original function
+     * @param <T>      the type of results supplied by this supplier
+     * @return a retryable function
+     */
+    static <T> CheckedFunction0<T> decorateCheckedSupplier(Retry retry,
+                                                           CheckedFunction0<T> supplier) {
+        return () -> {
+            Retry.Context<T> context = retry.context();
+            do {
+                try {
+                    T result = supplier.apply();
+                    final boolean validationOfResult = context.onResult(result);
+                    if (!validationOfResult) {
+                        context.onComplete();
+                        return result;
+                    }
+                } catch (Exception exception) {
+                    context.onError(exception);
+                }
+            } while (true);
+        };
+    }
+
+    /**
+     * Creates a retryable runnable.
+     *
+     * @param retry    the retry context
+     * @param runnable the original runnable
+     * @return a retryable runnable
+     */
+    static CheckedRunnable decorateCheckedRunnable(Retry retry, CheckedRunnable runnable) {
+        return () -> {
+            Retry.Context context = retry.context();
+            do {
+                try {
+                    runnable.run();
+                    context.onComplete();
+                    break;
+                } catch (Exception exception) {
+                    context.onError(exception);
+                }
+            } while (true);
+        };
+    }
+
+    /**
+     * Creates a retryable function.
+     *
+     * @param retry    the retry context
+     * @param function the original function
+     * @param <T>      the type of the input to the function
+     * @param <R>      the result type of the function
+     * @return a retryable function
+     */
+    static <T, R> CheckedFunction1<T, R> decorateCheckedFunction(Retry retry,
+                                                                 CheckedFunction1<T, R> function) {
+        return (T t) -> {
+            Retry.Context<R> context = retry.context();
+            do {
+                try {
+                    R result = function.apply(t);
+                    final boolean validationOfResult = context.onResult(result);
+                    if (!validationOfResult) {
+                        context.onComplete();
+                        return result;
+                    }
+                } catch (Exception exception) {
+                    context.onError(exception);
+                }
+            } while (true);
+        };
+    }
+
+    /**
+     * Creates a retryable supplier.
+     *
+     * @param retry    the retry context
+     * @param supplier the original function
+     * @param <T>      the type of results supplied by this supplier
+     * @return a retryable function
+     */
+    static <E extends Exception, T> Supplier<Either<E, T>> decorateEitherSupplier(Retry retry,
+                                                                                  Supplier<Either<E, T>> supplier) {
+        return () -> {
+            Retry.Context<T> context = retry.context();
+            do {
+                Either<E, T> result = supplier.get();
+                if (result.isRight()) {
+                    final boolean validationOfResult = context.onResult(result.get());
+                    if (!validationOfResult) {
+                        context.onComplete();
+                        return result;
+                    }
+                } else {
+                    E exception = result.getLeft();
+                    try {
+                        context.onError(result.getLeft());
+                    } catch (Exception e) {
+                        return Either.left(exception);
+                    }
+                }
+            } while (true);
+        };
+    }
+
+    /**
+     * Creates a retryable supplier.
+     *
+     * @param retry    the retry context
+     * @param supplier the original function
+     * @param <T>      the type of results supplied by this supplier
+     * @return a retryable function
+     */
+    static <T> Supplier<Try<T>> decorateTrySupplier(Retry retry, Supplier<Try<T>> supplier) {
+        return () -> {
+            Retry.Context<T> context = retry.context();
+            do {
+                Try<T> result = supplier.get();
+                if (result.isSuccess()) {
+                    final boolean validationOfResult = context.onResult(result.get());
+                    if (!validationOfResult) {
+                        context.onComplete();
+                        return result;
+                    }
+                } else {
+                    Throwable cause = result.getCause();
+                    if (cause instanceof Exception) {
+                        try {
+                            context.onError((Exception) result.getCause());
+                        } catch (Exception e) {
+                            return result;
+                        }
+                    } else {
+                        return result;
+                    }
+                }
+            } while (true);
+        };
+    }
+
+    /**
+     * Decorates and executes the decorated Supplier.
+     *
+     * @param checkedSupplier the original Supplier
+     * @param <T>             the type of results supplied by this supplier
+     * @return the result of the decorated Supplier.
+     * @throws Throwable if something goes wrong applying this function to the given arguments
+     */
+    static  <T> T executeCheckedSupplier(Retry retry, CheckedFunction0<T> checkedSupplier) throws Throwable {
+        return decorateCheckedSupplier(retry, checkedSupplier).apply();
+    }
+
+    /**
+     * Decorates and executes the decorated Supplier.
+     *
+     * @param supplier the original Supplier
+     * @param <T>      the type of results supplied by this supplier
+     * @return the result of the decorated Supplier.
+     */
+    static  <E extends Exception, T> Either<E, T> executeEitherSupplier(Retry retry, Supplier<Either<E, T>> supplier) {
+        return decorateEitherSupplier(retry, supplier).get();
+    }
+
+    /**
+     * Decorates and executes the decorated Supplier.
+     *
+     * @param supplier the original Supplier
+     * @param <T>      the type of results supplied by this supplier
+     * @return the result of the decorated Supplier.
+     */
+    static  <T> Try<T> executeTrySupplier(Retry retry, Supplier<Try<T>> supplier) {
+        return decorateTrySupplier(retry, supplier).get();
+    }
+}

--- a/resilience4j-vavr/src/test/java/io/github/resilience4j/circuitbreaker/VavrCircuitBreakerTest.java
+++ b/resilience4j-vavr/src/test/java/io/github/resilience4j/circuitbreaker/VavrCircuitBreakerTest.java
@@ -1,0 +1,485 @@
+/*
+ *
+ *  Copyright 2020: KrnSaurabh
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.circuitbreaker;
+
+import io.github.resilience4j.test.HelloWorldException;
+import io.github.resilience4j.test.HelloWorldService;
+import io.vavr.CheckedConsumer;
+import io.vavr.CheckedFunction0;
+import io.vavr.CheckedFunction1;
+import io.vavr.CheckedRunnable;
+import io.vavr.control.Either;
+import io.vavr.control.Try;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+
+public class VavrCircuitBreakerTest {
+    private HelloWorldService helloWorldService;
+
+    @Before
+    public void setUp() {
+        helloWorldService = mock(HelloWorldService.class);
+    }
+
+    @Test
+    public void shouldDecorateCheckedSupplierAndReturnWithSuccess() throws Throwable {
+        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
+        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
+        given(helloWorldService.returnHelloWorldWithException()).willReturn("Hello world");
+        CheckedFunction0<String> checkedSupplier = VavrCircuitBreaker
+            .decorateCheckedSupplier(circuitBreaker, helloWorldService::returnHelloWorldWithException);
+
+        String result = checkedSupplier.apply();
+
+        assertThat(result).isEqualTo("Hello world");
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(0);
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
+        then(helloWorldService).should().returnHelloWorldWithException();
+    }
+
+    @Test
+    public void shouldDecorateCheckedSupplierAndReturnWithException() throws Throwable {
+        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
+        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
+        given(helloWorldService.returnHelloWorldWithException())
+            .willThrow(new RuntimeException("BAM!"));
+        CheckedFunction0<String> checkedSupplier = VavrCircuitBreaker
+            .decorateCheckedSupplier(circuitBreaker, helloWorldService::returnHelloWorldWithException);
+
+        Try<String> result = Try.of(checkedSupplier);
+
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.failed().get()).isInstanceOf(RuntimeException.class);
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(0);
+        then(helloWorldService).should().returnHelloWorldWithException();
+    }
+
+    @Test
+    public void shouldDecorateCheckedRunnableAndReturnWithSuccess() throws Throwable {
+        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
+        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
+        CheckedRunnable checkedRunnable = VavrCircuitBreaker
+            .decorateCheckedRunnable(circuitBreaker, helloWorldService::sayHelloWorldWithException);
+
+        checkedRunnable.run();
+
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(0);
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
+        then(helloWorldService).should().sayHelloWorldWithException();
+    }
+
+    @Test
+    public void shouldDecorateCheckedRunnableAndReturnWithException() throws Throwable {
+        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
+        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
+        CheckedRunnable checkedRunnable = VavrCircuitBreaker.decorateCheckedRunnable(circuitBreaker, () -> {
+            throw new RuntimeException("BAM!");
+        });
+
+        Try<Void> result = Try.run(checkedRunnable);
+
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.failed().get()).isInstanceOf(RuntimeException.class);
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldDecorateCheckedConsumerAndReturnWithSuccess() throws Throwable {
+        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
+        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
+        CheckedConsumer<String> checkedConsumer = VavrCircuitBreaker
+            .decorateCheckedConsumer(circuitBreaker, helloWorldService::sayHelloWorldWithNameWithException);
+
+        checkedConsumer.accept("Tom");
+
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(0);
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
+        then(helloWorldService).should().sayHelloWorldWithNameWithException("Tom");
+    }
+
+    @Test
+    public void shouldDecorateCheckedConsumerAndReturnWithException() throws Throwable {
+        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
+        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        int numberOfBufferedCallsBefore = metrics.getNumberOfBufferedCalls();
+        CheckedConsumer<String> checkedConsumer = VavrCircuitBreaker
+            .decorateCheckedConsumer(circuitBreaker, (value) -> {
+                throw new RuntimeException("BAM!");
+            });
+
+        Try<Void> result = Try.run(() -> checkedConsumer.accept("Tom"));
+
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.failed().get()).isInstanceOf(RuntimeException.class);
+        assertThat(numberOfBufferedCallsBefore).isEqualTo(0);
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldDecorateCheckedFunctionAndReturnWithSuccess() throws Throwable {
+        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
+        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
+        given(helloWorldService.returnHelloWorldWithNameWithException("Tom"))
+            .willReturn("Hello world Tom");
+        CheckedFunction1<String, String> function = VavrCircuitBreaker
+            .decorateCheckedFunction(circuitBreaker,
+                helloWorldService::returnHelloWorldWithNameWithException);
+
+        String result = function.apply("Tom");
+
+        assertThat(result).isEqualTo("Hello world Tom");
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(0);
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
+        then(helloWorldService).should().returnHelloWorldWithNameWithException("Tom");
+    }
+
+
+    @Test
+    public void shouldDecorateCheckedFunctionAndReturnWithException() throws Throwable {
+        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
+        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
+        given(helloWorldService.returnHelloWorldWithNameWithException("Tom"))
+            .willThrow(new RuntimeException("BAM!"));
+        CheckedFunction1<String, String> function = VavrCircuitBreaker
+            .decorateCheckedFunction(circuitBreaker,
+                helloWorldService::returnHelloWorldWithNameWithException);
+
+        Try<String> result = Try.of(() -> function.apply("Tom"));
+
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.failed().get()).isInstanceOf(RuntimeException.class);
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldReturnFailureWithCircuitBreakerOpenException() {
+        // Given
+        CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
+            .slidingWindowSize(2)
+            .permittedNumberOfCallsInHalfOpenState(2)
+            .failureRateThreshold(50)
+            .waitDurationInOpenState(Duration.ofMillis(1000))
+            .build();
+        CircuitBreaker circuitBreaker = CircuitBreaker.of("testName", circuitBreakerConfig);
+        CheckedRunnable checkedRunnable = VavrCircuitBreaker.decorateCheckedRunnable(circuitBreaker, () -> {
+            throw new RuntimeException("BAM!");
+        });
+
+        // When
+        circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new RuntimeException());
+        circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new RuntimeException());
+
+        // Then
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.OPEN);
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(2);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(2);
+
+        // When
+        Try result = Try.run(checkedRunnable);
+
+        // Then
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.failed().get()).isInstanceOf(CallNotPermittedException.class);
+    }
+
+    @Test
+    public void shouldReturnFailureWithRuntimeException() {
+        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(0);
+        CheckedRunnable checkedRunnable = VavrCircuitBreaker.decorateCheckedRunnable(circuitBreaker, () -> {
+            throw new RuntimeException("BAM!");
+        });
+
+        Try result = Try.run(checkedRunnable);
+
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.failed().get()).isInstanceOf(RuntimeException.class);
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldNotRecordIOExceptionAsAFailure() {
+        // tag::shouldNotRecordIOExceptionAsAFailure[]
+        CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
+            .slidingWindowSize(2)
+            .permittedNumberOfCallsInHalfOpenState(2)
+            .waitDurationInOpenState(Duration.ofMillis(1000))
+            .ignoreExceptions(IOException.class)
+            .build();
+        CircuitBreaker circuitBreaker = CircuitBreaker.of("testName", circuitBreakerConfig);
+        // Simulate a failure attempt
+        circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new HelloWorldException());
+        // CircuitBreaker is still CLOSED, because 1 failure is allowed
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
+        CheckedRunnable checkedRunnable = VavrCircuitBreaker.decorateCheckedRunnable(circuitBreaker, () -> {
+            throw new SocketTimeoutException("BAM!");
+        });
+
+        Try result = Try.run(checkedRunnable);
+
+        assertThat(result.isFailure()).isTrue();
+        // CircuitBreaker is still CLOSED, because SocketTimeoutException has not been recorded as a failure
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
+        assertThat(result.failed().get()).isInstanceOf(IOException.class);
+        // end::shouldNotRecordIOExceptionAsAFailure[]
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldInvokeRecoverFunction() {
+        // tag::shouldInvokeRecoverFunction[]
+        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
+        // When I decorate my function and invoke the decorated function
+        CheckedFunction0<String> checkedSupplier = VavrCircuitBreaker.decorateCheckedSupplier(circuitBreaker, () -> {
+            throw new RuntimeException("BAM!");
+        });
+
+        Try<String> result = Try.of(checkedSupplier)
+            .recover(throwable -> "Hello Recovery");
+
+        // Then the function should be a success, because the exception could be recovered
+        assertThat(result.isSuccess()).isTrue();
+        // and the result must match the result of the recovery function.
+        assertThat(result.get()).isEqualTo("Hello Recovery");
+        // end::shouldInvokeRecoverFunction[]
+    }
+
+    @Test
+    public void shouldInvokeMap() {
+        // tag::shouldInvokeMap[]
+        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
+        // When I decorate my function
+        CheckedFunction0<String> decoratedSupplier = VavrCircuitBreaker
+            .decorateCheckedSupplier(circuitBreaker,
+                () -> "This can be any method which returns: 'Hello");
+
+        // and chain an other function with map
+        Try<String> result = Try.of(decoratedSupplier)
+            .map(value -> value + " world'");
+
+        // Then the Try Monad returns a Success<String>, if all functions ran successfully.
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.get()).isEqualTo("This can be any method which returns: 'Hello world'");
+        // end::shouldInvokeMap[]
+    }
+
+    @Test
+    public void shouldThrowCircuitBreakerOpenException() {
+        // tag::shouldThrowCircuitBreakerOpenException[]
+        CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
+            .slidingWindowSize(2)
+            .waitDurationInOpenState(Duration.ofMillis(1000))
+            .build();
+        CircuitBreaker circuitBreaker = CircuitBreaker.of("testName", circuitBreakerConfig);
+        // Simulate a failure attempt
+        circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new RuntimeException());
+        // CircuitBreaker is still CLOSED, because 1 failure is allowed
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
+        // Simulate a failure attempt
+        circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new RuntimeException());
+        // CircuitBreaker is OPEN, because the failure rate is above 50%
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.OPEN);
+
+        // When I decorate my function and invoke the decorated function
+        Try<String> result = Try.of(VavrCircuitBreaker.decorateCheckedSupplier(circuitBreaker, () -> "Hello"))
+            .map(value -> value + " world");
+
+        // Then the call fails, because CircuitBreaker is OPEN
+        assertThat(result.isFailure()).isTrue();
+        // Exception is CallNotPermittedException
+        assertThat(result.failed().get()).isInstanceOf(CallNotPermittedException.class);
+        // end::shouldThrowCircuitBreakerOpenException[]
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(2);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(2);
+    }
+
+    @Test
+    public void shouldChainDecoratedFunctions() {
+        // tag::shouldChainDecoratedFunctions[]
+        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
+        CircuitBreaker anotherCircuitBreaker = CircuitBreaker.ofDefaults("anotherTestName");
+        // When I create a Supplier and a Function which are decorated by different CircuitBreakers
+        CheckedFunction0<String> decoratedSupplier = VavrCircuitBreaker
+            .decorateCheckedSupplier(circuitBreaker, () -> "Hello");
+        CheckedFunction1<String, String> decoratedFunction = VavrCircuitBreaker
+            .decorateCheckedFunction(anotherCircuitBreaker, (input) -> input + " world");
+
+        // and I chain a function with map
+        Try<String> result = Try.of(decoratedSupplier)
+            .mapTry(decoratedFunction);
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.get()).isEqualTo("Hello world");
+        // end::shouldChainDecoratedFunctions[]
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(0);
+        CircuitBreaker.Metrics metrics2 = anotherCircuitBreaker.getMetrics();
+        assertThat(metrics2.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics2.getNumberOfFailedCalls()).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldExecuteTrySupplierAndReturnWithSuccess() {
+        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
+        given(helloWorldService.returnTry()).willReturn(Try.success("Hello world"));
+
+        Try<String> result = VavrCircuitBreaker.executeTrySupplier(circuitBreaker, helloWorldService::returnTry);
+
+        assertThat(result).contains("Hello world");
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(0);
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
+        then(helloWorldService).should().returnTry();
+    }
+
+    @Test
+    public void shouldExecuteEitherSupplierAndReturnWithSuccess() {
+        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
+        given(helloWorldService.returnEither()).willReturn(Either.right("Hello world"));
+
+        Either<Exception, String> result = VavrCircuitBreaker
+            .executeEitherSupplier(circuitBreaker, helloWorldService::returnEither);
+
+        assertThat(result).contains("Hello world");
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(0);
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
+        then(helloWorldService).should().returnEither();
+    }
+
+    @Test
+    public void shouldExecuteTrySupplierAndReturnWithFailure() {
+        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
+        given(helloWorldService.returnTry()).willReturn(Try.failure(new RuntimeException("BAM!")));
+
+        Try<String> result = VavrCircuitBreaker.executeTrySupplier(circuitBreaker, helloWorldService::returnTry);
+
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.failed().get()).isInstanceOf(RuntimeException.class);
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(0);
+        then(helloWorldService).should().returnTry();
+    }
+
+    @Test
+    public void shouldExecuteTrySupplierAndReturnWithCallNotPermittedException() {
+        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
+        circuitBreaker.transitionToOpenState();
+
+        Try<String> result = VavrCircuitBreaker.executeTrySupplier(circuitBreaker, helloWorldService::returnTry);
+
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.failed().get()).isInstanceOf(CallNotPermittedException.class);
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
+        assertThat(metrics.getNumberOfNotPermittedCalls()).isEqualTo(1);
+        then(helloWorldService).should(never()).returnTry();
+    }
+
+
+    @Test
+    public void shouldExecuteEitherSupplierAndReturnWithFailure() {
+        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
+        given(helloWorldService.returnEither()).willReturn(Either.left(new HelloWorldException()));
+
+        Either<Exception, String> result = VavrCircuitBreaker
+            .executeEitherSupplier(circuitBreaker, helloWorldService::returnEither);
+
+        assertThat(result.isLeft()).isTrue();
+        assertThat(result.getLeft()).isInstanceOf(RuntimeException.class);
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(0);
+        then(helloWorldService).should().returnEither();
+    }
+
+    @Test
+    public void shouldExecuteEitherSupplierAndReturnWithCallNotPermittedException() {
+        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
+        circuitBreaker.transitionToOpenState();
+
+        Either<Exception, String> result = VavrCircuitBreaker
+            .executeEitherSupplier(circuitBreaker, helloWorldService::returnEither);
+
+        assertThat(result.isLeft()).isTrue();
+        assertThat(result.getLeft()).isInstanceOf(CallNotPermittedException.class);
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
+        assertThat(metrics.getNumberOfNotPermittedCalls()).isEqualTo(1);
+        then(helloWorldService).should(never()).returnEither();
+    }
+}

--- a/resilience4j-vavr/src/test/java/io/github/resilience4j/retry/EventPublisherTest.java
+++ b/resilience4j-vavr/src/test/java/io/github/resilience4j/retry/EventPublisherTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2016 Robert Winkler
+ *  Copyright 2020: KrnSaurabh
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,11 +16,10 @@
  *
  *
  */
-package io.github.resilience4j.retry.internal;
+package io.github.resilience4j.retry;
 
-import io.github.resilience4j.retry.Retry;
-import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.retry.event.RetryEvent;
+import io.github.resilience4j.retry.internal.RetryImpl;
 import io.github.resilience4j.test.HelloWorldException;
 import io.github.resilience4j.test.HelloWorldService;
 import io.reactivex.subscribers.TestSubscriber;
@@ -46,7 +45,7 @@ public class EventPublisherTest {
     @Before
     public void setUp() {
         helloWorldService = mock(HelloWorldService.class);
-        RetryImpl.sleepFunction = sleep -> sleptTime += sleep;
+        RetryImpl.setSleepFunction(sleep -> sleptTime += sleep);
     }
 
     @Test
@@ -56,7 +55,7 @@ public class EventPublisherTest {
         TestSubscriber<RetryEvent.Type> testSubscriber = toFlowable(retry.getEventPublisher())
             .map(RetryEvent::getEventType)
             .test();
-        CheckedRunnable retryableRunnable = Retry
+        CheckedRunnable retryableRunnable = VavrRetry
             .decorateCheckedRunnable(retry, helloWorldService::sayHelloWorld);
 
         Try<Void> result = Try.run(retryableRunnable);
@@ -77,7 +76,7 @@ public class EventPublisherTest {
         TestSubscriber<RetryEvent.Type> testSubscriber = toFlowable(retry.getEventPublisher())
             .map(RetryEvent::getEventType)
             .test();
-        CheckedRunnable retryableRunnable = Retry
+        CheckedRunnable retryableRunnable = VavrRetry
             .decorateCheckedRunnable(retry, helloWorldService::sayHelloWorld);
 
         Try<Void> result = Try.run(retryableRunnable);
@@ -100,7 +99,7 @@ public class EventPublisherTest {
         TestSubscriber<RetryEvent.Type> testSubscriber = toFlowable(retry.getEventPublisher())
             .map(RetryEvent::getEventType)
             .test();
-        CheckedRunnable retryableRunnable = Retry
+        CheckedRunnable retryableRunnable = VavrRetry
             .decorateCheckedRunnable(retry, helloWorldService::sayHelloWorld);
 
         Try<Void> result = Try.run(retryableRunnable);

--- a/resilience4j-vavr/src/test/java/io/github/resilience4j/retry/SupplierVavrRetryTest.java
+++ b/resilience4j-vavr/src/test/java/io/github/resilience4j/retry/SupplierVavrRetryTest.java
@@ -1,0 +1,182 @@
+/*
+ *
+ *  Copyright 2020: KrnSaurabh
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.retry;
+
+import io.github.resilience4j.core.IntervalFunction;
+import io.github.resilience4j.retry.internal.RetryImpl;
+import io.github.resilience4j.test.HelloWorldException;
+import io.github.resilience4j.test.HelloWorldService;
+import io.vavr.API;
+import io.vavr.CheckedFunction0;
+import io.vavr.Predicates;
+import io.vavr.control.Try;
+import org.junit.Before;
+import org.junit.Test;
+
+import static io.vavr.API.$;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+public class SupplierVavrRetryTest {
+    private HelloWorldService helloWorldService;
+    private long sleptTime = 0L;
+
+    @Before
+    public void setUp() {
+        helloWorldService = mock(HelloWorldService.class);
+        RetryImpl.setSleepFunction(sleep -> sleptTime += sleep);
+    }
+
+    @Test
+    public void shouldNotRetryDecoratedTry() {
+        given(helloWorldService.returnTry()).willReturn(Try.success("Hello world"));
+        final RetryConfig tryAgain = RetryConfig.<String>custom()
+            .maxAttempts(2).build();
+        Retry retry = Retry.of("id", tryAgain);
+        Try<String> result = VavrRetry.executeTrySupplier(retry, helloWorldService::returnTry);
+        then(helloWorldService).should().returnTry();
+        assertThat(result.get()).isEqualTo("Hello world");
+    }
+
+    @Test
+    public void shouldReturnSuccessfullyAfterSecondAttempt() {
+        given(helloWorldService.returnHelloWorld())
+            .willThrow(new HelloWorldException())
+            .willReturn("Hello world");
+        Retry retry = Retry.ofDefaults("id");
+        CheckedFunction0<String> retryableSupplier = VavrRetry
+            .decorateCheckedSupplier(retry, helloWorldService::returnHelloWorld);
+
+        Try<String> result = Try.of(retryableSupplier);
+
+        then(helloWorldService).should(times(2)).returnHelloWorld();
+        assertThat(result.get()).isEqualTo("Hello world");
+        assertThat(sleptTime).isEqualTo(RetryConfig.DEFAULT_WAIT_DURATION);
+    }
+
+    @Test
+    public void shouldReturnAfterThreeAttempts() {
+        given(helloWorldService.returnHelloWorld()).willThrow(new HelloWorldException());
+        Retry retry = Retry.ofDefaults("id");
+        CheckedFunction0<String> retryableSupplier = VavrRetry
+            .decorateCheckedSupplier(retry, helloWorldService::returnHelloWorld);
+
+        Try<String> result = Try.of(retryableSupplier);
+
+        then(helloWorldService).should(times(3)).returnHelloWorld();
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.failed().get()).isInstanceOf(HelloWorldException.class);
+        assertThat(sleptTime).isEqualTo(RetryConfig.DEFAULT_WAIT_DURATION * 2);
+    }
+
+    @Test
+    public void shouldReturnAfterOneAttempt() {
+        given(helloWorldService.returnHelloWorld()).willThrow(new HelloWorldException());
+        RetryConfig config = RetryConfig.custom().maxAttempts(1).build();
+        Retry retry = Retry.of("id", config);
+        CheckedFunction0<String> retryableSupplier = VavrRetry
+            .decorateCheckedSupplier(retry, helloWorldService::returnHelloWorld);
+
+        Try<String> result = Try.of(retryableSupplier);
+
+        then(helloWorldService).should().returnHelloWorld();
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.failed().get()).isInstanceOf(HelloWorldException.class);
+        assertThat(sleptTime).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldReturnAfterOneAttemptAndIgnoreException() {
+        given(helloWorldService.returnHelloWorld()).willThrow(new HelloWorldException());
+        RetryConfig config = RetryConfig.custom()
+            .retryOnException(throwable -> API.Match(throwable).of(
+                API.Case($(Predicates.instanceOf(HelloWorldException.class)), false),
+                API.Case($(), true)))
+            .build();
+        Retry retry = Retry.of("id", config);
+        CheckedFunction0<String> retryableSupplier = VavrRetry
+            .decorateCheckedSupplier(retry, helloWorldService::returnHelloWorld);
+
+        Try<String> result = Try.of(retryableSupplier);
+
+        // Because the exception should be rethrown immediately.
+        then(helloWorldService).should().returnHelloWorld();
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.failed().get()).isInstanceOf(HelloWorldException.class);
+        assertThat(sleptTime).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldReturnAfterThreeAttemptsAndRecover() {
+        given(helloWorldService.returnHelloWorld()).willThrow(new HelloWorldException());
+        Retry retry = Retry.ofDefaults("id");
+        CheckedFunction0<String> retryableSupplier = VavrRetry
+            .decorateCheckedSupplier(retry, helloWorldService::returnHelloWorld);
+
+        Try<String> result = Try.of(retryableSupplier)
+            .recover((throwable) -> "Hello world from recovery function");
+        assertThat(retry.getMetrics().getNumberOfFailedCallsWithRetryAttempt()).isEqualTo(1);
+
+        then(helloWorldService).should(times(3)).returnHelloWorld();
+        assertThat(result.get()).isEqualTo("Hello world from recovery function");
+        assertThat(sleptTime).isEqualTo(RetryConfig.DEFAULT_WAIT_DURATION * 2);
+    }
+
+    @Test
+    public void shouldReturnAfterThreeAttemptsAndRecoverWithResult() {
+        given(helloWorldService.returnHelloWorld())
+            .willThrow(new HelloWorldException())
+            .willReturn("Hello world")
+            .willThrow(new HelloWorldException());
+        final RetryConfig tryAgain = RetryConfig.<String>custom()
+            .retryOnResult(s -> s.contains("Hello world"))
+            .maxAttempts(3).build();
+        Retry retry = Retry.of("id", tryAgain);
+        CheckedFunction0<String> retryableSupplier = VavrRetry
+            .decorateCheckedSupplier(retry, helloWorldService::returnHelloWorld);
+
+        Try<String> result = Try.of(retryableSupplier)
+            .recover((throwable) -> "Hello world from recovery function");
+
+        then(helloWorldService).should(times(3)).returnHelloWorld();
+        assertThat(result.get()).isEqualTo("Hello world from recovery function");
+        assertThat(sleptTime).isEqualTo(RetryConfig.DEFAULT_WAIT_DURATION * 2);
+    }
+
+    @Test
+    public void shouldTakeIntoAccountBackoffFunction() {
+        given(helloWorldService.returnHelloWorld()).willThrow(new HelloWorldException());
+        RetryConfig config = RetryConfig.custom()
+            .intervalFunction(IntervalFunction.ofExponentialBackoff(500, 2.0))
+            .build();
+        Retry retry = Retry.of("id", config);
+        CheckedFunction0<String> retryableSupplier = VavrRetry
+            .decorateCheckedSupplier(retry, helloWorldService::returnHelloWorld);
+
+        Try.of(retryableSupplier);
+
+        then(helloWorldService).should(times(3)).returnHelloWorld();
+        assertThat(sleptTime).isEqualTo(
+            RetryConfig.DEFAULT_WAIT_DURATION +
+                RetryConfig.DEFAULT_WAIT_DURATION * 2);
+    }
+}

--- a/resilience4j-vavr/src/test/java/io/github/resilience4j/retry/VavrRetryTest.java
+++ b/resilience4j-vavr/src/test/java/io/github/resilience4j/retry/VavrRetryTest.java
@@ -1,0 +1,224 @@
+/*
+ *
+ *  Copyright 2020: KrnSaurabh
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.retry;
+
+import io.github.resilience4j.core.IntervalFunction;
+import io.github.resilience4j.retry.internal.RetryImpl;
+import io.github.resilience4j.test.HelloWorldException;
+import io.github.resilience4j.test.HelloWorldService;
+import io.vavr.CheckedRunnable;
+import io.vavr.Predicates;
+import io.vavr.control.Either;
+import io.vavr.control.Try;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Duration;
+
+import static io.vavr.API.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+public class VavrRetryTest {
+
+    private HelloWorldService helloWorldService;
+    private long sleptTime = 0L;
+
+    @Before
+    public void setUp() throws Exception {
+        helloWorldService = mock(HelloWorldService.class);
+        RetryImpl.setSleepFunction(sleep -> sleptTime += sleep);
+    }
+
+    @Test
+    public void shouldReturnAfterThreeAttempts() {
+        willThrow(new HelloWorldException()).given(helloWorldService).sayHelloWorld();
+        Retry retry = Retry.ofDefaults("id");
+        CheckedRunnable retryableRunnable = VavrRetry
+            .decorateCheckedRunnable(retry, helloWorldService::sayHelloWorld);
+
+        Try<Void> result = Try.run(retryableRunnable);
+
+        then(helloWorldService).should(times(3)).sayHelloWorld();
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.failed().get()).isInstanceOf(HelloWorldException.class);
+        assertThat(sleptTime).isEqualTo(RetryConfig.DEFAULT_WAIT_DURATION * 2);
+    }
+
+    @Test
+    public void shouldReturnAfterOneAttempt() {
+        willThrow(new HelloWorldException()).given(helloWorldService).sayHelloWorld();
+        RetryConfig config = RetryConfig.custom().maxAttempts(1).build();
+        Retry retry = Retry.of("id", config);
+        CheckedRunnable retryableRunnable = VavrRetry
+            .decorateCheckedRunnable(retry, helloWorldService::sayHelloWorld);
+
+        Try<Void> result = Try.run(retryableRunnable);
+
+        then(helloWorldService).should().sayHelloWorld();
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.failed().get()).isInstanceOf(HelloWorldException.class);
+        assertThat(sleptTime).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldReturnAfterOneAttemptAndIgnoreException() {
+        willThrow(new HelloWorldException()).given(helloWorldService).sayHelloWorld();
+        RetryConfig config = RetryConfig.custom()
+            .retryOnException(throwable -> Match(throwable).of(
+                Case($(Predicates.instanceOf(HelloWorldException.class)), false),
+                Case($(), true)))
+            .build();
+        Retry retry = Retry.of("id", config);
+        CheckedRunnable retryableRunnable = VavrRetry
+            .decorateCheckedRunnable(retry, helloWorldService::sayHelloWorld);
+
+        Try<Void> result = Try.run(retryableRunnable);
+
+        // because the exception should be rethrown immediately
+        then(helloWorldService).should().sayHelloWorld();
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.failed().get()).isInstanceOf(HelloWorldException.class);
+        assertThat(sleptTime).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldTakeIntoAccountBackoffFunction() {
+        willThrow(new HelloWorldException()).given(helloWorldService).sayHelloWorld();
+        RetryConfig config = RetryConfig
+            .custom()
+            .intervalFunction(IntervalFunction.of(Duration.ofMillis(500), x -> x * x))
+            .build();
+        Retry retry = Retry.of("id", config);
+        CheckedRunnable retryableRunnable = VavrRetry
+            .decorateCheckedRunnable(retry, helloWorldService::sayHelloWorld);
+
+        Try.run(retryableRunnable);
+
+        then(helloWorldService).should(times(3)).sayHelloWorld();
+        assertThat(sleptTime).isEqualTo(
+            RetryConfig.DEFAULT_WAIT_DURATION +
+                RetryConfig.DEFAULT_WAIT_DURATION * RetryConfig.DEFAULT_WAIT_DURATION);
+    }
+
+    @Test
+    public void shouldNotRetryDecoratedEither() {
+        given(helloWorldService.returnEither()).willReturn(Either.right("Hello world"));
+        final RetryConfig tryAgain = RetryConfig.<String>custom()
+            .maxAttempts(2).build();
+        Retry retry = Retry.of("id", tryAgain);
+
+        Either<HelloWorldException, String> result = VavrRetry
+            .executeEitherSupplier(retry, helloWorldService::returnEither);
+
+        then(helloWorldService).should().returnEither();
+        assertThat(result.get()).isEqualTo("Hello world");
+    }
+
+    @Test
+    public void shouldRetryDecoratedTry() {
+        given(helloWorldService.returnTry()).willReturn(Try.success("Hello world"));
+        final RetryConfig tryAgain = RetryConfig.<String>custom()
+            .retryOnResult(s -> s.contains("Hello world"))
+            .maxAttempts(2).build();
+        Retry retry = Retry.of("id", tryAgain);
+
+        Try<String> result = VavrRetry.executeTrySupplier(retry, helloWorldService::returnTry);
+
+        then(helloWorldService).should(times(2)).returnTry();
+        assertThat(result.get()).isEqualTo("Hello world");
+    }
+
+    @Test
+    public void shouldRetryDecoratedEither() {
+        given(helloWorldService.returnEither()).willReturn(Either.right("Hello world"));
+        final RetryConfig tryAgain = RetryConfig.<String>custom()
+            .retryOnResult(s -> s.contains("Hello world"))
+            .maxAttempts(2).build();
+        Retry retry = Retry.of("id", tryAgain);
+
+        Either<HelloWorldException, String> result = VavrRetry
+            .executeEitherSupplier(retry, helloWorldService::returnEither);
+
+        then(helloWorldService).should(times(2)).returnEither();
+        assertThat(result.get()).isEqualTo("Hello world");
+    }
+
+    @Test
+    public void shouldFailToRetryDecoratedTry() {
+        given(helloWorldService.returnTry()).willReturn(Try.failure(new HelloWorldException()));
+        final RetryConfig tryAgain = RetryConfig.<String>custom()
+            .maxAttempts(2).build();
+        Retry retry = Retry.of("id", tryAgain);
+
+        Try<String> result = VavrRetry.executeTrySupplier(retry, helloWorldService::returnTry);
+
+        then(helloWorldService).should(times(2)).returnTry();
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.getCause()).isInstanceOf(HelloWorldException.class);
+    }
+
+    @Test
+    public void shouldFailToRetryDecoratedEither() {
+        given(helloWorldService.returnEither()).willReturn(Either.left(new HelloWorldException()));
+        final RetryConfig tryAgain = RetryConfig.<String>custom()
+            .maxAttempts(2).build();
+        Retry retry = Retry.of("id", tryAgain);
+
+        Either<HelloWorldException, String> result = VavrRetry
+            .executeEitherSupplier(retry, helloWorldService::returnEither);
+
+        then(helloWorldService).should(times(2)).returnEither();
+        assertThat(result.isLeft()).isTrue();
+        assertThat(result.getLeft()).isInstanceOf(HelloWorldException.class);
+    }
+
+    @Test
+    public void shouldIgnoreExceptionOfDecoratedTry() {
+        given(helloWorldService.returnTry()).willReturn(Try.failure(new HelloWorldException()));
+        final RetryConfig tryAgain = RetryConfig.<String>custom()
+            .ignoreExceptions(HelloWorldException.class)
+            .maxAttempts(2).build();
+        Retry retry = Retry.of("id", tryAgain);
+
+        Try<String> result = VavrRetry.executeTrySupplier(retry, helloWorldService::returnTry);
+
+        then(helloWorldService).should().returnTry();
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.getCause()).isInstanceOf(HelloWorldException.class);
+    }
+
+    @Test
+    public void shouldIgnoreExceptionOfDecoratedEither() {
+        given(helloWorldService.returnEither()).willReturn(Either.left(new HelloWorldException()));
+        final RetryConfig tryAgain = RetryConfig.<String>custom()
+            .ignoreExceptions(HelloWorldException.class)
+            .maxAttempts(2).build();
+        Retry retry = Retry.of("id", tryAgain);
+
+        Either<HelloWorldException, String> result = VavrRetry
+            .executeEitherSupplier(retry, helloWorldService::returnEither);
+
+        then(helloWorldService).should().returnEither();
+        assertThat(result.isLeft()).isTrue();
+        assertThat(result.getLeft()).isInstanceOf(HelloWorldException.class);
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -27,3 +27,5 @@ include 'resilience4j-micrometer'
 include 'resilience4j-bom'
 include 'resilience4j-framework-common'
 include 'resilience4j-kotlin'
+include 'resilience4j-vavr'
+


### PR DESCRIPTION
This Pull request is part of removing Vavr dependency from Resiliency4j- Phase 1.

This PR includes changes to make CircuitBreaker and Retry module entirely vavr independent. Changes are done to many other modules to back port the contract breaking changes done in core APIs.

My sincere apologies that the PR has become too long this time as I just couldn't keep track while back porting changes from core APIs.
I will try to keep the PRs smaller next time and iteratively remove Vavr from subsequent other modules.

@RobWin Let me know if the PR is too difficult to review. I will try to figure something out.