### PR TITLE
Issue #1414: Add support for calling bean methods with args from the annotated method

### DIFF
--- a/resilience4j-annotations/src/main/java/io/github/resilience4j/bulkhead/annotation/Bulkhead.java
+++ b/resilience4j-annotations/src/main/java/io/github/resilience4j/bulkhead/annotation/Bulkhead.java
@@ -14,9 +14,9 @@ public @interface Bulkhead {
 
     /**
      * Name of the bulkhead.
-     * It can be SpEL expression. If you want to use first parameter of the method as name, you can
-     * express it {@code #root.args[0]}, {@code #p0} or {@code #a0}. And method name can be accessed via
-     * {@code #root.methodName}
+     * It can be SpEL expression. If you want to use the first parameter of the method as name, you can
+     * express it as {@code #root.args[0]}, {@code #p0} or {@code #a0}. The method name can be accessed via
+     * {@code #root.methodName}.  To invoke a method on a Spring bean, pass {@code @yourBean.yourMethod(#a0)}.
      *
      * @return the name of the bulkhead
      */

--- a/resilience4j-annotations/src/main/java/io/github/resilience4j/circuitbreaker/annotation/CircuitBreaker.java
+++ b/resilience4j-annotations/src/main/java/io/github/resilience4j/circuitbreaker/annotation/CircuitBreaker.java
@@ -31,9 +31,9 @@ public @interface CircuitBreaker {
 
     /**
      * Name of the circuit breaker.
-     * It can be SpEL expression. If you want to use first parameter of the method as name, you can
-     * express it {@code #root.args[0]}, {@code #p0} or {@code #a0}. And method name can be accessed via
-     * {@code #root.methodName}
+     * It can be SpEL expression. If you want to use the first parameter of the method as name, you can
+     * express it as {@code #root.args[0]}, {@code #p0} or {@code #a0}. The method name can be accessed via
+     * {@code #root.methodName}.  To invoke a method on a Spring bean, pass {@code @yourBean.yourMethod(#a0)}.
      *
      * @return the name of the circuit breaker
      */

--- a/resilience4j-annotations/src/main/java/io/github/resilience4j/ratelimiter/annotation/RateLimiter.java
+++ b/resilience4j-annotations/src/main/java/io/github/resilience4j/ratelimiter/annotation/RateLimiter.java
@@ -31,9 +31,9 @@ public @interface RateLimiter {
 
     /**
      * Name of the rate limiter
-     * It can be SpEL expression. If you want to use first parameter of the method as name, you can
-     * express it {@code #root.args[0]}, {@code #p0} or {@code #a0}. And method name can be accessed via
-     * {@code #root.methodName}
+     * It can be SpEL expression. If you want to use the first parameter of the method as name, you can
+     * express it as {@code #root.args[0]}, {@code #p0} or {@code #a0}. The method name can be accessed via
+     * {@code #root.methodName}.  To invoke a method on a Spring bean, pass {@code @yourBean.yourMethod(#a0)}.
      *
      * @return the name of the limiter
      */

--- a/resilience4j-annotations/src/main/java/io/github/resilience4j/retry/annotation/Retry.java
+++ b/resilience4j-annotations/src/main/java/io/github/resilience4j/retry/annotation/Retry.java
@@ -30,9 +30,9 @@ public @interface Retry {
 
     /**
      * Name of the sync retry.
-     * It can be SpEL expression. If you want to use first parameter of the method as name, you can
-     * express it {@code #root.args[0]}, {@code #p0} or {@code #a0}. And method name can be accessed via
-     * {@code #root.methodName}
+     * It can be SpEL expression. If you want to use the first parameter of the method as name, you can
+     * express it as {@code #root.args[0]}, {@code #p0} or {@code #a0}. The method name can be accessed via
+     * {@code #root.methodName}.  To invoke a method on a Spring bean, pass {@code @yourBean.yourMethod(#a0)}.
      *
      * @return the name of the sync retry.
      */

--- a/resilience4j-annotations/src/main/java/io/github/resilience4j/timelimiter/annotation/TimeLimiter.java
+++ b/resilience4j-annotations/src/main/java/io/github/resilience4j/timelimiter/annotation/TimeLimiter.java
@@ -31,9 +31,9 @@ public @interface TimeLimiter {
 
     /**
      * Name of the sync timeLimiter.
-     * It can be SpEL expression. If you want to use first parameter of the method as name, you can
-     * express it {@code #root.args[0]}, {@code #p0} or {@code #a0}. And method name can be accessed via
-     * {@code #root.methodName}
+     * It can be SpEL expression. If you want to use the first parameter of the method as name, you can
+     * express it as {@code #root.args[0]}, {@code #p0} or {@code #a0}. The method name can be accessed via
+     * {@code #root.methodName}.  To invoke a method on a Spring bean, pass {@code @yourBean.yourMethod(#a0)}.
      *
      * @return the name of the sync timeLimiter.
      */

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/spelresolver/autoconfigure/SpelResolverConfigurationOnMissingBean.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/spelresolver/autoconfigure/SpelResolverConfigurationOnMissingBean.java
@@ -15,8 +15,10 @@
  */
 package io.github.resilience4j.spelresolver.autoconfigure;
 
+import io.github.resilience4j.spelresolver.DefaultSpelResolver;
 import io.github.resilience4j.spelresolver.SpelResolver;
 import io.github.resilience4j.spelresolver.configure.SpelResolverConfiguration;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -48,7 +50,7 @@ public class SpelResolverConfigurationOnMissingBean {
 
     @Bean
     @ConditionalOnMissingBean
-    public SpelResolver spelResolver(SpelExpressionParser spelExpressionParser, ParameterNameDiscoverer parameterNameDiscoverer) {
-        return configuration.spelResolver(spelExpressionParser, parameterNameDiscoverer);
+    public SpelResolver spelResolver(SpelExpressionParser spelExpressionParser, ParameterNameDiscoverer parameterNameDiscoverer, BeanFactory beanFactory) {
+        return configuration.spelResolver(spelExpressionParser, parameterNameDiscoverer, beanFactory);
     }
 }

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/SpringBootCommonTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/SpringBootCommonTest.java
@@ -38,11 +38,12 @@ import io.github.resilience4j.ratelimiter.configure.RateLimiterConfigurationProp
 import io.github.resilience4j.retry.RetryRegistry;
 import io.github.resilience4j.retry.autoconfigure.AbstractRetryConfigurationOnMissingBean;
 import io.github.resilience4j.retry.configure.RetryConfigurationProperties;
-import io.github.resilience4j.spelresolver.SpelResolver;
+import io.github.resilience4j.spelresolver.DefaultSpelResolver;
 import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
 import io.github.resilience4j.timelimiter.autoconfigure.AbstractTimeLimiterConfigurationOnMissingBean;
 import io.github.resilience4j.timelimiter.configure.TimeLimiterConfigurationProperties;
 import org.junit.Test;
+import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.core.StandardReflectionParameterNameDiscoverer;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 
@@ -79,7 +80,7 @@ public class SpringBootCommonTest {
                 ThreadPoolBulkheadRegistry.ofDefaults(), BulkheadRegistry.ofDefaults(),
                 Collections.emptyList(),
                 new FallbackDecorators(Arrays.asList(new CompletionStageFallbackDecorator())),
-            new SpelResolver(new SpelExpressionParser(), new StandardReflectionParameterNameDiscoverer()))).isNotNull();
+            new DefaultSpelResolver(new SpelExpressionParser(), new StandardReflectionParameterNameDiscoverer(), new GenericApplicationContext()))).isNotNull();
         assertThat(
             bulkheadConfigurationOnMissingBean.bulkheadRegistryEventConsumer(Optional.empty())).isNotNull();
     }
@@ -96,7 +97,7 @@ public class SpringBootCommonTest {
         assertThat(circuitBreakerConfig
             .circuitBreakerAspect(CircuitBreakerRegistry.ofDefaults(), Collections.emptyList(),
                 new FallbackDecorators(Arrays.asList(new CompletionStageFallbackDecorator())),
-            new SpelResolver(new SpelExpressionParser(), new StandardReflectionParameterNameDiscoverer()))).isNotNull();
+            new DefaultSpelResolver(new SpelExpressionParser(), new StandardReflectionParameterNameDiscoverer(), new GenericApplicationContext()))).isNotNull();
         assertThat(circuitBreakerConfig.circuitBreakerRegistryEventConsumer(Optional.empty())).isNotNull();
     }
 
