### PR TITLE
Issue #1043 Added IntervalBiFunction to calculate wait duration based on result/exception

### DIFF
--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/IntervalBiFunction.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/IntervalBiFunction.java
@@ -1,0 +1,18 @@
+package io.github.resilience4j.core;
+
+import io.vavr.control.Either;
+
+import java.util.function.BiFunction;
+
+/**
+ * An IntervalBiFunction which can be used to calculate the wait interval. The input parameters of the bi
+ * function is the number of attempts (attempt) and either result or exception, the output parameter is the wait interval in
+ * milliseconds. The attempt parameter starts at 1 and increases with every further attempt.
+ */
+@FunctionalInterface
+public interface IntervalBiFunction<T> extends BiFunction<Integer, Either<T, Throwable>, Long> {
+
+    static <T> IntervalBiFunction<T> ofIntervalFunction(IntervalFunction f) {
+        return (attempt, either) -> f.apply(attempt);
+    }
+}

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/IntervalBiFunction.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/IntervalBiFunction.java
@@ -10,7 +10,7 @@ import java.util.function.BiFunction;
  * milliseconds. The attempt parameter starts at 1 and increases with every further attempt.
  */
 @FunctionalInterface
-public interface IntervalBiFunction<T> extends BiFunction<Integer, Either<T, Throwable>, Long> {
+public interface IntervalBiFunction<T> extends BiFunction<Integer, Either<Throwable, T>, Long> {
 
     static <T> IntervalBiFunction<T> ofIntervalFunction(IntervalFunction f) {
         return (attempt, either) -> f.apply(attempt);

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/retry/configuration/RetryConfigurationPropertiesTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/retry/configuration/RetryConfigurationPropertiesTest.java
@@ -134,14 +134,14 @@ public class RetryConfigurationPropertiesTest {
             .createRetryConfig("backendWithDefaultConfig", compositeRetryCustomizer());
         assertThat(retry1).isNotNull();
         assertThat(retry1.getMaxAttempts()).isEqualTo(3);
-        assertThat(retry1.getIntervalFunction().apply(1)).isEqualTo(200L);
+        assertThat(retry1.getIntervalBiFunction().apply(1, null)).isEqualTo(200L);
 
         // Should get shared config and overwrite wait time
         RetryConfig retry2 = retryConfigurationProperties
             .createRetryConfig("backendWithSharedConfig", compositeRetryCustomizer());
         assertThat(retry2).isNotNull();
         assertThat(retry2.getMaxAttempts()).isEqualTo(2);
-        assertThat(retry2.getIntervalFunction().apply(1)).isEqualTo(300L);
+        assertThat(retry2.getIntervalBiFunction().apply(1, null)).isEqualTo(300L);
 
         // Unknown backend should get default config of Registry
         RetryConfig retry3 = retryConfigurationProperties

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/RetryConfig.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/RetryConfig.java
@@ -179,7 +179,7 @@ public class RetryConfig implements Serializable {
 
         public Builder<T> waitDuration(Duration waitDuration) {
             if (waitDuration.toMillis() >= 0) {
-                this.intervalFunction = (x) -> waitDuration.toMillis();
+                this.intervalBiFunction = (attempt, either) -> waitDuration.toMillis();
             } else {
                 throw new IllegalArgumentException(
                     "waitDuration must be a positive value");

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/internal/RetryImpl.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/internal/RetryImpl.java
@@ -24,10 +24,12 @@ import io.github.resilience4j.core.lang.Nullable;
 import io.github.resilience4j.retry.MaxRetriesExceeded;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
+import io.github.resilience4j.core.IntervalBiFunction;
 import io.github.resilience4j.retry.event.*;
 import io.vavr.CheckedConsumer;
 import io.vavr.collection.HashMap;
 import io.vavr.collection.Map;
+import io.vavr.control.Either;
 import io.vavr.control.Option;
 import io.vavr.control.Try;
 
@@ -36,7 +38,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
@@ -53,7 +54,7 @@ public class RetryImpl<T> implements Retry {
     private final Map<String, String> tags;
 
     private final int maxAttempts;
-    private final Function<Integer, Long> intervalFunction;
+    private final IntervalBiFunction<T> intervalBiFunction;
     private final Predicate<Throwable> exceptionPredicate;
     private final LongAdder succeededAfterRetryCounter;
     private final LongAdder failedAfterRetryCounter;
@@ -69,7 +70,7 @@ public class RetryImpl<T> implements Retry {
         this.config = config;
         this.tags = tags;
         this.maxAttempts = config.getMaxAttempts();
-        this.intervalFunction = config.getIntervalFunction();
+        this.intervalBiFunction = config.getIntervalBiFunction();
         this.exceptionPredicate = config.getExceptionPredicate();
         this.resultPredicate = config.getResultPredicate();
         this.metrics = this.new RetryMetrics();
@@ -176,7 +177,7 @@ public class RetryImpl<T> implements Retry {
                 if (currentNumOfAttempts >= maxAttempts) {
                     return false;
                 } else {
-                    waitIntervalAfterFailure(currentNumOfAttempts, null);
+                    waitIntervalAfterFailure(currentNumOfAttempts, Either.left(result));
                     return true;
                 }
             }
@@ -216,7 +217,7 @@ public class RetryImpl<T> implements Retry {
                     () -> new RetryOnErrorEvent(getName(), currentNumOfAttempts, throwable));
                 throw throwable;
             } else {
-                waitIntervalAfterFailure(currentNumOfAttempts, throwable);
+                waitIntervalAfterFailure(currentNumOfAttempts, Either.right(throwable));
             }
         }
 
@@ -229,16 +230,15 @@ public class RetryImpl<T> implements Retry {
                     () -> new RetryOnErrorEvent(getName(), currentNumOfAttempts, throwable));
                 throw throwable;
             } else {
-                waitIntervalAfterFailure(currentNumOfAttempts, throwable);
+                waitIntervalAfterFailure(currentNumOfAttempts, Either.right(throwable));
             }
         }
 
-        private void waitIntervalAfterFailure(int currentNumOfAttempts,
-                                              @Nullable Throwable throwable) {
+        private void waitIntervalAfterFailure(int currentNumOfAttempts, Either<T, Throwable> either) {
             // wait interval until the next attempt should start
-            long interval = intervalFunction.apply(numOfAttempts.get());
+            long interval = intervalBiFunction.apply(numOfAttempts.get(), either);
             publishRetryEvent(
-                () -> new RetryOnRetryEvent(getName(), currentNumOfAttempts, throwable, interval));
+                () -> new RetryOnRetryEvent(getName(), currentNumOfAttempts, either.getOrNull(), interval));
             Try.run(() -> sleepFunction.accept(interval))
                 .getOrElseThrow(ex -> lastRuntimeException.get());
         }
@@ -310,7 +310,7 @@ public class RetryImpl<T> implements Retry {
                 return -1;
             }
 
-            long interval = intervalFunction.apply(attempt);
+            long interval = intervalBiFunction.apply(attempt, Either.right(throwable));
             publishRetryEvent(() -> new RetryOnRetryEvent(getName(), attempt, throwable, interval));
             return interval;
         }
@@ -322,7 +322,7 @@ public class RetryImpl<T> implements Retry {
                 if (attempt >= maxAttempts) {
                     return -1;
                 }
-                return intervalFunction.apply(attempt);
+                return intervalBiFunction.apply(attempt, Either.left(result));
             } else {
                 return -1;
             }

--- a/resilience4j-retry/src/test/java/io/github/resilience4j/retry/RetryConfigBuilderTest.java
+++ b/resilience4j-retry/src/test/java/io/github/resilience4j/retry/RetryConfigBuilderTest.java
@@ -18,6 +18,8 @@
  */
 package io.github.resilience4j.retry;
 
+import io.github.resilience4j.core.IntervalBiFunction;
+import io.github.resilience4j.core.IntervalFunction;
 import org.junit.Test;
 
 import java.time.Duration;
@@ -68,6 +70,17 @@ public class RetryConfigBuilderTest {
         assertThat(config.getExceptionPredicate().test(new IllegalStateException())).isFalse();
     }
 
+    @Test
+    public void testCreateFromConfigurationShouldCopyIntervalBiFunction() {
+        IntervalBiFunction<Object> biFunction = IntervalBiFunction.ofIntervalFunction(IntervalFunction.ofExponentialBackoff());
+        RetryConfig config = RetryConfig
+            .from(RetryConfig.custom()
+                .intervalBiFunction(biFunction)
+                .build()).build();
+        assertThat(config).isNotNull();
+        assertThat(config.getIntervalBiFunction()).isNotNull();
+        assertThat(config.getIntervalBiFunction()).isEqualTo(biFunction);
+    }
 
     @Test
     public void waitIntervalOverTenMillisShouldSucceed() {

--- a/resilience4j-retry/src/test/java/io/github/resilience4j/retry/RetryConfigBuilderTest.java
+++ b/resilience4j-retry/src/test/java/io/github/resilience4j/retry/RetryConfigBuilderTest.java
@@ -40,13 +40,13 @@ public class RetryConfigBuilderTest {
     @Test
     public void zeroWaitInterval() {
         final RetryConfig config = RetryConfig.custom().waitDuration(Duration.ofMillis(0)).build();
-        assertThat(config.getIntervalFunction().apply(1)).isEqualTo(0);
+        assertThat(config.getIntervalBiFunction().apply(1, null)).isEqualTo(0);
     }
 
     @Test
     public void waitIntervalUnderTenMillisShouldSucceed() {
         RetryConfig config = RetryConfig.custom().waitDuration(Duration.ofMillis(5)).build();
-        assertThat(config.getIntervalFunction().apply(1)).isEqualTo(5L);
+        assertThat(config.getIntervalBiFunction().apply(1, null)).isEqualTo(5L);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/RunnableRetryTest.java
+++ b/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/RunnableRetryTest.java
@@ -172,23 +172,4 @@ public class RunnableRetryTest {
         then(helloWorldService).should(times(3)).sayHelloWorld();
         assertThat(sleptTime).isEqualTo(200);
     }
-
-    @Test
-    public void shouldNotTakeIntoAccountBackoffFunctionWhenBiFunctionIsSet() {
-        willThrow(new HelloWorldException()).given(helloWorldService).sayHelloWorld();
-        RetryConfig config = RetryConfig
-            .custom()
-            .maxAttempts(3)
-            .intervalFunction(IntervalFunction.of(Duration.ofMillis(500)))
-            .intervalBiFunction((attempt, result) -> result.mapLeft(e -> 100L).getLeft())
-            .build();
-        Retry retry = Retry.of("id", config);
-        CheckedRunnable retryableRunnable = Retry
-            .decorateCheckedRunnable(retry, helloWorldService::sayHelloWorld);
-
-        Try.run(retryableRunnable);
-
-        then(helloWorldService).should(times(3)).sayHelloWorld();
-        assertThat(sleptTime).isEqualTo(200);
-    }
 }

--- a/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/RunnableRetryTest.java
+++ b/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/RunnableRetryTest.java
@@ -161,7 +161,7 @@ public class RunnableRetryTest {
         RetryConfig config = RetryConfig
             .custom()
             .maxAttempts(3)
-            .intervalBiFunction((attempt, result) -> result.map(e -> 100L).get())
+            .intervalBiFunction((attempt, result) -> result.mapLeft(e -> 100L).getLeft())
             .build();
         Retry retry = Retry.of("id", config);
         CheckedRunnable retryableRunnable = Retry
@@ -180,7 +180,7 @@ public class RunnableRetryTest {
             .custom()
             .maxAttempts(3)
             .intervalFunction(IntervalFunction.of(Duration.ofMillis(500)))
-            .intervalBiFunction((attempt, result) -> result.map(e -> 100L).get())
+            .intervalBiFunction((attempt, result) -> result.mapLeft(e -> 100L).getLeft())
             .build();
         Retry retry = Retry.of("id", config);
         CheckedRunnable retryableRunnable = Retry

--- a/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/SupplierRetryTest.java
+++ b/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/SupplierRetryTest.java
@@ -534,8 +534,8 @@ public class SupplierRetryTest {
             .willReturn("Await 100")
             .willReturn("Await 200")
             .willReturn("Hello world");
-        IntervalBiFunction<String> intervalBiFunction = (attempt, result) -> result.map(e -> 1000L)
-                .mapLeft(r -> r.contains("100") ? 100L : 200L)
+        IntervalBiFunction<String> intervalBiFunction = (attempt, result) -> result.mapLeft(e -> 1000L)
+                .map(r -> r.contains("100") ? 100L : 200L)
                 .fold(Function.identity(), Function.identity());
 
         RetryConfig retryConfig = RetryConfig.<String>custom()

--- a/resilience4j-spring/src/test/java/io/github/resilience4j/retry/configure/RetryConfigurationTest.java
+++ b/resilience4j-spring/src/test/java/io/github/resilience4j/retry/configure/RetryConfigurationTest.java
@@ -87,12 +87,12 @@ public class RetryConfigurationTest {
         Retry retry1 = retryRegistry.retry("backendWithDefaultConfig");
         assertThat(retry1).isNotNull();
         assertThat(retry1.getRetryConfig().getMaxAttempts()).isEqualTo(3);
-        assertThat(retry1.getRetryConfig().getIntervalFunction().apply(1)).isEqualTo(200L);
+        assertThat(retry1.getRetryConfig().getIntervalBiFunction().apply(1, null)).isEqualTo(200L);
         // Should get shared config and overwrite wait time
         Retry retry2 = retryRegistry.retry("backendWithSharedConfig");
         assertThat(retry2).isNotNull();
         assertThat(retry2.getRetryConfig().getMaxAttempts()).isEqualTo(2);
-        assertThat(retry2.getRetryConfig().getIntervalFunction().apply(1)).isEqualTo(300L);
+        assertThat(retry2.getRetryConfig().getIntervalBiFunction().apply(1, null)).isEqualTo(300L);
         // Unknown backend should get default config of Registry
         Retry retry3 = retryRegistry.retry("unknownBackend");
         assertThat(retry3).isNotNull();


### PR DESCRIPTION
Pull request for issue https://github.com/resilience4j/resilience4j/issues/1043

Added `interface IntervalBiFunction<T> extends BiFunction<Integer, Either<T, Throwable>, Long>` to calculate retry wait interval on result or exception. When `IntervalBiFunction` is not set then the it will use the `IntervalFunction` as fallback.

An use case for this feature is to be able to respect HTTP `Retry-After` header.

Questions: 
- `IntervalBiFunction` should be placed in `resilience4j-core` or `resilience4j-retry`?
- `RetryConfig.intervalFunction` should be marked as deprecated? `RetryConfig.IntervalBiFunction` is the only one used to build a `Retry` instance. -> yes
