### PR TITLE
Issue #1281 Added Retry.failAfterMaxAttempts

### DIFF
--- a/libraries.gradle
+++ b/libraries.gradle
@@ -7,7 +7,7 @@ ext {
     reactorVersion = '3.4.0'
     junitVersion = '4.12'
     slf4jVersion = '1.7.30'
-    assertjVersion = '3.12.2'
+    assertjVersion = '3.18.1'
     logbackVersion = '1.2.3'
     mockitoVersion = '2.25.1'
     powermockVersion = '2.0.0'

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/retry/RetryOperatorTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/retry/RetryOperatorTest.java
@@ -272,6 +272,8 @@ public class RetryOperatorTest {
     }
 
     private RetryConfig retryConfig() {
-        return RetryConfig.custom().waitDuration(Duration.ofMillis(10)).build();
+        return RetryConfig.custom()
+            .waitDuration(Duration.ofMillis(10))
+            .build();
     }
 }

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/retry/RetryOperatorTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/retry/RetryOperatorTest.java
@@ -16,7 +16,7 @@
 
 package io.github.resilience4j.reactor.retry;
 
-import io.github.resilience4j.retry.MaxRetriesExceeded;
+import io.github.resilience4j.retry.MaxRetriesExceededException;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.test.HelloWorldException;
@@ -227,7 +227,7 @@ public class RetryOperatorTest {
         StepVerifier.create(Mono.fromCallable(helloWorldService::returnHelloWorld)
             .transformDeferred(RetryOperator.of(retry)))
             .expectSubscription()
-            .expectError(MaxRetriesExceeded.class)
+            .expectError(MaxRetriesExceededException.class)
             .verify(Duration.ofSeconds(1));
 
         then(helloWorldService).should(times(3)).returnHelloWorld();
@@ -307,7 +307,7 @@ public class RetryOperatorTest {
             .transformDeferred(RetryOperator.of(retry)))
             .expectSubscription()
             .expectNextCount(1)
-            .expectError(MaxRetriesExceeded.class)
+            .expectError(MaxRetriesExceededException.class)
             .verify(Duration.ofSeconds(1));
 
         Retry.Metrics metrics = retry.getMetrics();

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/retry/RetryOperatorTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/retry/RetryOperatorTest.java
@@ -16,6 +16,7 @@
 
 package io.github.resilience4j.reactor.retry;
 
+import io.github.resilience4j.retry.MaxRetriesExceeded;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.test.HelloWorldException;
@@ -212,6 +213,27 @@ public class RetryOperatorTest {
     }
 
     @Test
+    public void retryOnResultFailAfterMaxAttemptsWithExceptionUsingMono() {
+        RetryConfig config = RetryConfig.<String>custom()
+            .retryOnResult("retry"::equals)
+            .waitDuration(Duration.ofMillis(10))
+            .maxAttempts(3)
+            .failAfterMaxAttempts(true)
+            .build();
+        Retry retry = Retry.of("testName", config);
+        given(helloWorldService.returnHelloWorld())
+            .willReturn("retry");
+
+        StepVerifier.create(Mono.fromCallable(helloWorldService::returnHelloWorld)
+            .transformDeferred(RetryOperator.of(retry)))
+            .expectSubscription()
+            .expectError(MaxRetriesExceeded.class)
+            .verify(Duration.ofSeconds(1));
+
+        then(helloWorldService).should(times(3)).returnHelloWorld();
+    }
+
+    @Test
     public void shouldFailWithExceptionFlux() {
         RetryConfig config = retryConfig();
         Retry retry = Retry.of("testName", config);
@@ -264,6 +286,28 @@ public class RetryOperatorTest {
             .expectSubscription()
             .expectNextCount(1)
             .expectComplete()
+            .verify(Duration.ofSeconds(1));
+
+        Retry.Metrics metrics = retry.getMetrics();
+        assertThat(metrics.getNumberOfFailedCallsWithoutRetryAttempt()).isEqualTo(0);
+        assertThat(metrics.getNumberOfFailedCallsWithRetryAttempt()).isEqualTo(1);
+    }
+
+    @Test
+    public void retryOnResultFailAfterMaxAttemptsWithExceptionUsingFlux() {
+        RetryConfig config = RetryConfig.<String>custom()
+            .retryOnResult("retry"::equals)
+            .waitDuration(Duration.ofMillis(10))
+            .maxAttempts(3)
+            .failAfterMaxAttempts(true)
+            .build();
+        Retry retry = Retry.of("testName", config);
+
+        StepVerifier.create(Flux.just("retry")
+            .transformDeferred(RetryOperator.of(retry)))
+            .expectSubscription()
+            .expectNextCount(1)
+            .expectError(MaxRetriesExceeded.class)
             .verify(Duration.ofSeconds(1));
 
         Retry.Metrics metrics = retry.getMetrics();

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/MaxRetriesExceededException.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/MaxRetriesExceededException.java
@@ -1,0 +1,36 @@
+package io.github.resilience4j.retry;
+
+/**
+ * A {@link MaxRetriesExceededException} signals that a {@link Retry} has exhausted all attempts,
+ * and the result is still not satisfactory to {@link RetryConfig#getResultPredicate()}
+ */
+public class MaxRetriesExceededException extends RuntimeException {
+
+    private final transient String causingRetryName;
+
+    private MaxRetriesExceededException(String causingRetryName, String message, boolean writeableStackTrace) {
+        super(message, null, false, writeableStackTrace);
+        this.causingRetryName = causingRetryName;
+    }
+
+    /**
+     * Static method to construct a {@link MaxRetriesExceededException}
+     * @param retry the Retry which failed
+     */
+    public static MaxRetriesExceededException createMaxRetriesExceededException(Retry retry) {
+        boolean writeStackTrace = retry.getRetryConfig().isWritableStackTraceEnabled();
+        String message = String.format(
+            "Retry '%s' has exhausted all attempts (%d)",
+            retry.getName(),
+            retry.getRetryConfig().getMaxAttempts()
+        );
+        return new MaxRetriesExceededException(retry.getName(), message, writeStackTrace);
+    }
+
+    /**
+     * @return the name of the {@link Retry} that caused this exception
+     */
+    public String getCausingRetryName() {
+        return causingRetryName;
+    }
+}

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/Retry.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/Retry.java
@@ -678,8 +678,12 @@ public interface Retry {
             final long delay = retryContext.onResult(result);
 
             if (delay < 1) {
-                promise.complete(result);
-                retryContext.onComplete();
+                try {
+                    retryContext.onComplete();
+                    promise.complete(result);
+                } catch (Exception e) {
+                    promise.completeExceptionally(e);
+                }
             } else {
                 scheduler.schedule(this, delay, TimeUnit.MILLISECONDS);
             }

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/RetryConfig.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/RetryConfig.java
@@ -52,6 +52,7 @@ public class RetryConfig implements Serializable {
     private Predicate retryOnResultPredicate;
 
     private int maxAttempts = DEFAULT_MAX_ATTEMPTS;
+    private boolean failAfterMaxAttempts = false;
 
     @Nullable
     private IntervalFunction intervalFunction;
@@ -95,6 +96,13 @@ public class RetryConfig implements Serializable {
     }
 
     /**
+     * @return if exception should be thrown after max attempts are made with no satisfactory result
+     */
+    public boolean isFailAfterMaxAttempts() {
+        return failAfterMaxAttempts;
+    }
+
+    /**
      * Use {@link RetryConfig#intervalBiFunction} instead, this method is kept for backwards compatibility
      */
     @Nullable
@@ -134,6 +142,7 @@ public class RetryConfig implements Serializable {
     public static class Builder<T> {
 
         private int maxAttempts = DEFAULT_MAX_ATTEMPTS;
+        private boolean failAfterMaxAttempts = false;
 
         @Nullable
         private IntervalFunction intervalFunction;
@@ -160,6 +169,7 @@ public class RetryConfig implements Serializable {
             this.maxAttempts = baseConfig.maxAttempts;
             this.retryOnExceptionPredicate = baseConfig.retryOnExceptionPredicate;
             this.retryOnResultPredicate = baseConfig.retryOnResultPredicate;
+            this.failAfterMaxAttempts = baseConfig.failAfterMaxAttempts;
             this.retryExceptions = baseConfig.retryExceptions;
             this.ignoreExceptions = baseConfig.ignoreExceptions;
             if (baseConfig.intervalFunction != null) {
@@ -197,6 +207,18 @@ public class RetryConfig implements Serializable {
          */
         public Builder<T> retryOnResult(Predicate<T> predicate) {
             this.retryOnResultPredicate = predicate;
+            return this;
+        }
+
+        /**
+         * Configures the Retry to throw a {@link MaxRetriesExceeded} exception once {@link #maxAttempts} has been reached,
+         * and the result is still not satisfactory (according to {@link #retryOnResultPredicate})
+         *
+         * @param bool a boolean flag to enable or disable throwing. (Default is {@code false}
+         * @return the RetryConfig.Builder
+         */
+        public Builder<T> failAfterMaxAttempts(boolean bool) {
+            this.failAfterMaxAttempts = bool;
             return this;
         }
 
@@ -293,6 +315,7 @@ public class RetryConfig implements Serializable {
             }
             RetryConfig config = new RetryConfig();
             config.maxAttempts = maxAttempts;
+            config.failAfterMaxAttempts = failAfterMaxAttempts;
             config.retryOnExceptionPredicate = retryOnExceptionPredicate;
             config.retryOnResultPredicate = retryOnResultPredicate;
             config.retryExceptions = retryExceptions;

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/RetryConfig.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/RetryConfig.java
@@ -53,6 +53,7 @@ public class RetryConfig implements Serializable {
 
     private int maxAttempts = DEFAULT_MAX_ATTEMPTS;
     private boolean failAfterMaxAttempts = false;
+    private boolean writableStackTraceEnabled = true;
 
     @Nullable
     private IntervalFunction intervalFunction;
@@ -103,6 +104,13 @@ public class RetryConfig implements Serializable {
     }
 
     /**
+     * @return if any thrown {@link MaxRetriesExceededException} should contain a stacktrace
+     */
+    public boolean isWritableStackTraceEnabled() {
+        return writableStackTraceEnabled;
+    }
+
+    /**
      * Use {@link RetryConfig#intervalBiFunction} instead, this method is kept for backwards compatibility
      */
     @Nullable
@@ -143,6 +151,7 @@ public class RetryConfig implements Serializable {
 
         private int maxAttempts = DEFAULT_MAX_ATTEMPTS;
         private boolean failAfterMaxAttempts = false;
+        private boolean writableStackTraceEnabled = true;
 
         @Nullable
         private IntervalFunction intervalFunction;
@@ -170,6 +179,7 @@ public class RetryConfig implements Serializable {
             this.retryOnExceptionPredicate = baseConfig.retryOnExceptionPredicate;
             this.retryOnResultPredicate = baseConfig.retryOnResultPredicate;
             this.failAfterMaxAttempts = baseConfig.failAfterMaxAttempts;
+            this.writableStackTraceEnabled = baseConfig.writableStackTraceEnabled;
             this.retryExceptions = baseConfig.retryExceptions;
             this.ignoreExceptions = baseConfig.ignoreExceptions;
             if (baseConfig.intervalFunction != null) {
@@ -219,6 +229,20 @@ public class RetryConfig implements Serializable {
          */
         public Builder<T> failAfterMaxAttempts(boolean bool) {
             this.failAfterMaxAttempts = bool;
+            return this;
+        }
+
+        /**
+         * Enables writable stack traces. When set to false, {@link Exception#getStackTrace()}
+         * returns a zero length array. This may be used to reduce log spam when the Retry
+         * has exceeded the maximum nbr of attempts, and flag {@link #failAfterMaxAttempts} has been enabled.
+         * The thrown {@link MaxRetriesExceededException} will then have no stacktrace.
+         *
+         * @param bool the flag to enable writable stack traces.
+         * @return the RetryConfig.Builder
+         */
+        public Builder<T> writableStackTraceEnabled(boolean bool) {
+            this.writableStackTraceEnabled = bool;
             return this;
         }
 
@@ -316,6 +340,7 @@ public class RetryConfig implements Serializable {
             RetryConfig config = new RetryConfig();
             config.maxAttempts = maxAttempts;
             config.failAfterMaxAttempts = failAfterMaxAttempts;
+            config.writableStackTraceEnabled = writableStackTraceEnabled;
             config.retryOnExceptionPredicate = retryOnExceptionPredicate;
             config.retryOnResultPredicate = retryOnResultPredicate;
             config.retryExceptions = retryExceptions;

--- a/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/CompletionStageRetryTest.java
+++ b/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/CompletionStageRetryTest.java
@@ -18,6 +18,7 @@
  */
 package io.github.resilience4j.retry.internal;
 
+import io.github.resilience4j.retry.MaxRetriesExceeded;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.test.AsyncHelloWorldService;
@@ -26,10 +27,7 @@ import io.vavr.control.Try;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.*;
 import java.util.function.Supplier;
 
 import static io.github.resilience4j.retry.utils.AsyncUtils.awaitResult;
@@ -141,25 +139,30 @@ public class CompletionStageRetryTest {
         assertThat(result).isEqualTo("Hello world");
     }
 
-    private void shouldCompleteFutureAfterAttemptsInCaseOfExceptionAtSyncStage(int noOfAttempts) {
+    @Test
+    public void shouldThrowOnceMaxAttemptsReachedIfConfigured() {
         given(helloWorldService.returnHelloWorld())
-            .willThrow(new HelloWorldException());
-        Retry retryContext = Retry.of(
-            "id",
-            RetryConfig
-                .custom()
-                .maxAttempts(noOfAttempts)
-                .build());
+            .willReturn(CompletableFuture.completedFuture("invalid response"));
+        RetryConfig retryConfig = RetryConfig.<String>custom()
+            .retryOnResult(s -> s.equals("invalid response"))
+            .maxAttempts(3)
+            .failAfterMaxAttempts(true)
+            .build();
+
+        Retry retry = Retry.of("retry", retryConfig);
         Supplier<CompletionStage<String>> supplier = Retry.decorateCompletionStage(
-            retryContext,
+            retry,
             scheduler,
-            () -> helloWorldService.returnHelloWorld());
+            helloWorldService::returnHelloWorld
+        );
 
-        Try<String> resultTry = Try.of(() -> awaitResult(supplier.get()));
-
-        then(helloWorldService).should(times(noOfAttempts)).returnHelloWorld();
-        assertThat(resultTry.isFailure()).isTrue();
-        assertThat(resultTry.getCause().getCause()).isInstanceOf(HelloWorldException.class);
+        assertThat(supplier.get())
+            .failsWithin(5, TimeUnit.SECONDS)
+            .withThrowableOfType(ExecutionException.class)
+            .havingCause()
+            .isInstanceOf(MaxRetriesExceeded.class)
+            .withMessage("Max retries reached for retry=retry");
+        then(helloWorldService).should(times(3)).returnHelloWorld();
     }
 
     @Test

--- a/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/CompletionStageRetryTest.java
+++ b/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/CompletionStageRetryTest.java
@@ -18,7 +18,7 @@
  */
 package io.github.resilience4j.retry.internal;
 
-import io.github.resilience4j.retry.MaxRetriesExceeded;
+import io.github.resilience4j.retry.MaxRetriesExceededException;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.test.AsyncHelloWorldService;
@@ -160,8 +160,8 @@ public class CompletionStageRetryTest {
             .failsWithin(5, TimeUnit.SECONDS)
             .withThrowableOfType(ExecutionException.class)
             .havingCause()
-            .isInstanceOf(MaxRetriesExceeded.class)
-            .withMessage("Max retries reached for retry=retry");
+            .isInstanceOf(MaxRetriesExceededException.class)
+            .withMessage("Retry 'retry' has exhausted all attempts (3)");
         then(helloWorldService).should(times(3)).returnHelloWorld();
     }
 

--- a/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/SupplierRetryTest.java
+++ b/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/SupplierRetryTest.java
@@ -20,7 +20,7 @@ package io.github.resilience4j.retry.internal;
 
 import io.github.resilience4j.core.IntervalBiFunction;
 import io.github.resilience4j.core.IntervalFunction;
-import io.github.resilience4j.retry.MaxRetriesExceeded;
+import io.github.resilience4j.retry.MaxRetriesExceededException;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.test.AsyncHelloWorldService;
@@ -571,8 +571,8 @@ public class SupplierRetryTest {
             .decorateSupplier(retry, helloWorldService::returnHelloWorld);
 
         assertThatThrownBy(supplier::get)
-            .isInstanceOf(MaxRetriesExceeded.class)
-            .hasMessage("Max retries reached for retry=test");
+            .isInstanceOf(MaxRetriesExceededException.class)
+            .hasMessage("Retry 'test' has exhausted all attempts (3)");
 
         then(helloWorldService).should(times(3)).returnHelloWorld();
     }

--- a/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/SupplierRetryTest.java
+++ b/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/SupplierRetryTest.java
@@ -20,6 +20,7 @@ package io.github.resilience4j.retry.internal;
 
 import io.github.resilience4j.core.IntervalBiFunction;
 import io.github.resilience4j.core.IntervalFunction;
+import io.github.resilience4j.retry.MaxRetriesExceeded;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.test.AsyncHelloWorldService;
@@ -44,6 +45,7 @@ import static io.github.resilience4j.retry.utils.AsyncUtils.awaitResult;
 import static io.vavr.API.$;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
@@ -554,4 +556,43 @@ public class SupplierRetryTest {
         assertThat(sleptTime).isEqualTo(300L);
     }
 
+    @Test
+    public void shouldThrowMaxRetriesExceededIfConfigured() {
+        given(helloWorldService.returnHelloWorld())
+            .willReturn("retryable response");
+
+        RetryConfig retryConfig = RetryConfig.<String>custom()
+            .retryOnResult(s -> s.equals("retryable response"))
+            .maxAttempts(3)
+            .failAfterMaxAttempts(true)
+            .build();
+        Retry retry = Retry.of("test", retryConfig);
+        Supplier<String> supplier = Retry
+            .decorateSupplier(retry, helloWorldService::returnHelloWorld);
+
+        assertThatThrownBy(supplier::get)
+            .isInstanceOf(MaxRetriesExceeded.class)
+            .hasMessage("Max retries reached for retry=test");
+
+        then(helloWorldService).should(times(3)).returnHelloWorld();
+    }
+
+    @Test
+    public void shouldNotThrowMaxRetriesExceededIfCompletedExceptionally() {
+        given(helloWorldService.returnHelloWorld())
+            .willThrow(new HelloWorldException());
+
+        RetryConfig retryConfig = RetryConfig.<String>custom()
+            .maxAttempts(3)
+            .failAfterMaxAttempts(true)
+            .build();
+        Retry retry = Retry.of("test", retryConfig);
+        Supplier<String> supplier = Retry
+            .decorateSupplier(retry, helloWorldService::returnHelloWorld);
+
+        assertThatThrownBy(supplier::get)
+            .isInstanceOf(HelloWorldException.class);
+
+        then(helloWorldService).should(times(3)).returnHelloWorld();
+    }
 }

--- a/resilience4j-rxjava2/src/test/java/io/github/resilience4j/retry/transformer/RetryTransformerTest.java
+++ b/resilience4j-rxjava2/src/test/java/io/github/resilience4j/retry/transformer/RetryTransformerTest.java
@@ -16,7 +16,7 @@
 
 package io.github.resilience4j.retry.transformer;
 
-import io.github.resilience4j.retry.MaxRetriesExceeded;
+import io.github.resilience4j.retry.MaxRetriesExceededException;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.test.HelloWorldException;
@@ -703,7 +703,7 @@ public class RetryTransformerTest {
             .compose(RetryTransformer.of(retry))
             .test()
             .await()
-            .assertFailure(MaxRetriesExceeded.class, "retry");
+            .assertFailureAndMessage(MaxRetriesExceededException.class, "Retry 'testName' has exhausted all attempts (3)", "retry");
 
         then(helloWorldService).should(times(3)).returnHelloWorld();
     }

--- a/resilience4j-rxjava2/src/test/java/io/github/resilience4j/retry/transformer/RetryTransformerTest.java
+++ b/resilience4j-rxjava2/src/test/java/io/github/resilience4j/retry/transformer/RetryTransformerTest.java
@@ -16,6 +16,7 @@
 
 package io.github.resilience4j.retry.transformer;
 
+import io.github.resilience4j.retry.MaxRetriesExceeded;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.test.HelloWorldException;
@@ -682,6 +683,27 @@ public class RetryTransformerTest {
             .assertValue("retry")
             .assertComplete()
             .assertSubscribed();
+
+        then(helloWorldService).should(times(3)).returnHelloWorld();
+    }
+
+    @Test
+    public void shouldThrowMaxRetriesExceptionAfterRetriesExhaustedWhenConfigured() throws InterruptedException {
+        RetryConfig config = RetryConfig.<String>custom()
+            .retryOnResult("retry"::equals)
+            .waitDuration(Duration.ofMillis(50))
+            .maxAttempts(3)
+            .failAfterMaxAttempts(true)
+            .build();
+        Retry retry = Retry.of("testName", config);
+        given(helloWorldService.returnHelloWorld())
+            .willReturn("retry");
+
+        Flowable.fromCallable(helloWorldService::returnHelloWorld)
+            .compose(RetryTransformer.of(retry))
+            .test()
+            .await()
+            .assertFailure(MaxRetriesExceeded.class, "retry");
 
         then(helloWorldService).should(times(3)).returnHelloWorld();
     }

--- a/resilience4j-rxjava3/src/test/java/io/github/resilience4j/rxjava3/retry/transformer/RetryTransformerTest.java
+++ b/resilience4j-rxjava3/src/test/java/io/github/resilience4j/rxjava3/retry/transformer/RetryTransformerTest.java
@@ -16,10 +16,9 @@
 
 package io.github.resilience4j.rxjava3.retry.transformer;
 
-import io.github.resilience4j.retry.MaxRetriesExceeded;
+import io.github.resilience4j.retry.MaxRetriesExceededException;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
-import io.github.resilience4j.rxjava3.retry.transformer.RetryTransformer;
 import io.github.resilience4j.test.HelloWorldException;
 import io.github.resilience4j.test.HelloWorldService;
 import io.reactivex.rxjava3.core.*;
@@ -676,7 +675,7 @@ public class RetryTransformerTest {
             .compose(RetryTransformer.of(retry))
             .test()
             .await()
-            .assertFailure(MaxRetriesExceeded.class, "retry");
+            .assertFailure(MaxRetriesExceededException.class, "retry");
 
         then(helloWorldService).should(times(3)).returnHelloWorld();
     }


### PR DESCRIPTION
Adds property `failAfterMaxAttempts` (boolean) to the `RetryConfig`.
This property will be inspected on the `Retry.Context :: onComplete()`, and if found to be `true`, it will throw a `MaxRetriesExceeded` exception.

If `false`, behaviour should stay unaffected.

One more notable change made in this PR is the switch of calls in `AsyncRetryBlock :: onResult`.
This to make it more in-line with the synchronous result checking. Plus the fact that we can't complete our promise/future before we inspect if we would receive a `MaxRetriesExceeded` exception from `onComplete`.

The difference here is that we'll publish events before resolving our promise/future. Do you see that to be a problem? Happy to discuss!

Lastly, I bumped the `assertj` dependency, in order to be able to call
```java
CompletionStage.failsWithin(5, TimeUnit.SECONDS)
    .withThrowableOfType(ExecutionException.class)
```

Closes #1281 

Also: Let me know if I could help out updating the readme / user guide somehow. Couldn't find any documentation (other than javadoc) in this repo