### PR TITLE
Change timeLimiterExecutorService to instance field

### DIFF
--- a/resilience4j-spring/src/main/java/io/github/resilience4j/timelimiter/configure/TimeLimiterAspect.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/timelimiter/configure/TimeLimiterAspect.java
@@ -139,7 +139,7 @@ public class TimeLimiterAspect implements Ordered, AutoCloseable {
         }
     }
 
-    private static Object handleJoinPointCompletableFuture(
+    private Object handleJoinPointCompletableFuture(
             ProceedingJoinPoint proceedingJoinPoint, io.github.resilience4j.timelimiter.TimeLimiter timeLimiter) throws Throwable {
         return timeLimiter.executeCompletionStage(timeLimiterExecutorService, () -> {
             try {

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/timelimiter/configure/TimeLimiterAspect.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/timelimiter/configure/TimeLimiterAspect.java
@@ -45,8 +45,7 @@ public class TimeLimiterAspect implements Ordered, AutoCloseable {
 
     private final TimeLimiterRegistry timeLimiterRegistry;
     private final TimeLimiterConfigurationProperties properties;
-    private static final ScheduledExecutorService timeLimiterExecutorService = Executors
-        .newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
+    private final ScheduledExecutorService timeLimiterExecutorService;
     @Nullable
     private final List<TimeLimiterAspectExt> timeLimiterAspectExtList;
     private final FallbackDecorators fallbackDecorators;
@@ -62,6 +61,7 @@ public class TimeLimiterAspect implements Ordered, AutoCloseable {
         this.timeLimiterAspectExtList = timeLimiterAspectExtList;
         this.fallbackDecorators = fallbackDecorators;
         this.spelResolver = spelResolver;
+        this.timeLimiterExecutorService = Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
     }
 
     @Pointcut(value = "@within(timeLimiter) || @annotation(timeLimiter)", argNames = "timeLimiter")


### PR DESCRIPTION
Enhancement 1203 -
When running integration tests that refresh the Spring application context, the aspect is closed with the context. When the context is refreshed, the static Executor is not reinstantiated. Consequently, subsequent invocations of a @Timelimiter annotated method fail with a java.util.concurrent.RejectedExecutionException (The scheduler is shut down). The executor needs to be recreated each time the aspect is recreated with the context. Since the aspect is a singleton, the effect of the change should essentially be the same as if the field were static.