### PR TITLE
Timelimiter metrics/events: Register timeouts as timeouts and all other exceptions as errors

### DIFF
--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/timelimiter/TimeLimiter.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/timelimiter/TimeLimiter.kt
@@ -47,8 +47,7 @@ suspend fun <T> TimeLimiter.executeSuspendFunction(block: suspend () -> T): T =
         }
     } catch (t: Throwable) {
         if (isCancellation(coroutineContext, t)) {
-            val timeoutException = createdTimeoutExceptionWithName(name)
-            timeoutException.stackTrace = t.stackTrace
+            val timeoutException = TimeLimiter.createdTimeoutExceptionWithName(name, t)
             onError(timeoutException)
             throw timeoutException
         }
@@ -74,8 +73,4 @@ suspend fun <T> TimeLimiter.executeSuspendFunction(block: suspend () -> T): T =
  */
 fun <T> TimeLimiter.decorateSuspendFunction(block: suspend () -> T): suspend () -> T = {
     executeSuspendFunction(block)
-}
-
-private fun createdTimeoutExceptionWithName(name: String?): TimeoutException {
-    return TimeoutException(String.format("TimeLimiter '%s' recorded a timeout exception.", name))
 }

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/timelimiter/TimeLimiter.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/timelimiter/TimeLimiter.kt
@@ -22,6 +22,7 @@ import io.github.resilience4j.kotlin.isCancellation
 import io.github.resilience4j.timelimiter.TimeLimiter
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeout
+import java.util.concurrent.TimeoutException
 import kotlin.coroutines.coroutineContext
 
 /**
@@ -45,9 +46,9 @@ suspend fun <T> TimeLimiter.executeSuspendFunction(block: suspend () -> T): T =
         }
     } catch (t: Throwable) {
         if (isCancellation(coroutineContext, t)) {
-            onError(t)
+            onError(TimeoutException(t.message))
         } else {
-            onSuccess()
+            onError(t)
         }
         throw t
     }

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/timelimiter/TimeLimiter.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/timelimiter/TimeLimiter.kt
@@ -28,11 +28,12 @@ import kotlin.coroutines.coroutineContext
 /**
  * Decorates and executes the given suspend function [block].
  *
- * This is an alias for [withTimeout], reading the timeout from the receiver's
+ * This is a wrapper for [withTimeout], reading the timeout from the receiver's
  * [timeLimiterConfig][TimeLimiter.getTimeLimiterConfig].  Specifically, this means:
  *
- * 1. On timeout, a [TimeoutCancellationException] is raised, rather than a TimeoutException as with methods for
- *    non-suspending functions.
+ * 1. On timeout, a [TimeoutException] is raised as with methods for non-suspending functions. It's derived from
+ *    [java.util.concurrent.CancellationException] to ensure the exception is registered properly in events, and
+ *    a [TimeLimiter] can be used safely when using multiple decorators.
  * 1. When a timeout occurs, the coroutine is cancelled, rather than the thread being interrupted as with methods for
  *    non-suspending functions.
  * 1. After the timeout, the given block can only be stopped at a cancellable suspending function call.
@@ -46,10 +47,12 @@ suspend fun <T> TimeLimiter.executeSuspendFunction(block: suspend () -> T): T =
         }
     } catch (t: Throwable) {
         if (isCancellation(coroutineContext, t)) {
-            onError(TimeoutException(t.message))
-        } else {
-            onError(t)
+            val timeoutException = TimeoutException(t.message)
+            onError(timeoutException)
+            throw timeoutException
         }
+
+        onError(t)
         throw t
     }
 

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/timelimiter/TimeLimiter.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/timelimiter/TimeLimiter.kt
@@ -25,6 +25,8 @@ import kotlinx.coroutines.withTimeout
 import java.util.concurrent.TimeoutException
 import kotlin.coroutines.coroutineContext
 
+class TimeLimiterTimeoutException(override val message: String, override val cause: Throwable) : TimeoutException(message)
+
 /**
  * Decorates and executes the given suspend function [block].
  *
@@ -47,7 +49,7 @@ suspend fun <T> TimeLimiter.executeSuspendFunction(block: suspend () -> T): T =
         }
     } catch (t: Throwable) {
         if (isCancellation(coroutineContext, t)) {
-            val timeoutException = TimeoutException(t.message)
+            val timeoutException = TimeLimiterTimeoutException("Timelimited suspend function was cancelled.", t)
             onError(timeoutException)
             throw timeoutException
         }

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/timelimiter/CoroutineTimeLimiterTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/timelimiter/CoroutineTimeLimiterTest.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions
 import org.junit.Test
 import java.time.Duration
+import java.util.concurrent.TimeoutException
 
 class CoroutineTimeLimiterTest {
     @Test
@@ -89,8 +90,8 @@ class CoroutineTimeLimiterTest {
                 timelimiter.executeSuspendFunction {
                     helloWorldService.wait()
                 }
-                Assertions.failBecauseExceptionWasNotThrown<Nothing>(CancellationException::class.java)
-            } catch (e: CancellationException) {
+                Assertions.failBecauseExceptionWasNotThrown<Nothing>(TimeoutException::class.java)
+            } catch (e: TimeoutException) {
                 // nothing - proceed
             }
 

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/timelimiter/CoroutineTimeLimiterTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/timelimiter/CoroutineTimeLimiterTest.kt
@@ -23,7 +23,6 @@ import io.github.resilience4j.timelimiter.TimeLimiter
 import io.github.resilience4j.timelimiter.event.TimeLimiterOnErrorEvent
 import io.github.resilience4j.timelimiter.event.TimeLimiterOnSuccessEvent
 import io.github.resilience4j.timelimiter.event.TimeLimiterOnTimeoutEvent
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions
 import org.junit.Test

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/timelimiter/FlowTimeLimiterTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/timelimiter/FlowTimeLimiterTest.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions
 import org.junit.Test
 import java.time.Duration
+import java.util.concurrent.TimeoutException
 
 class FlowTimeLimiterTest {
 
@@ -94,8 +95,8 @@ class FlowTimeLimiterTest {
                 flow<String> { helloWorldService.wait() }
                     .timeLimiter(timelimiter)
                     .toList(resultList)
-                Assertions.failBecauseExceptionWasNotThrown<Nothing>(CancellationException::class.java)
-            } catch (e: CancellationException) {
+                Assertions.failBecauseExceptionWasNotThrown<Nothing>(TimeoutException::class.java)
+            } catch (e: TimeoutException) {
                 // nothing - proceed
             }
 

--- a/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/TimeLimiter.java
+++ b/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/TimeLimiter.java
@@ -7,11 +7,9 @@ import io.github.resilience4j.timelimiter.event.TimeLimiterOnSuccessEvent;
 import io.github.resilience4j.timelimiter.event.TimeLimiterOnTimeoutEvent;
 import io.github.resilience4j.timelimiter.internal.TimeLimiterImpl;
 
+import javax.annotation.Nullable;
 import java.time.Duration;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.*;
 import java.util.function.Supplier;
 
 /**
@@ -217,5 +215,13 @@ public interface TimeLimiter {
 
         EventPublisher onTimeout(EventConsumer<TimeLimiterOnTimeoutEvent> eventConsumer);
 
+    }
+
+    static TimeoutException createdTimeoutExceptionWithName(String name, @Nullable Throwable t) {
+        final TimeoutException timeoutException = new TimeoutException(String.format("TimeLimiter '%s' recorded a timeout exception.", name));
+        if(t != null){
+            timeoutException.setStackTrace(t.getStackTrace());
+        }
+        return timeoutException;
     }
 }

--- a/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/internal/TimeLimiterImpl.java
+++ b/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/internal/TimeLimiterImpl.java
@@ -48,8 +48,7 @@ public class TimeLimiterImpl implements TimeLimiter {
                 onSuccess();
                 return result;
             } catch (TimeoutException e) {
-                TimeoutException timeoutException = createdTimeoutExceptionWithName(name);
-                timeoutException.setStackTrace(e.getStackTrace());
+                TimeoutException timeoutException = TimeLimiter.createdTimeoutExceptionWithName(name, e);
                 onError(timeoutException);
                 if (getTimeLimiterConfig().shouldCancelRunningFuture()) {
                     future.cancel(true);
@@ -183,13 +182,9 @@ public class TimeLimiterImpl implements TimeLimiter {
             TimeUnit unit) {
             return scheduler.schedule(() -> {
                 if (future != null && !future.isDone()) {
-                    future.completeExceptionally(createdTimeoutExceptionWithName(name));
+                    future.completeExceptionally(TimeLimiter.createdTimeoutExceptionWithName(name, null));
                 }
             }, delay, unit);
         }
-    }
-
-    static TimeoutException createdTimeoutExceptionWithName(String name) {
-        return new TimeoutException(String.format("TimeLimiter '%s' recorded a timeout exception." , name));
     }
 }

--- a/resilience4j-timelimiter/src/test/java/io/github/resilience4j/timelimiter/internal/TimeLimiterTest.java
+++ b/resilience4j-timelimiter/src/test/java/io/github/resilience4j/timelimiter/internal/TimeLimiterTest.java
@@ -9,7 +9,6 @@ import java.time.Duration;
 import java.util.concurrent.*;
 import java.util.function.Supplier;
 
-import static io.github.resilience4j.timelimiter.internal.TimeLimiterImpl.createdTimeoutExceptionWithName;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -49,7 +48,7 @@ public class TimeLimiterTest {
 
         assertThat(decoratedResult.isFailure()).isTrue();
         assertThat(decoratedResult.getCause()).isInstanceOf(TimeoutException.class);
-        assertThat(decoratedResult.getCause()).hasMessage(createdTimeoutExceptionWithName(TIME_LIMITER_NAME).getMessage());
+        assertThat(decoratedResult.getCause()).hasMessage(TimeLimiter.createdTimeoutExceptionWithName(TIME_LIMITER_NAME, null).getMessage());
 
         then(mockFuture).should().cancel(true);
     }


### PR DESCRIPTION
Also see https://github.com/resilience4j/resilience4j/issues/1168 and https://github.com/resilience4j/resilience4j/pull/1095


The changes I'm making to resilience:
- A timelimiter rethrows any exception
- A timelimiter records `TimeoutCancellationException`s as `java.util.concurrent.TimeoutException`s, such that the event handler recognises this as a timeout.
- A timelimiter records any other exception as an error.
- A timelimiter records successfull results if no exception occured during execution
