### PR TITLE
Issue #1205: NullPointerException actuator metrics for retries using retryOnResult

### DIFF
--- a/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/retry/monitoring/endpoint/RetryEventDTOBuilder.java
+++ b/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/retry/monitoring/endpoint/RetryEventDTOBuilder.java
@@ -15,6 +15,7 @@
  */
 package io.github.resilience4j.common.retry.monitoring.endpoint;
 
+import io.github.resilience4j.core.lang.Nullable;
 import io.github.resilience4j.retry.event.RetryEvent;
 
 /**
@@ -35,8 +36,10 @@ class RetryEventDTOBuilder {
         this.creationTime = creationTime;
     }
 
-    RetryEventDTOBuilder throwable(Throwable throwable) {
-        this.errorMessage = throwable.toString();
+    RetryEventDTOBuilder throwable(@Nullable Throwable throwable) {
+        if (throwable != null) {
+            this.errorMessage = throwable.toString();
+        }
         return this;
     }
 

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/retry/monitoring/endpoint/RetryEventDTOFactoryTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/retry/monitoring/endpoint/RetryEventDTOFactoryTest.java
@@ -66,5 +66,18 @@ public class RetryEventDTOFactoryTest {
         assertThat(retryEventDTO.getErrorMessage()).isEqualTo("java.io.IOException: Error Message");
         assertThat(retryEventDTO.getCreationTime()).isNotNull();
     }
+
+    @Test
+    public void shouldMapRetryOnRetryEventWithoutThrowable() {
+        RetryOnRetryEvent event = new RetryOnRetryEvent("name", 1, null, 5000);
+
+        RetryEventDTO retryEventDTO = RetryEventDTOFactory.createRetryEventDTO(event);
+
+        assertThat(retryEventDTO.getRetryName()).isEqualTo("name");
+        assertThat(retryEventDTO.getNumberOfAttempts()).isEqualTo(1);
+        assertThat(retryEventDTO.getType()).isEqualTo(RetryEvent.Type.RETRY);
+        assertThat(retryEventDTO.getErrorMessage()).isNull();
+        assertThat(retryEventDTO.getCreationTime()).isNotNull();
+    }
 }
 


### PR DESCRIPTION
Now prints error message with errorMessage null for retry via retryOnResult:

```
{"retryName":"afterburner-retry","type":"RETRY","creationTime":"2020-10-15T13:22:30.730178+02:00[Europe/Amsterdam]","errorMessage":null,"numberOfAttempts":3}
```