### PR TITLE
Prevent the decoration of default methods in feign client

### DIFF
--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/FeignDecoratorsTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/FeignDecoratorsTest.java
@@ -20,6 +20,8 @@ import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import org.junit.Test;
 
+import java.lang.reflect.Method;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
@@ -44,8 +46,9 @@ public class FeignDecoratorsTest {
         final CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
         final FeignDecorators testSubject = FeignDecorators.builder()
             .withCircuitBreaker(circuitBreaker).build();
+        final Method method = FeignDecoratorsTest.class.getDeclaredMethods()[0];
 
-        final Object result = testSubject.decorate(args -> args[0], null, null, null)
+        final Object result = testSubject.decorate(args -> args[0], method, null, null)
             .apply(new Object[]{"test01"});
 
         assertThat(result)
@@ -62,8 +65,9 @@ public class FeignDecoratorsTest {
         final RateLimiter rateLimiter = spy(RateLimiter.ofDefaults("test"));
         final FeignDecorators testSubject = FeignDecorators.builder().withRateLimiter(rateLimiter)
             .build();
+        final Method method = FeignDecoratorsTest.class.getDeclaredMethods()[0];
 
-        final Object result = testSubject.decorate(args -> args[0], null, null, null)
+        final Object result = testSubject.decorate(args -> args[0], method, null, null)
             .apply(new Object[]{"test01"});
 
         assertThat(result)

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignBulkheadTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignBulkheadTest.java
@@ -45,6 +45,17 @@ public class Resilience4jFeignBulkheadTest {
         testService.greeting();
 
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+        verify(bulkhead).acquirePermission();
+    }
+
+    @Test
+    public void testSuccessfulCallWithDefaultMethod() {
+        givenResponse(200);
+
+        testService.defaultGreeting();
+
+        verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+        verify(bulkhead).acquirePermission();
     }
 
     @Test(expected = BulkheadFullException.class)

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignCircuitBreakerTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignCircuitBreakerTest.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2018
+ * Copyright 2020
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -61,6 +61,20 @@ public class Resilience4jFeignCircuitBreakerTest {
         setupStub(200);
 
         testService.greeting();
+
+        verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+        assertThat(metrics.getNumberOfSuccessfulCalls())
+            .describedAs("Successful Calls")
+            .isEqualTo(1);
+    }
+
+    @Test
+    public void testSuccessfulCallWithDefaultMethod() throws Exception {
+        final CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+
+        setupStub(200);
+
+        testService.defaultGreeting();
 
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
         assertThat(metrics.getNumberOfSuccessfulCalls())

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignRateLimiterTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignRateLimiterTest.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2018
+ * Copyright 2020
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -27,8 +27,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests the integration of the {@link Resilience4jFeign} with {@link RateLimiter}
@@ -60,6 +59,18 @@ public class Resilience4jFeignRateLimiterTest {
         testService.greeting();
 
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+        verify(rateLimiter).acquirePermission(anyInt());
+    }
+
+    @Test
+    public void testSuccessfulCallWithDefaultMethod() {
+        givenResponse(200);
+        when(rateLimiter.acquirePermission(1)).thenReturn(true);
+
+        testService.defaultGreeting();
+
+        verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+        verify(rateLimiter).acquirePermission(anyInt());
     }
 
     @Test(expected = RequestNotPermitted.class)

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignRetryTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignRetryTest.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2019 Mahmoud Romeh
+ * Copyright 2020 Mahmoud Romeh
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,12 +16,9 @@
  */
 package io.github.resilience4j.feign;
 
-import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import feign.FeignException;
 import io.github.resilience4j.feign.test.TestService;
-import io.github.resilience4j.ratelimiter.RateLimiterConfig;
-import io.github.resilience4j.ratelimiter.RequestNotPermitted;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
 import org.junit.Before;
@@ -30,8 +27,7 @@ import org.junit.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests the integration of the {@link Resilience4jFeign} with {@link Retry}
@@ -47,7 +43,7 @@ public class Resilience4jFeignRetryTest {
 
     @Before
     public void setUp() {
-        retry = Retry.ofDefaults("test");
+        retry = spy(Retry.ofDefaults("test"));
         final FeignDecorators decorators = FeignDecorators.builder()
             .withRetry(retry)
             .build();
@@ -62,6 +58,17 @@ public class Resilience4jFeignRetryTest {
         testService.greeting();
 
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+        verify(retry).context();
+    }
+
+    @Test
+    public void testSuccessfulCallWithDefaultMethod() {
+        givenResponse(200);
+
+        testService.defaultGreeting();
+
+        verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
+        verify(retry).context();
     }
 
     @Test(expected = FeignException.class)

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/test/TestService.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/test/TestService.java
@@ -11,6 +11,10 @@ public interface TestService {
     @RequestLine("GET /greeting")
     String greeting();
 
+    default String defaultGreeting() {
+        return greeting();
+    }
+
     static TestService create(String url, RateLimiter rateLimiter) {
         FeignDecorators decorators = FeignDecorators.builder()
             .withRateLimiter(rateLimiter)


### PR DESCRIPTION
Previously a default method calling an interface method would trigger the decorator twice. For instance two circuit-breaker events would be fired, one when calling the default method and one when the default method calls the actual interface method.

See the feign documentation: https://github.com/OpenFeign/feign#static-and-default-methods