### PR TITLE
Issue #1452: base config's exceptionPredicate should be null, when exceptions are instance-specific.

### DIFF
--- a/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationProperties.java
+++ b/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationProperties.java
@@ -139,14 +139,14 @@ public class CircuitBreakerConfigurationProperties extends CommonProperties {
                 properties.getPermittedNumberOfCallsInHalfOpenState());
         }
 
-        if (properties.recordFailurePredicate != null) {
-            buildRecordFailurePredicate(properties, builder);
-        }
-
         if (properties.recordExceptions != null) {
             builder.recordExceptions(properties.recordExceptions);
             // if instance config has set recordExceptions, then base config's recordExceptionPredicate is useless.
             builder.recordException(null);
+        }
+
+        if (properties.recordFailurePredicate != null) {
+            buildRecordFailurePredicate(properties, builder);
         }
 
         if (properties.ignoreExceptions != null) {

--- a/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationProperties.java
+++ b/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationProperties.java
@@ -145,10 +145,13 @@ public class CircuitBreakerConfigurationProperties extends CommonProperties {
 
         if (properties.recordExceptions != null) {
             builder.recordExceptions(properties.recordExceptions);
+            // if instance config has set recordExceptions, then base config's recordExceptionPredicate is useless.
+            builder.recordException(null);
         }
 
         if (properties.ignoreExceptions != null) {
             builder.ignoreExceptions(properties.ignoreExceptions);
+            builder.ignoreException(null);
         }
 
         if (properties.automaticTransitionFromOpenToHalfOpenEnabled != null) {

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationPropertiesTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationPropertiesTest.java
@@ -322,6 +322,42 @@ public class CircuitBreakerConfigurationPropertiesTest {
         assertThat(instance.getWaitIntervalFunctionInOpenState().apply(1)).isEqualTo(1000L);
     }
 
+    @Test
+    public void testRecordExceptionWithBaseConfig() {
+        CircuitBreakerConfigurationProperties.InstanceProperties defaultConfig = new CircuitBreakerConfigurationProperties.InstanceProperties();
+
+        CircuitBreakerConfigurationProperties.InstanceProperties instanceConfig = new CircuitBreakerConfigurationProperties.InstanceProperties();
+        instanceConfig.setBaseConfig("defaultConfig");
+        instanceConfig.setRecordExceptions(new Class[] {IllegalArgumentException.class});
+
+        CircuitBreakerConfigurationProperties circuitBreakerConfigurationProperties = new CircuitBreakerConfigurationProperties();
+        circuitBreakerConfigurationProperties.getConfigs().put("defaultConfig", defaultConfig);
+
+
+        CircuitBreakerConfig circuitBreakerConfig = circuitBreakerConfigurationProperties.createCircuitBreakerConfig("instanceConfig", instanceConfig, compositeCircuitBreakerCustomizer());
+
+        assertThat(circuitBreakerConfig.getRecordExceptionPredicate().test(new IllegalArgumentException())).isTrue();
+        assertThat(circuitBreakerConfig.getRecordExceptionPredicate().test(new NullPointerException())).isFalse();
+    }
+
+    @Test
+    public void testIgnoreExceptionWithBaseConfig() {
+        CircuitBreakerConfigurationProperties.InstanceProperties defaultConfig = new CircuitBreakerConfigurationProperties.InstanceProperties();
+
+        CircuitBreakerConfigurationProperties.InstanceProperties instanceConfig = new CircuitBreakerConfigurationProperties.InstanceProperties();
+        instanceConfig.setBaseConfig("defaultConfig");
+        instanceConfig.setIgnoreExceptions(new Class[] {IllegalArgumentException.class});
+
+        CircuitBreakerConfigurationProperties circuitBreakerConfigurationProperties = new CircuitBreakerConfigurationProperties();
+        circuitBreakerConfigurationProperties.getConfigs().put("defaultConfig", defaultConfig);
+
+
+        CircuitBreakerConfig circuitBreakerConfig = circuitBreakerConfigurationProperties.createCircuitBreakerConfig("instanceConfig", instanceConfig, compositeCircuitBreakerCustomizer());
+
+        assertThat(circuitBreakerConfig.getIgnoreExceptionPredicate().test(new IllegalArgumentException())).isTrue();
+        assertThat(circuitBreakerConfig.getIgnoreExceptionPredicate().test(new NullPointerException())).isFalse();
+    }
+
     private CompositeCustomizer<CircuitBreakerConfigCustomizer> compositeCircuitBreakerCustomizer() {
         return new CompositeCustomizer<>(Collections.emptyList());
     }

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationPropertiesTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationPropertiesTest.java
@@ -326,15 +326,16 @@ public class CircuitBreakerConfigurationPropertiesTest {
     public void testRecordExceptionWithBaseConfig() {
         CircuitBreakerConfigurationProperties.InstanceProperties defaultConfig = new CircuitBreakerConfigurationProperties.InstanceProperties();
 
-        CircuitBreakerConfigurationProperties.InstanceProperties instanceConfig = new CircuitBreakerConfigurationProperties.InstanceProperties();
-        instanceConfig.setBaseConfig("defaultConfig");
-        instanceConfig.setRecordExceptions(new Class[] {IllegalArgumentException.class});
+        CircuitBreakerConfigurationProperties.InstanceProperties instanceProperties = new CircuitBreakerConfigurationProperties.InstanceProperties();
+        instanceProperties.setBaseConfig("defaultConfig");
+        instanceProperties.setRecordExceptions(new Class[] {IllegalArgumentException.class});
 
         CircuitBreakerConfigurationProperties circuitBreakerConfigurationProperties = new CircuitBreakerConfigurationProperties();
         circuitBreakerConfigurationProperties.getConfigs().put("defaultConfig", defaultConfig);
 
 
-        CircuitBreakerConfig circuitBreakerConfig = circuitBreakerConfigurationProperties.createCircuitBreakerConfig("instanceConfig", instanceConfig, compositeCircuitBreakerCustomizer());
+        CircuitBreakerConfig circuitBreakerConfig = circuitBreakerConfigurationProperties
+            .createCircuitBreakerConfig("instanceWithDefaultConfig", instanceProperties, compositeCircuitBreakerCustomizer());
 
         assertThat(circuitBreakerConfig.getRecordExceptionPredicate().test(new IllegalArgumentException())).isTrue();
         assertThat(circuitBreakerConfig.getRecordExceptionPredicate().test(new NullPointerException())).isFalse();
@@ -344,15 +345,16 @@ public class CircuitBreakerConfigurationPropertiesTest {
     public void testIgnoreExceptionWithBaseConfig() {
         CircuitBreakerConfigurationProperties.InstanceProperties defaultConfig = new CircuitBreakerConfigurationProperties.InstanceProperties();
 
-        CircuitBreakerConfigurationProperties.InstanceProperties instanceConfig = new CircuitBreakerConfigurationProperties.InstanceProperties();
-        instanceConfig.setBaseConfig("defaultConfig");
-        instanceConfig.setIgnoreExceptions(new Class[] {IllegalArgumentException.class});
+        CircuitBreakerConfigurationProperties.InstanceProperties instanceProperties = new CircuitBreakerConfigurationProperties.InstanceProperties();
+        instanceProperties.setBaseConfig("defaultConfig");
+        instanceProperties.setIgnoreExceptions(new Class[] {IllegalArgumentException.class});
 
         CircuitBreakerConfigurationProperties circuitBreakerConfigurationProperties = new CircuitBreakerConfigurationProperties();
         circuitBreakerConfigurationProperties.getConfigs().put("defaultConfig", defaultConfig);
 
 
-        CircuitBreakerConfig circuitBreakerConfig = circuitBreakerConfigurationProperties.createCircuitBreakerConfig("instanceConfig", instanceConfig, compositeCircuitBreakerCustomizer());
+        CircuitBreakerConfig circuitBreakerConfig = circuitBreakerConfigurationProperties
+            .createCircuitBreakerConfig("instanceWithDefaultConfig", instanceProperties, compositeCircuitBreakerCustomizer());
 
         assertThat(circuitBreakerConfig.getIgnoreExceptionPredicate().test(new IllegalArgumentException())).isTrue();
         assertThat(circuitBreakerConfig.getIgnoreExceptionPredicate().test(new NullPointerException())).isFalse();


### PR DESCRIPTION
fix #1452 