### PR TITLE
Issue #1435: Fixed exception on spring boot versions less than 2.2

### DIFF
--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/circuitbreaker/autoconfigure/CircuitBreakersHealthIndicatorAutoConfiguration.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/circuitbreaker/autoconfigure/CircuitBreakersHealthIndicatorAutoConfiguration.java
@@ -16,7 +16,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ConditionalOnClass({CircuitBreaker.class, HealthIndicator.class})
+@ConditionalOnClass({CircuitBreaker.class, HealthIndicator.class, StatusAggregator.class})
 @AutoConfigureAfter(CircuitBreakerAutoConfiguration.class)
 @AutoConfigureBefore(HealthContributorAutoConfiguration.class)
 public class CircuitBreakersHealthIndicatorAutoConfiguration {

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/ratelimiter/autoconfigure/RateLimitersHealthIndicatorAutoConfiguration.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/ratelimiter/autoconfigure/RateLimitersHealthIndicatorAutoConfiguration.java
@@ -16,7 +16,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ConditionalOnClass({RateLimiter.class, HealthIndicator.class})
+@ConditionalOnClass({RateLimiter.class, HealthIndicator.class, StatusAggregator.class})
 @AutoConfigureAfter(RateLimiterAutoConfiguration.class)
 @AutoConfigureBefore(HealthContributorAutoConfiguration.class)
 public class RateLimitersHealthIndicatorAutoConfiguration {


### PR DESCRIPTION
Including actuator with spring boot version < 2.2 was giving the error
`ClassNotFoundException` for `StatusAggregator` class which was added in
version 2.2; Fixed by adding to `ConditionalOnClass`

Fixes #1435