### PR TITLE
Implemented Context Aware scheduled thread pool for bulkhead

### DIFF
--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfig.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfig.java
@@ -19,6 +19,7 @@
 package io.github.resilience4j.bulkhead;
 
 import io.github.resilience4j.core.ClassUtils;
+import io.github.resilience4j.core.ContextPropagator;
 import io.github.resilience4j.core.lang.Nullable;
 
 import java.time.Duration;

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/BulkheadNamingThreadFactory.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/BulkheadNamingThreadFactory.java
@@ -1,0 +1,14 @@
+package io.github.resilience4j.bulkhead.internal;
+
+import io.github.resilience4j.core.NamingThreadFactory;
+
+/**
+ * Creates threads using "bulkhead-$name-%d" pattern for naming. Is based on {@link
+ * java.util.concurrent.Executors.DefaultThreadFactory}.
+ */
+class BulkheadNamingThreadFactory extends NamingThreadFactory {
+
+    BulkheadNamingThreadFactory(String name) {
+        super(String.join("-", "bulkhead", name));
+    }
+}

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/FixedThreadPoolBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/FixedThreadPoolBulkhead.java
@@ -20,13 +20,13 @@ package io.github.resilience4j.bulkhead.internal;
 
 
 import io.github.resilience4j.bulkhead.BulkheadFullException;
-import io.github.resilience4j.bulkhead.ContextPropagator;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkheadConfig;
 import io.github.resilience4j.bulkhead.event.BulkheadEvent;
 import io.github.resilience4j.bulkhead.event.BulkheadOnCallFinishedEvent;
 import io.github.resilience4j.bulkhead.event.BulkheadOnCallPermittedEvent;
 import io.github.resilience4j.bulkhead.event.BulkheadOnCallRejectedEvent;
+import io.github.resilience4j.core.ContextPropagator;
 import io.github.resilience4j.core.EventConsumer;
 import io.github.resilience4j.core.EventProcessor;
 import io.github.resilience4j.core.lang.Nullable;

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/FixedThreadPoolBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/FixedThreadPoolBulkhead.java
@@ -83,7 +83,7 @@ public class FixedThreadPoolBulkhead implements ThreadPoolBulkhead {
             config.getMaxThreadPoolSize(),
             config.getKeepAliveDuration().toMillis(), TimeUnit.MILLISECONDS,
             new ArrayBlockingQueue<>(config.getQueueCapacity()),
-            new NamingThreadFactory(name),
+            new BulkheadNamingThreadFactory(name),
             config.getRejectedExecutionHandler());
         // adding prover jvm executor shutdown
         this.metrics = new FixedThreadPoolBulkhead.BulkheadMetrics();

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfigTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfigTest.java
@@ -18,6 +18,7 @@
  */
 package io.github.resilience4j.bulkhead;
 
+import io.github.resilience4j.core.ContextPropagator;
 import org.junit.Test;
 
 import java.time.Duration;

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/internal/FixedThreadPoolBulkheadTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/internal/FixedThreadPoolBulkheadTest.java
@@ -19,11 +19,11 @@
 package io.github.resilience4j.bulkhead.internal;
 
 
-import io.github.resilience4j.bulkhead.TestContextPropagators;
-import io.github.resilience4j.bulkhead.TestContextPropagators.TestThreadLocalContextPropagatorWithHolder.TestThreadLocalContextHolder;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkheadConfig;
 import io.github.resilience4j.core.registry.*;
+import io.github.resilience4j.test.TestContextPropagators;
+import io.github.resilience4j.test.TestContextPropagators.TestThreadLocalContextPropagatorWithHolder.TestThreadLocalContextHolder;
 import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.Before;
 import org.junit.Test;