@@ -113,7 +114,7 @@ public class SpringBootCommonTest {
             .retryAspect(new RetryConfigurationProperties(), RetryRegistry.ofDefaults(),
                 Collections.emptyList(),
                 new FallbackDecorators(Arrays.asList(new CompletionStageFallbackDecorator())),
-                new SpelResolver(new SpelExpressionParser(), new StandardReflectionParameterNameDiscoverer()), null)).isNotNull();
+                new DefaultSpelResolver(new SpelExpressionParser(), new StandardReflectionParameterNameDiscoverer(), new GenericApplicationContext()), null)).isNotNull();
         assertThat(retryConfigurationOnMissingBean.retryRegistryEventConsumer(Optional.empty())).isNotNull();
     }
 
@@ -131,7 +132,7 @@ public class SpringBootCommonTest {
             .rateLimiterAspect(new RateLimiterConfigurationProperties(),
                 RateLimiterRegistry.ofDefaults(), Collections.emptyList(),
                 new FallbackDecorators(Arrays.asList(new CompletionStageFallbackDecorator())),
-                new SpelResolver(new SpelExpressionParser(), new StandardReflectionParameterNameDiscoverer()))).isNotNull();
+                new DefaultSpelResolver(new SpelExpressionParser(), new StandardReflectionParameterNameDiscoverer(), new GenericApplicationContext()))).isNotNull();
         assertThat(rateLimiterConfigurationOnMissingBean
             .rateLimiterRegistryEventConsumer(Optional.empty())).isNotNull();
     }
