### PR TITLE
Issue #1514: Fixed CircuitBreakers prometheus metrics when replacing entry in the registry

### DIFF
--- a/resilience4j-prometheus/src/main/java/io/github/resilience4j/prometheus/collectors/CircuitBreakerMetricsCollector.java
+++ b/resilience4j-prometheus/src/main/java/io/github/resilience4j/prometheus/collectors/CircuitBreakerMetricsCollector.java
@@ -41,7 +41,8 @@ public class CircuitBreakerMetricsCollector extends AbstractCircuitBreakerMetric
             addMetrics(circuitBreaker);
         }
         circuitBreakerRegistry.getEventPublisher()
-            .onEntryAdded(event -> addMetrics(event.getAddedEntry()));
+            .onEntryAdded(event -> addMetrics(event.getAddedEntry()))
+            .onEntryReplaced(event -> addMetrics(event.getNewEntry()));
     }
 
     /**

--- a/resilience4j-prometheus/src/test/java/io/github/resilience4j/prometheus/collectors/CircuitBreakerMetricsCollectorTest.java
+++ b/resilience4j-prometheus/src/test/java/io/github/resilience4j/prometheus/collectors/CircuitBreakerMetricsCollectorTest.java
@@ -108,6 +108,27 @@ public class CircuitBreakerMetricsCollectorTest {
     }
 
     @Test
+    public void shouldReportReplacedCircuitBreaker() {
+        double successfulCallsBeforeReplace = registry.getSampleValue(
+            DEFAULT_CIRCUIT_BREAKER_CALLS + "_bucket",
+            new String[]{"name", "kind", "le"},
+            new String[]{circuitBreaker.getName(), "successful", "0.1"}
+        );
+
+        CircuitBreaker replacedCircuitBreaker = CircuitBreaker.of(circuitBreaker.getName(), CircuitBreakerConfig.ofDefaults());
+        circuitBreakerRegistry.replace(circuitBreaker.getName(), replacedCircuitBreaker);
+        replacedCircuitBreaker.onSuccess(100, TimeUnit.MILLISECONDS);
+
+        double successfulCallsAfterReplace = registry.getSampleValue(
+            DEFAULT_CIRCUIT_BREAKER_CALLS + "_bucket",
+            new String[]{"name", "kind", "le"},
+            new String[]{circuitBreaker.getName(), "successful", "0.1"}
+        );
+
+        assertThat(successfulCallsAfterReplace).isGreaterThan(successfulCallsBeforeReplace);
+    }
+
+    @Test
     public void successfulBufferedCallsReportsCorrespondingValue() {
         double successfulCalls = registry.getSampleValue(
             DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS,


### PR DESCRIPTION
We found a related bug to this when trying your library, so I tried to submit a PR for the fix of #1514.

Basically the Prometheus collector is only watching for added events but not for replace ones.

Tell me if I missed anything about how to contribute.