### PR TITLE
Perf: improve EventProcessor#processEvent(E) performance

### DIFF
--- a/resilience4j-all/src/main/java/io/github/resilience4j/decorators/Decorators.java
+++ b/resilience4j-all/src/main/java/io/github/resilience4j/decorators/Decorators.java
@@ -27,7 +27,7 @@ import java.util.function.*;
 /**
  * A Decorator builder which can be used to apply multiple decorators to a Supplier, Callable
  * Function, Runnable, CompletionStage or Consumer.
- * <p></p>
+ * <p>
  * Decorators are applied in the order of the builder chain. For example, consider:
  *
  * <pre>{@code

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/FixedThreadPoolBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/FixedThreadPoolBulkhead.java
@@ -261,7 +261,7 @@ public class FixedThreadPoolBulkhead implements ThreadPoolBulkhead {
         @Override
         public ThreadPoolBulkheadEventPublisher onCallPermitted(
             EventConsumer<BulkheadOnCallPermittedEvent> onCallPermittedEventConsumer) {
-            registerConsumer(BulkheadOnCallPermittedEvent.class.getSimpleName(),
+            registerConsumer(BulkheadOnCallPermittedEvent.class.getName(),
                 onCallPermittedEventConsumer);
             return this;
         }
@@ -269,7 +269,7 @@ public class FixedThreadPoolBulkhead implements ThreadPoolBulkhead {
         @Override
         public ThreadPoolBulkheadEventPublisher onCallRejected(
             EventConsumer<BulkheadOnCallRejectedEvent> onCallRejectedEventConsumer) {
-            registerConsumer(BulkheadOnCallRejectedEvent.class.getSimpleName(),
+            registerConsumer(BulkheadOnCallRejectedEvent.class.getName(),
                 onCallRejectedEventConsumer);
             return this;
         }
@@ -277,7 +277,7 @@ public class FixedThreadPoolBulkhead implements ThreadPoolBulkhead {
         @Override
         public ThreadPoolBulkheadEventPublisher onCallFinished(
             EventConsumer<BulkheadOnCallFinishedEvent> onCallFinishedEventConsumer) {
-            registerConsumer(BulkheadOnCallFinishedEvent.class.getSimpleName(),
+            registerConsumer(BulkheadOnCallFinishedEvent.class.getName(),
                 onCallFinishedEventConsumer);
             return this;
         }

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkhead.java
@@ -252,7 +252,7 @@ public class SemaphoreBulkhead implements Bulkhead {
         @Override
         public EventPublisher onCallPermitted(
             EventConsumer<BulkheadOnCallPermittedEvent> onCallPermittedEventConsumer) {
-            registerConsumer(BulkheadOnCallPermittedEvent.class.getSimpleName(),
+            registerConsumer(BulkheadOnCallPermittedEvent.class.getName(),
                 onCallPermittedEventConsumer);
             return this;
         }
@@ -260,7 +260,7 @@ public class SemaphoreBulkhead implements Bulkhead {
         @Override
         public EventPublisher onCallRejected(
             EventConsumer<BulkheadOnCallRejectedEvent> onCallRejectedEventConsumer) {
-            registerConsumer(BulkheadOnCallRejectedEvent.class.getSimpleName(),
+            registerConsumer(BulkheadOnCallRejectedEvent.class.getName(),
                 onCallRejectedEventConsumer);
             return this;
         }
@@ -268,7 +268,7 @@ public class SemaphoreBulkhead implements Bulkhead {
         @Override
         public EventPublisher onCallFinished(
             EventConsumer<BulkheadOnCallFinishedEvent> onCallFinishedEventConsumer) {
-            registerConsumer(BulkheadOnCallFinishedEvent.class.getSimpleName(),
+            registerConsumer(BulkheadOnCallFinishedEvent.class.getName(),
                 onCallFinishedEventConsumer);
             return this;
         }

--- a/resilience4j-cache/src/main/java/io/github/resilience4j/cache/internal/CacheImpl.java
+++ b/resilience4j-cache/src/main/java/io/github/resilience4j/cache/internal/CacheImpl.java
@@ -128,19 +128,19 @@ public class CacheImpl<K, V> implements Cache<K, V> {
 
         @Override
         public EventPublisher onCacheHit(EventConsumer<CacheOnHitEvent> eventConsumer) {
-            registerConsumer(CacheOnHitEvent.class.getSimpleName(), eventConsumer);
+            registerConsumer(CacheOnHitEvent.class.getName(), eventConsumer);
             return this;
         }
 
         @Override
         public EventPublisher onCacheMiss(EventConsumer<CacheOnMissEvent> eventConsumer) {
-            registerConsumer(CacheOnMissEvent.class.getSimpleName(), eventConsumer);
+            registerConsumer(CacheOnMissEvent.class.getName(), eventConsumer);
             return this;
         }
 
         @Override
         public EventPublisher onError(EventConsumer<CacheOnErrorEvent> eventConsumer) {
-            registerConsumer(CacheOnErrorEvent.class.getSimpleName(), eventConsumer);
+            registerConsumer(CacheOnErrorEvent.class.getName(), eventConsumer);
             return this;
         }
 

--- a/resilience4j-circuitbreaker/src/jmh/resources/resultsWithGCProfiling.txt
+++ b/resilience4j-circuitbreaker/src/jmh/resources/resultsWithGCProfiling.txt
@@ -1,23 +1,32 @@
-Benchmark                                                                                  Mode  Cnt     Score    Error   Units
-CircuitBreakerBenchmark.directSupplier                                                    thrpt   20    12.188 ±  0.038  ops/us
-CircuitBreakerBenchmark.directSupplier:·gc.alloc.rate                                     thrpt   20    ≈ 10⁻⁴           MB/sec
-CircuitBreakerBenchmark.directSupplier:·gc.alloc.rate.norm                                thrpt   20    ≈ 10⁻⁵             B/op
-CircuitBreakerBenchmark.directSupplier:·gc.count                                          thrpt   20       ≈ 0           counts
-CircuitBreakerBenchmark.protectedSupplier                                                 thrpt   20     5.668 ±  0.084  ops/us
-CircuitBreakerBenchmark.protectedSupplier:·gc.alloc.rate                                  thrpt   20   247.044 ±  3.659  MB/sec
-CircuitBreakerBenchmark.protectedSupplier:·gc.alloc.rate.norm                             thrpt   20    48.000 ±  0.001    B/op
-CircuitBreakerBenchmark.protectedSupplier:·gc.churn.PS_Eden_Space                         thrpt   20   247.769 ±  3.835  MB/sec
-CircuitBreakerBenchmark.protectedSupplier:·gc.churn.PS_Eden_Space.norm                    thrpt   20    48.141 ±  0.296    B/op
-CircuitBreakerBenchmark.protectedSupplier:·gc.churn.PS_Survivor_Space                     thrpt   20     0.012 ±  0.006  MB/sec
-CircuitBreakerBenchmark.protectedSupplier:·gc.churn.PS_Survivor_Space.norm                thrpt   20     0.002 ±  0.001    B/op
-CircuitBreakerBenchmark.protectedSupplier:·gc.count                                       thrpt   20  1270.000           counts
-CircuitBreakerBenchmark.protectedSupplier:·gc.time                                        thrpt   20   802.000               ms
-CircuitBreakerBenchmark.protectedSupplierWithSubscriber                                   thrpt   20     4.471 ±  0.013  ops/us
-CircuitBreakerBenchmark.protectedSupplierWithSubscriber:·gc.alloc.rate                    thrpt   20   633.298 ± 43.945  MB/sec
-CircuitBreakerBenchmark.protectedSupplierWithSubscriber:·gc.alloc.rate.norm               thrpt   20   156.000 ± 10.691    B/op
-CircuitBreakerBenchmark.protectedSupplierWithSubscriber:·gc.churn.PS_Eden_Space           thrpt   20   634.365 ± 43.957  MB/sec
-CircuitBreakerBenchmark.protectedSupplierWithSubscriber:·gc.churn.PS_Eden_Space.norm      thrpt   20   156.263 ± 10.692    B/op
-CircuitBreakerBenchmark.protectedSupplierWithSubscriber:·gc.churn.PS_Survivor_Space       thrpt   20     0.164 ±  0.016  MB/sec
-CircuitBreakerBenchmark.protectedSupplierWithSubscriber:·gc.churn.PS_Survivor_Space.norm  thrpt   20     0.040 ±  0.004    B/op
-CircuitBreakerBenchmark.protectedSupplierWithSubscriber:·gc.count                         thrpt   20  2837.000           counts
-CircuitBreakerBenchmark.protectedSupplierWithSubscriber:·gc.time                          thrpt   20  1823.000               ms
+Benchmark                                                                                    Mode  Cnt     Score    Error   Units
+CircuitBreakerBenchmark.directSupplier                                                      thrpt   20    12.258 ±  0.019  ops/us
+CircuitBreakerBenchmark.directSupplier:·gc.alloc.rate                                       thrpt   20    ≈ 10⁻⁴           MB/sec
+CircuitBreakerBenchmark.directSupplier:·gc.alloc.rate.norm                                  thrpt   20    ≈ 10⁻⁵             B/op
+CircuitBreakerBenchmark.directSupplier:·gc.count                                            thrpt   20       ≈ 0           counts
+CircuitBreakerBenchmark.protectedSupplier                                                   thrpt   20     4.122 ±  0.033  ops/us
+CircuitBreakerBenchmark.protectedSupplier:·gc.alloc.rate                                    thrpt   20  1017.650 ±  8.294  MB/sec
+CircuitBreakerBenchmark.protectedSupplier:·gc.alloc.rate.norm                               thrpt   20   272.000 ±  0.001    B/op
+CircuitBreakerBenchmark.protectedSupplier:·gc.churn.PS_Eden_Space                           thrpt   20  1019.431 ±  8.512  MB/sec
+CircuitBreakerBenchmark.protectedSupplier:·gc.churn.PS_Eden_Space.norm                      thrpt   20   272.476 ±  0.609    B/op
+CircuitBreakerBenchmark.protectedSupplier:·gc.churn.PS_Survivor_Space                       thrpt   20     0.162 ±  0.015  MB/sec
+CircuitBreakerBenchmark.protectedSupplier:·gc.churn.PS_Survivor_Space.norm                  thrpt   20     0.043 ±  0.004    B/op
+CircuitBreakerBenchmark.protectedSupplier:·gc.count                                         thrpt   20  2871.000           counts
+CircuitBreakerBenchmark.protectedSupplier:·gc.time                                          thrpt   20  1849.000               ms
+CircuitBreakerBenchmark.protectedSupplierWithDiffConsumer                                   thrpt   20     3.970 ±  0.023  ops/us
+CircuitBreakerBenchmark.protectedSupplierWithDiffConsumer:·gc.alloc.rate                    thrpt   20   894.224 ± 79.317  MB/sec
+CircuitBreakerBenchmark.protectedSupplierWithDiffConsumer:·gc.alloc.rate.norm               thrpt   20   248.000 ± 21.382    B/op
+CircuitBreakerBenchmark.protectedSupplierWithDiffConsumer:·gc.churn.PS_Eden_Space           thrpt   20   896.456 ± 79.367  MB/sec
+CircuitBreakerBenchmark.protectedSupplierWithDiffConsumer:·gc.churn.PS_Eden_Space.norm      thrpt   20   248.621 ± 21.406    B/op
+CircuitBreakerBenchmark.protectedSupplierWithDiffConsumer:·gc.churn.PS_Survivor_Space       thrpt   20     0.159 ±  0.014  MB/sec
+CircuitBreakerBenchmark.protectedSupplierWithDiffConsumer:·gc.churn.PS_Survivor_Space.norm  thrpt   20     0.044 ±  0.004    B/op
+CircuitBreakerBenchmark.protectedSupplierWithDiffConsumer:·gc.count                         thrpt   20  2912.000           counts
+CircuitBreakerBenchmark.protectedSupplierWithDiffConsumer:·gc.time                          thrpt   20  1821.000               ms
+CircuitBreakerBenchmark.protectedSupplierWithOneConsumer                                    thrpt   20     4.021 ±  0.036  ops/us
+CircuitBreakerBenchmark.protectedSupplierWithOneConsumer:·gc.alloc.rate                     thrpt   20  1037.001 ± 47.516  MB/sec
+CircuitBreakerBenchmark.protectedSupplierWithOneConsumer:·gc.alloc.rate.norm                thrpt   20   284.000 ± 10.691    B/op
+CircuitBreakerBenchmark.protectedSupplierWithOneConsumer:·gc.churn.PS_Eden_Space            thrpt   20  1038.596 ± 47.251  MB/sec
+CircuitBreakerBenchmark.protectedSupplierWithOneConsumer:·gc.churn.PS_Eden_Space.norm       thrpt   20   284.439 ± 10.642    B/op
+CircuitBreakerBenchmark.protectedSupplierWithOneConsumer:·gc.churn.PS_Survivor_Space        thrpt   20     0.168 ±  0.012  MB/sec
+CircuitBreakerBenchmark.protectedSupplierWithOneConsumer:·gc.churn.PS_Survivor_Space.norm   thrpt   20     0.046 ±  0.003    B/op
+CircuitBreakerBenchmark.protectedSupplierWithOneConsumer:·gc.count                          thrpt   20  2936.000           counts
+CircuitBreakerBenchmark.protectedSupplierWithOneConsumer:·gc.time                           thrpt   20  1840.000               ms

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachine.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachine.java
@@ -489,7 +489,7 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
         @Override
         public EventPublisher onSuccess(
             EventConsumer<CircuitBreakerOnSuccessEvent> onSuccessEventConsumer) {
-            registerConsumer(CircuitBreakerOnSuccessEvent.class.getSimpleName(),
+            registerConsumer(CircuitBreakerOnSuccessEvent.class.getName(),
                 onSuccessEventConsumer);
             return this;
         }
@@ -497,7 +497,7 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
         @Override
         public EventPublisher onError(
             EventConsumer<CircuitBreakerOnErrorEvent> onErrorEventConsumer) {
-            registerConsumer(CircuitBreakerOnErrorEvent.class.getSimpleName(),
+            registerConsumer(CircuitBreakerOnErrorEvent.class.getName(),
                 onErrorEventConsumer);
             return this;
         }
@@ -505,7 +505,7 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
         @Override
         public EventPublisher onStateTransition(
             EventConsumer<CircuitBreakerOnStateTransitionEvent> onStateTransitionEventConsumer) {
-            registerConsumer(CircuitBreakerOnStateTransitionEvent.class.getSimpleName(),
+            registerConsumer(CircuitBreakerOnStateTransitionEvent.class.getName(),
                 onStateTransitionEventConsumer);
             return this;
         }
@@ -513,7 +513,7 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
         @Override
         public EventPublisher onReset(
             EventConsumer<CircuitBreakerOnResetEvent> onResetEventConsumer) {
-            registerConsumer(CircuitBreakerOnResetEvent.class.getSimpleName(),
+            registerConsumer(CircuitBreakerOnResetEvent.class.getName(),
                 onResetEventConsumer);
             return this;
         }
@@ -521,7 +521,7 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
         @Override
         public EventPublisher onIgnoredError(
             EventConsumer<CircuitBreakerOnIgnoredErrorEvent> onIgnoredErrorEventConsumer) {
-            registerConsumer(CircuitBreakerOnIgnoredErrorEvent.class.getSimpleName(),
+            registerConsumer(CircuitBreakerOnIgnoredErrorEvent.class.getName(),
                 onIgnoredErrorEventConsumer);
             return this;
         }
@@ -529,7 +529,7 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
         @Override
         public EventPublisher onCallNotPermitted(
             EventConsumer<CircuitBreakerOnCallNotPermittedEvent> onCallNotPermittedEventConsumer) {
-            registerConsumer(CircuitBreakerOnCallNotPermittedEvent.class.getSimpleName(),
+            registerConsumer(CircuitBreakerOnCallNotPermittedEvent.class.getName(),
                 onCallNotPermittedEventConsumer);
             return this;
         }
@@ -537,7 +537,7 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
         @Override
         public EventPublisher onFailureRateExceeded(
             EventConsumer<CircuitBreakerOnFailureRateExceededEvent> onFailureRateExceededConsumer) {
-            registerConsumer(CircuitBreakerOnFailureRateExceededEvent.class.getSimpleName(),
+            registerConsumer(CircuitBreakerOnFailureRateExceededEvent.class.getName(),
                 onFailureRateExceededConsumer);
             return this;
         }
@@ -545,7 +545,7 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
         @Override
         public EventPublisher onSlowCallRateExceeded(
             EventConsumer<CircuitBreakerOnSlowCallRateExceededEvent> onSlowCallRateExceededConsumer) {
-            registerConsumer(CircuitBreakerOnSlowCallRateExceededEvent.class.getSimpleName(),
+            registerConsumer(CircuitBreakerOnSlowCallRateExceededEvent.class.getName(),
                 onSlowCallRateExceededConsumer);
             return this;
         }

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/EventProcessor.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/EventProcessor.java
@@ -36,8 +36,7 @@ public class EventProcessor<T> implements EventPublisher<T> {
     }
 
     @SuppressWarnings("unchecked")
-    public synchronized void registerConsumer(String className,
-        EventConsumer<? extends T> eventConsumer) {
+    public synchronized void registerConsumer(String className, EventConsumer<? extends T> eventConsumer) {
         this.eventConsumerMap.compute(className, (k, consumers) -> {
             if (consumers == null) {
                 consumers = new CopyOnWriteArrayList<>();
@@ -53,15 +52,20 @@ public class EventProcessor<T> implements EventPublisher<T> {
 
     public <E extends T> boolean processEvent(E event) {
         boolean consumed = false;
+        final List<EventConsumer<T>> onEventConsumers = this.onEventConsumers;
         if (!onEventConsumers.isEmpty()) {
-            onEventConsumers.forEach(onEventConsumer -> onEventConsumer.consumeEvent(event));
+            for (int i = 0, size = onEventConsumers.size(); i < size; i++) {
+                onEventConsumers.get(i).consumeEvent(event);
+            }
             consumed = true;
         }
+
         if (!eventConsumerMap.isEmpty()) {
-            List<EventConsumer<T>> eventConsumers = this.eventConsumerMap
-                .get(event.getClass().getSimpleName());
-            if (eventConsumers != null && !eventConsumers.isEmpty()) {
-                eventConsumers.forEach(consumer -> consumer.consumeEvent(event));
+            final List<EventConsumer<T>> consumers = this.eventConsumerMap.get(event.getClass().getName());
+            if (consumers != null && !consumers.isEmpty()) {
+                for (int i = 0, size = consumers.size(); i < size; i++) {
+                    consumers.get(i).consumeEvent(event);
+                }
                 consumed = true;
             }
         }

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/registry/AbstractRegistry.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/registry/AbstractRegistry.java
@@ -184,22 +184,21 @@ public class AbstractRegistry<E, C> implements Registry<E, C> {
         @Override
         public EventPublisher<E> onEntryAdded(
             EventConsumer<EntryAddedEvent<E>> onSuccessEventConsumer) {
-            registerConsumer(EntryAddedEvent.class.getSimpleName(), onSuccessEventConsumer);
+            registerConsumer(EntryAddedEvent.class.getName(), onSuccessEventConsumer);
             return this;
         }
 
         @Override
         public EventPublisher<E> onEntryRemoved(
             EventConsumer<EntryRemovedEvent<E>> onErrorEventConsumer) {
-            registerConsumer(EntryRemovedEvent.class.getSimpleName(), onErrorEventConsumer);
+            registerConsumer(EntryRemovedEvent.class.getName(), onErrorEventConsumer);
             return this;
         }
 
         @Override
         public EventPublisher<E> onEntryReplaced(
             EventConsumer<EntryReplacedEvent<E>> onStateTransitionEventConsumer) {
-            registerConsumer(EntryReplacedEvent.class.getSimpleName(),
-                onStateTransitionEventConsumer);
+            registerConsumer(EntryReplacedEvent.class.getName(), onStateTransitionEventConsumer);
             return this;
         }
 

--- a/resilience4j-core/src/test/java/io/github/resilience4j/core/EventProcessorTest.java
+++ b/resilience4j-core/src/test/java/io/github/resilience4j/core/EventProcessorTest.java
@@ -61,11 +61,11 @@ public class EventProcessorTest {
         EventProcessor<Number> eventProcessor = new EventProcessor<>();
         EventConsumer<Integer> eventConsumer = event -> logger.info(event.toString());
 
-        eventProcessor.registerConsumer(Integer.class.getSimpleName(), eventConsumer);
-        eventProcessor.registerConsumer(Integer.class.getSimpleName(), eventConsumer);
+        eventProcessor.registerConsumer(Integer.class.getName(), eventConsumer);
+        eventProcessor.registerConsumer(Integer.class.getName(), eventConsumer);
 
         assertThat(eventProcessor.eventConsumerMap).hasSize(1);
-        assertThat(eventProcessor.eventConsumerMap.get(Integer.class.getSimpleName())).hasSize(2);
+        assertThat(eventProcessor.eventConsumerMap.get(Integer.class.getName())).hasSize(2);
         boolean consumed = eventProcessor.processEvent(1);
         then(logger).should(times(2)).info("1");
         assertThat(consumed).isEqualTo(true);
@@ -77,12 +77,12 @@ public class EventProcessorTest {
         EventConsumer<Integer> integerConsumer = event -> logger.info(event.toString());
         EventConsumer<Float> floatConsumer = event -> logger.info(event.toString());
 
-        eventProcessor.registerConsumer(Integer.class.getSimpleName(), integerConsumer);
-        eventProcessor.registerConsumer(Float.class.getSimpleName(), floatConsumer);
+        eventProcessor.registerConsumer(Integer.class.getName(), integerConsumer);
+        eventProcessor.registerConsumer(Float.class.getName(), floatConsumer);
 
         assertThat(eventProcessor.eventConsumerMap).hasSize(2);
-        assertThat(eventProcessor.eventConsumerMap.get(Integer.class.getSimpleName())).hasSize(1);
-        assertThat(eventProcessor.eventConsumerMap.get(Float.class.getSimpleName())).hasSize(1);
+        assertThat(eventProcessor.eventConsumerMap.get(Integer.class.getName())).hasSize(1);
+        assertThat(eventProcessor.eventConsumerMap.get(Float.class.getName())).hasSize(1);
         boolean consumed = eventProcessor.processEvent(1);
         assertThat(consumed).isEqualTo(true);
         consumed = eventProcessor.processEvent(1.0f);
@@ -96,7 +96,7 @@ public class EventProcessorTest {
         EventProcessor<Number> eventProcessor = new EventProcessor<>();
         EventConsumer<Integer> eventConsumer = event -> logger.info(event.toString());
 
-        eventProcessor.registerConsumer(Integer.class.getSimpleName(), eventConsumer);
+        eventProcessor.registerConsumer(Integer.class.getName(), eventConsumer);
         eventProcessor.onEvent(event -> logger.info(event.toString()));
 
         boolean consumed = eventProcessor.processEvent(1);
@@ -133,7 +133,7 @@ public class EventProcessorTest {
         EventConsumer<Integer> eventConsumer2 = event -> logger.info(event.toString());
 
         // 1st consumer is added
-        eventProcessor.registerConsumer(Integer.class.getSimpleName(), eventConsumer1);
+        eventProcessor.registerConsumer(Integer.class.getName(), eventConsumer1);
 
         // process first event in a separate thread to create a race condition
         CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
@@ -143,7 +143,7 @@ public class EventProcessorTest {
         eventConsumed.await(1, TimeUnit.SECONDS);
 
         // 2nd consumer is added
-        eventProcessor.registerConsumer(Integer.class.getSimpleName(), eventConsumer2);
+        eventProcessor.registerConsumer(Integer.class.getName(), eventConsumer2);
 
         future.get();
 

--- a/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/internal/RateLimiterEventProcessor.java
+++ b/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/internal/RateLimiterEventProcessor.java
@@ -37,14 +37,14 @@ public class RateLimiterEventProcessor extends
     @Override
     public RateLimiter.EventPublisher onSuccess(
         EventConsumer<RateLimiterOnSuccessEvent> onSuccessEventConsumer) {
-        registerConsumer(RateLimiterOnSuccessEvent.class.getSimpleName(), onSuccessEventConsumer);
+        registerConsumer(RateLimiterOnSuccessEvent.class.getName(), onSuccessEventConsumer);
         return this;
     }
 
     @Override
     public RateLimiter.EventPublisher onFailure(
         EventConsumer<RateLimiterOnFailureEvent> onOnFailureEventConsumer) {
-        registerConsumer(RateLimiterOnFailureEvent.class.getSimpleName(), onOnFailureEventConsumer);
+        registerConsumer(RateLimiterOnFailureEvent.class.getName(), onOnFailureEventConsumer);
         return this;
     }
 }

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/internal/RetryImpl.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/internal/RetryImpl.java
@@ -382,27 +382,26 @@ public class RetryImpl<T> implements Retry {
 
         @Override
         public EventPublisher onRetry(EventConsumer<RetryOnRetryEvent> onRetryEventConsumer) {
-            registerConsumer(RetryOnRetryEvent.class.getSimpleName(), onRetryEventConsumer);
+            registerConsumer(RetryOnRetryEvent.class.getName(), onRetryEventConsumer);
             return this;
         }
 
         @Override
         public EventPublisher onSuccess(EventConsumer<RetryOnSuccessEvent> onSuccessEventConsumer) {
-            registerConsumer(RetryOnSuccessEvent.class.getSimpleName(), onSuccessEventConsumer);
+            registerConsumer(RetryOnSuccessEvent.class.getName(), onSuccessEventConsumer);
             return this;
         }
 
         @Override
         public EventPublisher onError(EventConsumer<RetryOnErrorEvent> onErrorEventConsumer) {
-            registerConsumer(RetryOnErrorEvent.class.getSimpleName(), onErrorEventConsumer);
+            registerConsumer(RetryOnErrorEvent.class.getName(), onErrorEventConsumer);
             return this;
         }
 
         @Override
         public EventPublisher onIgnoredError(
             EventConsumer<RetryOnIgnoredErrorEvent> onIgnoredErrorEventConsumer) {
-            registerConsumer(RetryOnIgnoredErrorEvent.class.getSimpleName(),
-                onIgnoredErrorEventConsumer);
+            registerConsumer(RetryOnIgnoredErrorEvent.class.getName(), onIgnoredErrorEventConsumer);
             return this;
         }
     }

--- a/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/internal/TimeLimiterEventProcessor.java
+++ b/resilience4j-timelimiter/src/main/java/io/github/resilience4j/timelimiter/internal/TimeLimiterEventProcessor.java
@@ -38,21 +38,21 @@ public class TimeLimiterEventProcessor extends EventProcessor<TimeLimiterEvent> 
     @Override
     public TimeLimiter.EventPublisher onSuccess(
         EventConsumer<TimeLimiterOnSuccessEvent> onSuccessEventConsumer) {
-        registerConsumer(TimeLimiterOnSuccessEvent.class.getSimpleName(), onSuccessEventConsumer);
+        registerConsumer(TimeLimiterOnSuccessEvent.class.getName(), onSuccessEventConsumer);
         return this;
     }
 
     @Override
     public TimeLimiter.EventPublisher onError(
         EventConsumer<TimeLimiterOnErrorEvent> onOnFailureEventConsumer) {
-        registerConsumer(TimeLimiterOnErrorEvent.class.getSimpleName(), onOnFailureEventConsumer);
+        registerConsumer(TimeLimiterOnErrorEvent.class.getName(), onOnFailureEventConsumer);
         return this;
     }
 
     @Override
     public TimeLimiter.EventPublisher onTimeout(
         EventConsumer<TimeLimiterOnTimeoutEvent> onOnFailureEventConsumer) {
-        registerConsumer(TimeLimiterOnTimeoutEvent.class.getSimpleName(), onOnFailureEventConsumer);
+        registerConsumer(TimeLimiterOnTimeoutEvent.class.getName(), onOnFailureEventConsumer);
         return this;
     }
 }


### PR DESCRIPTION
Hi, I did some minor performance optimizations for `EventProcessor#processEvent(E)`:
* Use `Class#getName()` instead of `Class#getSimpleName()` to get `List<EventConsumer>`.
* Use `fori` to traverse `List<EventConsumer>` instead of `foreach`.

The following is a comparison of benchmark results before and after optimization:
* Before optimization:
```
Benchmark                                                                                    Mode  Cnt     Score    Error   Units
CircuitBreakerBenchmark.directSupplier                                                      thrpt   20    12.254 ±  0.022  ops/us
CircuitBreakerBenchmark.directSupplier:·gc.alloc.rate                                       thrpt   20    ≈ 10⁻⁴           MB/sec
CircuitBreakerBenchmark.directSupplier:·gc.alloc.rate.norm                                  thrpt   20    ≈ 10⁻⁵             B/op
CircuitBreakerBenchmark.directSupplier:·gc.count                                            thrpt   20       ≈ 0           counts
CircuitBreakerBenchmark.protectedSupplier                                                   thrpt   20     4.018 ±  0.029  ops/us
CircuitBreakerBenchmark.protectedSupplier:·gc.alloc.rate                                    thrpt   20   904.160 ± 75.567  MB/sec
CircuitBreakerBenchmark.protectedSupplier:·gc.alloc.rate.norm                               thrpt   20   248.000 ± 21.382    B/op
CircuitBreakerBenchmark.protectedSupplier:·gc.churn.PS_Eden_Space                           thrpt   20   905.489 ± 75.432  MB/sec
CircuitBreakerBenchmark.protectedSupplier:·gc.churn.PS_Eden_Space.norm                      thrpt   20   248.366 ± 21.358    B/op
CircuitBreakerBenchmark.protectedSupplier:·gc.churn.PS_Survivor_Space                       thrpt   20     0.155 ±  0.016  MB/sec
CircuitBreakerBenchmark.protectedSupplier:·gc.churn.PS_Survivor_Space.norm                  thrpt   20     0.043 ±  0.005    B/op
CircuitBreakerBenchmark.protectedSupplier:·gc.count                                         thrpt   20  2880.000           counts
CircuitBreakerBenchmark.protectedSupplier:·gc.time                                          thrpt   20  1849.000               ms
CircuitBreakerBenchmark.protectedSupplierWithDiffConsumer                                   thrpt   20     3.100 ±  0.076  ops/us
CircuitBreakerBenchmark.protectedSupplierWithDiffConsumer:·gc.alloc.rate                    thrpt   20   969.956 ± 83.507  MB/sec
CircuitBreakerBenchmark.protectedSupplierWithDiffConsumer:·gc.alloc.rate.norm               thrpt   20   344.000 ± 21.382    B/op
CircuitBreakerBenchmark.protectedSupplierWithDiffConsumer:·gc.churn.PS_Eden_Space           thrpt   20   971.674 ± 83.789  MB/sec
CircuitBreakerBenchmark.protectedSupplierWithDiffConsumer:·gc.churn.PS_Eden_Space.norm      thrpt   20   344.608 ± 21.465    B/op
CircuitBreakerBenchmark.protectedSupplierWithDiffConsumer:·gc.churn.PS_Survivor_Space       thrpt   20     0.176 ±  0.021  MB/sec
CircuitBreakerBenchmark.protectedSupplierWithDiffConsumer:·gc.churn.PS_Survivor_Space.norm  thrpt   20     0.062 ±  0.007    B/op
CircuitBreakerBenchmark.protectedSupplierWithDiffConsumer:·gc.count                         thrpt   20  3025.000           counts
CircuitBreakerBenchmark.protectedSupplierWithDiffConsumer:·gc.time                          thrpt   20  1778.000               ms
CircuitBreakerBenchmark.protectedSupplierWithOneConsumer                                    thrpt   20     3.981 ±  0.044  ops/us
CircuitBreakerBenchmark.protectedSupplierWithOneConsumer:·gc.alloc.rate                     thrpt   20   983.143 ± 10.839  MB/sec
CircuitBreakerBenchmark.protectedSupplierWithOneConsumer:·gc.alloc.rate.norm                thrpt   20   272.000 ±  0.001    B/op
CircuitBreakerBenchmark.protectedSupplierWithOneConsumer:·gc.churn.PS_Eden_Space            thrpt   20   984.850 ± 10.901  MB/sec
CircuitBreakerBenchmark.protectedSupplierWithOneConsumer:·gc.churn.PS_Eden_Space.norm       thrpt   20   272.473 ±  0.611    B/op
CircuitBreakerBenchmark.protectedSupplierWithOneConsumer:·gc.churn.PS_Survivor_Space        thrpt   20     0.159 ±  0.014  MB/sec
CircuitBreakerBenchmark.protectedSupplierWithOneConsumer:·gc.churn.PS_Survivor_Space.norm   thrpt   20     0.044 ±  0.004    B/op
CircuitBreakerBenchmark.protectedSupplierWithOneConsumer:·gc.count                          thrpt   20  2885.000           counts
CircuitBreakerBenchmark.protectedSupplierWithOneConsumer:·gc.time                           thrpt   20  1850.000               ms
```

* After optimization:
```
Benchmark                                                                                    Mode  Cnt     Score    Error   Units
CircuitBreakerBenchmark.directSupplier                                                      thrpt   20    12.258 ±  0.019  ops/us
CircuitBreakerBenchmark.directSupplier:·gc.alloc.rate                                       thrpt   20    ≈ 10⁻⁴           MB/sec
CircuitBreakerBenchmark.directSupplier:·gc.alloc.rate.norm                                  thrpt   20    ≈ 10⁻⁵             B/op
CircuitBreakerBenchmark.directSupplier:·gc.count                                            thrpt   20       ≈ 0           counts
CircuitBreakerBenchmark.protectedSupplier                                                   thrpt   20     4.122 ±  0.033  ops/us
CircuitBreakerBenchmark.protectedSupplier:·gc.alloc.rate                                    thrpt   20  1017.650 ±  8.294  MB/sec
CircuitBreakerBenchmark.protectedSupplier:·gc.alloc.rate.norm                               thrpt   20   272.000 ±  0.001    B/op
CircuitBreakerBenchmark.protectedSupplier:·gc.churn.PS_Eden_Space                           thrpt   20  1019.431 ±  8.512  MB/sec
CircuitBreakerBenchmark.protectedSupplier:·gc.churn.PS_Eden_Space.norm                      thrpt   20   272.476 ±  0.609    B/op
CircuitBreakerBenchmark.protectedSupplier:·gc.churn.PS_Survivor_Space                       thrpt   20     0.162 ±  0.015  MB/sec
CircuitBreakerBenchmark.protectedSupplier:·gc.churn.PS_Survivor_Space.norm                  thrpt   20     0.043 ±  0.004    B/op
CircuitBreakerBenchmark.protectedSupplier:·gc.count                                         thrpt   20  2871.000           counts
CircuitBreakerBenchmark.protectedSupplier:·gc.time                                          thrpt   20  1849.000               ms
CircuitBreakerBenchmark.protectedSupplierWithDiffConsumer                                   thrpt   20     3.970 ±  0.023  ops/us
CircuitBreakerBenchmark.protectedSupplierWithDiffConsumer:·gc.alloc.rate                    thrpt   20   894.224 ± 79.317  MB/sec
CircuitBreakerBenchmark.protectedSupplierWithDiffConsumer:·gc.alloc.rate.norm               thrpt   20   248.000 ± 21.382    B/op
CircuitBreakerBenchmark.protectedSupplierWithDiffConsumer:·gc.churn.PS_Eden_Space           thrpt   20   896.456 ± 79.367  MB/sec
CircuitBreakerBenchmark.protectedSupplierWithDiffConsumer:·gc.churn.PS_Eden_Space.norm      thrpt   20   248.621 ± 21.406    B/op
CircuitBreakerBenchmark.protectedSupplierWithDiffConsumer:·gc.churn.PS_Survivor_Space       thrpt   20     0.159 ±  0.014  MB/sec
CircuitBreakerBenchmark.protectedSupplierWithDiffConsumer:·gc.churn.PS_Survivor_Space.norm  thrpt   20     0.044 ±  0.004    B/op
CircuitBreakerBenchmark.protectedSupplierWithDiffConsumer:·gc.count                         thrpt   20  2912.000           counts
CircuitBreakerBenchmark.protectedSupplierWithDiffConsumer:·gc.time                          thrpt   20  1821.000               ms
CircuitBreakerBenchmark.protectedSupplierWithOneConsumer                                    thrpt   20     4.021 ±  0.036  ops/us
CircuitBreakerBenchmark.protectedSupplierWithOneConsumer:·gc.alloc.rate                     thrpt   20  1037.001 ± 47.516  MB/sec
CircuitBreakerBenchmark.protectedSupplierWithOneConsumer:·gc.alloc.rate.norm                thrpt   20   284.000 ± 10.691    B/op
CircuitBreakerBenchmark.protectedSupplierWithOneConsumer:·gc.churn.PS_Eden_Space            thrpt   20  1038.596 ± 47.251  MB/sec
CircuitBreakerBenchmark.protectedSupplierWithOneConsumer:·gc.churn.PS_Eden_Space.norm       thrpt   20   284.439 ± 10.642    B/op
CircuitBreakerBenchmark.protectedSupplierWithOneConsumer:·gc.churn.PS_Survivor_Space        thrpt   20     0.168 ±  0.012  MB/sec
CircuitBreakerBenchmark.protectedSupplierWithOneConsumer:·gc.churn.PS_Survivor_Space.norm   thrpt   20     0.046 ±  0.003    B/op
CircuitBreakerBenchmark.protectedSupplierWithOneConsumer:·gc.count                          thrpt   20  2936.000           counts
CircuitBreakerBenchmark.protectedSupplierWithOneConsumer:·gc.time                           thrpt   20  1840.000               ms
```