### PR TITLE
feature: add publisher extension to support rxJava2/rxJava3/Reactor for micronaut

### DIFF
--- a/resilience4j-micronaut/build.gradle
+++ b/resilience4j-micronaut/build.gradle
@@ -16,11 +16,18 @@ dependencies {
     implementation "io.micronaut:micronaut-validation"
     implementation "io.micronaut:micronaut-router"
 
+
+    compileOnly(libraries.rxjava2)
+    compileOnly(libraries.rxjava3)
+    compileOnly(libraries.reactor)
+    compileOnly project(':resilience4j-reactor')
+    compileOnly project(':resilience4j-rxjava2')
+    compileOnly project(':resilience4j-rxjava3')
+
     compileOnly project(':resilience4j-circuitbreaker')
     compileOnly project(':resilience4j-ratelimiter')
     compileOnly project(':resilience4j-timelimiter')
     compileOnly project(':resilience4j-retry')
-    compileOnly project(':resilience4j-rxjava2')
     compileOnly project(':resilience4j-bulkhead')
     compileOnly project(':resilience4j-consumer')
     compileOnly project(':resilience4j-core')
@@ -31,8 +38,8 @@ dependencies {
     testImplementation project(':resilience4j-timelimiter')
     testImplementation project(':resilience4j-bulkhead')
     testImplementation project(':resilience4j-retry')
-    testImplementation project(':resilience4j-rxjava2')
     testImplementation project(':resilience4j-consumer')
+    testImplementation project(':resilience4j-rxjava2')
     testImplementation "io.micronaut:micronaut-aop"
 
     testImplementation "io.micronaut:micronaut-http-client"

--- a/resilience4j-micronaut/src/main/java/io/github/resilience4j/micronaut/bulkhead/BulkheadInterceptor.java
+++ b/resilience4j-micronaut/src/main/java/io/github/resilience4j/micronaut/bulkhead/BulkheadInterceptor.java
@@ -105,9 +105,12 @@ public class BulkheadInterceptor extends BaseInterceptor implements MethodInterc
             try {
                 switch (interceptedMethod.resultType()) {
                     case PUBLISHER:
-                        return interceptedMethod.handleResult(fallbackReactiveTypes(
-                            Flowable.fromPublisher(interceptedMethod.interceptResultAsPublisher()).compose(BulkheadOperator.of(bulkhead)),
-                            context));
+                        return interceptedMethod.handleResult(
+                            extension.fallbackPublisher(
+                                extension.bulkhead(interceptedMethod.interceptResultAsPublisher(), bulkhead),
+                                context,
+                                this::findFallbackMethod));
+
                     case COMPLETION_STAGE:
                         return interceptedMethod.handleResult(
                             fallbackForFuture(

--- a/resilience4j-micronaut/src/main/java/io/github/resilience4j/micronaut/bulkhead/BulkheadInterceptor.java
+++ b/resilience4j-micronaut/src/main/java/io/github/resilience4j/micronaut/bulkhead/BulkheadInterceptor.java
@@ -20,6 +20,7 @@ import io.github.resilience4j.bulkhead.*;
 import io.github.resilience4j.bulkhead.operator.BulkheadOperator;
 import io.github.resilience4j.micronaut.BaseInterceptor;
 import io.github.resilience4j.micronaut.ResilienceInterceptPhase;
+import io.github.resilience4j.micronaut.util.PublisherExtension;
 import io.micronaut.aop.InterceptedMethod;
 import io.micronaut.aop.MethodInterceptor;
 import io.micronaut.aop.MethodInvocationContext;
@@ -50,6 +51,7 @@ public class BulkheadInterceptor extends BaseInterceptor implements MethodInterc
     private final BulkheadRegistry bulkheadRegistry;
     private final ThreadPoolBulkheadRegistry threadPoolBulkheadRegistry;
     private final ExecutionHandleLocator executionHandleLocator;
+    private final PublisherExtension extension;
 
     /**
      * @param executionHandleLocator                The bean context to allow for DI of class annotated with {@link javax.inject.Inject}.
@@ -57,10 +59,11 @@ public class BulkheadInterceptor extends BaseInterceptor implements MethodInterc
      * @param threadPoolBulkheadRegistry thread pool bulkhead registry used to retrieve {@link Bulkhead} by name
      */
     public BulkheadInterceptor(BeanContext executionHandleLocator,
-                               BulkheadRegistry bulkheadRegistry, ThreadPoolBulkheadRegistry threadPoolBulkheadRegistry) {
+                               BulkheadRegistry bulkheadRegistry, ThreadPoolBulkheadRegistry threadPoolBulkheadRegistry, PublisherExtension extension) {
         this.bulkheadRegistry = bulkheadRegistry;
         this.executionHandleLocator = executionHandleLocator;
         this.threadPoolBulkheadRegistry = threadPoolBulkheadRegistry;
+        this.extension = extension;
     }
 
     @Override

--- a/resilience4j-micronaut/src/main/java/io/github/resilience4j/micronaut/util/PublisherExtension.java
+++ b/resilience4j-micronaut/src/main/java/io/github/resilience4j/micronaut/util/PublisherExtension.java
@@ -1,0 +1,27 @@
+package io.github.resilience4j.micronaut.util;
+
+import io.github.resilience4j.bulkhead.Bulkhead;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.timelimiter.TimeLimiter;
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.inject.MethodExecutionHandle;
+import org.reactivestreams.Publisher;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+public interface PublisherExtension {
+    <T> Publisher<T> bulkhead(Publisher<T> publisher, Bulkhead handler);
+
+    <T> Publisher<T> circuitBreaker(Publisher<T> publisher, CircuitBreaker handler);
+
+    <T> Publisher<T> timeLimiter(Publisher<T> publisher, TimeLimiter handler);
+
+    <T> Publisher<T> retry(Publisher<T> publisher, Retry handler);
+
+    <T> Publisher<T> rateLimiter(Publisher<T> publisher, RateLimiter handler);
+
+    <T> Publisher<T> fallbackPublisher(Publisher<T> publisher, MethodInvocationContext<Object, Object> context,  Function<MethodInvocationContext<Object, Object>, Optional<? extends MethodExecutionHandle<?, Object>>> handler);
+}

--- a/resilience4j-micronaut/src/main/java/io/github/resilience4j/micronaut/util/ReactorPublisherExtension.java
+++ b/resilience4j-micronaut/src/main/java/io/github/resilience4j/micronaut/util/ReactorPublisherExtension.java
@@ -1,0 +1,88 @@
+package io.github.resilience4j.micronaut.util;
+
+import io.github.resilience4j.bulkhead.Bulkhead;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import io.github.resilience4j.reactor.AbstractSubscriber;
+import io.github.resilience4j.reactor.bulkhead.operator.BulkheadOperator;
+import io.github.resilience4j.reactor.circuitbreaker.operator.CircuitBreakerOperator;
+import io.github.resilience4j.reactor.ratelimiter.operator.RateLimiterOperator;
+import io.github.resilience4j.reactor.retry.RetryOperator;
+import io.github.resilience4j.reactor.timelimiter.TimeLimiterOperator;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.timelimiter.TimeLimiter;
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.inject.MethodExecutionHandle;
+import io.micronaut.retry.exception.FallbackException;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+
+import javax.inject.Singleton;
+import java.util.Optional;
+import java.util.function.Function;
+
+@Singleton
+@Requires(classes = {Flux.class, AbstractSubscriber.class})
+public class ReactorPublisherExtension implements PublisherExtension {
+    private static final Logger logger = LoggerFactory.getLogger(ReactorPublisherExtension.class);
+
+    @Override
+    public <T> Publisher<T> bulkhead(Publisher<T> publisher, Bulkhead bulkhead) {
+        return Flux.from(publisher)
+            .transformDeferred(BulkheadOperator.of(bulkhead));
+    }
+
+    @Override
+    public <T> Publisher<T> circuitBreaker(Publisher<T> publisher, CircuitBreaker circuitBreaker) {
+        return Flux.from(publisher)
+            .transformDeferred(CircuitBreakerOperator.of(circuitBreaker));
+    }
+
+    @Override
+    public <T> Publisher<T> timeLimiter(Publisher<T> publisher, TimeLimiter timeLimiter) {
+        return Flux.from(publisher)
+            .transformDeferred(TimeLimiterOperator.of(timeLimiter));
+    }
+
+    @Override
+    public <T> Publisher<T> retry(Publisher<T> publisher, Retry retry) {
+        return Flux.from(publisher)
+            .transformDeferred(RetryOperator.of(retry));
+    }
+
+    @Override
+    public <T> Publisher<T> rateLimiter(Publisher<T> publisher, RateLimiter rateLimiter) {
+        return Flux.from(publisher)
+            .transformDeferred(RateLimiterOperator.of(rateLimiter));
+    }
+
+    @Override
+    public <T> Publisher<T> fallbackPublisher(Publisher<T> publisher, MethodInvocationContext<Object, Object> context, Function<MethodInvocationContext<Object, Object>, Optional<? extends MethodExecutionHandle<?, Object>>> handler) {
+        return Flux.from(publisher).onErrorResume(throwable -> {
+            Optional<? extends MethodExecutionHandle<?, Object>> fallbackMethod = handler.apply(context);
+            if (fallbackMethod.isPresent()) {
+                MethodExecutionHandle<?, Object> fallbackHandle = fallbackMethod.get();
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Type [{}] resolved fallback: {}", context.getTarget().getClass(), fallbackHandle);
+                }
+                Object fallbackResult;
+                try {
+                    fallbackResult = fallbackHandle.invoke(context.getParameterValues());
+                } catch (Exception e) {
+                    return Flux.error(throwable);
+                }
+                if (fallbackResult == null) {
+                    return Flux.error(new FallbackException("Fallback handler [" + fallbackHandle + "] returned null value"));
+                } else {
+                    return ConversionService.SHARED.convert(fallbackResult, Publisher.class)
+                        .orElseThrow(() -> new FallbackException("Unsupported Reactive type: " + fallbackResult));
+                }
+            }
+            return Flux.error(throwable);
+        });
+    }
+}

--- a/resilience4j-micronaut/src/main/java/io/github/resilience4j/micronaut/util/RxJava2PublisherExtension.java
+++ b/resilience4j-micronaut/src/main/java/io/github/resilience4j/micronaut/util/RxJava2PublisherExtension.java
@@ -1,0 +1,83 @@
+package io.github.resilience4j.micronaut.util;
+
+import io.github.resilience4j.AbstractSubscriber;
+import io.github.resilience4j.bulkhead.Bulkhead;
+import io.github.resilience4j.bulkhead.operator.BulkheadOperator;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.operator.CircuitBreakerOperator;
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import io.github.resilience4j.ratelimiter.operator.RateLimiterOperator;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.transformer.RetryTransformer;
+import io.github.resilience4j.timelimiter.TimeLimiter;
+import io.github.resilience4j.timelimiter.transformer.TimeLimiterTransformer;
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.inject.MethodExecutionHandle;
+import io.micronaut.retry.exception.FallbackException;
+import io.reactivex.Flowable;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Singleton;
+import java.util.Optional;
+import java.util.function.Function;
+
+@Singleton
+@Requires(classes = {Flowable.class, AbstractSubscriber.class})
+public class RxJava2PublisherExtension implements PublisherExtension {
+    private static final Logger logger = LoggerFactory.getLogger(RxJava2PublisherExtension.class);
+
+    @Override
+    public <T> Publisher<T> bulkhead(Publisher<T> publisher, Bulkhead bulkhead) {
+        return Flowable.fromPublisher(publisher).compose(BulkheadOperator.of(bulkhead));
+    }
+
+    @Override
+    public <T> Publisher<T> circuitBreaker(Publisher<T> publisher, CircuitBreaker circuitBreaker) {
+        return Flowable.fromPublisher(publisher).compose(CircuitBreakerOperator.of(circuitBreaker));
+    }
+
+    @Override
+    public <T> Publisher<T> timeLimiter(Publisher<T> publisher, TimeLimiter timeLimiter) {
+        return Flowable.fromPublisher(publisher).compose(TimeLimiterTransformer.of(timeLimiter));
+    }
+
+    @Override
+    public <T> Publisher<T> retry(Publisher<T> publisher, Retry retry) {
+        return Flowable.fromPublisher(publisher).compose(RetryTransformer.of(retry));
+    }
+
+    @Override
+    public <T> Publisher<T> rateLimiter(Publisher<T> publisher, RateLimiter rateLimiter) {
+        return Flowable.fromPublisher(publisher).compose(RateLimiterOperator.of(rateLimiter));
+    }
+
+    @Override
+    public <T> Publisher<T> fallbackPublisher(Publisher<T> publisher, MethodInvocationContext<Object, Object> context, Function<MethodInvocationContext<Object, Object>, Optional<? extends MethodExecutionHandle<?, Object>>> handler) {
+        return Flowable.fromPublisher(publisher).onErrorResumeNext(throwable -> {
+            Optional<? extends MethodExecutionHandle<?, Object>> fallbackMethod = handler.apply(context);
+            if (fallbackMethod.isPresent()) {
+                MethodExecutionHandle<?, Object> fallbackHandle = fallbackMethod.get();
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Type [{}] resolved fallback: {}", context.getTarget().getClass(), fallbackHandle);
+                }
+                Object fallbackResult;
+                try {
+                    fallbackResult = fallbackHandle.invoke(context.getParameterValues());
+                } catch (Exception e) {
+                    return Flowable.error(throwable);
+                }
+                if (fallbackResult == null) {
+                    return Flowable.error(new FallbackException("Fallback handler [" + fallbackHandle + "] returned null value"));
+                } else {
+                    return ConversionService.SHARED.convert(fallbackResult, Publisher.class)
+                        .orElseThrow(() -> new FallbackException("Unsupported Reactive type: " + fallbackResult));
+                }
+            }
+            return Flowable.error(throwable);
+        });
+    }
+}

--- a/resilience4j-micronaut/src/main/java/io/github/resilience4j/micronaut/util/RxJava3PublisherExtension.java
+++ b/resilience4j-micronaut/src/main/java/io/github/resilience4j/micronaut/util/RxJava3PublisherExtension.java
@@ -1,0 +1,83 @@
+package io.github.resilience4j.micronaut.util;
+
+import io.github.resilience4j.bulkhead.Bulkhead;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.rxjava3.AbstractSubscriber;
+import io.github.resilience4j.rxjava3.bulkhead.operator.BulkheadOperator;
+import io.github.resilience4j.rxjava3.circuitbreaker.operator.CircuitBreakerOperator;
+import io.github.resilience4j.rxjava3.ratelimiter.operator.RateLimiterOperator;
+import io.github.resilience4j.rxjava3.retry.transformer.RetryTransformer;
+import io.github.resilience4j.rxjava3.timelimiter.transformer.TimeLimiterTransformer;
+import io.github.resilience4j.timelimiter.TimeLimiter;
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.inject.MethodExecutionHandle;
+import io.micronaut.retry.exception.FallbackException;
+import io.reactivex.rxjava3.core.Flowable;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Singleton;
+import java.util.Optional;
+import java.util.function.Function;
+
+@Singleton
+@Requires(classes = {Flowable.class, AbstractSubscriber.class})
+public class RxJava3PublisherExtension implements PublisherExtension {
+    private static final Logger logger = LoggerFactory.getLogger(RxJava2PublisherExtension.class);
+
+    @Override
+    public <T> Publisher<T> bulkhead(Publisher<T> publisher, Bulkhead bulkhead) {
+        return Flowable.fromPublisher(publisher).compose(BulkheadOperator.of(bulkhead));
+    }
+
+    @Override
+    public <T> Publisher<T> circuitBreaker(Publisher<T> publisher, CircuitBreaker circuitBreaker) {
+        return Flowable.fromPublisher(publisher).compose(CircuitBreakerOperator.of(circuitBreaker));
+    }
+
+    @Override
+    public <T> Publisher<T> timeLimiter(Publisher<T> publisher, TimeLimiter timeLimiter) {
+        return Flowable.fromPublisher(publisher).compose(TimeLimiterTransformer.of(timeLimiter));
+    }
+
+    @Override
+    public <T> Publisher<T> retry(Publisher<T> publisher, Retry retry) {
+        return Flowable.fromPublisher(publisher).compose(RetryTransformer.of(retry));
+    }
+
+    @Override
+    public <T> Publisher<T> rateLimiter(Publisher<T> publisher, RateLimiter rateLimiter) {
+        return Flowable.fromPublisher(publisher).compose(RateLimiterOperator.of(rateLimiter));
+    }
+
+    @Override
+    public <T> Publisher<T> fallbackPublisher(Publisher<T> publisher, MethodInvocationContext<Object, Object> context, Function<MethodInvocationContext<Object, Object>, Optional<? extends MethodExecutionHandle<?, Object>>> handler) {
+        return Flowable.fromPublisher(publisher).onErrorResumeNext(throwable -> {
+            Optional<? extends MethodExecutionHandle<?, Object>> fallbackMethod = handler.apply(context);
+            if (fallbackMethod.isPresent()) {
+                MethodExecutionHandle<?, Object> fallbackHandle = fallbackMethod.get();
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Type [{}] resolved fallback: {}", context.getTarget().getClass(), fallbackHandle);
+                }
+                Object fallbackResult;
+                try {
+                    fallbackResult = fallbackHandle.invoke(context.getParameterValues());
+                } catch (Exception e) {
+                    return Flowable.error(throwable);
+                }
+                if (fallbackResult == null) {
+                    return Flowable.error(new FallbackException("Fallback handler [" + fallbackHandle + "] returned null value"));
+                } else {
+                    return ConversionService.SHARED.convert(fallbackResult, Publisher.class)
+                        .orElseThrow(() -> new FallbackException("Unsupported Reactive type: " + fallbackResult));
+                }
+            }
+            return Flowable.error(throwable);
+        });
+    }
+}


### PR DESCRIPTION
still need to do some more testing but this should be a good start to get this mostly working.  the only thing I'm not entirly sure about is this fallbackPublisher that I have was seeing how I could avoid the extra wrapping around the method. 

any clue how I can test this across these variations? any gradle configuration magic to configure this for the different test.

here are the changes to address the comments here: https://github.com/resilience4j/resilience4j/issues/1485