### PR TITLE
feature: rework with reactive stream api

### DIFF
--- a/libraries.gradle
+++ b/libraries.gradle
@@ -56,6 +56,7 @@ ext {
             awaitility: "com.jayway.awaitility:awaitility:${awaitilityVersion}",
             reactor_test: "io.projectreactor:reactor-test:${reactorVersion}",
             reactive_streams_tck: "org.reactivestreams:reactive-streams-tck:${reactiveStreamsVersion}",
+            reactive_streams: "org.reactivestreams:reactive-streams-tck:${reactiveStreamsVersion}",
             mock_clock: "com.statemachinesystems:mock-clock:1.0",
             blockhound: "io.projectreactor.tools:blockhound:${blockhoundVersion}",
 

--- a/resilience4j-micronaut/build.gradle
+++ b/resilience4j-micronaut/build.gradle
@@ -20,7 +20,6 @@ dependencies {
     compileOnly project(':resilience4j-ratelimiter')
     compileOnly project(':resilience4j-timelimiter')
     compileOnly project(':resilience4j-retry')
-    compileOnly project(':resilience4j-rxjava2')
     compileOnly project(':resilience4j-bulkhead')
     compileOnly project(':resilience4j-consumer')
     compileOnly project(':resilience4j-core')
@@ -31,7 +30,6 @@ dependencies {
     testImplementation project(':resilience4j-timelimiter')
     testImplementation project(':resilience4j-bulkhead')
     testImplementation project(':resilience4j-retry')
-    testImplementation project(':resilience4j-rxjava2')
     testImplementation project(':resilience4j-consumer')
     testImplementation "io.micronaut:micronaut-aop"
 

--- a/resilience4j-micronaut/src/main/java/io/github/resilience4j/micronaut/ratelimiter/RateLimiterInterceptor.java
+++ b/resilience4j-micronaut/src/main/java/io/github/resilience4j/micronaut/ratelimiter/RateLimiterInterceptor.java
@@ -30,6 +30,7 @@ import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.inject.ExecutableMethod;
 import io.micronaut.inject.MethodExecutionHandle;
 import io.reactivex.Flowable;
+import org.reactivestreams.Subscriber;
 
 import javax.inject.Singleton;
 import java.util.Optional;
@@ -80,6 +81,7 @@ public class RateLimiterInterceptor extends BaseInterceptor implements MethodInt
         try {
             switch (interceptedMethod.resultType()) {
                 case PUBLISHER:
+
                     return interceptedMethod.handleResult(fallbackReactiveTypes(
                         Flowable.fromPublisher(interceptedMethod.interceptResultAsPublisher()).compose(RateLimiterOperator.of(rateLimiter)),
                         context));

--- a/resilience4j-micronaut/src/main/java/io/github/resilience4j/micronaut/retry/RetryInterceptor.java
+++ b/resilience4j-micronaut/src/main/java/io/github/resilience4j/micronaut/retry/RetryInterceptor.java
@@ -31,6 +31,11 @@ import io.micronaut.inject.ExecutableMethod;
 import io.micronaut.inject.MethodExecutionHandle;
 import io.micronaut.scheduling.TaskExecutors;
 import io.reactivex.Flowable;
+import io.reactivex.FlowableTransformer;
+import org.jetbrains.annotations.NotNull;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 
 import javax.inject.Named;
 import javax.inject.Singleton;

--- a/resilience4j-reactive-streams/build.gradle
+++ b/resilience4j-reactive-streams/build.gradle
@@ -1,0 +1,9 @@
+dependencies {
+    compileOnly project(':resilience4j-circuitbreaker')
+    compileOnly project(':resilience4j-ratelimiter')
+    compileOnly project(':resilience4j-timelimiter')
+    compileOnly project(':resilience4j-bulkhead')
+    compileOnly project(':resilience4j-retry')
+    compileOnly(libraries.reactive_streams)
+}
+ext.moduleName = 'io.github.resilience4j.reactive-streams'

--- a/resilience4j-reactive-streams/src/main/java/io/github/resilience4j/retry/transformer/RetryPublisher.java
+++ b/resilience4j-reactive-streams/src/main/java/io/github/resilience4j/retry/transformer/RetryPublisher.java
@@ -1,0 +1,33 @@
+package io.github.resilience4j.retry.transformer;
+
+import io.github.resilience4j.retry.Retry;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+public class RetryPublisher implements Subscriber<Object> {
+    private Retry.AsyncContext context;
+    public RetryPublisher(Retry retry) {
+
+        this.context = retry.asyncContext();
+    }
+
+    @Override
+    public void onSubscribe(Subscription s) {
+
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        context.onError(t);
+    }
+
+    @Override
+    public void onComplete() {
+        context.onComplete();;
+    }
+
+    @Override
+    public void onNext(Object o) {
+        long waitDurationMillis = context.onResult(o);
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -28,4 +28,5 @@ include 'resilience4j-bom'
 include 'resilience4j-framework-common'
 include 'resilience4j-kotlin'
 include 'resilience4j-micronaut'
+include 'resilience4j-reactive-streams'
 


### PR DESCRIPTION
I'm seeing how this can be handled. One solution is to have multiple implementations of this base library or implement something based off of the base implementation of reactive-streams. ends up becoming a bit more verbose but as long as it follows the spec then it should handle all these cases well. is there any problems with implementing in like this @RobWin ? looking at this a bit and I don't think this is generalizable though :/

https://github.com/resilience4j/resilience4j/issues/1485