@@ -152,7 +153,7 @@ public class SpringBootCommonTest {
             .timeLimiterAspect(new TimeLimiterConfigurationProperties(),
                 TimeLimiterRegistry.ofDefaults(), Collections.emptyList(),
                 new FallbackDecorators(Arrays.asList(new CompletionStageFallbackDecorator())),
-                new SpelResolver(new SpelExpressionParser(), new StandardReflectionParameterNameDiscoverer()),
+                new DefaultSpelResolver(new SpelExpressionParser(), new StandardReflectionParameterNameDiscoverer(), new GenericApplicationContext()),
                 null)).isNotNull();
         assertThat(timeLimiterConfigurationOnMissingBean
             .timeLimiterRegistryEventConsumer(Optional.empty())).isNotNull();

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/spelresolver/DefaultSpelResolver.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/spelresolver/DefaultSpelResolver.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 Kyuhyen Hwang
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.spelresolver;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.context.EmbeddedValueResolverAware;
+import org.springframework.context.expression.BeanFactoryResolver;
+import org.springframework.context.expression.MethodBasedEvaluationContext;
+import org.springframework.core.ParameterNameDiscoverer;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.util.StringUtils;
+import org.springframework.util.StringValueResolver;
+
+import java.lang.reflect.Method;
+
+public class DefaultSpelResolver implements EmbeddedValueResolverAware, SpelResolver {
+    private static final String PLACEHOLDER_SPEL_REGEX = "^[$#]\\{.+}$";
+    private static final String METHOD_SPEL_REGEX = "^#.+$";
+    private static final String BEAN_SPEL_REGEX = "^@.+";
+
+    private final SpelExpressionParser expressionParser;
+    private final ParameterNameDiscoverer parameterNameDiscoverer;
+    private final BeanFactory beanFactory;
+    private StringValueResolver stringValueResolver;
+
+    public DefaultSpelResolver(SpelExpressionParser spelExpressionParser, ParameterNameDiscoverer parameterNameDiscoverer, BeanFactory beanFactory) {
+        this.expressionParser = spelExpressionParser;
+        this.parameterNameDiscoverer = parameterNameDiscoverer;
+        this.beanFactory = beanFactory;
+    }
+
+    @Override
+    public String resolve(Method method, Object[] arguments, String spelExpression) {
+        if (StringUtils.isEmpty(spelExpression)) {
+            return spelExpression;
+        }
+
+        if (spelExpression.matches(PLACEHOLDER_SPEL_REGEX) && stringValueResolver != null) {
+            return stringValueResolver.resolveStringValue(spelExpression);
+        }
+
+        if (spelExpression.matches(METHOD_SPEL_REGEX)) {
+            SpelRootObject rootObject = new SpelRootObject(method, arguments);
+            MethodBasedEvaluationContext evaluationContext = new MethodBasedEvaluationContext(rootObject, method, arguments, parameterNameDiscoverer);
+            Object evaluated = expressionParser.parseExpression(spelExpression).getValue(evaluationContext);
+
+            return (String) evaluated;
+        }
+
+        if (spelExpression.matches(BEAN_SPEL_REGEX)) {
+            SpelRootObject rootObject = new SpelRootObject(method, arguments);
+
+            MethodBasedEvaluationContext evaluationContext = new MethodBasedEvaluationContext(rootObject, method, arguments, parameterNameDiscoverer);
+            evaluationContext.setBeanResolver(new BeanFactoryResolver(this.beanFactory));
+
+            Object evaluated = expressionParser.parseExpression(spelExpression).getValue(evaluationContext);
+
+            return (String) evaluated;
+        }
+
+        return spelExpression;
+    }
+
+    @Override
+    public void setEmbeddedValueResolver(StringValueResolver resolver) {
+        this.stringValueResolver = resolver;
+    }
+}

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/spelresolver/SpelResolver.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/spelresolver/SpelResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Kyuhyen Hwang
+ * Copyright 2021 Aaron Asch
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,50 +15,8 @@
  */
 package io.github.resilience4j.spelresolver;
 