--- a/resilience4j-core/build.gradle
+++ b/resilience4j-core/build.gradle
@@ -2,4 +2,5 @@ ext.moduleName = 'io.github.resilience4j.core'
 
 dependencies {
     testCompile(libraries.mock_clock)
+    testCompile project(':resilience4j-test')
 }

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/ContextAwareScheduledThreadPool.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/ContextAwareScheduledThreadPool.java
@@ -1,0 +1,110 @@
+/*
+ *
+ *  Copyright 2020 krnsaurabh
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.core;
+
+import io.github.resilience4j.core.lang.Nullable;
+import org.slf4j.MDC;
+
+import java.util.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class ContextAwareScheduledThreadPool extends ScheduledThreadPoolExecutor {
+
+    private final List<ContextPropagator> contextPropagators;
+
+    public ContextAwareScheduledThreadPool(int corePoolSize) {
+        this(corePoolSize, null);
+    }
+
+    public ContextAwareScheduledThreadPool(int corePoolSize,
+                                           @Nullable List<ContextPropagator> contextPropagators) {
+        super(corePoolSize);
+        this.contextPropagators = contextPropagators != null ? contextPropagators : new ArrayList<>();
+    }
+
+    public List<ContextPropagator> getContextPropagators() {
+        return Collections.unmodifiableList(this.contextPropagators);
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        Map<String, String> mdcContextMap = getMdcContextMap();
+        return super.schedule(ContextPropagator.decorateRunnable(contextPropagators, () -> {
+                try {
+                    setMDCContext(mdcContextMap);
+                    command.run();
+                } finally {
+                    MDC.clear();
+                }
+            }), delay, unit);
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        Map<String, String> mdcContextMap = getMdcContextMap();
+        return super.schedule(ContextPropagator.decorateCallable(contextPropagators, () -> {
+            try {
+                setMDCContext(mdcContextMap);
+                return callable.call();
+            } finally {
+                MDC.clear();
+            }
+        }), delay, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+        Map<String, String> mdcContextMap = getMdcContextMap();
+        return super.scheduleAtFixedRate(ContextPropagator.decorateRunnable(contextPropagators, () -> {
+            try {
+                setMDCContext(mdcContextMap);
+                command.run();
+            } finally {
+                MDC.clear();
+            }
+        }), initialDelay, period, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+        Map<String, String> mdcContextMap = getMdcContextMap();
+        return super.scheduleWithFixedDelay(ContextPropagator.decorateRunnable(contextPropagators, () -> {
+            try {
+                setMDCContext(mdcContextMap);
+                command.run();
+            } finally {
+                MDC.clear();
+            }
+        }), initialDelay, delay, unit);
+    }
+
+    private Map<String, String> getMdcContextMap() {
+        return Optional.ofNullable(MDC.getCopyOfContextMap()).orElse(Collections.emptyMap());
+    }
+
+    private void setMDCContext(Map<String, String> contextMap) {
+        MDC.clear();
+        if (contextMap != null) {
+            MDC.setContextMap(contextMap);
+        }
+    }
+}

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/ContextAwareScheduledThreadPoolExecutor.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/ContextAwareScheduledThreadPoolExecutor.java
@@ -27,17 +27,18 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-public class ContextAwareScheduledThreadPool extends ScheduledThreadPoolExecutor {
+public class ContextAwareScheduledThreadPoolExecutor extends ScheduledThreadPoolExecutor {
 
     private final List<ContextPropagator> contextPropagators;
+    private static final String THREAD_PREFIX = "ContextAwareScheduledThreadPool";
 
-    public ContextAwareScheduledThreadPool(int corePoolSize) {
+    public ContextAwareScheduledThreadPoolExecutor(int corePoolSize) {
         this(corePoolSize, null);
     }
 
-    public ContextAwareScheduledThreadPool(int corePoolSize,
-                                           @Nullable List<ContextPropagator> contextPropagators) {
-        super(corePoolSize);
+    public ContextAwareScheduledThreadPoolExecutor(int corePoolSize,
+                                                   @Nullable List<ContextPropagator> contextPropagators) {
+        super(corePoolSize, new NamingThreadFactory(THREAD_PREFIX));
         this.contextPropagators = contextPropagators != null ? contextPropagators : new ArrayList<>();
     }
 

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/NamingThreadFactory.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/NamingThreadFactory.java
@@ -1,11 +1,11 @@
 package io.github.resilience4j.core;
 
+import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Creates threads using "bulkhead-$name-%d" pattern for naming. Is based on {@link
- * java.util.concurrent.Executors.DefaultThreadFactory}.
+ * Creates threads using "$name-%d" pattern for naming. Is based on {@link Executors#defaultThreadFactory}
  */
 public class NamingThreadFactory implements ThreadFactory {
 

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/NamingThreadFactory.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/NamingThreadFactory.java
@@ -1,4 +1,4 @@
-package io.github.resilience4j.bulkhead.internal;
+package io.github.resilience4j.core;
 
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -7,15 +7,15 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Creates threads using "bulkhead-$name-%d" pattern for naming. Is based on {@link
  * java.util.concurrent.Executors.DefaultThreadFactory}.
  */
-class NamingThreadFactory implements ThreadFactory {
+public class NamingThreadFactory implements ThreadFactory {
 
     private final ThreadGroup group;
     private final AtomicInteger threadNumber = new AtomicInteger(1);
     private final String prefix;
 
-    NamingThreadFactory(String name) {
+    public NamingThreadFactory(String name) {
         this.group = getThreadGroup();
-        this.prefix = String.join("-", "bulkhead", name, "");
+        this.prefix = String.join("-",name, "");
     }
 
     private ThreadGroup getThreadGroup() {

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/NamingThreadFactory.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/NamingThreadFactory.java
@@ -1,3 +1,21 @@
+/*
+ *
+ *  Copyright 2020 krnsaurabh
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
 package io.github.resilience4j.core;
 
 import java.util.concurrent.Executors;

--- a/resilience4j-core/src/test/java/io/github/resilience4j/core/ContextAwareScheduledThreadPoolExecutorTest.java
+++ b/resilience4j-core/src/test/java/io/github/resilience4j/core/ContextAwareScheduledThreadPoolExecutorTest.java
@@ -34,13 +34,13 @@ import static com.jayway.awaitility.Awaitility.matches;
 import static com.jayway.awaitility.Awaitility.waitAtMost;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ContextAwareScheduledThreadPoolTest {
+public class ContextAwareScheduledThreadPoolExecutorTest {
 
-    private ContextAwareScheduledThreadPool schedulerService;
+    private ContextAwareScheduledThreadPoolExecutor schedulerService;
 
     @Before
     public void initialise() {
-        schedulerService = new ContextAwareScheduledThreadPool(
+        schedulerService = new ContextAwareScheduledThreadPoolExecutor(
             20,
             Stream.of(new TestContextPropagators.TestThreadLocalContextPropagatorWithHolder())
                 .collect(Collectors.toList()));
@@ -90,7 +90,7 @@ public class ContextAwareScheduledThreadPoolTest {
 
     @Test
     public void testMDCWithoutContextPropagator() {
-        final ContextAwareScheduledThreadPool schedulerService = new ContextAwareScheduledThreadPool(
+        final ContextAwareScheduledThreadPoolExecutor schedulerService = new ContextAwareScheduledThreadPoolExecutor(
             10);
 
         MDC.put("key", "value");

--- a/resilience4j-core/src/test/java/io/github/resilience4j/core/ContextAwareScheduledThreadPoolTest.java
+++ b/resilience4j-core/src/test/java/io/github/resilience4j/core/ContextAwareScheduledThreadPoolTest.java
@@ -1,0 +1,105 @@
+/*
+ *
+ *  Copyright 2020 krnsaurabh
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.core;
+
+import io.github.resilience4j.test.TestContextPropagators;
+import io.github.resilience4j.test.TestContextPropagators.TestThreadLocalContextPropagatorWithHolder.TestThreadLocalContextHolder;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.MDC;
+
+import java.util.Map;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.jayway.awaitility.Awaitility.matches;
+import static com.jayway.awaitility.Awaitility.waitAtMost;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ContextAwareScheduledThreadPoolTest {
+
+    private ContextAwareScheduledThreadPool schedulerService;
+
+    @Before
+    public void initialise() {
+        schedulerService = new ContextAwareScheduledThreadPool(
+            20,
+            Stream.of(new TestContextPropagators.TestThreadLocalContextPropagatorWithHolder())
+                .collect(Collectors.toList()));
+    }
+
+    @Test
+    public void testConfigs() {
+        assertThat(schedulerService.getCorePoolSize()).isEqualTo(20);
+    }
+
+    @Test
+    public void testScheduleRunnablePropagatesContext() throws Exception{
+        TestThreadLocalContextHolder.put("ValueShouldCrossThreadBoundary");
+        final ScheduledFuture<?> schedule = schedulerService.schedule(() -> {
+            TestThreadLocalContextHolder.get().orElseThrow(() -> new RuntimeException("Found No Context"));
+        }, 0, TimeUnit.MILLISECONDS);
+        schedule.get();
+    }
+
+    @Test
+    public void testScheduleCallablePropagatesContext() {
+        TestThreadLocalContextHolder.put("ValueShouldCrossThreadBoundary");
+        final ScheduledFuture<?> schedule = schedulerService.schedule(() -> TestThreadLocalContextHolder.get().orElse(null), 0, TimeUnit.MILLISECONDS);
+        waitAtMost(1, TimeUnit.SECONDS).until(matches(() ->
+            assertThat(schedule.get()).isEqualTo("ValueShouldCrossThreadBoundary")));
+    }
+
+    @Test
+    public void testScheduleCallableWithDelayPropagatesContext() {
+        TestThreadLocalContextHolder.put("ValueShouldCrossThreadBoundary");
+        final ScheduledFuture<?> schedule = schedulerService.schedule(() -> TestThreadLocalContextHolder.get().orElse(null), 100, TimeUnit.MILLISECONDS);
+        waitAtMost(200, TimeUnit.MILLISECONDS).until(matches(() ->
+            assertThat(schedule.get()).isEqualTo("ValueShouldCrossThreadBoundary")));
+    }
+
+    @Test
+    public void testMDC() {
+        MDC.put("key", "value");
+        MDC.put("key2","value2");
+        final Map<String, String> contextMap = MDC.getCopyOfContextMap();
+        final ScheduledFuture<Map<String, String>> scheduledFuture = this.schedulerService
+            .schedule(TestThreadLocalContextHolder::getMDCContext, 0, TimeUnit.MILLISECONDS);
+
+        waitAtMost(1, TimeUnit.SECONDS).until(matches(() ->
+            assertThat(scheduledFuture.get()).hasSize(2).containsExactlyEntriesOf(contextMap)));
+    }
+
+    @Test
+    public void testMDCWithoutContextPropagator() {
+        final ContextAwareScheduledThreadPool schedulerService = new ContextAwareScheduledThreadPool(
+            10);
+
+        MDC.put("key", "value");
+        MDC.put("key2","value2");
+        final Map<String, String> contextMap = MDC.getCopyOfContextMap();
+        final ScheduledFuture<Map<String, String>> scheduledFuture = schedulerService
+            .schedule(TestThreadLocalContextHolder::getMDCContext, 0, TimeUnit.MILLISECONDS);
+
+        waitAtMost(1, TimeUnit.SECONDS).until(matches(() ->
+            assertThat(scheduledFuture.get()).hasSize(2).containsExactlyEntriesOf(contextMap)));
+    }
+}

--- a/resilience4j-core/src/test/java/io/github/resilience4j/core/ContextPropagatorTest.java
+++ b/resilience4j-core/src/test/java/io/github/resilience4j/core/ContextPropagatorTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -58,6 +59,15 @@ public class ContextPropagatorTest {
 
         waitAtMost(5, TimeUnit.SECONDS).until(matches(() ->
             assertThat(future).isCompletedWithValue("Hello World")));
+    }
+
+    @Test
+    public void contextPropagationEmptyListShouldNotFailWithCallable() {
+        //Thread boundary
+        Callable<String> decorateCallable = ContextPropagator.decorateCallable(Collections.emptyList(), () -> "Hello World");
+
+        waitAtMost(5, TimeUnit.SECONDS).until(matches(() ->
+            assertThat(decorateCallable.call()).isEqualTo("Hello World")));
     }
 
     @Test
@@ -104,6 +114,29 @@ public class ContextPropagatorTest {
     }
 
     @Test
+    public void contextPropagationSupplierMultipleTestWithCallable() {
+        ThreadLocal<String> threadLocalOne = new ThreadLocal<>();
+        threadLocalOne.set("FirstValueShouldCrossThreadBoundary");
+
+        ThreadLocal<String> threadLocalTwo = new ThreadLocal<>();
+        threadLocalTwo.set("SecondValueShouldCrossThreadBoundary");
+
+        TestThreadLocalContextPropagator propagatorOne = new TestThreadLocalContextPropagator(threadLocalOne);
+        TestThreadLocalContextPropagator propagatorTwo = new TestThreadLocalContextPropagator(threadLocalTwo);
+
+        Callable<List<String>> callable = ContextPropagator.decorateCallable(
+            Arrays.asList(propagatorOne, propagatorTwo),
+            () -> Arrays.asList(threadLocalOne.get(), threadLocalTwo.get()));
+        //Thread boundary
+
+        waitAtMost(5, TimeUnit.SECONDS).until(matches(() ->
+            assertThat(callable.call()).containsExactlyInAnyOrder(
+                "FirstValueShouldCrossThreadBoundary",
+                "SecondValueShouldCrossThreadBoundary")
+        ));
+    }
+
+    @Test
     public void contextPropagationSupplierSingleTest() {
         ThreadLocal<String> threadLocal = new ThreadLocal<>();
         threadLocal.set("SingleValueShouldCrossThreadBoundary");
@@ -116,6 +149,19 @@ public class ContextPropagatorTest {
 
         waitAtMost(5, TimeUnit.SECONDS).until(matches(() ->
             assertThat(future).isCompletedWithValue("SingleValueShouldCrossThreadBoundary")));
+    }
+
+    @Test
+    public void contextPropagationSupplierSingleTestWithCallable() {
+        ThreadLocal<String> threadLocal = new ThreadLocal<>();
+        threadLocal.set("SingleValueShouldCrossThreadBoundary");
+
+        Callable<String> callable = ContextPropagator.decorateCallable(
+            new TestThreadLocalContextPropagator(threadLocal),
+            threadLocal::get);
+
+        waitAtMost(200, TimeUnit.MILLISECONDS).until(matches(() ->
+            assertThat(callable.call()).isEqualTo("SingleValueShouldCrossThreadBoundary")));
     }
 
     @Test

--- a/resilience4j-core/src/test/java/io/github/resilience4j/core/ContextPropagatorTest.java
+++ b/resilience4j-core/src/test/java/io/github/resilience4j/core/ContextPropagatorTest.java
@@ -1,6 +1,24 @@
-package io.github.resilience4j.bulkhead;
+/*
+ *
+ *  Copyright 2020 krnsaurabh
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.core;
 
-import io.github.resilience4j.bulkhead.TestContextPropagators.TestThreadLocalContextPropagator;
+import io.github.resilience4j.test.TestContextPropagators.TestThreadLocalContextPropagator;
 import org.junit.Test;
 
 import java.util.Arrays;

--- a/resilience4j-framework-common/build.gradle
+++ b/resilience4j-framework-common/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     compile project(':resilience4j-retry')
     compile project(':resilience4j-bulkhead')
     compile project(':resilience4j-timelimiter')
+    testCompile project(':resilience4j-test')
 }
 
 ext.moduleName = 'io.github.resilience4j.frameworkcommon'

--- a/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/bulkhead/configuration/ThreadPoolBulkheadConfigurationProperties.java
+++ b/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/bulkhead/configuration/ThreadPoolBulkheadConfigurationProperties.java
@@ -16,11 +16,11 @@
 package io.github.resilience4j.common.bulkhead.configuration;
 
 import io.github.resilience4j.bulkhead.Bulkhead;
-import io.github.resilience4j.bulkhead.ContextPropagator;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkheadConfig;
 import io.github.resilience4j.common.CommonProperties;
 import io.github.resilience4j.common.CompositeCustomizer;
 import io.github.resilience4j.core.ConfigurationNotFoundException;
+import io.github.resilience4j.core.ContextPropagator;
 import io.github.resilience4j.core.StringUtils;
 import io.github.resilience4j.core.lang.Nullable;
 

--- a/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/scheduled/threadpool/configuration/ContextAwareScheduledThreadPoolConfigurationProperties.java
+++ b/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/scheduled/threadpool/configuration/ContextAwareScheduledThreadPoolConfigurationProperties.java
@@ -19,7 +19,7 @@
 package io.github.resilience4j.common.scheduled.threadpool.configuration;
 
 import io.github.resilience4j.core.ClassUtils;
-import io.github.resilience4j.core.ContextAwareScheduledThreadPool;
+import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
 import io.github.resilience4j.core.ContextPropagator;
 
 import java.util.List;
@@ -54,7 +54,7 @@ public class ContextAwareScheduledThreadPoolConfigurationProperties {
             : new Class[0];
     }
 
-    public ContextAwareScheduledThreadPool build() {
+    public ContextAwareScheduledThreadPoolExecutor build() {
         if (this.coreThreadPoolSize < 1) {
             return null;
         }
@@ -64,7 +64,7 @@ public class ContextAwareScheduledThreadPoolConfigurationProperties {
                 .map(ClassUtils::instantiateClassDefConstructor)
                 .collect(toList());
         }
-        return new ContextAwareScheduledThreadPool(this.coreThreadPoolSize, contextPropagatorsList);
+        return new ContextAwareScheduledThreadPoolExecutor(this.coreThreadPoolSize, contextPropagatorsList);
     }
 
 }

--- a/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/scheduled/threadpool/configuration/ContextAwareScheduledThreadPoolConfigurationProperties.java
+++ b/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/scheduled/threadpool/configuration/ContextAwareScheduledThreadPoolConfigurationProperties.java
@@ -29,19 +29,19 @@ import static java.util.stream.Collectors.toList;
 
 public class ContextAwareScheduledThreadPoolConfigurationProperties {
 
-    private int coreThreadPoolSize;
+    private int corePoolSize;
     private Class<? extends ContextPropagator>[] contextPropagators = new Class[0];
 
-    public int getCoreThreadPoolSize() {
-        return coreThreadPoolSize;
+    public int getCorePoolSize() {
+        return corePoolSize;
     }
 
-    public void setCoreThreadPoolSize(int coreThreadPoolSize) {
-        if (coreThreadPoolSize < 1) {
+    public void setCorePoolSize(int corePoolSize) {
+        if (corePoolSize < 1) {
             throw new IllegalArgumentException(
-                "coreThreadPoolSize must be a positive integer value >= 1");
+                "corePoolSize must be a positive integer value >= 1");
         }
-        this.coreThreadPoolSize = coreThreadPoolSize;
+        this.corePoolSize = corePoolSize;
     }
 
     public Class<? extends ContextPropagator>[] getContextPropagators() {
@@ -55,16 +55,14 @@ public class ContextAwareScheduledThreadPoolConfigurationProperties {
     }
 
     public ContextAwareScheduledThreadPoolExecutor build() {
-        if (this.coreThreadPoolSize < 1) {
-            return null;
-        }
-        List<ContextPropagator> contextPropagatorsList = null;
-        if (contextPropagators.length > 0) {
-            contextPropagatorsList = stream(this.contextPropagators)
-                .map(ClassUtils::instantiateClassDefConstructor)
-                .collect(toList());
-        }
-        return new ContextAwareScheduledThreadPoolExecutor(this.coreThreadPoolSize, contextPropagatorsList);
+        List<ContextPropagator> contextPropagatorsList = stream(this.contextPropagators)
+            .map(ClassUtils::instantiateClassDefConstructor)
+            .collect(toList());
+
+        return ContextAwareScheduledThreadPoolExecutor.newScheduledThreadPool()
+            .corePoolSize(this.corePoolSize)
+            .contextPropagators(contextPropagatorsList.toArray(new ContextPropagator[0]))
+            .build();
     }
 
 }

--- a/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/scheduled/threadpool/configuration/ContextAwareScheduledThreadPoolConfigurationProperties.java
+++ b/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/scheduled/threadpool/configuration/ContextAwareScheduledThreadPoolConfigurationProperties.java
@@ -1,0 +1,70 @@
+/*
+ *
+ *  Copyright 2020 krnsaurabh
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.common.scheduled.threadpool.configuration;
+
+import io.github.resilience4j.core.ClassUtils;
+import io.github.resilience4j.core.ContextAwareScheduledThreadPool;
+import io.github.resilience4j.core.ContextPropagator;
+
+import java.util.List;
+
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toList;
+
+public class ContextAwareScheduledThreadPoolConfigurationProperties {
+
+    private int coreThreadPoolSize;
+    private Class<? extends ContextPropagator>[] contextPropagators = new Class[0];
+
+    public int getCoreThreadPoolSize() {
+        return coreThreadPoolSize;
+    }
+
+    public void setCoreThreadPoolSize(int coreThreadPoolSize) {
+        if (coreThreadPoolSize < 1) {
+            throw new IllegalArgumentException(
+                "coreThreadPoolSize must be a positive integer value >= 1");
+        }
+        this.coreThreadPoolSize = coreThreadPoolSize;
+    }
+
+    public Class<? extends ContextPropagator>[] getContextPropagators() {
+        return contextPropagators;
+    }
+
+    public void setContextPropagators(Class<? extends ContextPropagator>... contextPropagators) {
+        this.contextPropagators = contextPropagators != null
+            ? contextPropagators
+            : new Class[0];
+    }
+
+    public ContextAwareScheduledThreadPool build() {
+        if (this.coreThreadPoolSize < 1) {
+            return null;
+        }
+        List<ContextPropagator> contextPropagatorsList = null;
+        if (contextPropagators.length > 0) {
+            contextPropagatorsList = stream(this.contextPropagators)
+                .map(ClassUtils::instantiateClassDefConstructor)
+                .collect(toList());
+        }
+        return new ContextAwareScheduledThreadPool(this.coreThreadPoolSize, contextPropagatorsList);
+    }
+
+}

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/scheduled/threadpool/configuration/ContextAwareScheduledThreadPoolConfigurationPropertiesTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/scheduled/threadpool/configuration/ContextAwareScheduledThreadPoolConfigurationPropertiesTest.java
@@ -1,0 +1,66 @@
+/*
+ *
+ *  Copyright 2020 krnsaurabh
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.common.scheduled.threadpool.configuration;
+
+import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
+import io.github.resilience4j.test.TestContextPropagators.TestThreadLocalContextPropagatorWithHolder;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public class ContextAwareScheduledThreadPoolConfigurationPropertiesTest {
+
+    @Test
+    public void buildPropertiesWithValidArguments() {
+        ContextAwareScheduledThreadPoolConfigurationProperties poolConfigurationProperties = new ContextAwareScheduledThreadPoolConfigurationProperties();
+        poolConfigurationProperties.setContextPropagators(TestThreadLocalContextPropagatorWithHolder.class);
+        poolConfigurationProperties.setCorePoolSize(10);
+
+        final ContextAwareScheduledThreadPoolExecutor contextAwareScheduledThreadPoolExecutor = poolConfigurationProperties.build();
+        assertThat(contextAwareScheduledThreadPoolExecutor.getCorePoolSize()).isEqualTo(10);
+        assertThat(contextAwareScheduledThreadPoolExecutor.getContextPropagators()).hasSize(1).hasOnlyElementsOfTypes(TestThreadLocalContextPropagatorWithHolder.class);
+    }
+
+    @Test
+    public void shouldThrowErrorWhenCorePoolSizeIsLessThanOne() {
+        ContextAwareScheduledThreadPoolConfigurationProperties poolConfigurationProperties = new ContextAwareScheduledThreadPoolConfigurationProperties();
+        poolConfigurationProperties.setContextPropagators(TestThreadLocalContextPropagatorWithHolder.class);
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> poolConfigurationProperties.setCorePoolSize(0));
+    }
+
+    @Test
+    public void buildPropertiesWithNoContextPropagator() {
+        ContextAwareScheduledThreadPoolConfigurationProperties poolConfigurationProperties = new ContextAwareScheduledThreadPoolConfigurationProperties();
+        poolConfigurationProperties.setCorePoolSize(10);
+
+        final ContextAwareScheduledThreadPoolExecutor contextAwareScheduledThreadPoolExecutor = poolConfigurationProperties.build();
+        assertThat(contextAwareScheduledThreadPoolExecutor.getCorePoolSize()).isEqualTo(10);
+        assertThat(contextAwareScheduledThreadPoolExecutor.getContextPropagators()).isEmpty();
+    }
+
+    @Test
+    public void shouldThrowErrorIfPropertiesNotSet() {
+        ContextAwareScheduledThreadPoolConfigurationProperties poolConfigurationProperties = new ContextAwareScheduledThreadPoolConfigurationProperties();
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(poolConfigurationProperties::build);
+    }
+
+}

--- a/resilience4j-spring-boot2/build.gradle
+++ b/resilience4j-spring-boot2/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     testCompile(libraries.spring_cloud_context)
     testCompile(libraries.feign_wiremock)
     testCompile(libraries.spring_boot2_webflux)
+    testCompile project(':resilience4j-test')
 }
 
 compileJava.dependsOn(processResources)

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/retry/autoconfigure/AbstractRetryConfigurationOnMissingBean.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/retry/autoconfigure/AbstractRetryConfigurationOnMissingBean.java
@@ -18,6 +18,7 @@ package io.github.resilience4j.retry.autoconfigure;
 import io.github.resilience4j.common.CompositeCustomizer;
 import io.github.resilience4j.common.retry.configuration.RetryConfigCustomizer;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
+import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
 import io.github.resilience4j.fallback.FallbackDecorators;
 import io.github.resilience4j.fallback.autoconfigure.FallbackConfigurationOnMissingBean;
@@ -96,11 +97,12 @@ public abstract class AbstractRetryConfigurationOnMissingBean {
         RetryRegistry retryRegistry,
         @Autowired(required = false) List<RetryAspectExt> retryAspectExtList,
         FallbackDecorators fallbackDecorators,
-        SpelResolver spelResolver
+        SpelResolver spelResolver,
+        @Autowired(required = false) ContextAwareScheduledThreadPoolExecutor contextAwareScheduledThreadPoolExecutor
     ) {
         return retryConfiguration
             .retryAspect(retryConfigurationProperties, retryRegistry, retryAspectExtList,
-                fallbackDecorators, spelResolver);
+                fallbackDecorators, spelResolver, contextAwareScheduledThreadPoolExecutor);
     }
 
     @Bean

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/scheduled/threadpool/autoconfigure/ContextAwareScheduledThreadPoolAutoConfiguration.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/scheduled/threadpool/autoconfigure/ContextAwareScheduledThreadPoolAutoConfiguration.java
@@ -18,7 +18,7 @@
  */
 package io.github.resilience4j.scheduled.threadpool.autoconfigure;
 
-import io.github.resilience4j.core.ContextAwareScheduledThreadPool;
+import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -28,7 +28,7 @@ import org.springframework.context.annotation.Configuration;
 public class ContextAwareScheduledThreadPoolAutoConfiguration {
 
     @Bean
-    public ContextAwareScheduledThreadPool getContextAwareScheduledThreadPool(ContextAwareScheduledThreadPoolProperties contextAwareScheduledThreadPoolProperties) {
+    public ContextAwareScheduledThreadPoolExecutor getContextAwareScheduledThreadPool(ContextAwareScheduledThreadPoolProperties contextAwareScheduledThreadPoolProperties) {
         return contextAwareScheduledThreadPoolProperties.build();
     }
 }

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/scheduled/threadpool/autoconfigure/ContextAwareScheduledThreadPoolAutoConfiguration.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/scheduled/threadpool/autoconfigure/ContextAwareScheduledThreadPoolAutoConfiguration.java
@@ -19,12 +19,14 @@
 package io.github.resilience4j.scheduled.threadpool.autoconfigure;
 
 import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableConfigurationProperties(ContextAwareScheduledThreadPoolProperties.class)
+@ConditionalOnProperty(value = "resilience4j.scheduled.executor.corePoolSize")
+@EnableConfigurationProperties({ContextAwareScheduledThreadPoolProperties.class})
 public class ContextAwareScheduledThreadPoolAutoConfiguration {
 
     @Bean

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/scheduled/threadpool/autoconfigure/ContextAwareScheduledThreadPoolAutoConfiguration.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/scheduled/threadpool/autoconfigure/ContextAwareScheduledThreadPoolAutoConfiguration.java
@@ -1,0 +1,34 @@
+/*
+ *
+ *  Copyright 2020 krnsaurabh
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.scheduled.threadpool.autoconfigure;
+
+import io.github.resilience4j.core.ContextAwareScheduledThreadPool;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(ContextAwareScheduledThreadPoolProperties.class)
+public class ContextAwareScheduledThreadPoolAutoConfiguration {
+
+    @Bean
+    public ContextAwareScheduledThreadPool getContextAwareScheduledThreadPool(ContextAwareScheduledThreadPoolProperties contextAwareScheduledThreadPoolProperties) {
+        return contextAwareScheduledThreadPoolProperties.build();
+    }
+}

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/scheduled/threadpool/autoconfigure/ContextAwareScheduledThreadPoolProperties.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/scheduled/threadpool/autoconfigure/ContextAwareScheduledThreadPoolProperties.java
@@ -1,0 +1,27 @@
+/*
+ *
+ *  Copyright 2020 krnsaurabh
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.scheduled.threadpool.autoconfigure;
+
+import io.github.resilience4j.common.scheduled.threadpool.configuration.ContextAwareScheduledThreadPoolConfigurationProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "resilience4j.scheduled.executor")
+public class ContextAwareScheduledThreadPoolProperties extends ContextAwareScheduledThreadPoolConfigurationProperties {
+
+}

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/timelimiter/autoconfigure/AbstractTimeLimiterConfigurationOnMissingBean.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/timelimiter/autoconfigure/AbstractTimeLimiterConfigurationOnMissingBean.java
@@ -19,7 +19,7 @@ package io.github.resilience4j.timelimiter.autoconfigure;
 import io.github.resilience4j.common.CompositeCustomizer;
 import io.github.resilience4j.common.timelimiter.configuration.TimeLimiterConfigCustomizer;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
-import io.github.resilience4j.core.ContextAwareScheduledThreadPool;
+import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
 import io.github.resilience4j.fallback.FallbackDecorators;
 import io.github.resilience4j.fallback.autoconfigure.FallbackConfigurationOnMissingBean;
@@ -85,10 +85,10 @@ public abstract class AbstractTimeLimiterConfigurationOnMissingBean {
         @Autowired(required = false) List<TimeLimiterAspectExt> timeLimiterAspectExtList,
         FallbackDecorators fallbackDecorators,
         SpelResolver spelResolver,
-        @Autowired(required = false) ContextAwareScheduledThreadPool contextAwareScheduledThreadPool
+        @Autowired(required = false) ContextAwareScheduledThreadPoolExecutor contextAwareScheduledThreadPoolExecutor
     ) {
         return timeLimiterConfiguration.timeLimiterAspect(
-            timeLimiterProperties, timeLimiterRegistry, timeLimiterAspectExtList, fallbackDecorators, spelResolver, contextAwareScheduledThreadPool);
+            timeLimiterProperties, timeLimiterRegistry, timeLimiterAspectExtList, fallbackDecorators, spelResolver, contextAwareScheduledThreadPoolExecutor);
     }
 
     @Bean

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/timelimiter/autoconfigure/AbstractTimeLimiterConfigurationOnMissingBean.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/timelimiter/autoconfigure/AbstractTimeLimiterConfigurationOnMissingBean.java
@@ -19,6 +19,7 @@ package io.github.resilience4j.timelimiter.autoconfigure;
 import io.github.resilience4j.common.CompositeCustomizer;
 import io.github.resilience4j.common.timelimiter.configuration.TimeLimiterConfigCustomizer;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
+import io.github.resilience4j.core.ContextAwareScheduledThreadPool;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
 import io.github.resilience4j.fallback.FallbackDecorators;
 import io.github.resilience4j.fallback.autoconfigure.FallbackConfigurationOnMissingBean;
@@ -83,10 +84,11 @@ public abstract class AbstractTimeLimiterConfigurationOnMissingBean {
         TimeLimiterRegistry timeLimiterRegistry,
         @Autowired(required = false) List<TimeLimiterAspectExt> timeLimiterAspectExtList,
         FallbackDecorators fallbackDecorators,
-        SpelResolver spelResolver
+        SpelResolver spelResolver,
+        @Autowired(required = false) ContextAwareScheduledThreadPool contextAwareScheduledThreadPool
     ) {
         return timeLimiterConfiguration.timeLimiterAspect(
-            timeLimiterProperties, timeLimiterRegistry, timeLimiterAspectExtList, fallbackDecorators, spelResolver);
+            timeLimiterProperties, timeLimiterRegistry, timeLimiterAspectExtList, fallbackDecorators, spelResolver, contextAwareScheduledThreadPool);
     }
 
     @Bean

--- a/resilience4j-spring-boot2/src/main/resources/META-INF/spring.factories
+++ b/resilience4j-spring-boot2/src/main/resources/META-INF/spring.factories
@@ -12,4 +12,5 @@ io.github.resilience4j.ratelimiter.autoconfigure.RateLimiterAutoConfiguration,\
 io.github.resilience4j.ratelimiter.autoconfigure.RateLimiterMetricsAutoConfiguration,\
 io.github.resilience4j.ratelimiter.autoconfigure.RateLimitersHealthIndicatorAutoConfiguration,\
 io.github.resilience4j.timelimiter.autoconfigure.TimeLimiterAutoConfiguration,\
-io.github.resilience4j.timelimiter.autoconfigure.TimeLimiterMetricsAutoConfiguration
+io.github.resilience4j.timelimiter.autoconfigure.TimeLimiterMetricsAutoConfiguration,\
+io.github.resilience4j.scheduled.threadpool.autoconfigure.ContextAwareScheduledThreadPoolAutoConfiguration

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/SpringBootCommonTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/SpringBootCommonTest.java
@@ -29,7 +29,6 @@ import io.github.resilience4j.common.bulkhead.configuration.ThreadPoolBulkheadCo
 import io.github.resilience4j.common.circuitbreaker.configuration.CircuitBreakerConfigCustomizer;
 import io.github.resilience4j.common.timelimiter.configuration.TimeLimiterConfigCustomizer;
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
-import io.github.resilience4j.core.ContextAwareScheduledThreadPool;
 import io.github.resilience4j.core.registry.CompositeRegistryEventConsumer;
 import io.github.resilience4j.fallback.CompletionStageFallbackDecorator;
 import io.github.resilience4j.fallback.FallbackDecorators;
@@ -114,7 +113,7 @@ public class SpringBootCommonTest {
             .retryAspect(new RetryConfigurationProperties(), RetryRegistry.ofDefaults(),
                 Collections.emptyList(),
                 new FallbackDecorators(Arrays.asList(new CompletionStageFallbackDecorator())),
-                new SpelResolver(new SpelExpressionParser(), new StandardReflectionParameterNameDiscoverer()))).isNotNull();
+                new SpelResolver(new SpelExpressionParser(), new StandardReflectionParameterNameDiscoverer()), null)).isNotNull();
         assertThat(retryConfigurationOnMissingBean.retryRegistryEventConsumer(Optional.empty())).isNotNull();
     }
 

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/SpringBootCommonTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/SpringBootCommonTest.java
@@ -29,6 +29,7 @@ import io.github.resilience4j.common.bulkhead.configuration.ThreadPoolBulkheadCo
 import io.github.resilience4j.common.circuitbreaker.configuration.CircuitBreakerConfigCustomizer;
 import io.github.resilience4j.common.timelimiter.configuration.TimeLimiterConfigCustomizer;
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
+import io.github.resilience4j.core.ContextAwareScheduledThreadPool;
 import io.github.resilience4j.core.registry.CompositeRegistryEventConsumer;
 import io.github.resilience4j.fallback.CompletionStageFallbackDecorator;
 import io.github.resilience4j.fallback.FallbackDecorators;
@@ -152,7 +153,8 @@ public class SpringBootCommonTest {
             .timeLimiterAspect(new TimeLimiterConfigurationProperties(),
                 TimeLimiterRegistry.ofDefaults(), Collections.emptyList(),
                 new FallbackDecorators(Arrays.asList(new CompletionStageFallbackDecorator())),
-                new SpelResolver(new SpelExpressionParser(), new StandardReflectionParameterNameDiscoverer()))).isNotNull();
+                new SpelResolver(new SpelExpressionParser(), new StandardReflectionParameterNameDiscoverer()),
+                null)).isNotNull();
         assertThat(timeLimiterConfigurationOnMissingBean
             .timeLimiterRegistryEventConsumer(Optional.empty())).isNotNull();
     }

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/TestThreadLocalContextPropagator.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/TestThreadLocalContextPropagator.java
@@ -1,6 +1,6 @@
 package io.github.resilience4j;
 
-import io.github.resilience4j.bulkhead.ContextPropagator;
+import io.github.resilience4j.core.ContextPropagator;
 
 import java.util.Optional;
 import java.util.function.Consumer;

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/retry/autoconfigure/RetryConfigurationOnMissingBeanTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/retry/autoconfigure/RetryConfigurationOnMissingBeanTest.java
@@ -18,6 +18,7 @@ package io.github.resilience4j.retry.autoconfigure;
 import io.github.resilience4j.TestUtils;
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
+import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
 import io.github.resilience4j.fallback.FallbackDecorators;
 import io.github.resilience4j.retry.RetryRegistry;
 import io.github.resilience4j.retry.configure.RetryAspect;
@@ -93,10 +94,11 @@ public class RetryConfigurationOnMissingBeanTest {
             RetryRegistry retryRegistry,
             @Autowired(required = false) List<RetryAspectExt> retryAspectExts,
             FallbackDecorators fallbackDecorators,
-            SpelResolver spelResolver
+            SpelResolver spelResolver,
+            @Autowired(required = false) ContextAwareScheduledThreadPoolExecutor contextAwareScheduledThreadPoolExecutor
         ) {
             this.retryAspect = new RetryAspect(new RetryProperties(), retryRegistry,
-                retryAspectExts, fallbackDecorators, spelResolver);
+                retryAspectExts, fallbackDecorators, spelResolver, contextAwareScheduledThreadPoolExecutor);
             return retryAspect;
         }
 

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/service/test/BeanContextPropagator.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/service/test/BeanContextPropagator.java
@@ -1,6 +1,6 @@
 package io.github.resilience4j.service.test;
 
-import io.github.resilience4j.bulkhead.ContextPropagator;
+import io.github.resilience4j.core.ContextPropagator;
 
 import java.util.Optional;
 import java.util.function.Consumer;

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/service/test/DummyService.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/service/test/DummyService.java
@@ -7,8 +7,11 @@ import java.util.concurrent.CompletableFuture;
 public interface DummyService {
 
     String BACKEND = "backendA";
+    String BACKEND_B = "backendB";
 
     void doSomething(boolean throwException) throws IOException;
+
+    CompletableFuture<String> longDoSomethingAsync() throws InterruptedException;
 
     CompletableFuture<String> doSomethingAsync(boolean throwException) throws IOException;
 }

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/service/test/DummyServiceImpl.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/service/test/DummyServiceImpl.java
@@ -1,9 +1,12 @@
 package io.github.resilience4j.service.test;
 
 
+import io.github.resilience4j.bulkhead.annotation.Bulkhead;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
+import io.github.resilience4j.service.test.bulkhead.BulkheadDummyService;
 import io.github.resilience4j.timelimiter.annotation.TimeLimiter;
+import io.vavr.control.Try;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -31,5 +34,12 @@ public class DummyServiceImpl implements DummyService {
             return future;
         }
         return CompletableFuture.supplyAsync(() -> "Test result");
+    }
+
+    @Bulkhead(name = BulkheadDummyService.BACKEND_D, type = Bulkhead.Type.THREADPOOL)
+    @TimeLimiter(name = BACKEND_B)
+    public CompletableFuture<String> longDoSomethingAsync() {
+        Try.run(() -> Thread.sleep(2000));
+        return CompletableFuture.completedFuture("Test result");
     }
 }

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/service/test/TestApplication.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/service/test/TestApplication.java
@@ -1,13 +1,13 @@
 package io.github.resilience4j.service.test;
 
 import io.github.resilience4j.bulkhead.BulkheadConfig;
-import io.github.resilience4j.bulkhead.ContextPropagator;
 import io.github.resilience4j.common.bulkhead.configuration.BulkheadConfigCustomizer;
 import io.github.resilience4j.common.bulkhead.configuration.ThreadPoolBulkheadConfigCustomizer;
 import io.github.resilience4j.common.circuitbreaker.configuration.CircuitBreakerConfigCustomizer;
 import io.github.resilience4j.common.ratelimiter.configuration.RateLimiterConfigCustomizer;
 import io.github.resilience4j.common.retry.configuration.RetryConfigCustomizer;
 import io.github.resilience4j.common.timelimiter.configuration.TimeLimiterConfigCustomizer;
+import io.github.resilience4j.core.ContextPropagator;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/timelimiter/TimeLimiterAutoConfigurationTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/timelimiter/TimeLimiterAutoConfigurationTest.java
@@ -106,6 +106,7 @@ public class TimeLimiterAutoConfigurationTest {
         TestThreadLocalContextHolder.put("ValueShouldCrossThreadBoundary");
         final CompletableFuture<String> future = dummyService.longDoSomethingAsync().exceptionally(throwable -> {
             if (throwable != null) {
+                assertThat(Thread.currentThread().getName()).contains("ContextAwareScheduledThreadPool-");
                 assertThat(TestThreadLocalContextHolder.get().get()).isEqualTo("ValueShouldCrossThreadBoundary");
                 return (String) TestThreadLocalContextHolder.get().orElse(null);
             }
@@ -143,8 +144,9 @@ public class TimeLimiterAutoConfigurationTest {
         final Map<String, String> contextMap = MDC.getCopyOfContextMap();
         final CompletableFuture<String> future = dummyService.longDoSomethingAsync().exceptionally(throwable -> {
             if (throwable != null) {
-                assertThat(TestThreadLocalContextHolder.getMDCContext()).hasSize(2).containsExactlyEntriesOf(contextMap);
-                return TestThreadLocalContextHolder.getMDCContext().get("key");
+                assertThat(Thread.currentThread().getName()).contains("ContextAwareScheduledThreadPool-");
+                assertThat(MDC.getCopyOfContextMap()).hasSize(2).containsExactlyEntriesOf(contextMap);
+                return MDC.getCopyOfContextMap().get("key");
             }
             return null;
         });

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/timelimiter/TimeLimiterAutoConfigurationTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/timelimiter/TimeLimiterAutoConfigurationTest.java
@@ -6,19 +6,25 @@ import io.github.resilience4j.common.timelimiter.configuration.TimeLimiterConfig
 import io.github.resilience4j.common.timelimiter.monitoring.endpoint.TimeLimiterEventsEndpointResponse;
 import io.github.resilience4j.service.test.DummyService;
 import io.github.resilience4j.service.test.TestApplication;
+import io.github.resilience4j.test.TestContextPropagators.TestThreadLocalContextPropagatorWithHolder.TestThreadLocalContextHolder;
 import io.github.resilience4j.timelimiter.autoconfigure.TimeLimiterProperties;
 import io.github.resilience4j.timelimiter.configure.TimeLimiterAspect;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
+import static com.jayway.awaitility.Awaitility.matches;
+import static com.jayway.awaitility.Awaitility.waitAtMost;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -81,6 +87,78 @@ public class TimeLimiterAutoConfigurationTest {
         timeLimiterEventList = timeLimiterEvents("/actuator/timelimiterevents/backendA");
         assertThat(timeLimiterEventList.getTimeLimiterEvents())
             .hasSize(timeLimiterEventsForABefore.getTimeLimiterEvents().size() + 2);
+
+        assertThat(timeLimiterAspect.getOrder()).isEqualTo(398);
+    }
+
+    @Test
+    public void shouldThrowTimeOutExceptionAndPropagateContext() throws InterruptedException {
+        TimeLimiterEventsEndpointResponse timeLimiterEventsBefore =
+            timeLimiterEvents("/actuator/timelimiterevents");
+        TimeLimiterEventsEndpointResponse timeLimiterEventsForABefore =
+            timeLimiterEvents("/actuator/timelimiterevents/backendB");
+
+        TimeLimiter timeLimiter = timeLimiterRegistry.timeLimiter(DummyService.BACKEND_B);
+        assertThat(timeLimiter).isNotNull();
+
+        assertThat(timeLimiter.getTimeLimiterConfig().getTimeoutDuration()).isEqualTo(Duration.ofSeconds(1));
+
+        TestThreadLocalContextHolder.put("ValueShouldCrossThreadBoundary");
+        final CompletableFuture<String> future = dummyService.longDoSomethingAsync().exceptionally(throwable -> {
+            if (throwable != null) {
+                assertThat(TestThreadLocalContextHolder.get().get()).isEqualTo("ValueShouldCrossThreadBoundary");
+                return (String) TestThreadLocalContextHolder.get().orElse(null);
+            }
+            return null;
+        });
+
+        waitAtMost(3, TimeUnit.SECONDS).until(matches(() ->
+            assertThat(future).isCompletedWithValue("ValueShouldCrossThreadBoundary")));
+
+        TimeLimiterEventsEndpointResponse timeLimiterEventList = timeLimiterEvents("/actuator/timelimiterevents");
+        assertThat(timeLimiterEventList.getTimeLimiterEvents())
+            .hasSize(timeLimiterEventsBefore.getTimeLimiterEvents().size() + 1);
+
+        timeLimiterEventList = timeLimiterEvents("/actuator/timelimiterevents/backendB");
+        assertThat(timeLimiterEventList.getTimeLimiterEvents())
+            .hasSize(timeLimiterEventsForABefore.getTimeLimiterEvents().size() + 1);
+
+        assertThat(timeLimiterAspect.getOrder()).isEqualTo(398);
+    }
+
+    @Test
+    public void shouldThrowTimeOutExceptionAndPropagateMDCContext() throws InterruptedException {
+        TimeLimiterEventsEndpointResponse timeLimiterEventsBefore =
+            timeLimiterEvents("/actuator/timelimiterevents");
+        TimeLimiterEventsEndpointResponse timeLimiterEventsForABefore =
+            timeLimiterEvents("/actuator/timelimiterevents/backendB");
+
+        TimeLimiter timeLimiter = timeLimiterRegistry.timeLimiter(DummyService.BACKEND_B);
+        assertThat(timeLimiter).isNotNull();
+
+        assertThat(timeLimiter.getTimeLimiterConfig().getTimeoutDuration()).isEqualTo(Duration.ofSeconds(1));
+
+        MDC.put("key", "ValueShouldCrossThreadBoundary");
+        MDC.put("key2","value2");
+        final Map<String, String> contextMap = MDC.getCopyOfContextMap();
+        final CompletableFuture<String> future = dummyService.longDoSomethingAsync().exceptionally(throwable -> {
+            if (throwable != null) {
+                assertThat(TestThreadLocalContextHolder.getMDCContext()).hasSize(2).containsExactlyEntriesOf(contextMap);
+                return TestThreadLocalContextHolder.getMDCContext().get("key");
+            }
+            return null;
+        });
+
+        waitAtMost(3, TimeUnit.SECONDS).until(matches(() ->
+            assertThat(future).isCompletedWithValue("ValueShouldCrossThreadBoundary")));
+
+        TimeLimiterEventsEndpointResponse timeLimiterEventList = timeLimiterEvents("/actuator/timelimiterevents");
+        assertThat(timeLimiterEventList.getTimeLimiterEvents())
+            .hasSize(timeLimiterEventsBefore.getTimeLimiterEvents().size() + 1);
+
+        timeLimiterEventList = timeLimiterEvents("/actuator/timelimiterevents/backendB");
+        assertThat(timeLimiterEventList.getTimeLimiterEvents())
+            .hasSize(timeLimiterEventsForABefore.getTimeLimiterEvents().size() + 1);
 
         assertThat(timeLimiterAspect.getOrder()).isEqualTo(398);
     }

--- a/resilience4j-spring-boot2/src/test/resources/application.yaml
+++ b/resilience4j-spring-boot2/src/test/resources/application.yaml
@@ -1,5 +1,5 @@
 resilience4j.scheduled.executor:
-  coreThreadPoolSize: 10
+  corePoolSize: 10
   contextPropagators:
     - io.github.resilience4j.test.TestContextPropagators.TestThreadLocalContextPropagatorWithHolder
 resilience4j.retry:

--- a/resilience4j-spring-boot2/src/test/resources/application.yaml
+++ b/resilience4j-spring-boot2/src/test/resources/application.yaml
@@ -1,3 +1,7 @@
+resilience4j.scheduled.executor:
+  coreThreadPoolSize: 10
+  contextPropagators:
+    - io.github.resilience4j.test.TestContextPropagators.TestThreadLocalContextPropagatorWithHolder
 resilience4j.retry:
   retryAspectOrder: 399
   tags:
@@ -181,6 +185,8 @@ resilience4j.timelimiter:
   instances:
     backendA:
       timeoutDuration: 5s
+    backendB:
+      timeoutDuration: 1s
 
 management.security.enabled: false
 management.endpoints.web.exposure.include: '*'

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/retry/configure/RetryAspect.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/retry/configure/RetryAspect.java
@@ -15,6 +15,7 @@
  */
 package io.github.resilience4j.retry.configure;
 
+import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
 import io.github.resilience4j.core.lang.Nullable;
 import io.github.resilience4j.fallback.FallbackDecorators;
 import io.github.resilience4j.fallback.FallbackMethod;
@@ -64,8 +65,7 @@ import java.util.concurrent.*;
 public class RetryAspect implements Ordered, AutoCloseable {
 
     private static final Logger logger = LoggerFactory.getLogger(RetryAspect.class);
-    private final static ScheduledExecutorService retryExecutorService = Executors
-        .newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
+    private final ScheduledExecutorService retryExecutorService;
     private final RetryConfigurationProperties retryConfigurationProperties;
     private final RetryRegistry retryRegistry;
     private final @Nullable
@@ -84,12 +84,16 @@ public class RetryAspect implements Ordered, AutoCloseable {
                        RetryRegistry retryRegistry,
                        @Autowired(required = false) List<RetryAspectExt> retryAspectExtList,
                        FallbackDecorators fallbackDecorators,
-                       SpelResolver spelResolver) {
+                       SpelResolver spelResolver,
+                       @Nullable ContextAwareScheduledThreadPoolExecutor contextAwareScheduledThreadPoolExecutor) {
         this.retryConfigurationProperties = retryConfigurationProperties;
         this.retryRegistry = retryRegistry;
         this.retryAspectExtList = retryAspectExtList;
         this.fallbackDecorators = fallbackDecorators;
         this.spelResolver = spelResolver;
+        this.retryExecutorService = contextAwareScheduledThreadPoolExecutor != null ?
+            contextAwareScheduledThreadPoolExecutor :
+            Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
     }
 
     @Pointcut(value = "@within(retry) || @annotation(retry)", argNames = "retry")

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/retry/configure/RetryConfiguration.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/retry/configure/RetryConfiguration.java
@@ -20,6 +20,7 @@ import io.github.resilience4j.common.retry.configuration.RetryConfigCustomizer;
 import io.github.resilience4j.common.retry.configuration.RetryConfigurationProperties.InstanceProperties;
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
+import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
 import io.github.resilience4j.core.registry.CompositeRegistryEventConsumer;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
 import io.github.resilience4j.fallback.FallbackDecorators;
@@ -145,10 +146,11 @@ public class RetryConfiguration {
         RetryRegistry retryRegistry,
         @Autowired(required = false) List<RetryAspectExt> retryAspectExtList,
         FallbackDecorators fallbackDecorators,
-        SpelResolver spelResolver
+        SpelResolver spelResolver,
+        @Autowired(required = false) ContextAwareScheduledThreadPoolExecutor contextAwareScheduledThreadPoolExecutor
     ) {
         return new RetryAspect(retryConfigurationProperties, retryRegistry, retryAspectExtList,
-            fallbackDecorators, spelResolver);
+            fallbackDecorators, spelResolver, contextAwareScheduledThreadPoolExecutor);
     }
 
     @Bean

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/timelimiter/configure/TimeLimiterAspect.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/timelimiter/configure/TimeLimiterAspect.java
@@ -16,7 +16,7 @@
 
 package io.github.resilience4j.timelimiter.configure;
 
-import io.github.resilience4j.core.ContextAwareScheduledThreadPool;
+import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
 import io.github.resilience4j.core.lang.Nullable;
 import io.github.resilience4j.fallback.FallbackDecorators;
 import io.github.resilience4j.fallback.FallbackMethod;
@@ -57,14 +57,14 @@ public class TimeLimiterAspect implements Ordered, AutoCloseable {
                              @Nullable List<TimeLimiterAspectExt> timeLimiterAspectExtList,
                              FallbackDecorators fallbackDecorators,
                              SpelResolver spelResolver,
-                             @Nullable ContextAwareScheduledThreadPool contextAwareScheduledThreadPool) {
+                             @Nullable ContextAwareScheduledThreadPoolExecutor contextAwareScheduledThreadPoolExecutor) {
         this.timeLimiterRegistry = timeLimiterRegistry;
         this.properties = properties;
         this.timeLimiterAspectExtList = timeLimiterAspectExtList;
         this.fallbackDecorators = fallbackDecorators;
         this.spelResolver = spelResolver;
-        this.timeLimiterExecutorService = contextAwareScheduledThreadPool != null ?
-            contextAwareScheduledThreadPool :
+        this.timeLimiterExecutorService = contextAwareScheduledThreadPoolExecutor != null ?
+            contextAwareScheduledThreadPoolExecutor :
             Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
     }
 

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/timelimiter/configure/TimeLimiterAspect.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/timelimiter/configure/TimeLimiterAspect.java
@@ -16,6 +16,7 @@
 
 package io.github.resilience4j.timelimiter.configure;
 
+import io.github.resilience4j.core.ContextAwareScheduledThreadPool;
 import io.github.resilience4j.core.lang.Nullable;
 import io.github.resilience4j.fallback.FallbackDecorators;
 import io.github.resilience4j.fallback.FallbackMethod;
@@ -55,13 +56,16 @@ public class TimeLimiterAspect implements Ordered, AutoCloseable {
                              TimeLimiterConfigurationProperties properties,
                              @Nullable List<TimeLimiterAspectExt> timeLimiterAspectExtList,
                              FallbackDecorators fallbackDecorators,
-                             SpelResolver spelResolver) {
+                             SpelResolver spelResolver,
+                             @Nullable ContextAwareScheduledThreadPool contextAwareScheduledThreadPool) {
         this.timeLimiterRegistry = timeLimiterRegistry;
         this.properties = properties;
         this.timeLimiterAspectExtList = timeLimiterAspectExtList;
         this.fallbackDecorators = fallbackDecorators;
         this.spelResolver = spelResolver;
-        this.timeLimiterExecutorService = Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
+        this.timeLimiterExecutorService = contextAwareScheduledThreadPool != null ?
+            contextAwareScheduledThreadPool :
+            Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
     }
 
     @Pointcut(value = "@within(timeLimiter) || @annotation(timeLimiter)", argNames = "timeLimiter")

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/timelimiter/configure/TimeLimiterConfiguration.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/timelimiter/configure/TimeLimiterConfiguration.java
@@ -21,7 +21,7 @@ import io.github.resilience4j.common.timelimiter.configuration.TimeLimiterConfig
 import io.github.resilience4j.common.timelimiter.configuration.TimeLimiterConfigurationProperties.InstanceProperties;
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
-import io.github.resilience4j.core.ContextAwareScheduledThreadPool;
+import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
 import io.github.resilience4j.core.registry.CompositeRegistryEventConsumer;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
 import io.github.resilience4j.fallback.FallbackDecorators;
@@ -90,9 +90,9 @@ public class TimeLimiterConfiguration {
         @Autowired(required = false) List<TimeLimiterAspectExt> timeLimiterAspectExtList,
         FallbackDecorators fallbackDecorators,
         SpelResolver spelResolver,
-        @Autowired(required = false) ContextAwareScheduledThreadPool contextAwareScheduledThreadPool
+        @Autowired(required = false) ContextAwareScheduledThreadPoolExecutor contextAwareScheduledThreadPoolExecutor
     ) {
-        return new TimeLimiterAspect(timeLimiterRegistry, timeLimiterConfigurationProperties, timeLimiterAspectExtList, fallbackDecorators, spelResolver, contextAwareScheduledThreadPool);
+        return new TimeLimiterAspect(timeLimiterRegistry, timeLimiterConfigurationProperties, timeLimiterAspectExtList, fallbackDecorators, spelResolver, contextAwareScheduledThreadPoolExecutor);
     }
 
     @Bean

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/timelimiter/configure/TimeLimiterConfiguration.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/timelimiter/configure/TimeLimiterConfiguration.java
@@ -21,6 +21,7 @@ import io.github.resilience4j.common.timelimiter.configuration.TimeLimiterConfig
 import io.github.resilience4j.common.timelimiter.configuration.TimeLimiterConfigurationProperties.InstanceProperties;
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
+import io.github.resilience4j.core.ContextAwareScheduledThreadPool;
 import io.github.resilience4j.core.registry.CompositeRegistryEventConsumer;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
 import io.github.resilience4j.fallback.FallbackDecorators;
@@ -88,9 +89,10 @@ public class TimeLimiterConfiguration {
         TimeLimiterRegistry timeLimiterRegistry,
         @Autowired(required = false) List<TimeLimiterAspectExt> timeLimiterAspectExtList,
         FallbackDecorators fallbackDecorators,
-        SpelResolver spelResolver
+        SpelResolver spelResolver,
+        @Autowired(required = false) ContextAwareScheduledThreadPool contextAwareScheduledThreadPool
     ) {
-        return new TimeLimiterAspect(timeLimiterRegistry, timeLimiterConfigurationProperties, timeLimiterAspectExtList, fallbackDecorators, spelResolver);
+        return new TimeLimiterAspect(timeLimiterRegistry, timeLimiterConfigurationProperties, timeLimiterAspectExtList, fallbackDecorators, spelResolver, contextAwareScheduledThreadPool);
     }
 
     @Bean

--- a/resilience4j-spring/src/test/java/io/github/resilience4j/TestThreadLocalContextPropagator.java
+++ b/resilience4j-spring/src/test/java/io/github/resilience4j/TestThreadLocalContextPropagator.java
@@ -1,6 +1,6 @@
 package io.github.resilience4j;
 
-import io.github.resilience4j.bulkhead.ContextPropagator;
+import io.github.resilience4j.core.ContextPropagator;
 
 import java.util.Optional;
 import java.util.function.Consumer;

--- a/resilience4j-spring/src/test/java/io/github/resilience4j/bulkhead/configure/BulkHeadConfigurationTest.java
+++ b/resilience4j-spring/src/test/java/io/github/resilience4j/bulkhead/configure/BulkHeadConfigurationTest.java
@@ -8,6 +8,7 @@ import io.github.resilience4j.common.CompositeCustomizer;
 import io.github.resilience4j.common.bulkhead.configuration.ThreadPoolBulkheadConfigurationProperties;
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.core.ConfigurationNotFoundException;
+import io.github.resilience4j.core.ContextPropagator;
 import io.github.resilience4j.core.registry.CompositeRegistryEventConsumer;
 import org.junit.Test;
 

--- a/resilience4j-spring/src/test/java/io/github/resilience4j/bulkhead/configure/BulkheadBuilderCustomizerTest.java
+++ b/resilience4j-spring/src/test/java/io/github/resilience4j/bulkhead/configure/BulkheadBuilderCustomizerTest.java
@@ -10,6 +10,7 @@ import io.github.resilience4j.common.bulkhead.configuration.ThreadPoolBulkheadCo
 import io.github.resilience4j.common.bulkhead.configuration.ThreadPoolBulkheadConfigurationProperties;
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
+import io.github.resilience4j.core.ContextPropagator;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/resilience4j-spring/src/test/java/io/github/resilience4j/retry/configure/RetryConfigurationSpringTest.java
+++ b/resilience4j-spring/src/test/java/io/github/resilience4j/retry/configure/RetryConfigurationSpringTest.java
@@ -17,6 +17,7 @@ package io.github.resilience4j.retry.configure;
 
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
+import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
 import io.github.resilience4j.fallback.FallbackDecorators;
 import io.github.resilience4j.fallback.configure.FallbackConfiguration;
 import io.github.resilience4j.retry.RetryRegistry;
@@ -68,6 +69,8 @@ public class RetryConfigurationSpringTest {
 
         private RetryConfigurationProperties retryConfigurationProperties;
 
+        private ContextAwareScheduledThreadPoolExecutor contextAwareScheduledThreadPoolExecutor;
+
         @Bean
         public RetryRegistry retryRegistry() {
             retryRegistry = RetryRegistry.ofDefaults();
@@ -82,7 +85,7 @@ public class RetryConfigurationSpringTest {
             SpelResolver spelResolver
         ) {
             retryAspect = new RetryAspect(retryConfigurationProperties(), retryRegistry,
-                retryAspectExts, fallbackDecorators, spelResolver);
+                retryAspectExts, fallbackDecorators, spelResolver,contextAwareScheduledThreadPoolExecutor);
             return retryAspect;
         }
 

--- a/resilience4j-spring/src/test/java/io/github/resilience4j/timelimiter/configure/TimeLimiterConfigurationSpringTest.java
+++ b/resilience4j-spring/src/test/java/io/github/resilience4j/timelimiter/configure/TimeLimiterConfigurationSpringTest.java
@@ -2,6 +2,7 @@ package io.github.resilience4j.timelimiter.configure;
 
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
+import io.github.resilience4j.core.ContextAwareScheduledThreadPool;
 import io.github.resilience4j.fallback.FallbackDecorators;
 import io.github.resilience4j.spelresolver.SpelResolver;
 import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
@@ -30,6 +31,8 @@ public class TimeLimiterConfigurationSpringTest {
     private ConfigWithOverrides configWithOverrides;
 
 
+
+
     @Test
     public void testAllCircuitBreakerConfigurationBeansOverridden() {
         assertNotNull(configWithOverrides.timeLimiterRegistry);
@@ -52,6 +55,8 @@ public class TimeLimiterConfigurationSpringTest {
 
         private TimeLimiterConfigurationProperties timeLimiterConfigurationProperties;
 
+        private ContextAwareScheduledThreadPool contextAwareScheduledThreadPool;
+
         @Bean
         public TimeLimiterRegistry timeLimiterRegistry() {
             timeLimiterRegistry = TimeLimiterRegistry.ofDefaults();
@@ -65,7 +70,7 @@ public class TimeLimiterConfigurationSpringTest {
             FallbackDecorators fallbackDecorators,
             SpelResolver spelResolver
         ) {
-            timeLimiterAspect = new TimeLimiterAspect(timeLimiterRegistry, timeLimiterConfigurationProperties(), timeLimiterAspectExtList, fallbackDecorators, spelResolver);
+            timeLimiterAspect = new TimeLimiterAspect(timeLimiterRegistry, timeLimiterConfigurationProperties(), timeLimiterAspectExtList, fallbackDecorators, spelResolver, contextAwareScheduledThreadPool);
             return timeLimiterAspect;
         }
 

--- a/resilience4j-spring/src/test/java/io/github/resilience4j/timelimiter/configure/TimeLimiterConfigurationSpringTest.java
+++ b/resilience4j-spring/src/test/java/io/github/resilience4j/timelimiter/configure/TimeLimiterConfigurationSpringTest.java
@@ -2,7 +2,7 @@ package io.github.resilience4j.timelimiter.configure;
 
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
-import io.github.resilience4j.core.ContextAwareScheduledThreadPool;
+import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
 import io.github.resilience4j.fallback.FallbackDecorators;
 import io.github.resilience4j.spelresolver.SpelResolver;
 import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
@@ -55,7 +55,7 @@ public class TimeLimiterConfigurationSpringTest {
 
         private TimeLimiterConfigurationProperties timeLimiterConfigurationProperties;
 
-        private ContextAwareScheduledThreadPool contextAwareScheduledThreadPool;
+        private ContextAwareScheduledThreadPoolExecutor contextAwareScheduledThreadPoolExecutor;
 
         @Bean
         public TimeLimiterRegistry timeLimiterRegistry() {
@@ -70,7 +70,7 @@ public class TimeLimiterConfigurationSpringTest {
             FallbackDecorators fallbackDecorators,
             SpelResolver spelResolver
         ) {
-            timeLimiterAspect = new TimeLimiterAspect(timeLimiterRegistry, timeLimiterConfigurationProperties(), timeLimiterAspectExtList, fallbackDecorators, spelResolver, contextAwareScheduledThreadPool);
+            timeLimiterAspect = new TimeLimiterAspect(timeLimiterRegistry, timeLimiterConfigurationProperties(), timeLimiterAspectExtList, fallbackDecorators, spelResolver, contextAwareScheduledThreadPoolExecutor);
             return timeLimiterAspect;
         }
 

--- a/resilience4j-test/build.gradle
+++ b/resilience4j-test/build.gradle
@@ -1,4 +1,6 @@
 artifactoryPublish.skip = true
 sonarqube.skipProject = true
-
+dependencies {
+    compile project(':resilience4j-core')
+}
 ext.moduleName = 'io.github.resilience4j.test'

--- a/resilience4j-test/src/main/java/io/github/resilience4j/test/TestContextPropagators.java
+++ b/resilience4j-test/src/main/java/io/github/resilience4j/test/TestContextPropagators.java
@@ -1,5 +1,28 @@
-package io.github.resilience4j.bulkhead;
+/*
+ *
+ *  Copyright 2020 krnsaurabh
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.test;
 
+import io.github.resilience4j.core.ContextPropagator;
+import org.slf4j.MDC;
+
+import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -72,6 +95,9 @@ public class TestContextPropagators {
                     clear();
                 }
                 threadLocal.set(context);
+            }
+            public static Map<String, String> getMDCContext() {
+                return Optional.ofNullable(MDC.getCopyOfContextMap()).orElse(Collections.emptyMap());
             }
 
             public static void clear() {


### PR DESCRIPTION
As per our internal discussion, replaced `ThreadPoolExecutor` by `ContextAwareBoundedScheduledThreadPool` inside `ThreadPoolBulkhead`.
`ContextAwareBoundedScheduledThreadPool` extends to `ScheduledThreadPoolExecutor` but maintains a boundedBlocking queue implementation using semaphore to control number of task submitted to queue.
it respects list of `ContextPropagators` configured in `ThreadPoolBulkhead` and propagates the same. Also it propagates `MDC` contextMap by default if set in caller thread.

Kindly review implementation of `ContextAwareBoundedScheduledThreadPool`. would it be better to implement `ScheduledThreadPoolExecutor` by ThreadPoolBulkhead itself or a separate implementation like this is fine ?
Also how are we planning to use the same threadpool in timeLimiter and retry? I guess we might need additional config to pass bulkhead instance to timeLimiter ?
@RobWin .