### PR TITLE
Retry failing tests up to 3 times

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,7 @@ configure(project.coreProjects) {
         retry {
             maxRetries = 3
             maxFailures = 20
+            failOnPassedAfterRetry = true
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id "me.champeau.gradle.jmh" version "0.4.8"
     id 'org.asciidoctor.convert' version '1.6.0'
     id "com.jfrog.artifactory" version "4.18.3"
+    id "org.gradle.test-retry" version "1.2.0"
     id 'idea'
 }
 
@@ -42,6 +43,7 @@ configure(project.coreProjects) {
     apply plugin: 'com.jfrog.artifactory'
     apply from: "${rootDir}/publishing.gradle"
     apply plugin: 'me.champeau.gradle.jmh'
+    apply plugin: "org.gradle.test-retry"
 
     dependencies {
         compile(libraries.vavr)
@@ -73,7 +75,12 @@ configure(project.coreProjects) {
         duplicateClassesStrategy = 'warn'
     }
 
-
+    test {
+        retry {
+            maxRetries = 3
+            maxFailures = 20
+        }
+    }
 
     jacocoTestReport {
         reports {

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/timelimiter/TimeLimiterOperatorTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/timelimiter/TimeLimiterOperatorTest.java
@@ -22,6 +22,7 @@ import io.github.resilience4j.timelimiter.TimeLimiterConfig;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
 import java.time.Duration;
@@ -108,7 +109,7 @@ public class TimeLimiterOperatorTest {
         given(timeLimiter.getTimeLimiterConfig())
             .willReturn(toConfig(Duration.ofMinutes(1)));
 
-        Flux<?> flux = Flux.interval(Duration.ofMillis(1))
+        Flux<?> flux = Flux.interval(Duration.ofMillis(1), Schedulers.single())
             .take(2)
             .transformDeferred(TimeLimiterOperator.of(timeLimiter));
 


### PR DESCRIPTION
The resilience4j test suite has been very flaky for me and I never got it to complete without failing tests on my machine (current `master` branch).

Since the failing tests were different in every run and were mostly related to timing problems, I think introducing the Test Retry Gradle plugin makes sense in this case.

References:
- https://blog.gradle.org/gradle-flaky-test-retry-plugin
- https://github.com/gradle/test-retry-gradle-plugin