### PR TITLE
Add new `active.thread.count` metric

### DIFF
--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkhead.java
@@ -312,6 +312,13 @@ public interface ThreadPoolBulkhead extends AutoCloseable {
          * @return the queue capacity
          */
         int getQueueCapacity();
+
+        /**
+         * Returns the number of actively executing tasks.
+         *
+         * @return the number of executing tasks
+         */
+        int getActiveThreadCount();
     }
 
     /**

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/FixedThreadPoolBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/FixedThreadPoolBulkhead.java
@@ -325,5 +325,10 @@ public class FixedThreadPoolBulkhead implements ThreadPoolBulkhead {
         public int getQueueCapacity() {
             return config.getQueueCapacity();
         }
+
+        @Override
+        public int getActiveThreadCount() {
+            return executorService.getActiveCount();
+        }
     }
 }

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractThreadPoolBulkheadMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractThreadPoolBulkheadMetrics.java
@@ -86,6 +86,13 @@ abstract class AbstractThreadPoolBulkheadMetrics extends AbstractMetrics {
             .tags(customTags)
             .register(meterRegistry).getId());
 
+        idSet.add(Gauge.builder(names.getActiveThreadCountMetricName(), bulkhead,
+            bh -> bh.getMetrics().getActiveThreadCount())
+            .description("The number of active threads")
+            .tag(TagNames.NAME, bulkhead.getName())
+            .tags(customTags)
+            .register(meterRegistry).getId());
+
         meterIdMap.put(bulkhead.getName(), idSet);
     }
 

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/ThreadPoolBulkheadMetricNames.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/ThreadPoolBulkheadMetricNames.java
@@ -15,11 +15,14 @@ public class ThreadPoolBulkheadMetricNames {
         DEFAULT_PREFIX + ".max.thread.pool.size";
     public static final String DEFAULT_CORE_THREAD_POOL_SIZE_METRIC_NAME =
         DEFAULT_PREFIX + ".core.thread.pool.size";
+    public static final String DEFAULT_BULKHEAD_ACTIVE_THREAD_COUNT_METRIC_NAME =
+        DEFAULT_PREFIX + ".active.thread.count";
     private String queueDepthMetricName = DEFAULT_BULKHEAD_QUEUE_DEPTH_METRIC_NAME;
     private String threadPoolSizeMetricName = DEFAULT_THREAD_POOL_SIZE_METRIC_NAME;
     private String maxThreadPoolSizeMetricName = DEFAULT_MAX_THREAD_POOL_SIZE_METRIC_NAME;
     private String coreThreadPoolSizeMetricName = DEFAULT_CORE_THREAD_POOL_SIZE_METRIC_NAME;
     private String queueCapacityMetricName = DEFAULT_BULKHEAD_QUEUE_CAPACITY_METRIC_NAME;
+    private String activeThreadCountMetricName = DEFAULT_BULKHEAD_ACTIVE_THREAD_COUNT_METRIC_NAME;
 
     protected ThreadPoolBulkheadMetricNames() {
     }
@@ -94,6 +97,16 @@ public class ThreadPoolBulkheadMetricNames {
     }
 
     /**
+     * Returns the metric name for bulkhead active count, defaults to {@value
+     * DEFAULT_BULKHEAD_ACTIVE_THREAD_COUNT_METRIC_NAME}.
+     *
+     * @return The active thread count metric name.
+     */
+    public String getActiveThreadCountMetricName() {
+        return activeThreadCountMetricName;
+    }
+
+    /**
      * Helps building custom instance of {@link ThreadPoolBulkheadMetricNames}.
      */
     public static class Builder {
@@ -159,6 +172,20 @@ public class ThreadPoolBulkheadMetricNames {
          */
         public Builder queueCapacityMetricName(String queueCapacityMetricName) {
             metricNames.queueCapacityMetricName = requireNonNull(queueCapacityMetricName);
+            return this;
+        }
+
+        /**
+         * Overrides the default metric name {@value ThreadPoolBulkheadMetricNames#DEFAULT_BULKHEAD_ACTIVE_THREAD_COUNT_METRIC_NAME}
+         * with a given one.
+         *
+         * @param activeThreadCountMetricName The active thread count metric name.
+         * @return The builder.
+         */
+        public Builder activeThreadCountMetricName(
+            String activeThreadCountMetricName) {
+            metricNames.activeThreadCountMetricName = requireNonNull(
+                activeThreadCountMetricName);
             return this;
         }
 

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedThreadPoolBulkheadMetricsPublisherTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedThreadPoolBulkheadMetricsPublisherTest.java
@@ -35,6 +35,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TaggedThreadPoolBulkheadMetricsPublisherTest {
 
+    private static final List<String> EXPECTED_METERS = Arrays.asList(
+        "custom.max.thread.pool.size",
+        "custom.core.thread.pool.size",
+        "resilience4j.bulkhead.queue.depth",
+        "resilience4j.bulkhead.queue.capacity",
+        "resilience4j.bulkhead.thread.pool.size",
+        "resilience4j.bulkhead.active.thread.count"
+    );
+    private  static final int EXPECTED_METER_COUNT = EXPECTED_METERS.size();
     private MeterRegistry meterRegistry;
     private ThreadPoolBulkhead bulkhead;
     private ThreadPoolBulkheadRegistry bulkheadRegistry;
@@ -60,11 +69,11 @@ public class TaggedThreadPoolBulkheadMetricsPublisherTest {
         ThreadPoolBulkhead newBulkhead = bulkheadRegistry.bulkhead("backendB");
 
         assertThat(taggedBulkheadMetricsPublisher.meterIdMap).containsKeys("backendA", "backendB");
-        assertThat(taggedBulkheadMetricsPublisher.meterIdMap.get("backendA")).hasSize(5);
-        assertThat(taggedBulkheadMetricsPublisher.meterIdMap.get("backendB")).hasSize(5);
+        assertThat(taggedBulkheadMetricsPublisher.meterIdMap.get("backendA")).hasSize(EXPECTED_METER_COUNT);
+        assertThat(taggedBulkheadMetricsPublisher.meterIdMap.get("backendB")).hasSize(EXPECTED_METER_COUNT);
 
         List<Meter> meters = meterRegistry.getMeters();
-        assertThat(meters).hasSize(10);
+        assertThat(meters).hasSize(EXPECTED_METER_COUNT * 2);
 
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_MAX_THREAD_POOL_SIZE_METRIC_NAME)
             .gauges();
@@ -78,7 +87,7 @@ public class TaggedThreadPoolBulkheadMetricsPublisherTest {
     @Test
     public void shouldRemovedMetricsForRemovedRetry() {
         List<Meter> meters = meterRegistry.getMeters();
-        assertThat(meters).hasSize(5);
+        assertThat(meters).hasSize(EXPECTED_METER_COUNT);
 
         assertThat(taggedBulkheadMetricsPublisher.meterIdMap).containsKeys("backendA");
         bulkheadRegistry.remove("backendA");
@@ -159,6 +168,18 @@ public class TaggedThreadPoolBulkheadMetricsPublisherTest {
     }
 
     @Test
+    public void activeThreadCountIsRegistered() {
+        Gauge activeCount = meterRegistry.get(DEFAULT_BULKHEAD_ACTIVE_THREAD_COUNT_METRIC_NAME).gauge();
+
+        assertThat(activeCount).isNotNull();
+        // `greaterThanOrEqualTo` prevents timing issue where active count drops
+        // between getting the value from the gauge and
+        // asserting it is equal to the current value
+        assertThat(activeCount.value()).isGreaterThanOrEqualTo(bulkhead.getMetrics().getActiveThreadCount());
+        assertThat(activeCount.getId().getTag(TagNames.NAME)).isEqualTo(bulkhead.getName());
+    }
+
+    @Test
     public void customMetricNamesGetApplied() {
         MeterRegistry meterRegistry = new SimpleMeterRegistry();
         TaggedThreadPoolBulkheadMetricsPublisher taggedBulkheadMetricsPublisher =
@@ -178,13 +199,7 @@ public class TaggedThreadPoolBulkheadMetricsPublisherTest {
             .map(Meter.Id::getName)
             .collect(Collectors.toSet());
 
-        assertThat(metricNames).hasSameElementsAs(Arrays.asList(
-            "custom.max.thread.pool.size",
-            "custom.core.thread.pool.size",
-            "resilience4j.bulkhead.queue.depth",
-            "resilience4j.bulkhead.queue.capacity",
-            "resilience4j.bulkhead.thread.pool.size"
-        ));
+        assertThat(metricNames).hasSameElementsAs(EXPECTED_METERS);
     }
 
     @Test
@@ -196,7 +211,7 @@ public class TaggedThreadPoolBulkheadMetricsPublisherTest {
         oldOne.executeSupplier(() -> "Bla");
 
         assertThat(taggedBulkheadMetricsPublisher.meterIdMap).containsKeys("backendC");
-        assertThat(taggedBulkheadMetricsPublisher.meterIdMap.get("backendC")).hasSize(5);
+        assertThat(taggedBulkheadMetricsPublisher.meterIdMap.get("backendC")).hasSize(EXPECTED_METER_COUNT);
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_MAX_THREAD_POOL_SIZE_METRIC_NAME)
             .gauges();
         Optional<Gauge> successful = findMeterByNamesTag(gauges, oldOne.getName());
@@ -214,7 +229,7 @@ public class TaggedThreadPoolBulkheadMetricsPublisherTest {
         newOne.executeSupplier(() -> "Bla");
 
         assertThat(taggedBulkheadMetricsPublisher.meterIdMap).containsKeys("backendC");
-        assertThat(taggedBulkheadMetricsPublisher.meterIdMap.get("backendC")).hasSize(5);
+        assertThat(taggedBulkheadMetricsPublisher.meterIdMap.get("backendC")).hasSize(EXPECTED_METER_COUNT);
         gauges = meterRegistry.get(DEFAULT_MAX_THREAD_POOL_SIZE_METRIC_NAME)
             .gauges();
         successful = findMeterByNamesTag(gauges, newOne.getName());


### PR DESCRIPTION
Fixes #1496.

One of the tests for this seemed a little flakey due to a timing issue, I think it's due to `ExecutorService.getActiveCount()` not being guaranteed to always provide the exact answer. Open to suggestions about how to guarantee it always working. 