### PR TITLE
Correct Retrofit usage guide link

### DIFF
--- a/resilience4j-retrofit/README.adoc
+++ b/resilience4j-retrofit/README.adoc
@@ -2,7 +2,7 @@
 
 https://square.github.io/retrofit/[Retrofit] client circuit breaking & rate limiting.
 
-NOTE: For detailed documentation look at our *http://resilience4j.github.io/resilience4j/#_retrofit[Usage Guide]*
+NOTE: For detailed documentation look at our *https://resilience4j.readme.io/docs/retrofit[Usage Guide]*
 
 == License
 


### PR DESCRIPTION
I also noticed the the links for [Dropwizard](https://github.com/resilience4j/resilience4j/blob/master/resilience4j-metrics/README.adoc) and [Prometheus](https://github.com/resilience4j/resilience4j/blob/master/resilience4j-prometheus/README.adoc) are not correct. But I could not find the proper URLs on https://resilience4j.readme.io/docs for these 2 projects.