### PR TITLE
Add new `available.thread.count` metric to `ThreadPoolBulkhead`

### DIFF
--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkhead.java
@@ -319,6 +319,14 @@ public interface ThreadPoolBulkhead extends AutoCloseable {
          * @return the number of executing tasks
          */
         int getActiveThreadCount();
+
+        /**
+         * Returns the maximum number of available threads.
+         * Equivalent to <code>getMaximumThreadPoolSize() - getActiveThreadCount()</code>
+         *
+         * @return the number of executing tasks
+         */
+        int getAvailableThreadCount();
     }
 
     /**

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/FixedThreadPoolBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/FixedThreadPoolBulkhead.java
@@ -330,5 +330,10 @@ public class FixedThreadPoolBulkhead implements ThreadPoolBulkhead {
         public int getActiveThreadCount() {
             return executorService.getActiveCount();
         }
+
+        @Override
+        public int getAvailableThreadCount() {
+            return getMaximumThreadPoolSize() - getActiveThreadCount();
+        }
     }
 }

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractThreadPoolBulkheadMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractThreadPoolBulkheadMetrics.java
@@ -93,6 +93,13 @@ abstract class AbstractThreadPoolBulkheadMetrics extends AbstractMetrics {
             .tags(customTags)
             .register(meterRegistry).getId());
 
+        idSet.add(Gauge.builder(names.getAvailableThreadCountMetricName(), bulkhead,
+            bh -> bh.getMetrics().getAvailableThreadCount())
+            .description("The number of available threads")
+            .tag(TagNames.NAME, bulkhead.getName())
+            .tags(customTags)
+            .register(meterRegistry).getId());
+
         meterIdMap.put(bulkhead.getName(), idSet);
     }
 

--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/ThreadPoolBulkheadMetricNames.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/ThreadPoolBulkheadMetricNames.java
@@ -17,12 +17,15 @@ public class ThreadPoolBulkheadMetricNames {
         DEFAULT_PREFIX + ".core.thread.pool.size";
     public static final String DEFAULT_BULKHEAD_ACTIVE_THREAD_COUNT_METRIC_NAME =
         DEFAULT_PREFIX + ".active.thread.count";
+    public static final String DEFAULT_BULKHEAD_AVAILABLE_THREAD_COUNT_METRIC_NAME =
+        DEFAULT_PREFIX + ".available.thread.count";
     private String queueDepthMetricName = DEFAULT_BULKHEAD_QUEUE_DEPTH_METRIC_NAME;
     private String threadPoolSizeMetricName = DEFAULT_THREAD_POOL_SIZE_METRIC_NAME;
     private String maxThreadPoolSizeMetricName = DEFAULT_MAX_THREAD_POOL_SIZE_METRIC_NAME;
     private String coreThreadPoolSizeMetricName = DEFAULT_CORE_THREAD_POOL_SIZE_METRIC_NAME;
     private String queueCapacityMetricName = DEFAULT_BULKHEAD_QUEUE_CAPACITY_METRIC_NAME;
     private String activeThreadCountMetricName = DEFAULT_BULKHEAD_ACTIVE_THREAD_COUNT_METRIC_NAME;
+    private String availableThreadCountMetricName = DEFAULT_BULKHEAD_AVAILABLE_THREAD_COUNT_METRIC_NAME;
 
     protected ThreadPoolBulkheadMetricNames() {
     }
@@ -107,6 +110,16 @@ public class ThreadPoolBulkheadMetricNames {
     }
 
     /**
+     * Returns the metric name for bulkhead available thread count,
+     * defaults to {@value DEFAULT_BULKHEAD_AVAILABLE_THREAD_COUNT_METRIC_NAME}.
+     *
+     * @return The available thread count metric name.
+     */
+    public String getAvailableThreadCountMetricName() {
+        return availableThreadCountMetricName;
+    }
+
+    /**
      * Helps building custom instance of {@link ThreadPoolBulkheadMetricNames}.
      */
     public static class Builder {
@@ -186,6 +199,20 @@ public class ThreadPoolBulkheadMetricNames {
             String activeThreadCountMetricName) {
             metricNames.activeThreadCountMetricName = requireNonNull(
                 activeThreadCountMetricName);
+            return this;
+        }
+
+        /**
+         * Overrides the default metric name {@value ThreadPoolBulkheadMetricNames#DEFAULT_BULKHEAD_AVAILABLE_THREAD_COUNT_METRIC_NAME}
+         * with a given one.
+         *
+         * @param availableThreadCountMetricName The active thread count metric name.
+         * @return The builder.
+         */
+        public Builder availableThreadCountMetricName(
+            String availableThreadCountMetricName) {
+            metricNames.availableThreadCountMetricName = requireNonNull(
+                availableThreadCountMetricName);
             return this;
         }
 

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedThreadPoolBulkheadMetricsPublisherTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedThreadPoolBulkheadMetricsPublisherTest.java
@@ -41,7 +41,8 @@ public class TaggedThreadPoolBulkheadMetricsPublisherTest {
         "resilience4j.bulkhead.queue.depth",
         "resilience4j.bulkhead.queue.capacity",
         "resilience4j.bulkhead.thread.pool.size",
-        "resilience4j.bulkhead.active.thread.count"
+        "resilience4j.bulkhead.active.thread.count",
+        "resilience4j.bulkhead.available.thread.count"
     );
     private  static final int EXPECTED_METER_COUNT = EXPECTED_METERS.size();
     private MeterRegistry meterRegistry;
@@ -177,6 +178,15 @@ public class TaggedThreadPoolBulkheadMetricsPublisherTest {
         // asserting it is equal to the current value
         assertThat(activeCount.value()).isGreaterThanOrEqualTo(bulkhead.getMetrics().getActiveThreadCount());
         assertThat(activeCount.getId().getTag(TagNames.NAME)).isEqualTo(bulkhead.getName());
+    }
+
+    @Test
+    public void availableThreadCountIsRegistered() {
+        Gauge availableThreadCount = meterRegistry.get(DEFAULT_BULKHEAD_AVAILABLE_THREAD_COUNT_METRIC_NAME).gauge();
+
+        assertThat(availableThreadCount).isNotNull();
+        assertThat(availableThreadCount.value()).isEqualTo(bulkhead.getMetrics().getAvailableThreadCount());
+        assertThat(availableThreadCount.getId().getTag(TagNames.NAME)).isEqualTo(bulkhead.getName());
     }
 
     @Test

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedThreadPoolBulkheadMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedThreadPoolBulkheadMetricsTest.java
@@ -40,7 +40,8 @@ public class TaggedThreadPoolBulkheadMetricsTest {
         "resilience4j.bulkhead.queue.depth",
         "resilience4j.bulkhead.queue.capacity",
         "resilience4j.bulkhead.thread.pool.size",
-        "resilience4j.bulkhead.active.thread.count"
+        "resilience4j.bulkhead.active.thread.count",
+        "resilience4j.bulkhead.available.thread.count"
     );
     private static final int EXPECTED_METER_COUNT = EXPECTED_METERS.size();
     private MeterRegistry meterRegistry;
@@ -177,6 +178,15 @@ public class TaggedThreadPoolBulkheadMetricsTest {
         assertThat(maxAllowed).isNotNull();
         assertThat(maxAllowed.value()).isEqualTo(bulkhead.getMetrics().getThreadPoolSize());
         assertThat(maxAllowed.getId().getTag(TagNames.NAME)).isEqualTo(bulkhead.getName());
+    }
+
+    @Test
+    public void availableThreadCountIsRegistered() {
+        Gauge availableThreadCount = meterRegistry.get(DEFAULT_BULKHEAD_AVAILABLE_THREAD_COUNT_METRIC_NAME).gauge();
+
+        assertThat(availableThreadCount).isNotNull();
+        assertThat(availableThreadCount.value()).isEqualTo(bulkhead.getMetrics().getAvailableThreadCount());
+        assertThat(availableThreadCount.getId().getTag(TagNames.NAME)).isEqualTo(bulkhead.getName());
     }
 
     @Test


### PR DESCRIPTION
Fixes #1500 

Allows for tracking the max threads remaining which can execute work. Similar to `available.concurrent.calls` from `Bulkhead`