### PR TITLE
Updates the ReadMe to replace maxWaitTime with maxWaitDuration for Bu…

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -80,7 +80,7 @@ TimeLimiter timeLimiter = TimeLimiter.of(Duration.ofSeconds(1));
 
 CompletableFuture<String> future = Decorators.ofSupplier(supplier)
     .withThreadPoolBulkhead(threadPoolBulkhead)
-    .withTimeLimiter(timeLimiter, scheduledExecutorService)
+    .withTimeLimiter(timeLimiter, scheduler)
     .withCircuitBreaker(circuitBreaker)
     .withFallback(asList(TimeoutException.class, CallNotPermittedException.class, BulkheadFullException.class),
       throwable -> "Hello from Recovery")
@@ -293,7 +293,7 @@ It is based on a semaphore, and unlike Hystrix, does not provide "shadow" thread
 // Create a custom Bulkhead configuration
 BulkheadConfig config = BulkheadConfig.custom()
     .maxConcurrentCalls(150)
-    .maxWaitTime(100)
+    .maxWaitDuration(100)
     .build();
 
 Bulkhead bulkhead = Bulkhead.of("backendName", config);

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/bulkhead/Bulkhead.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/bulkhead/Bulkhead.kt
@@ -28,7 +28,7 @@ import kotlin.coroutines.coroutineContext
 /**
  * Decorates and executes the given suspend function [block].
  *
- * If [BulkheadConfig.maxWaitTime] is non-zero, *blocks* until the max wait time is reached or permission is obtained.
+ * If [BulkheadConfig.maxWaitDuration] is non-zero, *blocks* until the max wait time is reached or permission is obtained.
  * For this reason, it is not recommended to use this extension function with Bulkheads with non-zero max wait times.
  */
 suspend fun <T> Bulkhead.executeSuspendFunction(block: suspend () -> T): T {
@@ -48,7 +48,7 @@ suspend fun <T> Bulkhead.executeSuspendFunction(block: suspend () -> T): T {
 /**
  * Decorates the given function [block] and returns it.
  *
- * If [BulkheadConfig.maxWaitTime] is non-zero, *blocks* until the max wait time is reached or permission is obtained.
+ * If [BulkheadConfig.maxWaitDuration] is non-zero, *blocks* until the max wait time is reached or permission is obtained.
  * For this reason, it is not recommended to use this extension function with Bulkheads with non-zero max wait times.
  */
 fun <T> Bulkhead.decorateFunction(block: () -> T): () -> T = {
@@ -58,7 +58,7 @@ fun <T> Bulkhead.decorateFunction(block: () -> T): () -> T = {
 /**
  * Decorates and executes the given function [block].
  *
- * If [BulkheadConfig.maxWaitTime] is non-zero, *blocks* until the max wait time is reached or permission is obtained.
+ * If [BulkheadConfig.maxWaitDuration] is non-zero, *blocks* until the max wait time is reached or permission is obtained.
  * For this reason, it is not recommended to use this extension function with Bulkheads with non-zero max wait times.
  */
 fun <T> Bulkhead.executeFunction(block: () -> T): T {
@@ -68,7 +68,7 @@ fun <T> Bulkhead.executeFunction(block: () -> T): T {
 /**
  * Decorates the given suspend function [block] and returns it.
  *
- * If [BulkheadConfig.maxWaitTime] is non-zero, *blocks* until the max wait time is reached or permission is obtained.
+ * If [BulkheadConfig.maxWaitDuration] is non-zero, *blocks* until the max wait time is reached or permission is obtained.
  * For this reason, it is not recommended to use this extension function with Bulkheads with non-zero max wait times.
  */
 fun <T> Bulkhead.decorateSuspendFunction(block: suspend () -> T): suspend () -> T = {


### PR DESCRIPTION
This replaces `maxWaitTime` with `maxWaitDuration` for the BulkheadConfig in the ReadMe and in some code comments. It seems the function name was changed before but some naming changes were missed. 

This also updates the ReadMe to use the proper name for the ScheduledExecutorService in the Completable Future example.

Hoping this helps others who are going through the documentation for getting things set up.