### PR TITLE
Upgrade to Dropwizard Metrics 4.1.16

### DIFF
--- a/libraries.gradle
+++ b/libraries.gradle
@@ -13,7 +13,7 @@ ext {
     powermockVersion = '2.0.0'
     jcacheVersion = '1.1.0'
     awaitilityVersion = '1.7.0'
-    metricsVersion = '3.2.6'
+    metricsVersion = '4.1.16'
     vertxVersion = '3.7.0'
     aspectjVersion = '1.9.2'
     springVersion = '5.2.6.RELEASE'


### PR DESCRIPTION
The Metrics 3.2.x version line is not maintained anymore, so it should be update to the latest stable and maintained version.

<img width="592" alt="Dropwizard Metrics maintenance matrix" src="https://user-images.githubusercontent.com/43951/102934475-78fb6a00-44a4-11eb-9db6-e77a07f7342d.png">

The table outlining which versions are still maintained can be found at https://github.com/dropwizard/metrics#versions.