### PR TITLE
Phase-4[Final] Removing Vavr dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,12 +44,12 @@ configure(project.coreProjects) {
     apply plugin: 'me.champeau.gradle.jmh'
 
     dependencies {
-        compile(libraries.vavr)
         compile(libraries.slf4j)
 
         // JSR-305 only used for non-required meta-annotations
         compileOnly "com.google.code.findbugs:jsr305:3.0.2"
 
+        testCompile(libraries.vavr)
         testCompile(libraries.junit)
         testCompile(libraries.assertj)
         testCompile(libraries.logback)

--- a/resilience4j-all/src/test/java/io/github/resilience4j/decorators/DecoratorsTest.java
+++ b/resilience4j-all/src/test/java/io/github/resilience4j/decorators/DecoratorsTest.java
@@ -24,7 +24,12 @@ import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
 import io.github.resilience4j.cache.Cache;
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.core.functions.CheckedFunction;
+import io.github.resilience4j.core.functions.CheckedRunnable;
+import io.github.resilience4j.core.functions.CheckedSupplier;
 import io.github.resilience4j.ratelimiter.RateLimiter;
+import io.github.resilience4j.ratelimiter.RateLimiterConfig;
+import io.github.resilience4j.ratelimiter.RequestNotPermitted;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.test.HelloWorldService;
 import io.github.resilience4j.timelimiter.TimeLimiter;
@@ -48,6 +53,7 @@ import static org.mockito.Mockito.*;
 
 public class DecoratorsTest {
 
+    private boolean state = false;
     private HelloWorldService helloWorldService;
 
     @Before
@@ -130,6 +136,25 @@ public class DecoratorsTest {
             .decorate();
 
         String result = decoratedSupplier.call();
+
+        assertThat(result).isEqualTo("Bla");
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
+        then(helloWorldService).should(times(1)).returnHelloWorldWithException();
+    }
+
+    @Test
+    public void testDecorateCheckedSupplierWithFallbackFromResult() throws Throwable {
+        given(helloWorldService.returnHelloWorldWithException()).willReturn("Hello world");
+        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
+        CheckedSupplier<String> decoratedSupplier = Decorators
+            .ofCheckedSupplier(() -> helloWorldService.returnHelloWorldWithException())
+            .withFallback((result) -> result.equals("Hello world"), (result) -> "Bla")
+            .withCircuitBreaker(circuitBreaker)
+            .decorate();
+
+        String result = decoratedSupplier.get();
 
         assertThat(result).isEqualTo("Bla");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
@@ -236,6 +261,46 @@ public class DecoratorsTest {
             .decorate();
 
         String result = decoratedSupplier.get();
+
+        assertThat(result).isEqualTo("Fallback");
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfNotPermittedCalls()).isEqualTo(1);
+        then(helloWorldService).should(never()).returnHelloWorld();
+    }
+
+    @Test
+    public void testDecorateCheckedSupplier() throws IOException {
+        given(helloWorldService.returnHelloWorldWithException()).willReturn("Hello world");
+        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
+        CheckedSupplier<String> decoratedSupplier = Decorators
+            .ofCheckedSupplier(() -> helloWorldService.returnHelloWorldWithException())
+            .withCircuitBreaker(circuitBreaker)
+            .withRetry(Retry.ofDefaults("id"))
+            .withRateLimiter(RateLimiter.ofDefaults("testName"))
+            .withBulkhead(Bulkhead.ofDefaults("testName"))
+            .decorate();
+
+        String result = Try.of(() -> decoratedSupplier.get()).get();
+
+        assertThat(result).isEqualTo("Hello world");
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
+        then(helloWorldService).should(times(1)).returnHelloWorldWithException();
+    }
+
+    @Test
+    public void testDecorateCheckedSupplierWithFallback() throws Throwable {
+        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
+        circuitBreaker.transitionToOpenState();
+
+        CheckedSupplier<String> checkedSupplier = Decorators
+            .ofCheckedSupplier(() -> helloWorldService.returnHelloWorldWithException())
+            .withCircuitBreaker(circuitBreaker)
+            .withFallback(CallNotPermittedException.class, e -> "Fallback")
+            .decorate();
+
+        String result = checkedSupplier.get();
 
         assertThat(result).isEqualTo("Fallback");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
@@ -379,6 +444,27 @@ public class DecoratorsTest {
         then(helloWorldService).should(times(1)).sayHelloWorld();
     }
 
+
+    @Test
+    public void testDecorateCheckedRunnable() throws IOException {
+        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
+        CheckedRunnable decoratedRunnable = Decorators
+            .ofCheckedRunnable(() -> helloWorldService.sayHelloWorldWithException())
+            .withCircuitBreaker(circuitBreaker)
+            .withRetry(Retry.ofDefaults("id"))
+            .withRateLimiter(RateLimiter.ofDefaults("testName"))
+            .withBulkhead(Bulkhead.ofDefaults("testName"))
+            .decorate();
+
+        Try.run(() -> decoratedRunnable.run());
+
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
+        then(helloWorldService).should(times(1)).sayHelloWorldWithException();
+    }
+
+
     @Test
     public void testDecorateCompletionStage() throws ExecutionException, InterruptedException {
         given(helloWorldService.returnHelloWorld()).willReturn("Hello world");
@@ -440,6 +526,27 @@ public class DecoratorsTest {
     }
 
     @Test
+    public void testDecorateCheckedFunction() throws IOException {
+        given(helloWorldService.returnHelloWorldWithNameWithException("Name"))
+            .willReturn("Hello world Name");
+        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
+        CheckedFunction<String, String> decoratedFunction = Decorators
+            .ofCheckedFunction(helloWorldService::returnHelloWorldWithNameWithException)
+            .withCircuitBreaker(circuitBreaker)
+            .withRetry(Retry.ofDefaults("id"))
+            .withRateLimiter(RateLimiter.ofDefaults("testName"))
+            .withBulkhead(Bulkhead.ofDefaults("testName"))
+            .decorate();
+
+        String result = Try.of(() -> decoratedFunction.apply("Name")).get();
+
+        assertThat(result).isEqualTo("Hello world Name");
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
+    }
+
+    @Test
     public void testDecoratorBuilderWithRetry() {
         given(helloWorldService.returnHelloWorld()).willThrow(new RuntimeException("BAM!"));
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
@@ -457,6 +564,59 @@ public class DecoratorsTest {
         assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(3);
         then(helloWorldService).should(times(3)).returnHelloWorld();
     }
+
+    @Test
+    public void testDecoratorBuilderWithRateLimiter() {
+        given(helloWorldService.returnHelloWorld()).willReturn("Hello world");
+        RateLimiterConfig config = RateLimiterConfig.custom()
+            .timeoutDuration(Duration.ofMillis(100))
+            .limitRefreshPeriod(Duration.ofSeconds(1))
+            .limitForPeriod(1)
+            .build();
+        RateLimiter rateLimiter = RateLimiter.of("backendName", config);
+        CheckedSupplier<String> restrictedSupplier = Decorators
+            .ofCheckedSupplier(() -> helloWorldService.returnHelloWorld())
+            .withRateLimiter(rateLimiter)
+            .decorate();
+        alignTime(rateLimiter);
+
+        Try<String> firstTry = Try.of(() -> restrictedSupplier.get());
+        Try<String> secondTry = Try.of(() -> restrictedSupplier.get());
+
+        assertThat(firstTry.isSuccess()).isTrue();
+        assertThat(secondTry.isFailure()).isTrue();
+        assertThat(secondTry.getCause()).isInstanceOf(RequestNotPermitted.class);
+        then(helloWorldService).should(times(1)).returnHelloWorld();
+    }
+
+    private void alignTime(RateLimiter rateLimiter) {
+        RateLimiter.Metrics metrics = rateLimiter.getMetrics();
+        while (rateLimiter.acquirePermission()) {
+            state = !state;
+        }
+        // Wait to the start of the next cycle in spin loop
+        while (metrics.getAvailablePermissions() == 0) {
+            state = !state;
+        }
+        System.out.println(state);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testDecorateCheckedSupplierWithCache() {
+        javax.cache.Cache<String, String> cache = mock(javax.cache.Cache.class);
+        given(cache.containsKey("testKey")).willReturn(true);
+        given(cache.get("testKey")).willReturn("Hello from cache");
+        CheckedFunction<String, String> cachedFunction = Decorators
+            .ofCheckedSupplier(() -> "Hello world")
+            .withCache(Cache.of(cache))
+            .decorate();
+
+        Try<String> value = Try.of(() -> cachedFunction.apply("testKey"));
+
+        assertThat(value).contains("Hello from cache");
+    }
+
 
     @SuppressWarnings("unchecked")
     @Test

--- a/resilience4j-cache/build.gradle
+++ b/resilience4j-cache/build.gradle
@@ -2,7 +2,6 @@ dependencies {
     compile project(':resilience4j-core')
     compile(libraries.jcache)
     testCompile project(':resilience4j-rxjava2')
-    testCompile project(':resilience4j-vavr')
     testCompile(libraries.rxjava2)
 }
 ext.moduleName = 'io.github.resilience4j.cache'

--- a/resilience4j-cache/src/main/java/io/github/resilience4j/cache/Cache.java
+++ b/resilience4j-cache/src/main/java/io/github/resilience4j/cache/Cache.java
@@ -24,8 +24,11 @@ import io.github.resilience4j.cache.event.CacheOnHitEvent;
 import io.github.resilience4j.cache.event.CacheOnMissEvent;
 import io.github.resilience4j.cache.internal.CacheImpl;
 import io.github.resilience4j.core.EventConsumer;
+import io.github.resilience4j.core.functions.CheckedFunction;
+import io.github.resilience4j.core.functions.CheckedSupplier;
 
 import java.util.Objects;
+import java.util.concurrent.Callable;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -54,8 +57,37 @@ public interface Cache<K, V> {
      * @param <R>      the type of value
      * @return a supplier which is secured by a CircuitBreaker.
      */
-    static <K, R> Function<K, R> decorateSupplier(Cache<K, R> cache, Supplier<R> supplier) {
+    static <K, R> CheckedFunction<K, R> decorateCheckedSupplier(Cache<K, R> cache,
+                                                                CheckedSupplier<R> supplier) {
         return (K cacheKey) -> cache.computeIfAbsent(cacheKey, supplier);
+    }
+
+    /**
+     * Creates a functions which returns a value from a cache, if it exists. Otherwise it calls the
+     * Supplier.
+     *
+     * @param cache    the Cache
+     * @param supplier the original Supplier
+     * @param <K>      the type of key
+     * @param <R>      the type of value
+     * @return a supplier which is secured by a CircuitBreaker.
+     */
+    static <K, R> Function<K, R> decorateSupplier(Cache<K, R> cache, Supplier<R> supplier) {
+        return (K cacheKey) -> cache.computeIfAbsent(cacheKey, supplier::get);
+    }
+
+    /**
+     * Creates a functions which returns a value from a cache, if it exists. Otherwise it calls the
+     * Callable.
+     *
+     * @param cache    the Cache
+     * @param callable the original Callable
+     * @param <K>      the type of key
+     * @param <R>      the type of value
+     * @return a supplier which is secured by a CircuitBreaker.
+     */
+    static <K, R> CheckedFunction<K, R> decorateCallable(Cache<K, R> cache, Callable<R> callable) {
+        return (K cacheKey) -> cache.computeIfAbsent(cacheKey, callable::call);
     }
 
     /**
@@ -79,7 +111,7 @@ public interface Cache<K, V> {
      * @param supplier value to be associated with the specified key
      * @return cached value
      */
-    V computeIfAbsent(K key, Supplier<V> supplier);
+    V computeIfAbsent(K key, CheckedSupplier<V> supplier);
 
     /**
      * Returns an EventPublisher which can be used to register event consumers.

--- a/resilience4j-cache/src/test/java/io/github/resilience4j/cache/CacheEventPublisherTest.java
+++ b/resilience4j-cache/src/test/java/io/github/resilience4j/cache/CacheEventPublisherTest.java
@@ -18,7 +18,7 @@
  */
 package io.github.resilience4j.cache;
 
-import io.vavr.CheckedFunction1;
+import io.github.resilience4j.core.functions.CheckedFunction;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -56,7 +56,7 @@ public class CacheEventPublisherTest {
         Cache<String, String> cacheContext = Cache.of(cache);
         cacheContext.getEventPublisher().onCacheHit(
             event -> logger.info(event.getEventType().toString()));
-        CheckedFunction1<String, String> cachedFunction = VavrCache
+        CheckedFunction<String, String> cachedFunction = Cache
             .decorateCheckedSupplier(cacheContext, () -> "Hello world");
 
         String value = cachedFunction.apply("testKey");
@@ -71,7 +71,7 @@ public class CacheEventPublisherTest {
         Cache<String, String> cacheContext = Cache.of(cache);
         cacheContext.getEventPublisher().onCacheMiss(
             event -> logger.info(event.getEventType().toString()));
-        CheckedFunction1<String, String> cachedFunction = VavrCache
+        CheckedFunction<String, String> cachedFunction = Cache
             .decorateCheckedSupplier(cacheContext, () -> "Hello world");
 
         String value = cachedFunction.apply("testKey");
@@ -86,7 +86,7 @@ public class CacheEventPublisherTest {
         Cache<String, String> cacheContext = Cache.of(cache);
         cacheContext.getEventPublisher().onError(
             event -> logger.info(event.getEventType().toString()));
-        CheckedFunction1<String, String> cachedFunction = VavrCache
+        CheckedFunction<String, String> cachedFunction = Cache
             .decorateCheckedSupplier(cacheContext, () -> "Hello world");
         String value = cachedFunction.apply("testKey");
 

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreaker.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreaker.java
@@ -21,7 +21,7 @@ package io.github.resilience4j.circuitbreaker;
 import io.github.resilience4j.circuitbreaker.event.*;
 import io.github.resilience4j.circuitbreaker.internal.CircuitBreakerStateMachine;
 import io.github.resilience4j.core.EventConsumer;
-import io.github.resilience4j.core.functions.OnceConsumer;
+import io.github.resilience4j.core.functions.*;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -52,6 +52,33 @@ import java.util.stream.Collectors;
  * If the failure rate is below or equal to the threshold, the state changes back to CLOSED.
  */
 public interface CircuitBreaker {
+
+    /**
+     * Returns a supplier which is decorated by a CircuitBreaker.
+     *
+     * @param circuitBreaker the CircuitBreaker
+     * @param supplier       the original supplier
+     * @param <T>            the type of results supplied by this supplier
+     * @return a supplier which is decorated by a CircuitBreaker.
+     */
+    static <T> CheckedSupplier<T> decorateCheckedSupplier(CircuitBreaker circuitBreaker, CheckedSupplier<T> supplier) {
+        return () -> {
+            circuitBreaker.acquirePermission();
+            final long start = circuitBreaker.getCurrentTimestamp();
+            try {
+                T returnValue = supplier.get();
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onSuccess(duration, circuitBreaker.getTimestampUnit());
+                return returnValue;
+            } catch (Exception exception) {
+                // Do not handle java.lang.Error
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onError(duration, circuitBreaker.getTimestampUnit(), exception);
+                throw exception;
+            }
+        };
+    }
+
     /**
      * Returns a supplier which is decorated by a CircuitBreaker.
      *
@@ -96,6 +123,30 @@ public interface CircuitBreaker {
             }
 
             return promise;
+        };
+    }
+
+    /**
+     * Returns a runnable which is decorated by a CircuitBreaker.
+     *
+     * @param circuitBreaker the CircuitBreaker
+     * @param runnable       the original runnable
+     * @return a runnable which is decorated by a CircuitBreaker.
+     */
+    static CheckedRunnable decorateCheckedRunnable(CircuitBreaker circuitBreaker, CheckedRunnable runnable) {
+        return () -> {
+            circuitBreaker.acquirePermission();
+            final long start = circuitBreaker.getCurrentTimestamp();
+            try {
+                runnable.run();
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onSuccess(duration, circuitBreaker.getTimestampUnit());
+            } catch (Exception exception) {
+                // Do not handle java.lang.Error
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onError(duration, circuitBreaker.getTimestampUnit(), exception);
+                throw exception;
+            }
         };
     }
 
@@ -177,6 +228,31 @@ public interface CircuitBreaker {
     }
 
     /**
+     * Returns a consumer which is decorated by a CircuitBreaker.
+     *
+     * @param circuitBreaker the CircuitBreaker
+     * @param consumer       the original consumer
+     * @param <T>            the type of the input to the consumer
+     * @return a consumer which is decorated by a CircuitBreaker.
+     */
+    static <T> CheckedConsumer<T> decorateCheckedConsumer(CircuitBreaker circuitBreaker, CheckedConsumer<T> consumer) {
+        return (t) -> {
+            circuitBreaker.acquirePermission();
+            final long start = circuitBreaker.getCurrentTimestamp();
+            try {
+                consumer.accept(t);
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onSuccess(duration, circuitBreaker.getTimestampUnit());
+            } catch (Exception exception) {
+                // Do not handle java.lang.Error
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onError(duration, circuitBreaker.getTimestampUnit(), exception);
+                throw exception;
+            }
+        };
+    }
+
+    /**
      * Returns a runnable which is decorated by a CircuitBreaker.
      *
      * @param circuitBreaker the CircuitBreaker
@@ -211,6 +287,33 @@ public interface CircuitBreaker {
      */
     static <T, R> Function<T, R> decorateFunction(CircuitBreaker circuitBreaker,
         Function<T, R> function) {
+        return (T t) -> {
+            circuitBreaker.acquirePermission();
+            final long start = circuitBreaker.getCurrentTimestamp();
+            try {
+                R returnValue = function.apply(t);
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onSuccess(duration, circuitBreaker.getTimestampUnit());
+                return returnValue;
+            } catch (Exception exception) {
+                // Do not handle java.lang.Error
+                long duration = circuitBreaker.getCurrentTimestamp() - start;
+                circuitBreaker.onError(duration, circuitBreaker.getTimestampUnit(), exception);
+                throw exception;
+            }
+        };
+    }
+
+    /**
+     * Returns a function which is decorated by a CircuitBreaker.
+     *
+     * @param circuitBreaker the CircuitBreaker
+     * @param function       the original function
+     * @param <T>            the type of the input to the function
+     * @param <R>            the type of the result of the function
+     * @return a function which is decorated by a CircuitBreaker.
+     */
+    static <T, R> CheckedFunction<T, R> decorateCheckedFunction(CircuitBreaker circuitBreaker, CheckedFunction<T, R> function) {
         return (T t) -> {
             circuitBreaker.acquirePermission();
             final long start = circuitBreaker.getCurrentTimestamp();
@@ -597,6 +700,48 @@ public interface CircuitBreaker {
     }
 
     /**
+     * Decorates and executes the decorated Supplier.
+     *
+     * @param checkedSupplier the original Supplier
+     * @param <T>             the type of results supplied by this supplier
+     * @return the result of the decorated Supplier.
+     * @throws Throwable if something goes wrong applying this function to the given arguments
+     */
+    default <T> T executeCheckedSupplier(CheckedSupplier<T> checkedSupplier) throws Throwable {
+        return decorateCheckedSupplier(this, checkedSupplier).get();
+    }
+
+    /**
+     * Returns a supplier which is decorated by a CircuitBreaker.
+     *
+     * @param checkedSupplier the original supplier
+     * @param <T>             the type of results supplied by this supplier
+     * @return a supplier which is decorated by a CircuitBreaker.
+     */
+    default <T> CheckedSupplier<T> decorateCheckedSupplier(CheckedSupplier<T> checkedSupplier) {
+        return decorateCheckedSupplier(this, checkedSupplier);
+    }
+
+    /**
+     * Returns a runnable which is decorated by a CircuitBreaker.
+     *
+     * @param runnable the original runnable
+     * @return a runnable which is decorated by a CircuitBreaker.
+     */
+    default CheckedRunnable decorateCheckedRunnable(CheckedRunnable runnable) {
+        return decorateCheckedRunnable(this, runnable);
+    }
+
+    /**
+     * Decorates and executes the decorated Runnable.
+     *
+     * @param runnable the original runnable
+     */
+    default void executeCheckedRunnable(CheckedRunnable runnable) throws Throwable {
+        decorateCheckedRunnable(this, runnable).run();
+    }
+
+    /**
      * Returns a consumer which is decorated by a CircuitBreaker.
      *
      * @param consumer the original consumer
@@ -605,6 +750,17 @@ public interface CircuitBreaker {
      */
     default <T> Consumer<T> decorateConsumer(Consumer<T> consumer) {
         return decorateConsumer(this, consumer);
+    }
+
+    /**
+     * Returns a consumer which is decorated by a CircuitBreaker.
+     *
+     * @param consumer the original consumer
+     * @param <T>      the type of the input to the consumer
+     * @return a consumer which is decorated by a CircuitBreaker.
+     */
+    default <T> CheckedConsumer<T> decorateCheckedConsumer(CheckedConsumer<T> consumer) {
+        return decorateCheckedConsumer(this, consumer);
     }
 
     /**
@@ -918,7 +1074,7 @@ public interface CircuitBreaker {
                     .applyOnce(cb -> cb.onSuccess(cb.getCurrentTimestamp() - start, cb.getTimestampUnit()));
                 return v;
             } catch (CancellationException | InterruptedException e) {
-                onceToCircuitbreaker.applyOnce(cb -> cb.releasePermission());
+                onceToCircuitbreaker.applyOnce(CircuitBreaker::releasePermission);
                 throw e;
             } catch (Exception e) {
                 onceToCircuitbreaker.applyOnce(

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerTest.java
@@ -18,6 +18,10 @@
  */
 package io.github.resilience4j.circuitbreaker;
 
+import io.github.resilience4j.core.functions.CheckedConsumer;
+import io.github.resilience4j.core.functions.CheckedFunction;
+import io.github.resilience4j.core.functions.CheckedRunnable;
+import io.github.resilience4j.core.functions.CheckedSupplier;
 import io.github.resilience4j.test.HelloWorldException;
 import io.github.resilience4j.test.HelloWorldService;
 import io.vavr.control.Try;
@@ -103,6 +107,47 @@ public class CircuitBreakerTest {
     }
 
     @Test
+    public void shouldDecorateCheckedSupplierAndReturnWithSuccess() throws Throwable {
+        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
+        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
+        given(helloWorldService.returnHelloWorldWithException()).willReturn("Hello world");
+        CheckedSupplier<String> checkedSupplier = circuitBreaker
+            .decorateCheckedSupplier(helloWorldService::returnHelloWorldWithException);
+
+        String result = checkedSupplier.get();
+
+        assertThat(result).isEqualTo("Hello world");
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(0);
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
+        then(helloWorldService).should().returnHelloWorldWithException();
+    }
+
+
+    @Test
+    public void shouldDecorateCheckedSupplierAndReturnWithException() throws Throwable {
+        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
+        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
+        given(helloWorldService.returnHelloWorldWithException())
+            .willThrow(new RuntimeException("BAM!"));
+        CheckedSupplier<String> checkedSupplier = circuitBreaker
+            .decorateCheckedSupplier(helloWorldService::returnHelloWorldWithException);
+
+        Try<String> result = Try.of(() -> checkedSupplier.get());
+
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.failed().get()).isInstanceOf(RuntimeException.class);
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(0);
+        then(helloWorldService).should().returnHelloWorldWithException();
+    }
+
+    @Test
     public void shouldDecorateCallableAndReturnWithSuccess() throws Throwable {
         CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
         CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
@@ -157,6 +202,42 @@ public class CircuitBreakerTest {
         assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
         assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(0);
         then(helloWorldService).should().returnHelloWorldWithException();
+    }
+
+    @Test
+    public void shouldDecorateCheckedRunnableAndReturnWithSuccess() throws Throwable {
+        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
+        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
+        CheckedRunnable checkedRunnable = circuitBreaker
+            .decorateCheckedRunnable(helloWorldService::sayHelloWorldWithException);
+
+        checkedRunnable.run();
+
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(0);
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
+        then(helloWorldService).should().sayHelloWorldWithException();
+    }
+
+    @Test
+    public void shouldDecorateCheckedRunnableAndReturnWithException() throws Throwable {
+        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
+        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
+        CheckedRunnable checkedRunnable = circuitBreaker.decorateCheckedRunnable(() -> {
+            throw new RuntimeException("BAM!");
+        });
+
+        Try<Void> result = Try.run(() -> checkedRunnable.run());
+
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.failed().get()).isInstanceOf(RuntimeException.class);
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(0);
     }
 
     @Test
@@ -246,6 +327,44 @@ public class CircuitBreakerTest {
     }
 
     @Test
+    public void shouldDecorateCheckedConsumerAndReturnWithSuccess() throws Throwable {
+        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
+        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
+        CheckedConsumer<String> checkedConsumer = circuitBreaker
+            .decorateCheckedConsumer(helloWorldService::sayHelloWorldWithNameWithException);
+
+        checkedConsumer.accept("Tom");
+
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(0);
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
+        then(helloWorldService).should().sayHelloWorldWithNameWithException("Tom");
+    }
+
+    @Test
+    public void shouldDecorateCheckedConsumerAndReturnWithException() throws Throwable {
+        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
+        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        int numberOfBufferedCallsBefore = metrics.getNumberOfBufferedCalls();
+        CheckedConsumer<String> checkedConsumer = circuitBreaker
+            .decorateCheckedConsumer((value) -> {
+                throw new RuntimeException("BAM!");
+            });
+
+        Try<Void> result = Try.run(() -> checkedConsumer.accept("Tom"));
+
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.failed().get()).isInstanceOf(RuntimeException.class);
+        assertThat(numberOfBufferedCallsBefore).isEqualTo(0);
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(0);
+    }
+
+    @Test
     public void shouldDecorateFunctionAndReturnWithSuccess() throws Throwable {
         CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
         CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
@@ -282,6 +401,199 @@ public class CircuitBreakerTest {
         assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
         assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
         assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldDecorateCheckedFunctionAndReturnWithSuccess() throws Throwable {
+        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
+        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
+        given(helloWorldService.returnHelloWorldWithNameWithException("Tom"))
+            .willReturn("Hello world Tom");
+        CheckedFunction<String, String> function = CircuitBreaker
+            .decorateCheckedFunction(circuitBreaker,
+                helloWorldService::returnHelloWorldWithNameWithException);
+
+        String result = function.apply("Tom");
+
+        assertThat(result).isEqualTo("Hello world Tom");
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(0);
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
+        then(helloWorldService).should().returnHelloWorldWithNameWithException("Tom");
+    }
+
+
+    @Test
+    public void shouldDecorateCheckedFunctionAndReturnWithException() throws Throwable {
+        CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
+        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
+        given(helloWorldService.returnHelloWorldWithNameWithException("Tom"))
+            .willThrow(new RuntimeException("BAM!"));
+        CheckedFunction<String, String> function = CircuitBreaker
+            .decorateCheckedFunction(circuitBreaker,
+                helloWorldService::returnHelloWorldWithNameWithException);
+
+        Try<String> result = Try.of(() -> function.apply("Tom"));
+
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.failed().get()).isInstanceOf(RuntimeException.class);
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldReturnFailureWithCircuitBreakerOpenException() {
+        // Given
+        CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
+            .slidingWindowSize(2)
+            .permittedNumberOfCallsInHalfOpenState(2)
+            .failureRateThreshold(50)
+            .waitDurationInOpenState(Duration.ofMillis(1000))
+            .build();
+        CircuitBreaker circuitBreaker = CircuitBreaker.of("testName", circuitBreakerConfig);
+        CheckedRunnable checkedRunnable = circuitBreaker.decorateCheckedRunnable(() -> {
+            throw new RuntimeException("BAM!");
+        });
+
+        // When
+        circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new RuntimeException());
+        circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new RuntimeException());
+
+        // Then
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.OPEN);
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(2);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(2);
+
+        // When
+        Try result = Try.run(() -> checkedRunnable.run());
+
+        // Then
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.failed().get()).isInstanceOf(CallNotPermittedException.class);
+    }
+
+    @Test
+    public void shouldReturnFailureWithRuntimeException() {
+        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(0);
+        CheckedRunnable checkedRunnable = circuitBreaker.decorateCheckedRunnable(() -> {
+            throw new RuntimeException("BAM!");
+        });
+
+        Try result = Try.run(() -> checkedRunnable.run());
+
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.failed().get()).isInstanceOf(RuntimeException.class);
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldNotRecordIOExceptionAsAFailure() {
+        // tag::shouldNotRecordIOExceptionAsAFailure[]
+        CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
+            .slidingWindowSize(2)
+            .permittedNumberOfCallsInHalfOpenState(2)
+            .waitDurationInOpenState(Duration.ofMillis(1000))
+            .ignoreExceptions(IOException.class)
+            .build();
+        CircuitBreaker circuitBreaker = CircuitBreaker.of("testName", circuitBreakerConfig);
+        // Simulate a failure attempt
+        circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new HelloWorldException());
+        // CircuitBreaker is still CLOSED, because 1 failure is allowed
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
+        CheckedRunnable checkedRunnable = circuitBreaker.decorateCheckedRunnable(() -> {
+            throw new SocketTimeoutException("BAM!");
+        });
+
+        Try result = Try.run(() -> checkedRunnable.run());
+
+        assertThat(result.isFailure()).isTrue();
+        // CircuitBreaker is still CLOSED, because SocketTimeoutException has not been recorded as a failure
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
+        assertThat(result.failed().get()).isInstanceOf(IOException.class);
+        // end::shouldNotRecordIOExceptionAsAFailure[]
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldInvokeRecoverFunction() {
+        // tag::shouldInvokeRecoverFunction[]
+        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
+        // When I decorate my function and invoke the decorated function
+        CheckedSupplier<String> checkedSupplier = circuitBreaker.decorateCheckedSupplier(() -> {
+            throw new RuntimeException("BAM!");
+        });
+
+        Try<String> result = Try.of(() -> checkedSupplier.get())
+            .recover(throwable -> "Hello Recovery");
+
+        // Then the function should be a success, because the exception could be recovered
+        assertThat(result.isSuccess()).isTrue();
+        // and the result must match the result of the recovery function.
+        assertThat(result.get()).isEqualTo("Hello Recovery");
+        // end::shouldInvokeRecoverFunction[]
+    }
+
+    @Test
+    public void shouldInvokeMap() {
+        // tag::shouldInvokeMap[]
+        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
+        // When I decorate my function
+        CheckedSupplier<String> decoratedSupplier = CircuitBreaker
+            .decorateCheckedSupplier(circuitBreaker,
+                () -> "This can be any method which returns: 'Hello");
+
+        // and chain an other function with map
+        Try<String> result = Try.of(() -> decoratedSupplier.get())
+            .map(value -> value + " world'");
+
+        // Then the Try Monad returns a Success<String>, if all functions ran successfully.
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.get()).isEqualTo("This can be any method which returns: 'Hello world'");
+        // end::shouldInvokeMap[]
+    }
+
+    @Test
+    public void shouldThrowCircuitBreakerOpenException() {
+        // tag::shouldThrowCircuitBreakerOpenException[]
+        CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
+            .slidingWindowSize(2)
+            .waitDurationInOpenState(Duration.ofMillis(1000))
+            .build();
+        CircuitBreaker circuitBreaker = CircuitBreaker.of("testName", circuitBreakerConfig);
+        // Simulate a failure attempt
+        circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new RuntimeException());
+        // CircuitBreaker is still CLOSED, because 1 failure is allowed
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
+        // Simulate a failure attempt
+        circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new RuntimeException());
+        // CircuitBreaker is OPEN, because the failure rate is above 50%
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.OPEN);
+
+        // When I decorate my function and invoke the decorated function
+        Try<String> result = Try.of(() -> circuitBreaker.decorateCheckedSupplier(() -> "Hello").get())
+            .map(value -> value + " world");
+
+        // Then the call fails, because CircuitBreaker is OPEN
+        assertThat(result.isFailure()).isTrue();
+        // Exception is CallNotPermittedException
+        assertThat(result.failed().get()).isInstanceOf(CallNotPermittedException.class);
+        // end::shouldThrowCircuitBreakerOpenException[]
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(2);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(2);
     }
 
     @Test
@@ -423,6 +735,32 @@ public class CircuitBreakerTest {
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
         assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(0);
         assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldChainDecoratedFunctions() {
+        // tag::shouldChainDecoratedFunctions[]
+        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
+        CircuitBreaker anotherCircuitBreaker = CircuitBreaker.ofDefaults("anotherTestName");
+        // When I create a Supplier and a Function which are decorated by different CircuitBreakers
+        CheckedSupplier<String> decoratedSupplier = CircuitBreaker
+            .decorateCheckedSupplier(circuitBreaker, () -> "Hello");
+        CheckedFunction<String, String> decoratedFunction = CircuitBreaker
+            .decorateCheckedFunction(anotherCircuitBreaker, (input) -> input + " world");
+
+        // and I chain a function with map
+        Try<String> result = Try.of(() -> decoratedSupplier.get())
+            .mapTry(value -> decoratedFunction.apply(value));
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.get()).isEqualTo("Hello world");
+        // end::shouldChainDecoratedFunctions[]
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(0);
+        CircuitBreaker.Metrics metrics2 = anotherCircuitBreaker.getMetrics();
+        assertThat(metrics2.getNumberOfBufferedCalls()).isEqualTo(1);
+        assertThat(metrics2.getNumberOfFailedCalls()).isEqualTo(0);
     }
 
     @Test

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/CheckedFunctionUtils.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/CheckedFunctionUtils.java
@@ -18,34 +18,34 @@
  */
 package io.github.resilience4j.core;
 
-import io.vavr.CheckedFunction0;
-import io.vavr.CheckedFunction1;
-import io.vavr.CheckedFunction2;
+import io.github.resilience4j.core.functions.CheckedBiFunction;
+import io.github.resilience4j.core.functions.CheckedFunction;
+import io.github.resilience4j.core.functions.CheckedSupplier;
 
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
 
-public class CheckFunctionUtils {
+public class CheckedFunctionUtils {
 
-    private CheckFunctionUtils() {
+    private CheckedFunctionUtils() {
     }
 
 
     /**
-     * Returns a composed function that first executes the function and optionally recovers from an
+     * Returns a composed supplier that first executes the supplier and optionally recovers from an
      * exception.
      *
      * @param <T>              return type of after
-     * @param function the function which should be recovered from a certain exception
+     * @param supplier the supplier which should be recovered from a certain exception
      * @param exceptionHandler the exception handler
-     * @return a function composed of callable and exceptionHandler
+     * @return a supplier composed of callable and exceptionHandler
      */
-    public static <T> CheckedFunction0<T> recover(CheckedFunction0<T> function,
-        CheckedFunction1<Throwable, T> exceptionHandler) {
+    public static <T> CheckedSupplier<T> recover(CheckedSupplier<T> supplier,
+                                                 CheckedFunction<Throwable, T> exceptionHandler) {
         return () -> {
             try {
-                return function.apply();
+                return supplier.get();
             } catch (Throwable throwable) {
                 return exceptionHandler.apply(throwable);
             }
@@ -53,20 +53,20 @@ public class CheckFunctionUtils {
     }
 
     /**
-     * Returns a composed function that first applies the function and then applies {@linkplain
+     * Returns a composed supplier that first applies the supplier and then applies {@linkplain
      * BiFunction} {@code after} to the result.
      *
      * @param <T>     return type of callable
      * @param <R>     return type of handler
-     * @param function the function
-     * @param handler the function applied after callable
-     * @return a function composed of supplier and handler
+     * @param supplier the supplier
+     * @param handler the supplier applied after callable
+     * @return a supplier composed of supplier and handler
      */
-    public static <T, R> CheckedFunction0<R> andThen(CheckedFunction0<T> function,
-        CheckedFunction2<T, Throwable, R> handler) {
+    public static <T, R> CheckedSupplier<R> andThen(CheckedSupplier<T> supplier,
+        CheckedBiFunction<T, Throwable, R> handler) {
         return () -> {
             try {
-                return handler.apply(function.apply(), null);
+                return handler.apply(supplier.get(), null);
             } catch (Throwable throwable) {
                 return handler.apply(null, throwable);
             }
@@ -74,18 +74,18 @@ public class CheckFunctionUtils {
     }
 
     /**
-     * Returns a composed function that first executes the function and optionally recovers from a specific result.
+     * Returns a composed supplier that first executes the supplier and optionally recovers from a specific result.
      *
      * @param <T>              return type of after
-     * @param function the function
+     * @param supplier the supplier
      * @param resultPredicate the result predicate
      * @param resultHandler the result handler
-     * @return a function composed of supplier and exceptionHandler
+     * @return a supplier composed of supplier and exceptionHandler
      */
-    public static <T> CheckedFunction0<T> recover(CheckedFunction0<T> function,
-        Predicate<T> resultPredicate, CheckedFunction1<T, T> resultHandler) {
+    public static <T> CheckedSupplier<T> recover(CheckedSupplier<T> supplier,
+        Predicate<T> resultPredicate, CheckedFunction<T, T> resultHandler) {
         return () -> {
-            T result = function.apply();
+            T result = supplier.get();
             if(resultPredicate.test(result)){
                 return resultHandler.apply(result);
             }
@@ -94,21 +94,21 @@ public class CheckFunctionUtils {
     }
 
     /**
-     * Returns a composed function that first executes the function and optionally recovers from an
+     * Returns a composed supplier that first executes the supplier and optionally recovers from an
      * exception.
      *
      * @param <T>              return type of after
-     * @param function the function which should be recovered from a certain exception
+     * @param supplier the supplier which should be recovered from a certain exception
      * @param exceptionTypes the specific exception types that should be recovered
      * @param exceptionHandler the exception handler
-     * @return a function composed of supplier and exceptionHandler
+     * @return a supplier composed of supplier and exceptionHandler
      */
-    public static <T> CheckedFunction0<T> recover(CheckedFunction0<T> function,
+    public static <T> CheckedSupplier<T> recover(CheckedSupplier<T> supplier,
         List<Class<? extends Throwable>> exceptionTypes,
-        CheckedFunction1<Throwable, T> exceptionHandler) {
+        CheckedFunction<Throwable, T> exceptionHandler) {
         return () -> {
             try {
-                return function.apply();
+                return supplier.get();
             } catch (Exception exception) {
                 if(exceptionTypes.stream().anyMatch(exceptionType -> exceptionType.isAssignableFrom(exception.getClass()))){
                     return exceptionHandler.apply(exception);
@@ -120,21 +120,21 @@ public class CheckFunctionUtils {
     }
 
     /**
-     * Returns a composed function that first executes the function and optionally recovers from an
+     * Returns a composed supplier that first executes the supplier and optionally recovers from an
      * exception.
      *
      * @param <T>              return type of after
-     * @param function the function which should be recovered from a certain exception
+     * @param supplier the supplier which should be recovered from a certain exception
      * @param exceptionType the specific exception type that should be recovered
      * @param exceptionHandler the exception handler
-     * @return a function composed of callable and exceptionHandler
+     * @return a supplier composed of callable and exceptionHandler
      */
-    public static <X extends Throwable, T> CheckedFunction0<T> recover(CheckedFunction0<T> function,
+    public static <X extends Throwable, T> CheckedSupplier<T> recover(CheckedSupplier<T> supplier,
         Class<X> exceptionType,
-        CheckedFunction1<Throwable, T> exceptionHandler) {
+        CheckedFunction<Throwable, T> exceptionHandler) {
         return () -> {
             try {
-                return function.apply();
+                return supplier.get();
             } catch (Throwable throwable) {
                 if(exceptionType.isAssignableFrom(throwable.getClass())) {
                     return exceptionHandler.apply(throwable);

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/functions/CheckedBiFunction.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/functions/CheckedBiFunction.java
@@ -18,12 +18,12 @@
  */
 package io.github.resilience4j.core.functions;
 
-import java.util.function.Consumer;
+import java.util.function.BiFunction;
 
 /**
- * A {@link Consumer}-like interface which allows throwing Error.
+ * A {@link BiFunction}-like interface which allows throwing Error.
  */
 @FunctionalInterface
-public interface CheckedConsumer<T> {
-    void accept(T t) throws Throwable;
-} 
+public interface CheckedBiFunction<T, U, R> {
+    R apply(T t, U u) throws Throwable;
+}

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/functions/CheckedFunction.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/functions/CheckedFunction.java
@@ -18,12 +18,12 @@
  */
 package io.github.resilience4j.core.functions;
 
-import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
- * A {@link Consumer}-like interface which allows throwing Error.
+ * A {@link Function}-like interface which allows throwing Error.
  */
 @FunctionalInterface
-public interface CheckedConsumer<T> {
-    void accept(T t) throws Throwable;
-} 
+public interface CheckedFunction<T, R> {
+    R apply(T t) throws Throwable;
+}

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/functions/CheckedRunnable.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/functions/CheckedRunnable.java
@@ -18,12 +18,10 @@
  */
 package io.github.resilience4j.core.functions;
 
-import java.util.function.Consumer;
-
 /**
- * A {@link Consumer}-like interface which allows throwing Error.
+ * A {@link Runnable}-like interface which allows throwing Error.
  */
 @FunctionalInterface
-public interface CheckedConsumer<T> {
-    void accept(T t) throws Throwable;
-} 
+public interface CheckedRunnable {
+    void run() throws Throwable;
+}

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/functions/CheckedSupplier.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/functions/CheckedSupplier.java
@@ -18,12 +18,18 @@
  */
 package io.github.resilience4j.core.functions;
 
-import java.util.function.Consumer;
+import java.util.Objects;
+import java.util.function.Supplier;
 
 /**
- * A {@link Consumer}-like interface which allows throwing Error.
+ * A {@link Supplier}-like interface which allows throwing Error.
  */
 @FunctionalInterface
-public interface CheckedConsumer<T> {
-    void accept(T t) throws Throwable;
-} 
+public interface CheckedSupplier<T> {
+    T get() throws Throwable;
+
+    default <V> CheckedSupplier<V> andThen(CheckedFunction<? super T, ? extends V> after) {
+        Objects.requireNonNull(after, "after is null");
+        return () -> after.apply(get());
+    }
+}

--- a/resilience4j-core/src/test/java/io/github/resilience4j/core/CheckedFunctionUtilsTest.java
+++ b/resilience4j-core/src/test/java/io/github/resilience4j/core/CheckedFunctionUtilsTest.java
@@ -1,0 +1,123 @@
+/*
+ *
+ *  Copyright 2020: Robert Winkler
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.core;
+
+import io.github.resilience4j.core.functions.CheckedSupplier;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CheckedFunctionUtilsTest {
+
+    @Test
+    public void shouldRecoverFromException() throws Throwable {
+        CheckedSupplier<String> callable = () -> {
+            throw new IOException("BAM!");
+        };
+        CheckedSupplier<String> callableWithRecovery = CheckedFunctionUtils.recover(callable, (ex) -> "Bla");
+
+        String result = callableWithRecovery.get();
+
+        assertThat(result).isEqualTo("Bla");
+    }
+
+    @Test
+    public void shouldRecoverFromSpecificExceptions() throws Throwable {
+        CheckedSupplier<String> callable = () -> {
+            throw new IOException("BAM!");
+        };
+
+        CheckedSupplier<String> callableWithRecovery = CheckedFunctionUtils.recover(callable,
+            asList(IllegalArgumentException.class, IOException.class),
+            (ex) -> "Bla");
+
+        String result = callableWithRecovery.get();
+
+        assertThat(result).isEqualTo("Bla");
+    }
+
+    @Test
+    public void shouldRecoverFromResult() throws Throwable {
+        CheckedSupplier<String> callable = () -> "Wrong Result";
+
+        CheckedSupplier<String> callableWithRecovery = CheckedFunctionUtils.andThen(callable, (result, ex) -> {
+            if(result.equals("Wrong Result")){
+                return "Bla";
+            }
+            return result;
+        });
+
+        String result = callableWithRecovery.get();
+
+        assertThat(result).isEqualTo("Bla");
+    }
+
+    @Test
+    public void shouldRecoverFromException2() throws Throwable {
+        CheckedSupplier<String> callable = () -> {
+            throw new IllegalArgumentException("BAM!");
+        };
+        CheckedSupplier<String> callableWithRecovery = CheckedFunctionUtils.andThen(callable, (result, ex) -> {
+            if(ex instanceof IllegalArgumentException){
+                return "Bla";
+            }
+            return result;
+        });
+
+        String result = callableWithRecovery.get();
+
+        assertThat(result).isEqualTo("Bla");
+    }
+
+    @Test
+    public void shouldRecoverFromSpecificResult() throws Throwable {
+        CheckedSupplier<String> supplier = () -> "Wrong Result";
+
+        CheckedSupplier<String> callableWithRecovery = CheckedFunctionUtils.recover(supplier, (result) -> result.equals("Wrong Result"), (r) -> "Bla");
+        String result = callableWithRecovery.get();
+
+        assertThat(result).isEqualTo("Bla");
+    }
+
+
+    @Test(expected = RuntimeException.class)
+    public void shouldRethrowException() throws Throwable {
+        CheckedSupplier<String> callable = () -> {
+            throw new IOException("BAM!");
+        };
+        CheckedSupplier<String> callableWithRecovery = CheckedFunctionUtils.recover(callable, (ex) -> {
+            throw new RuntimeException();
+        });
+
+        callableWithRecovery.get();
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void shouldRethrowException2() throws Throwable {
+        CheckedSupplier<String> callable = () -> {
+            throw new RuntimeException("BAM!");
+        };
+        CheckedSupplier<String> callableWithRecovery = CheckedFunctionUtils.recover(callable, IllegalArgumentException.class, (ex) -> "Bla");
+
+        callableWithRecovery.get();
+    }
+}

--- a/resilience4j-feign/build.gradle
+++ b/resilience4j-feign/build.gradle
@@ -4,7 +4,6 @@ dependencies {
     compile project(':resilience4j-circuitbreaker')
     compile project(':resilience4j-ratelimiter')
     compile project(':resilience4j-bulkhead')
-    compile project(':resilience4j-vavr')
     testCompile(libraries.feign_wiremock)
     testCompile(libraries.feign)
 }

--- a/resilience4j-feign/src/main/java/io/github/resilience4j/feign/DecoratorInvocationHandler.java
+++ b/resilience4j-feign/src/main/java/io/github/resilience4j/feign/DecoratorInvocationHandler.java
@@ -18,7 +18,7 @@ package io.github.resilience4j.feign;
 
 import feign.InvocationHandlerFactory.MethodHandler;
 import feign.Target;
-import io.vavr.CheckedFunction1;
+import io.github.resilience4j.core.functions.CheckedFunction;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
@@ -35,7 +35,7 @@ import static feign.Util.checkNotNull;
 class DecoratorInvocationHandler implements InvocationHandler {
 
     private final Target<?> target;
-    private final Map<Method, CheckedFunction1<Object[], Object>> decoratedDispatch;
+    private final Map<Method, CheckedFunction<Object[], Object>> decoratedDispatch;
 
     public DecoratorInvocationHandler(Target<?> target,
         Map<Method, MethodHandler> dispatch,
@@ -47,7 +47,7 @@ class DecoratorInvocationHandler implements InvocationHandler {
 
     /**
      * Applies the specified {@link FeignDecorator} to all specified {@link MethodHandler}s and
-     * returns the result as a map of {@link CheckedFunction1}s. Invoking a {@link CheckedFunction1}
+     * returns the result as a map of {@link CheckedFunction}s. Invoking a {@link CheckedFunction}
      * will therefore invoke the decorator which, in turn, may invoke the corresponding {@link
      * MethodHandler}.
      *
@@ -59,15 +59,15 @@ class DecoratorInvocationHandler implements InvocationHandler {
      * @return a new map where the {@link MethodHandler}s are decorated with the {@link
      * FeignDecorator}.
      */
-    private Map<Method, CheckedFunction1<Object[], Object>> decorateMethodHandlers(
+    private Map<Method, CheckedFunction<Object[], Object>> decorateMethodHandlers(
         Map<Method, MethodHandler> dispatch,
         FeignDecorator invocationDecorator, Target<?> target) {
-        final Map<Method, CheckedFunction1<Object[], Object>> map = new HashMap<>();
+        final Map<Method, CheckedFunction<Object[], Object>> map = new HashMap<>();
         for (final Map.Entry<Method, MethodHandler> entry : dispatch.entrySet()) {
             final Method method = entry.getKey();
             final MethodHandler methodHandler = entry.getValue();
             if (methodHandler != null) {
-                CheckedFunction1<Object[], Object> decorated = invocationDecorator
+                CheckedFunction<Object[], Object> decorated = invocationDecorator
                     .decorate(methodHandler::invoke, method, methodHandler, target);
                 map.put(method, decorated);
             }

--- a/resilience4j-feign/src/main/java/io/github/resilience4j/feign/DefaultFallbackHandler.java
+++ b/resilience4j-feign/src/main/java/io/github/resilience4j/feign/DefaultFallbackHandler.java
@@ -16,7 +16,7 @@
  */
 package io.github.resilience4j.feign;
 
-import io.vavr.CheckedFunction1;
+import io.github.resilience4j.core.functions.CheckedFunction;
 
 import java.lang.reflect.Method;
 import java.util.function.Predicate;
@@ -35,8 +35,8 @@ class DefaultFallbackHandler<T> implements FallbackHandler<T> {
     }
 
     @Override
-    public CheckedFunction1<Object[], Object> decorate(
-        CheckedFunction1<Object[], Object> invocationCall,
+    public CheckedFunction<Object[], Object> decorate(
+        CheckedFunction<Object[], Object> invocationCall,
         Method method,
         Predicate<Exception> filter) {
         validateFallback(fallback, method);

--- a/resilience4j-feign/src/main/java/io/github/resilience4j/feign/FallbackDecorator.java
+++ b/resilience4j-feign/src/main/java/io/github/resilience4j/feign/FallbackDecorator.java
@@ -18,7 +18,7 @@ package io.github.resilience4j.feign;
 
 import feign.InvocationHandlerFactory.MethodHandler;
 import feign.Target;
-import io.vavr.CheckedFunction1;
+import io.github.resilience4j.core.functions.CheckedFunction;
 
 import java.lang.reflect.Method;
 import java.util.function.Predicate;
@@ -64,8 +64,8 @@ class FallbackDecorator<T> implements FeignDecorator {
      *                                  fallback method.
      */
     @Override
-    public CheckedFunction1<Object[], Object> decorate(
-        CheckedFunction1<Object[], Object> invocationCall,
+    public CheckedFunction<Object[], Object> decorate(
+        CheckedFunction<Object[], Object> invocationCall,
         Method method,
         MethodHandler methodHandler,
         Target<?> target) {

--- a/resilience4j-feign/src/main/java/io/github/resilience4j/feign/FallbackFactory.java
+++ b/resilience4j-feign/src/main/java/io/github/resilience4j/feign/FallbackFactory.java
@@ -16,7 +16,7 @@
  */
 package io.github.resilience4j.feign;
 
-import io.vavr.CheckedFunction1;
+import io.github.resilience4j.core.functions.CheckedFunction;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -39,8 +39,8 @@ class FallbackFactory<T> implements FallbackHandler<T> {
     }
 
     @Override
-    public CheckedFunction1<Object[], Object> decorate(
-        CheckedFunction1<Object[], Object> invocationCall,
+    public CheckedFunction<Object[], Object> decorate(
+        CheckedFunction<Object[], Object> invocationCall,
         Method method,
         Predicate<Exception> filter) {
         return args -> {

--- a/resilience4j-feign/src/main/java/io/github/resilience4j/feign/FallbackHandler.java
+++ b/resilience4j-feign/src/main/java/io/github/resilience4j/feign/FallbackHandler.java
@@ -16,7 +16,7 @@
  */
 package io.github.resilience4j.feign;
 
-import io.vavr.CheckedFunction1;
+import io.github.resilience4j.core.functions.CheckedFunction;
 
 import java.lang.reflect.Method;
 import java.util.function.Predicate;
@@ -28,8 +28,8 @@ import java.util.function.Predicate;
  */
 interface FallbackHandler<T> {
 
-    CheckedFunction1<Object[], Object> decorate(CheckedFunction1<Object[], Object> invocationCall,
-        Method method, Predicate<Exception> filter);
+    CheckedFunction<Object[], Object> decorate(CheckedFunction<Object[], Object> invocationCall,
+                                               Method method, Predicate<Exception> filter);
 
     default void validateFallback(T fallback, Method method) {
         if (fallback.getClass().isAssignableFrom(method.getDeclaringClass())) {

--- a/resilience4j-feign/src/main/java/io/github/resilience4j/feign/FeignDecorator.java
+++ b/resilience4j-feign/src/main/java/io/github/resilience4j/feign/FeignDecorator.java
@@ -18,7 +18,7 @@ package io.github.resilience4j.feign;
 
 import feign.InvocationHandlerFactory.MethodHandler;
 import feign.Target;
-import io.vavr.CheckedFunction1;
+import io.github.resilience4j.core.functions.CheckedFunction;
 
 import java.lang.reflect.Method;
 
@@ -38,8 +38,8 @@ public interface FeignDecorator {
      * @param methodHandler  the feign methodHandler that executes the http request.
      * @return the decorated invocationCall
      */
-    CheckedFunction1<Object[], Object> decorate(CheckedFunction1<Object[], Object> invocationCall,
-        Method method, MethodHandler methodHandler,
-        Target<?> target);
+    CheckedFunction<Object[], Object> decorate(CheckedFunction<Object[], Object> invocationCall,
+                                               Method method, MethodHandler methodHandler,
+                                               Target<?> target);
 
 }

--- a/resilience4j-feign/src/main/java/io/github/resilience4j/feign/FeignDecorators.java
+++ b/resilience4j-feign/src/main/java/io/github/resilience4j/feign/FeignDecorators.java
@@ -19,14 +19,10 @@ package io.github.resilience4j.feign;
 import feign.InvocationHandlerFactory.MethodHandler;
 import feign.Target;
 import io.github.resilience4j.bulkhead.Bulkhead;
-import io.github.resilience4j.bulkhead.VavrBulkhead;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
-import io.github.resilience4j.circuitbreaker.VavrCircuitBreaker;
+import io.github.resilience4j.core.functions.CheckedFunction;
 import io.github.resilience4j.ratelimiter.RateLimiter;
-import io.github.resilience4j.ratelimiter.VavrRateLimiter;
 import io.github.resilience4j.retry.Retry;
-import io.github.resilience4j.retry.VavrRetry;
-import io.vavr.CheckedFunction1;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -71,9 +67,9 @@ public class FeignDecorators implements FeignDecorator {
     }
 
     @Override
-    public CheckedFunction1<Object[], Object> decorate(CheckedFunction1<Object[], Object> fn,
-        Method method, MethodHandler methodHandler, Target<?> target) {
-        CheckedFunction1<Object[], Object> decoratedFn = fn;
+    public CheckedFunction<Object[], Object> decorate(CheckedFunction<Object[], Object> fn,
+                                                      Method method, MethodHandler methodHandler, Target<?> target) {
+        CheckedFunction<Object[], Object> decoratedFn = fn;
         for (final FeignDecorator decorator : decorators) {
             decoratedFn = decorator.decorate(decoratedFn, method, methodHandler, target);
         }
@@ -93,7 +89,7 @@ public class FeignDecorators implements FeignDecorator {
          */
         public Builder withRetry(Retry retry) {
             decorators
-                .add((fn, m, mh, t) -> VavrRetry.decorateCheckedFunction(retry, fn));
+                .add((fn, m, mh, t) -> Retry.decorateCheckedFunction(retry, fn));
             return this;
         }
 
@@ -105,7 +101,7 @@ public class FeignDecorators implements FeignDecorator {
          */
         public Builder withCircuitBreaker(CircuitBreaker circuitBreaker) {
             decorators
-                .add((fn, m, mh, t) -> VavrCircuitBreaker.decorateCheckedFunction(circuitBreaker, fn));
+                .add((fn, m, mh, t) -> CircuitBreaker.decorateCheckedFunction(circuitBreaker, fn));
             return this;
         }
 
@@ -116,7 +112,7 @@ public class FeignDecorators implements FeignDecorator {
          * @return the builder
          */
         public Builder withRateLimiter(RateLimiter rateLimiter) {
-            decorators.add((fn, m, mh, t) -> VavrRateLimiter.decorateCheckedFunction(rateLimiter, fn));
+            decorators.add((fn, m, mh, t) -> RateLimiter.decorateCheckedFunction(rateLimiter, fn));
             return this;
         }
 
@@ -218,7 +214,7 @@ public class FeignDecorators implements FeignDecorator {
          * @return the builder
          */
         public Builder withBulkhead(Bulkhead bulkhead) {
-            decorators.add((fn, m, mh, t) -> VavrBulkhead.decorateCheckedFunction(bulkhead, fn));
+            decorators.add((fn, m, mh, t) -> Bulkhead.decorateCheckedFunction(bulkhead, fn));
             return this;
         }
 

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/test/TestFeignDecorator.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/test/TestFeignDecorator.java
@@ -2,15 +2,15 @@ package io.github.resilience4j.feign.test;
 
 import feign.InvocationHandlerFactory.MethodHandler;
 import feign.Target;
+import io.github.resilience4j.core.functions.CheckedFunction;
 import io.github.resilience4j.feign.FeignDecorator;
-import io.vavr.CheckedFunction1;
 
 import java.lang.reflect.Method;
 
 public class TestFeignDecorator implements FeignDecorator {
 
     private volatile boolean called = false;
-    private volatile CheckedFunction1<Object[], Object> alternativeFunction;
+    private volatile CheckedFunction<Object[], Object> alternativeFunction;
 
     public boolean isCalled() {
         return called;
@@ -20,17 +20,17 @@ public class TestFeignDecorator implements FeignDecorator {
         this.called = called;
     }
 
-    public CheckedFunction1<Object[], Object> getAlternativeFunction() {
+    public CheckedFunction<Object[], Object> getAlternativeFunction() {
         return alternativeFunction;
     }
 
-    public void setAlternativeFunction(CheckedFunction1<Object[], Object> alternativeFunction) {
+    public void setAlternativeFunction(CheckedFunction<Object[], Object> alternativeFunction) {
         this.alternativeFunction = alternativeFunction;
     }
 
     @Override
-    public CheckedFunction1<Object[], Object> decorate(
-        CheckedFunction1<Object[], Object> invocationCall,
+    public CheckedFunction<Object[], Object> decorate(
+        CheckedFunction<Object[], Object> invocationCall,
         Method method, MethodHandler methodHandler,
         Target<?> target) {
         called = true;

--- a/resilience4j-ratpack/build.gradle
+++ b/resilience4j-ratpack/build.gradle
@@ -11,7 +11,6 @@ dependencies {
     compile project(':resilience4j-consumer')
     compile project(':resilience4j-reactor')
     compile project(':resilience4j-timelimiter')
-    compile project(':resilience4j-vavr')
     compile(libraries.reactor)
     compileOnly(libraries.ratpack_metrics)
     compileOnly project(':resilience4j-prometheus')

--- a/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/bulkhead/BulkheadMethodInterceptor.java
+++ b/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/bulkhead/BulkheadMethodInterceptor.java
@@ -18,7 +18,6 @@ package io.github.resilience4j.ratpack.bulkhead;
 import com.google.inject.Inject;
 import io.github.resilience4j.bulkhead.BulkheadFullException;
 import io.github.resilience4j.bulkhead.BulkheadRegistry;
-import io.github.resilience4j.bulkhead.VavrBulkhead;
 import io.github.resilience4j.bulkhead.annotation.Bulkhead;
 import io.github.resilience4j.core.lang.Nullable;
 import io.github.resilience4j.ratpack.internal.AbstractMethodInterceptor;
@@ -138,7 +137,8 @@ public class BulkheadMethodInterceptor extends AbstractMethodInterceptor {
         io.github.resilience4j.bulkhead.Bulkhead bulkhead, RecoveryFunction<?> recoveryFunction)
         throws Throwable {
         try {
-            return VavrBulkhead.decorateCheckedSupplier(bulkhead, invocation::proceed).apply();
+            return io.github.resilience4j.bulkhead.Bulkhead
+                .decorateCheckedSupplier(bulkhead, invocation::proceed).get();
         } catch (Throwable throwable) {
             return recoveryFunction.apply(throwable);
         }

--- a/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/circuitbreaker/CircuitBreakerMethodInterceptor.java
+++ b/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/circuitbreaker/CircuitBreakerMethodInterceptor.java
@@ -17,7 +17,6 @@ package io.github.resilience4j.ratpack.circuitbreaker;
 
 import com.google.inject.Inject;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
-import io.github.resilience4j.circuitbreaker.VavrCircuitBreaker;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.core.lang.Nullable;
 import io.github.resilience4j.ratpack.internal.AbstractMethodInterceptor;
@@ -174,7 +173,7 @@ public class CircuitBreakerMethodInterceptor extends AbstractMethodInterceptor {
         io.github.resilience4j.circuitbreaker.CircuitBreaker breaker,
         RecoveryFunction<?> recoveryFunction) throws Throwable {
         try {
-            return VavrCircuitBreaker.decorateCheckedSupplier(breaker, invocation::proceed).apply();
+            return io.github.resilience4j.circuitbreaker.CircuitBreaker.decorateCheckedSupplier(breaker, invocation::proceed).get();
         } catch (Throwable throwable) {
             return recoveryFunction.apply(throwable);
         }

--- a/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/ratelimiter/RateLimiterMethodInterceptor.java
+++ b/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/ratelimiter/RateLimiterMethodInterceptor.java
@@ -19,7 +19,6 @@ package io.github.resilience4j.ratpack.ratelimiter;
 import com.google.inject.Inject;
 import io.github.resilience4j.core.lang.Nullable;
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
-import io.github.resilience4j.ratelimiter.VavrRateLimiter;
 import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import io.github.resilience4j.ratpack.internal.AbstractMethodInterceptor;
 import io.github.resilience4j.ratpack.recovery.DefaultRecoveryFunction;
@@ -130,7 +129,7 @@ public class RateLimiterMethodInterceptor extends AbstractMethodInterceptor {
         io.github.resilience4j.ratelimiter.RateLimiter rateLimiter,
         RecoveryFunction<?> recoveryFunction) throws Throwable {
         try {
-            return VavrRateLimiter.decorateCheckedSupplier(rateLimiter, invocation::proceed).apply();
+            return io.github.resilience4j.ratelimiter.RateLimiter.decorateCheckedSupplier(rateLimiter, invocation::proceed).get();
         } catch (Throwable t) {
             return recoveryFunction.apply(t);
         }

--- a/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/retry/RetryMethodInterceptor.java
+++ b/resilience4j-ratpack/src/main/java/io/github/resilience4j/ratpack/retry/RetryMethodInterceptor.java
@@ -21,7 +21,6 @@ import io.github.resilience4j.ratpack.internal.AbstractMethodInterceptor;
 import io.github.resilience4j.ratpack.recovery.DefaultRecoveryFunction;
 import io.github.resilience4j.ratpack.recovery.RecoveryFunction;
 import io.github.resilience4j.retry.RetryRegistry;
-import io.github.resilience4j.retry.VavrRetry;
 import io.github.resilience4j.retry.annotation.Retry;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
@@ -156,8 +155,8 @@ public class RetryMethodInterceptor extends AbstractMethodInterceptor {
         io.github.resilience4j.retry.Retry retry, RecoveryFunction<?> recoveryFunction)
         throws Throwable {
         try {
-            return VavrRetry
-                .decorateCheckedSupplier(retry, invocation::proceed).apply();
+            return io.github.resilience4j.retry.Retry
+                .decorateCheckedSupplier(retry, invocation::proceed).get();
         } catch (Throwable t) {
             return recoveryFunction.apply(t);
         }

--- a/resilience4j-ratpack/src/test/groovy/io/github/resilience4j/ratpack/retry/monitoring/endpoint/RetryChainSpec.groovy
+++ b/resilience4j-ratpack/src/test/groovy/io/github/resilience4j/ratpack/retry/monitoring/endpoint/RetryChainSpec.groovy
@@ -18,11 +18,11 @@ package io.github.resilience4j.ratpack.retry.monitoring.endpoint
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.github.resilience4j.common.retry.monitoring.endpoint.RetryEventsEndpointResponse
+import io.github.resilience4j.core.functions.CheckedSupplier
 import io.github.resilience4j.ratpack.Resilience4jModule
+import io.github.resilience4j.retry.Retry
 import io.github.resilience4j.retry.RetryRegistry
-import io.github.resilience4j.retry.VavrRetry
 import io.github.resilience4j.retry.event.RetryEvent
-import io.vavr.CheckedFunction0
 import io.vavr.control.Try
 import ratpack.http.client.HttpClient
 import ratpack.test.embed.EmbeddedApp
@@ -88,9 +88,11 @@ class RetryChainSpec extends Specification {
         when: "we get all retry events"
         ['test1', 'test2'].each {
             def r = retryRegistry.retry(it)
-            Try.of(VavrRetry.decorateCheckedSupplier(r, {
-                throw new Exception('derek olk'); 'unreachable'
-            } as CheckedFunction0<String>)).recover { "recovered" }.get()
+            Try.of({ ->
+                Retry.decorateCheckedSupplier(r, {
+                    throw new Exception('derek olk'); 'unreachable'
+                } as CheckedSupplier<String>).get()
+            }).recover { "recovered" }.get()
         }
         actual = client.get('retry/events')
         def dto = mapper.readValue(actual.body.text, RetryEventsEndpointResponse)
@@ -158,9 +160,11 @@ class RetryChainSpec extends Specification {
         def retryRegistry = app.server.registry.get().get(RetryRegistry)
         ['test1', 'test2'].each {
             def r = retryRegistry.retry(it)
-            Try.of(VavrRetry.decorateCheckedSupplier(r, {
-                throw new Exception('derek olk'); 'unreachable'
-            } as CheckedFunction0<String>)).recover { "recovered" }.get()
+            Try.of({ ->
+                Retry.decorateCheckedSupplier(r, {
+                    throw new Exception('derek olk'); 'unreachable'
+                } as CheckedSupplier<String>)
+            }).recover { "recovered" }.get()
         }
         def actual = ExecHarness.yieldSingle {
             streamer.requestStream(new URI("http://$app.server.bindHost:$app.server.bindPort/retry/stream/events")) {
@@ -229,9 +233,11 @@ class RetryChainSpec extends Specification {
         def retryRegistry = app.server.registry.get().get(RetryRegistry)
         ['test1', 'test2'].each {
             def r = retryRegistry.retry(it)
-            Try.of(VavrRetry.decorateCheckedSupplier(r, {
-                throw new Exception('derek olk'); 'unreachable'
-            } as CheckedFunction0<String>)).recover { "recovered" }.get()
+            Try.of({ ->
+                Retry.decorateCheckedSupplier(r, {
+                    throw new Exception('derek olk'); 'unreachable'
+                } as CheckedSupplier<String>)
+            }).recover { "recovered" }.get()
         }
         def actual = client.get('retry/events')
 

--- a/resilience4j-retrofit/build.gradle
+++ b/resilience4j-retrofit/build.gradle
@@ -2,7 +2,6 @@ dependencies {
     compileOnly(libraries.retrofit)
     compile project(':resilience4j-circuitbreaker')
     compile project(':resilience4j-ratelimiter')
-    compile project(':resilience4j-vavr')
     testCompile(libraries.retrofit_test)
     testCompile(libraries.retrofit_wiremock)
     testCompile(libraries.retrofit)

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/internal/RetryImpl.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/internal/RetryImpl.java
@@ -42,7 +42,7 @@ import java.util.function.Supplier;
 public class RetryImpl<T> implements Retry {
 
 
-    /*package*/ static CheckedConsumer<Long, Exception> sleepFunction = Thread::sleep;
+    /*package*/ static CheckedConsumer<Long> sleepFunction = Thread::sleep;
     private final Metrics metrics;
     private final RetryEventProcessor eventProcessor;
     @Nullable
@@ -79,7 +79,7 @@ public class RetryImpl<T> implements Retry {
         failedWithoutRetryCounter = new LongAdder();
     }
 
-    public static void setSleepFunction(CheckedConsumer<Long, Exception> sleepFunction) {
+    public static void setSleepFunction(CheckedConsumer<Long> sleepFunction) {
         RetryImpl.sleepFunction = sleepFunction;
     }
 
@@ -245,6 +245,8 @@ public class RetryImpl<T> implements Retry {
             try {
                 sleepFunction.accept(interval);
             } catch (Exception ex) {
+                throw lastRuntimeException.get();
+            } catch (Throwable e) {
                 throw lastRuntimeException.get();
             }
         }

--- a/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/EventPublisherTest.java
+++ b/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/EventPublisherTest.java
@@ -1,0 +1,113 @@
+/*
+ *
+ *  Copyright 2016: Robert Winkler
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.retry.internal;
+
+import io.github.resilience4j.core.functions.CheckedRunnable;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryConfig;
+import io.github.resilience4j.retry.event.RetryEvent;
+import io.github.resilience4j.test.HelloWorldException;
+import io.github.resilience4j.test.HelloWorldService;
+import io.reactivex.subscribers.TestSubscriber;
+import io.vavr.control.Try;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static io.github.resilience4j.adapter.RxJava2Adapter.toFlowable;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+public class EventPublisherTest {
+
+    private HelloWorldService helloWorldService;
+    private long sleptTime = 0L;
+
+    @Before
+    public void setUp() {
+        helloWorldService = mock(HelloWorldService.class);
+        RetryImpl.setSleepFunction(sleep -> sleptTime += sleep);
+    }
+
+    @Test
+    public void shouldReturnAfterThreeAttempts() {
+        willThrow(new HelloWorldException()).given(helloWorldService).sayHelloWorld();
+        Retry retry = Retry.ofDefaults("id");
+        TestSubscriber<RetryEvent.Type> testSubscriber = toFlowable(retry.getEventPublisher())
+            .map(RetryEvent::getEventType)
+            .test();
+        CheckedRunnable retryableRunnable = Retry
+            .decorateCheckedRunnable(retry, helloWorldService::sayHelloWorld);
+
+        Try<Void> result = Try.run(() -> retryableRunnable.run());
+
+        then(helloWorldService).should(times(3)).sayHelloWorld();
+        assertThat(result.isFailure()).isTrue();
+        assertThat(result.failed().get()).isInstanceOf(HelloWorldException.class);
+        assertThat(sleptTime).isEqualTo(RetryConfig.DEFAULT_WAIT_DURATION * 2);
+        testSubscriber.assertValueCount(3)
+            .assertValues(RetryEvent.Type.RETRY, RetryEvent.Type.RETRY, RetryEvent.Type.ERROR);
+    }
+
+    @Test
+    public void shouldReturnAfterTwoAttempts() {
+        willThrow(new HelloWorldException()).willDoNothing().given(helloWorldService)
+            .sayHelloWorld();
+        Retry retry = Retry.ofDefaults("id");
+        TestSubscriber<RetryEvent.Type> testSubscriber = toFlowable(retry.getEventPublisher())
+            .map(RetryEvent::getEventType)
+            .test();
+        CheckedRunnable retryableRunnable = Retry
+            .decorateCheckedRunnable(retry, helloWorldService::sayHelloWorld);
+
+        Try<Void> result = Try.run(() -> retryableRunnable.run());
+
+        then(helloWorldService).should(times(2)).sayHelloWorld();
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(sleptTime).isEqualTo(RetryConfig.DEFAULT_WAIT_DURATION);
+        testSubscriber.assertValueCount(2)
+            .assertValues(RetryEvent.Type.RETRY, RetryEvent.Type.SUCCESS);
+    }
+
+    @Test
+    public void shouldIgnoreError() {
+        willThrow(new HelloWorldException()).willDoNothing().given(helloWorldService)
+            .sayHelloWorld();
+        RetryConfig config = RetryConfig.custom()
+            .retryOnException(t -> t instanceof IOException)
+            .maxAttempts(3).build();
+        Retry retry = Retry.of("id", config);
+        TestSubscriber<RetryEvent.Type> testSubscriber = toFlowable(retry.getEventPublisher())
+            .map(RetryEvent::getEventType)
+            .test();
+        CheckedRunnable retryableRunnable = Retry
+            .decorateCheckedRunnable(retry, helloWorldService::sayHelloWorld);
+
+        Try<Void> result = Try.run(() -> retryableRunnable.run());
+
+        then(helloWorldService).should().sayHelloWorld();
+        assertThat(result.isFailure()).isTrue();
+        assertThat(sleptTime).isEqualTo(0);
+        testSubscriber.assertValueCount(1).assertValues(RetryEvent.Type.IGNORED_ERROR);
+    }
+}

--- a/resilience4j-spring/build.gradle
+++ b/resilience4j-spring/build.gradle
@@ -1,7 +1,6 @@
 dependencies {
     compile project(':resilience4j-annotations')
     compile project(':resilience4j-consumer')
-    compile project(':resilience4j-vavr')
     compile project(':resilience4j-framework-common')
 
     compileOnly(libraries.aspectj)

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/circuitbreaker/configure/CircuitBreakerAspect.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/circuitbreaker/configure/CircuitBreakerAspect.java
@@ -16,7 +16,6 @@
 package io.github.resilience4j.circuitbreaker.configure;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
-import io.github.resilience4j.circuitbreaker.VavrCircuitBreaker;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.core.lang.Nullable;
 import io.github.resilience4j.fallback.FallbackDecorators;
@@ -116,7 +115,7 @@ public class CircuitBreakerAspect implements Ordered {
             .create(fallbackMethodValue, method,
                 proceedingJoinPoint.getArgs(), proceedingJoinPoint.getTarget());
         return fallbackDecorators.decorate(fallbackMethod,
-            () -> proceed(proceedingJoinPoint, methodName, circuitBreaker, returnType)).apply();
+            () -> proceed(proceedingJoinPoint, methodName, circuitBreaker, returnType)).get();
     }
 
     private Object proceed(ProceedingJoinPoint proceedingJoinPoint, String methodName,
@@ -186,7 +185,7 @@ public class CircuitBreakerAspect implements Ordered {
      */
     private Object defaultHandling(ProceedingJoinPoint proceedingJoinPoint,
         io.github.resilience4j.circuitbreaker.CircuitBreaker circuitBreaker) throws Throwable {
-        return VavrCircuitBreaker.executeCheckedSupplier(circuitBreaker, proceedingJoinPoint::proceed);
+        return circuitBreaker.executeCheckedSupplier(proceedingJoinPoint::proceed);
     }
 
     @Override

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/fallback/CompletionStageFallbackDecorator.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/fallback/CompletionStageFallbackDecorator.java
@@ -15,7 +15,7 @@
  */
 package io.github.resilience4j.fallback;
 
-import io.vavr.CheckedFunction0;
+import io.github.resilience4j.core.functions.CheckedSupplier;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -34,8 +34,8 @@ public class CompletionStageFallbackDecorator implements FallbackDecorator {
 
     @SuppressWarnings("unchecked")
     @Override
-    public CheckedFunction0<Object> decorate(FallbackMethod fallbackMethod,
-        CheckedFunction0<Object> supplier) {
+    public CheckedSupplier<Object> decorate(FallbackMethod fallbackMethod,
+                                            CheckedSupplier<Object> supplier) {
         return supplier.andThen(request -> {
             CompletionStage<Object> completionStage = (CompletionStage) request;
             CompletableFuture promise = new CompletableFuture();

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/fallback/DefaultFallbackDecorator.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/fallback/DefaultFallbackDecorator.java
@@ -15,8 +15,8 @@
  */
 package io.github.resilience4j.fallback;
 
+import io.github.resilience4j.core.functions.CheckedSupplier;
 import io.github.resilience4j.timelimiter.configure.IllegalReturnTypeException;
-import io.vavr.CheckedFunction0;
 
 /**
  * default fallbackMethod decorator. it catches throwable and invoke the fallbackMethod method.
@@ -29,11 +29,11 @@ public class DefaultFallbackDecorator implements FallbackDecorator {
     }
 
     @Override
-    public CheckedFunction0<Object> decorate(FallbackMethod fallbackMethod,
-        CheckedFunction0<Object> supplier) {
+    public CheckedSupplier<Object> decorate(FallbackMethod fallbackMethod,
+                                            CheckedSupplier<Object> supplier) {
         return () -> {
             try {
-                return supplier.apply();
+                return supplier.get();
             } catch (IllegalReturnTypeException e) {
                 throw e;
             } catch (Throwable throwable) {

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/fallback/FallbackDecorator.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/fallback/FallbackDecorator.java
@@ -15,7 +15,7 @@
  */
 package io.github.resilience4j.fallback;
 
-import io.vavr.CheckedFunction0;
+import io.github.resilience4j.core.functions.CheckedSupplier;
 
 /**
  * interface of FallbackDecorator
@@ -29,6 +29,6 @@ public interface FallbackDecorator {
      * @param supplier       target function should be decorated.
      * @return decorated function
      */
-    CheckedFunction0<Object> decorate(FallbackMethod fallbackMethod,
-        CheckedFunction0<Object> supplier);
+    CheckedSupplier<Object> decorate(FallbackMethod fallbackMethod,
+                                     CheckedSupplier<Object> supplier);
 }

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/fallback/FallbackDecorators.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/fallback/FallbackDecorators.java
@@ -15,7 +15,7 @@
  */
 package io.github.resilience4j.fallback;
 
-import io.vavr.CheckedFunction0;
+import io.github.resilience4j.core.functions.CheckedSupplier;
 
 import java.util.List;
 
@@ -39,8 +39,8 @@ public class FallbackDecorators {
      * @param supplier       original function
      * @return a function which is decorated by a {@link FallbackMethod}
      */
-    public CheckedFunction0<Object> decorate(FallbackMethod fallbackMethod,
-        CheckedFunction0<Object> supplier) {
+    public CheckedSupplier<Object> decorate(FallbackMethod fallbackMethod,
+                                            CheckedSupplier<Object> supplier) {
         return get(fallbackMethod.getReturnType())
             .decorate(fallbackMethod, supplier);
     }

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/fallback/ReactorFallbackDecorator.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/fallback/ReactorFallbackDecorator.java
@@ -15,7 +15,7 @@
  */
 package io.github.resilience4j.fallback;
 
-import io.vavr.CheckedFunction0;
+import io.github.resilience4j.core.functions.CheckedSupplier;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -40,8 +40,8 @@ public class ReactorFallbackDecorator implements FallbackDecorator {
 
     @SuppressWarnings("unchecked")
     @Override
-    public CheckedFunction0<Object> decorate(FallbackMethod fallbackMethod,
-        CheckedFunction0<Object> supplier) {
+    public CheckedSupplier<Object> decorate(FallbackMethod fallbackMethod,
+                                            CheckedSupplier<Object> supplier) {
         return supplier.andThen(returnValue -> {
             if (Flux.class.isAssignableFrom(returnValue.getClass())) {
                 Flux fluxReturnValue = (Flux) returnValue;

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/fallback/RxJava2FallbackDecorator.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/fallback/RxJava2FallbackDecorator.java
@@ -15,8 +15,8 @@
  */
 package io.github.resilience4j.fallback;
 
+import io.github.resilience4j.core.functions.CheckedSupplier;
 import io.reactivex.*;
-import io.vavr.CheckedFunction0;
 
 import java.util.Set;
 import java.util.function.Function;
@@ -38,8 +38,8 @@ public class RxJava2FallbackDecorator implements FallbackDecorator {
     }
 
     @Override
-    public CheckedFunction0<Object> decorate(FallbackMethod fallbackMethod,
-        CheckedFunction0<Object> supplier) {
+    public CheckedSupplier<Object> decorate(FallbackMethod fallbackMethod,
+                                            CheckedSupplier<Object> supplier) {
         return supplier.andThen(request -> {
             if (request instanceof ObservableSource) {
                 Observable<?> observable = (Observable<?>) request;

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/ratelimiter/configure/RateLimiterAspect.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/ratelimiter/configure/RateLimiterAspect.java
@@ -20,7 +20,6 @@ import io.github.resilience4j.fallback.FallbackDecorators;
 import io.github.resilience4j.fallback.FallbackMethod;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
-import io.github.resilience4j.ratelimiter.VavrRateLimiter;
 import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import io.github.resilience4j.spelresolver.SpelResolver;
 import io.github.resilience4j.utils.AnnotationExtractor;
@@ -123,7 +122,7 @@ public class RateLimiterAspect implements Ordered {
             .create(fallbackMethodValue, method, proceedingJoinPoint.getArgs(),
                 proceedingJoinPoint.getTarget());
         return fallbackDecorators.decorate(fallbackMethod,
-            () -> proceed(proceedingJoinPoint, methodName, returnType, rateLimiter)).apply();
+            () -> proceed(proceedingJoinPoint, methodName, returnType, rateLimiter)).get();
     }
 
     private Object proceed(ProceedingJoinPoint proceedingJoinPoint, String methodName,
@@ -177,7 +176,7 @@ public class RateLimiterAspect implements Ordered {
     private Object handleJoinPoint(ProceedingJoinPoint proceedingJoinPoint,
         io.github.resilience4j.ratelimiter.RateLimiter rateLimiter)
         throws Throwable {
-        return VavrRateLimiter.executeCheckedSupplier(rateLimiter, proceedingJoinPoint::proceed);
+        return rateLimiter.executeCheckedSupplier(proceedingJoinPoint::proceed);
     }
 
     /**

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/retry/configure/RetryAspect.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/retry/configure/RetryAspect.java
@@ -19,7 +19,6 @@ import io.github.resilience4j.core.lang.Nullable;
 import io.github.resilience4j.fallback.FallbackDecorators;
 import io.github.resilience4j.fallback.FallbackMethod;
 import io.github.resilience4j.retry.RetryRegistry;
-import io.github.resilience4j.retry.VavrRetry;
 import io.github.resilience4j.retry.annotation.Retry;
 import io.github.resilience4j.spelresolver.SpelResolver;
 import io.github.resilience4j.utils.AnnotationExtractor;
@@ -120,7 +119,7 @@ public class RetryAspect implements Ordered, AutoCloseable {
             .create(fallbackMethodValue, method, proceedingJoinPoint.getArgs(),
                 proceedingJoinPoint.getTarget());
         return fallbackDecorators.decorate(fallbackMethod,
-            () -> proceed(proceedingJoinPoint, methodName, retry, returnType)).apply();
+            () -> proceed(proceedingJoinPoint, methodName, retry, returnType)).get();
     }
 
     private Object proceed(ProceedingJoinPoint proceedingJoinPoint, String methodName,
@@ -178,7 +177,7 @@ public class RetryAspect implements Ordered, AutoCloseable {
      */
     private Object handleDefaultJoinPoint(ProceedingJoinPoint proceedingJoinPoint,
         io.github.resilience4j.retry.Retry retry) throws Throwable {
-        return VavrRetry.executeCheckedSupplier(retry, proceedingJoinPoint::proceed);
+        return retry.executeCheckedSupplier(proceedingJoinPoint::proceed);
     }
 
     /**

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/timelimiter/configure/TimeLimiterAspect.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/timelimiter/configure/TimeLimiterAspect.java
@@ -93,7 +93,7 @@ public class TimeLimiterAspect implements Ordered, AutoCloseable {
             .create(fallbackMethodValue, method,
                 proceedingJoinPoint.getArgs(), proceedingJoinPoint.getTarget());
         return fallbackDecorators.decorate(fallbackMethod,
-            () -> proceed(proceedingJoinPoint, methodName, timeLimiter, returnType)).apply();
+            () -> proceed(proceedingJoinPoint, methodName, timeLimiter, returnType)).get();
     }
 
     private Object proceed(ProceedingJoinPoint proceedingJoinPoint, String methodName,

--- a/resilience4j-vavr/src/main/java/io/github/resilience4j/cache/VavrCache.java
+++ b/resilience4j-vavr/src/main/java/io/github/resilience4j/cache/VavrCache.java
@@ -37,13 +37,7 @@ public interface VavrCache {
      */
     static <K, R> CheckedFunction1<K, R> decorateCheckedSupplier(Cache<K, R> cache,
                                                                  CheckedFunction0<R> supplier) {
-        return (K cacheKey) -> cache.computeIfAbsent(cacheKey, () -> {
-            try {
-                return supplier.apply();
-            } catch (Throwable throwable) {
-                throw new RuntimeException(throwable);
-            }
-        });
+        return (K cacheKey) -> cache.computeIfAbsent(cacheKey, supplier::apply);
     }
 
     /**
@@ -57,13 +51,7 @@ public interface VavrCache {
      * @return a supplier which is secured by a CircuitBreaker.
      */
     static <K, R> CheckedFunction1<K, R> decorateCallable(Cache<K, R> cache, Callable<R> callable) {
-        return (K cacheKey) -> cache.computeIfAbsent(cacheKey, () -> {
-            try {
-                return callable.call();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        });
+        return (K cacheKey) -> cache.computeIfAbsent(cacheKey, callable::call);
     }
 
 }

--- a/resilience4j-vavr/src/main/java/io/github/resilience4j/core/VavrCheckedFunctionUtils.java
+++ b/resilience4j-vavr/src/main/java/io/github/resilience4j/core/VavrCheckedFunctionUtils.java
@@ -1,0 +1,147 @@
+/*
+ *
+ *  Copyright 2020: Robert Winkler
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.core;
+
+import io.vavr.CheckedFunction0;
+import io.vavr.CheckedFunction1;
+import io.vavr.CheckedFunction2;
+
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+
+public class VavrCheckedFunctionUtils {
+
+    private VavrCheckedFunctionUtils() {
+    }
+
+
+    /**
+     * Returns a composed function that first executes the function and optionally recovers from an
+     * exception.
+     *
+     * @param <T>              return type of after
+     * @param function the function which should be recovered from a certain exception
+     * @param exceptionHandler the exception handler
+     * @return a function composed of callable and exceptionHandler
+     */
+    public static <T> CheckedFunction0<T> recover(CheckedFunction0<T> function,
+        CheckedFunction1<Throwable, T> exceptionHandler) {
+        return () -> {
+            try {
+                return function.apply();
+            } catch (Throwable throwable) {
+                return exceptionHandler.apply(throwable);
+            }
+        };
+    }
+
+    /**
+     * Returns a composed function that first applies the function and then applies {@linkplain
+     * BiFunction} {@code after} to the result.
+     *
+     * @param <T>     return type of callable
+     * @param <R>     return type of handler
+     * @param function the function
+     * @param handler the function applied after callable
+     * @return a function composed of supplier and handler
+     */
+    public static <T, R> CheckedFunction0<R> andThen(CheckedFunction0<T> function,
+        CheckedFunction2<T, Throwable, R> handler) {
+        return () -> {
+            try {
+                return handler.apply(function.apply(), null);
+            } catch (Throwable throwable) {
+                return handler.apply(null, throwable);
+            }
+        };
+    }
+
+    /**
+     * Returns a composed function that first executes the function and optionally recovers from a specific result.
+     *
+     * @param <T>              return type of after
+     * @param function the function
+     * @param resultPredicate the result predicate
+     * @param resultHandler the result handler
+     * @return a function composed of supplier and exceptionHandler
+     */
+    public static <T> CheckedFunction0<T> recover(CheckedFunction0<T> function,
+        Predicate<T> resultPredicate, CheckedFunction1<T, T> resultHandler) {
+        return () -> {
+            T result = function.apply();
+            if(resultPredicate.test(result)){
+                return resultHandler.apply(result);
+            }
+            return result;
+        };
+    }
+
+    /**
+     * Returns a composed function that first executes the function and optionally recovers from an
+     * exception.
+     *
+     * @param <T>              return type of after
+     * @param function the function which should be recovered from a certain exception
+     * @param exceptionTypes the specific exception types that should be recovered
+     * @param exceptionHandler the exception handler
+     * @return a function composed of supplier and exceptionHandler
+     */
+    public static <T> CheckedFunction0<T> recover(CheckedFunction0<T> function,
+        List<Class<? extends Throwable>> exceptionTypes,
+        CheckedFunction1<Throwable, T> exceptionHandler) {
+        return () -> {
+            try {
+                return function.apply();
+            } catch (Exception exception) {
+                if(exceptionTypes.stream().anyMatch(exceptionType -> exceptionType.isAssignableFrom(exception.getClass()))){
+                    return exceptionHandler.apply(exception);
+                }else{
+                    throw exception;
+                }
+            }
+        };
+    }
+
+    /**
+     * Returns a composed function that first executes the function and optionally recovers from an
+     * exception.
+     *
+     * @param <T>              return type of after
+     * @param function the function which should be recovered from a certain exception
+     * @param exceptionType the specific exception type that should be recovered
+     * @param exceptionHandler the exception handler
+     * @return a function composed of callable and exceptionHandler
+     */
+    public static <X extends Throwable, T> CheckedFunction0<T> recover(CheckedFunction0<T> function,
+        Class<X> exceptionType,
+        CheckedFunction1<Throwable, T> exceptionHandler) {
+        return () -> {
+            try {
+                return function.apply();
+            } catch (Throwable throwable) {
+                if(exceptionType.isAssignableFrom(throwable.getClass())) {
+                    return exceptionHandler.apply(throwable);
+                }else{
+                    throw throwable;
+                }
+            }
+        };
+    }
+}

--- a/resilience4j-vavr/src/main/java/io/github/resilience4j/decorators/VavrDecorators.java
+++ b/resilience4j-vavr/src/main/java/io/github/resilience4j/decorators/VavrDecorators.java
@@ -24,7 +24,7 @@ import io.github.resilience4j.cache.Cache;
 import io.github.resilience4j.cache.VavrCache;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.VavrCircuitBreaker;
-import io.github.resilience4j.core.CheckFunctionUtils;
+import io.github.resilience4j.core.VavrCheckedFunctionUtils;
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.VavrRateLimiter;
 import io.github.resilience4j.retry.Retry;
@@ -89,27 +89,27 @@ public interface VavrDecorators {
         }
 
         public DecorateCheckedSupplier<T> withFallback(CheckedFunction2<T, Throwable, T> handler) {
-            supplier = CheckFunctionUtils.andThen(supplier, handler);
+            supplier = VavrCheckedFunctionUtils.andThen(supplier, handler);
             return this;
         }
 
         public DecorateCheckedSupplier<T> withFallback(Predicate<T> resultPredicate, CheckedFunction1<T, T> resultHandler) {
-            supplier = CheckFunctionUtils.recover(supplier, resultPredicate, resultHandler);
+            supplier = VavrCheckedFunctionUtils.recover(supplier, resultPredicate, resultHandler);
             return this;
         }
 
         public DecorateCheckedSupplier<T> withFallback(List<Class<? extends Throwable>> exceptionTypes, CheckedFunction1<Throwable, T> exceptionHandler) {
-            supplier = CheckFunctionUtils.recover(supplier, exceptionTypes, exceptionHandler);
+            supplier = VavrCheckedFunctionUtils.recover(supplier, exceptionTypes, exceptionHandler);
             return this;
         }
 
         public DecorateCheckedSupplier<T> withFallback(CheckedFunction1<Throwable, T> exceptionHandler) {
-            supplier = CheckFunctionUtils.recover(supplier, exceptionHandler);
+            supplier = VavrCheckedFunctionUtils.recover(supplier, exceptionHandler);
             return this;
         }
 
         public <X extends Throwable> DecorateCheckedSupplier<T> withFallback(Class<X> exceptionType, CheckedFunction1<Throwable, T> exceptionHandler) {
-            supplier = CheckFunctionUtils.recover(supplier, exceptionType, exceptionHandler);
+            supplier = VavrCheckedFunctionUtils.recover(supplier, exceptionType, exceptionHandler);
             return this;
         }
 

--- a/resilience4j-vavr/src/test/java/io/github/resilience4j/core/VavrCheckedFunctionUtilsTest.java
+++ b/resilience4j-vavr/src/test/java/io/github/resilience4j/core/VavrCheckedFunctionUtilsTest.java
@@ -26,14 +26,14 @@ import java.io.IOException;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CheckFunctionUtilsTest {
+public class VavrCheckedFunctionUtilsTest {
 
     @Test
     public void shouldRecoverFromException() throws Throwable {
         CheckedFunction0<String> callable = () -> {
             throw new IOException("BAM!");
         };
-        CheckedFunction0<String> callableWithRecovery = CheckFunctionUtils.recover(callable, (ex) -> "Bla");
+        CheckedFunction0<String> callableWithRecovery = VavrCheckedFunctionUtils.recover(callable, (ex) -> "Bla");
 
         String result = callableWithRecovery.apply();
 
@@ -46,7 +46,7 @@ public class CheckFunctionUtilsTest {
             throw new IOException("BAM!");
         };
 
-        CheckedFunction0<String> callableWithRecovery = CheckFunctionUtils.recover(callable,
+        CheckedFunction0<String> callableWithRecovery = VavrCheckedFunctionUtils.recover(callable,
             asList(IllegalArgumentException.class, IOException.class),
             (ex) -> "Bla");
 
@@ -59,7 +59,7 @@ public class CheckFunctionUtilsTest {
     public void shouldRecoverFromResult() throws Throwable {
         CheckedFunction0<String> callable = () -> "Wrong Result";
 
-        CheckedFunction0<String> callableWithRecovery = CheckFunctionUtils.andThen(callable, (result, ex) -> {
+        CheckedFunction0<String> callableWithRecovery = VavrCheckedFunctionUtils.andThen(callable, (result, ex) -> {
             if(result.equals("Wrong Result")){
                 return "Bla";
             }
@@ -76,7 +76,7 @@ public class CheckFunctionUtilsTest {
         CheckedFunction0<String> callable = () -> {
             throw new IllegalArgumentException("BAM!");
         };
-        CheckedFunction0<String> callableWithRecovery = CheckFunctionUtils.andThen(callable, (result, ex) -> {
+        CheckedFunction0<String> callableWithRecovery = VavrCheckedFunctionUtils.andThen(callable, (result, ex) -> {
             if(ex instanceof IllegalArgumentException){
                 return "Bla";
             }
@@ -92,7 +92,7 @@ public class CheckFunctionUtilsTest {
     public void shouldRecoverFromSpecificResult() throws Throwable {
         CheckedFunction0<String> supplier = () -> "Wrong Result";
 
-        CheckedFunction0<String> callableWithRecovery = CheckFunctionUtils.recover(supplier, (result) -> result.equals("Wrong Result"), (r) -> "Bla");
+        CheckedFunction0<String> callableWithRecovery = VavrCheckedFunctionUtils.recover(supplier, (result) -> result.equals("Wrong Result"), (r) -> "Bla");
         String result = callableWithRecovery.apply();
 
         assertThat(result).isEqualTo("Bla");
@@ -104,7 +104,7 @@ public class CheckFunctionUtilsTest {
         CheckedFunction0<String> callable = () -> {
             throw new IOException("BAM!");
         };
-        CheckedFunction0<String> callableWithRecovery = CheckFunctionUtils.recover(callable, (ex) -> {
+        CheckedFunction0<String> callableWithRecovery = VavrCheckedFunctionUtils.recover(callable, (ex) -> {
             throw new RuntimeException();
         });
 
@@ -116,7 +116,7 @@ public class CheckFunctionUtilsTest {
         CheckedFunction0<String> callable = () -> {
             throw new RuntimeException("BAM!");
         };
-        CheckedFunction0<String> callableWithRecovery = CheckFunctionUtils.recover(callable, IllegalArgumentException.class, (ex) -> "Bla");
+        CheckedFunction0<String> callableWithRecovery = VavrCheckedFunctionUtils.recover(callable, IllegalArgumentException.class, (ex) -> "Bla");
 
         callableWithRecovery.apply();
     }

--- a/resilience4j-vavr/src/test/java/io/github/resilience4j/retry/VavrRetryTest.java
+++ b/resilience4j-vavr/src/test/java/io/github/resilience4j/retry/VavrRetryTest.java
@@ -43,7 +43,7 @@ public class VavrRetryTest {
     private long sleptTime = 0L;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         helloWorldService = mock(HelloWorldService.class);
         RetryImpl.setSleepFunction(sleep -> sleptTime += sleep);
     }


### PR DESCRIPTION
This PR is final and in continuation of Removing vavr dependency from Resilience4j.
Created custom Checked*** Functional Interfaces and brought back all related test cases too as discussed in previous PR: https://github.com/resilience4j/resilience4j/pull/1156#discussion_r488573709

With this PR, removal of Vavr dependency from Resilience4j should be marked as done.
Once again apology for the long PR.

@RobWin Kindly review.