### PR TITLE
Issue https://github.com/resilience4j/resilience4j/issues/1244 add logic for start nano time (should nano time start when is first i…

### DIFF
--- a/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/internal/AtomicRateLimiter.java
+++ b/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/internal/AtomicRateLimiter.java
@@ -47,7 +47,7 @@ import static java.util.concurrent.locks.LockSupport.parkNanos;
  */
 public class AtomicRateLimiter implements RateLimiter {
 
-    private static final long nanoTimeStart = nanoTime();
+    private long nanoTimeStart;
 
     private final String name;
     private final AtomicInteger waitingThreads;
@@ -63,6 +63,7 @@ public class AtomicRateLimiter implements RateLimiter {
                              Map<String, String> tags) {
         this.name = name;
         this.tags = tags;
+        this.nanoTimeStart = nanoTime();
 
         waitingThreads = new AtomicInteger(0);
         state = new AtomicReference<>(new State(
@@ -106,6 +107,10 @@ public class AtomicRateLimiter implements RateLimiter {
         return nanoTime() - nanoTimeStart;
     }
 
+    long getNanoTimeStart() {
+        return this.nanoTimeStart;
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -115,6 +120,7 @@ public class AtomicRateLimiter implements RateLimiter {
         State modifiedState = updateStateWithBackOff(permits, timeoutInNanos);
         boolean result = waitForPermissionIfNecessary(timeoutInNanos, modifiedState.nanosToWait);
         publishRateLimiterEvent(result, permits);
+
         return result;
     }
 


### PR DESCRIPTION
…teration in rate limiting)

When you instance more than one AtomicRateLimiter everyone AtomicRateLimiter has the nanoTimeStart equals, that is a error because nanoTimeStart is used for caclualted the time for an activate cycle then nanoTimeStart should inicialize when start first cycle the limiter (not before).