-import org.springframework.context.EmbeddedValueResolverAware;
-import org.springframework.context.expression.MethodBasedEvaluationContext;
-import org.springframework.core.ParameterNameDiscoverer;
-import org.springframework.expression.spel.standard.SpelExpressionParser;
-import org.springframework.util.StringUtils;
-import org.springframework.util.StringValueResolver;
-
 import java.lang.reflect.Method;
 
-public class SpelResolver implements EmbeddedValueResolverAware {
-    private static final String BEAN_SPEL_REGEX = "^[$#]\\{.+}$";
-    private static final String METHOD_SPEL_REGEX = "^#.+$";
-
-    private final SpelExpressionParser expressionParser;
-    private final ParameterNameDiscoverer parameterNameDiscoverer;
-    private StringValueResolver stringValueResolver;
-
-    public SpelResolver(SpelExpressionParser spelExpressionParser, ParameterNameDiscoverer parameterNameDiscoverer) {
-        this.expressionParser = spelExpressionParser;
-        this.parameterNameDiscoverer = parameterNameDiscoverer;
-    }
-
-    public String resolve(Method method, Object[] arguments, String spelExpression) {
-        if (StringUtils.isEmpty(spelExpression)) {
-            return spelExpression;
-        }
-
-        if (spelExpression.matches(BEAN_SPEL_REGEX) && stringValueResolver != null) {
-            return stringValueResolver.resolveStringValue(spelExpression);
-        }
-
-        if (spelExpression.matches(METHOD_SPEL_REGEX)) {
-            SpelRootObject rootObject = new SpelRootObject(method, arguments);
-            MethodBasedEvaluationContext evaluationContext = new MethodBasedEvaluationContext(rootObject, method, arguments, parameterNameDiscoverer);
-            Object evaluated = expressionParser.parseExpression(spelExpression).getValue(evaluationContext);
-
-            return (String) evaluated;
-        }
-
-        return spelExpression;
-    }
-
-    @Override
-    public void setEmbeddedValueResolver(StringValueResolver resolver) {
-        this.stringValueResolver = resolver;
-    }
+public interface SpelResolver {
+    String resolve(Method method, Object[] arguments, String spelExpression);
 }

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/spelresolver/configure/SpelResolverConfiguration.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/spelresolver/configure/SpelResolverConfiguration.java
@@ -15,7 +15,9 @@
  */
 package io.github.resilience4j.spelresolver.configure;
 
+import io.github.resilience4j.spelresolver.DefaultSpelResolver;
 import io.github.resilience4j.spelresolver.SpelResolver;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.ParameterNameDiscoverer;
@@ -28,8 +30,8 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
 @Configuration
 public class SpelResolverConfiguration {
     @Bean
-    public SpelResolver spelResolver(SpelExpressionParser spelExpressionParser, ParameterNameDiscoverer parameterNameDiscoverer) {
-        return new SpelResolver(spelExpressionParser, parameterNameDiscoverer);
+    public SpelResolver spelResolver(SpelExpressionParser spelExpressionParser, ParameterNameDiscoverer parameterNameDiscoverer, BeanFactory beanFactory) {
+        return new DefaultSpelResolver(spelExpressionParser, parameterNameDiscoverer, beanFactory);
     }
 
     @Bean

--- a/resilience4j-spring/src/test/java/io/github/resilience4j/DummySpelBean.java
+++ b/resilience4j-spring/src/test/java/io/github/resilience4j/DummySpelBean.java
@@ -1,0 +1,5 @@
+package io.github.resilience4j;
+
+public interface DummySpelBean {
+    String getBulkheadName(String param1);
+}


### PR DESCRIPTION
I also extract a simple interface from SpelResolver to enable library consumers to cleanly define their own SpelResolver bean if they want to override the DefaultSpelResolver

