### PR TITLE
Adding SynchronousQueue support to FixedThreadPoolBulkhead

### DIFF
--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfig.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfig.java
@@ -27,7 +27,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 
 import static java.util.Arrays.stream;
@@ -190,14 +192,15 @@ public class ThreadPoolBulkheadConfig {
 
         /**
          * Configures the capacity of the queue.
+         * Use {@link SynchronousQueue} when {@code queueCapacity == 0} or {@link ArrayBlockingQueue} when {@code queueCapacity > 0}.
          *
          * @param queueCapacity max concurrent calls
          * @return the BulkheadConfig.Builder
          */
         public Builder queueCapacity(int queueCapacity) {
-            if (queueCapacity < 1) {
+            if (queueCapacity < 0) {
                 throw new IllegalArgumentException(
-                    "queueCapacity must be a positive integer value >= 1");
+                    "queueCapacity must be a positive integer value >= 0");
             }
             config.queueCapacity = queueCapacity;
             return this;

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/FixedThreadPoolBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/FixedThreadPoolBulkhead.java
@@ -82,7 +82,7 @@ public class FixedThreadPoolBulkhead implements ThreadPoolBulkhead {
         this.executorService = new ThreadPoolExecutor(config.getCoreThreadPoolSize(),
             config.getMaxThreadPoolSize(),
             config.getKeepAliveDuration().toMillis(), TimeUnit.MILLISECONDS,
-            new ArrayBlockingQueue<>(config.getQueueCapacity()),
+            config.getQueueCapacity() == 0 ? new SynchronousQueue<>() : new ArrayBlockingQueue<>(config.getQueueCapacity()),
             new BulkheadNamingThreadFactory(name),
             config.getRejectedExecutionHandler());
         // adding prover jvm executor shutdown

--- a/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/bulkhead/configuration/ThreadPoolBulkheadConfigurationProperties.java
+++ b/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/bulkhead/configuration/ThreadPoolBulkheadConfigurationProperties.java
@@ -96,7 +96,7 @@ public class ThreadPoolBulkheadConfigurationProperties extends CommonProperties 
             return ThreadPoolBulkheadConfig.custom().build();
         }
 
-        if (properties.getQueueCapacity() > 0) {
+        if (properties.getQueueCapacity() >= 0) {
             builder.queueCapacity(properties.getQueueCapacity());
         }
         if (properties.getCoreThreadPoolSize() > 0) {
@@ -137,7 +137,7 @@ public class ThreadPoolBulkheadConfigurationProperties extends CommonProperties 
 
         private int maxThreadPoolSize;
         private int coreThreadPoolSize;
-        private int queueCapacity;
+        private int queueCapacity = -1;
         private Duration keepAliveDuration;
 
         @Nullable

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/bulkhead/configuration/ThreadPoolBulkheadConfigurationPropertiesTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/bulkhead/configuration/ThreadPoolBulkheadConfigurationPropertiesTest.java
@@ -25,17 +25,21 @@ public class ThreadPoolBulkheadConfigurationPropertiesTest  {
         ThreadPoolBulkheadConfigurationProperties.InstanceProperties backendProperties2 = new ThreadPoolBulkheadConfigurationProperties.InstanceProperties();
         backendProperties2.setCoreThreadPoolSize(2);
 
+        ThreadPoolBulkheadConfigurationProperties.InstanceProperties backendProperties3 = new ThreadPoolBulkheadConfigurationProperties.InstanceProperties();
+        backendProperties3.setQueueCapacity(0);
+
         ThreadPoolBulkheadConfigurationProperties bulkheadConfigurationProperties = new ThreadPoolBulkheadConfigurationProperties();
         bulkheadConfigurationProperties.getBackends().put("backend1", backendProperties1);
         bulkheadConfigurationProperties.getBackends().put("backend2", backendProperties2);
+        bulkheadConfigurationProperties.getBackends().put("backend3", backendProperties3);
         Map<String, String> tags = new HashMap<>();
         tags.put("testKey1", "testKet2");
         bulkheadConfigurationProperties.setTags(tags);
 
         //Then
         assertThat(bulkheadConfigurationProperties.getTags()).isNotEmpty();
-        assertThat(bulkheadConfigurationProperties.getBackends().size()).isEqualTo(2);
-        assertThat(bulkheadConfigurationProperties.getInstances().size()).isEqualTo(2);
+        assertThat(bulkheadConfigurationProperties.getBackends()).hasSize(3);
+        assertThat(bulkheadConfigurationProperties.getInstances()).hasSize(3);
         ThreadPoolBulkheadConfig bulkhead1 = bulkheadConfigurationProperties
             .createThreadPoolBulkheadConfig("backend1", compositeThreadPoolBulkheadCustomizer());
         assertThat(bulkhead1).isNotNull();
@@ -45,6 +49,11 @@ public class ThreadPoolBulkheadConfigurationPropertiesTest  {
             .createThreadPoolBulkheadConfig("backend2", compositeThreadPoolBulkheadCustomizer());
         assertThat(bulkhead2).isNotNull();
         assertThat(bulkhead2.getCoreThreadPoolSize()).isEqualTo(2);
+
+        ThreadPoolBulkheadConfig bulkhead3 = bulkheadConfigurationProperties
+            .createThreadPoolBulkheadConfig("backend3", compositeThreadPoolBulkheadCustomizer());
+        assertThat(bulkhead3).isNotNull();
+        assertThat(bulkhead3.getQueueCapacity()).isZero();
 
     }
 


### PR DESCRIPTION
From #1503 

I modified the code related to the above issue.
- If queueCapacity is 0, use SynchronousQueue, and if it is greater than 0, use ArrayBlockingQueue.