### PR TITLE
Issue #1518 - Eliminated code duplication around resolving fallback method and using it

### DIFF
--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/bulkhead/autoconfigure/AbstractBulkheadConfigurationOnMissingBean.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/bulkhead/autoconfigure/AbstractBulkheadConfigurationOnMissingBean.java
@@ -28,7 +28,7 @@ import io.github.resilience4j.common.bulkhead.configuration.ThreadPoolBulkheadCo
 import io.github.resilience4j.common.bulkhead.configuration.ThreadPoolBulkheadConfigurationProperties;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
-import io.github.resilience4j.fallback.FallbackDecorators;
+import io.github.resilience4j.fallback.FallbackExecutor;
 import io.github.resilience4j.fallback.autoconfigure.FallbackConfigurationOnMissingBean;
 import io.github.resilience4j.spelresolver.SpelResolver;
 import io.github.resilience4j.spelresolver.autoconfigure.SpelResolverConfigurationOnMissingBean;
@@ -94,11 +94,11 @@ public abstract class AbstractBulkheadConfigurationOnMissingBean {
         ThreadPoolBulkheadRegistry threadPoolBulkheadRegistry,
         BulkheadRegistry bulkheadRegistry,
         @Autowired(required = false) List<BulkheadAspectExt> bulkHeadAspectExtList,
-        FallbackDecorators fallbackDecorators,
+        FallbackExecutor fallbackExecutor,
         SpelResolver spelResolver) {
         return bulkheadConfiguration
             .bulkheadAspect(bulkheadConfigurationProperties, threadPoolBulkheadRegistry,
-                bulkheadRegistry, bulkHeadAspectExtList, fallbackDecorators, spelResolver);
+                bulkheadRegistry, bulkHeadAspectExtList, fallbackExecutor, spelResolver);
     }
 
     @Bean

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/circuitbreaker/autoconfigure/AbstractCircuitBreakerConfigurationOnMissingBean.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/circuitbreaker/autoconfigure/AbstractCircuitBreakerConfigurationOnMissingBean.java
@@ -23,7 +23,7 @@ import io.github.resilience4j.common.CompositeCustomizer;
 import io.github.resilience4j.common.circuitbreaker.configuration.CircuitBreakerConfigCustomizer;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
-import io.github.resilience4j.fallback.FallbackDecorators;
+import io.github.resilience4j.fallback.FallbackExecutor;
 import io.github.resilience4j.fallback.autoconfigure.FallbackConfigurationOnMissingBean;
 import io.github.resilience4j.spelresolver.SpelResolver;
 import io.github.resilience4j.spelresolver.autoconfigure.SpelResolverConfigurationOnMissingBean;
@@ -85,12 +85,12 @@ public abstract class AbstractCircuitBreakerConfigurationOnMissingBean {
     public CircuitBreakerAspect circuitBreakerAspect(
         CircuitBreakerRegistry circuitBreakerRegistry,
         @Autowired(required = false) List<CircuitBreakerAspectExt> circuitBreakerAspectExtList,
-        FallbackDecorators fallbackDecorators,
+        FallbackExecutor fallbackExecutor,
         SpelResolver spelResolver
     ) {
         return circuitBreakerConfiguration
             .circuitBreakerAspect(circuitBreakerRegistry, circuitBreakerAspectExtList,
-                fallbackDecorators, spelResolver);
+                fallbackExecutor, spelResolver);
     }
 
     @Bean

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/fallback/autoconfigure/FallbackConfigurationOnMissingBean.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/fallback/autoconfigure/FallbackConfigurationOnMissingBean.java
@@ -17,6 +17,8 @@ package io.github.resilience4j.fallback.autoconfigure;
 
 import io.github.resilience4j.fallback.*;
 import io.github.resilience4j.fallback.configure.FallbackConfiguration;
+import io.github.resilience4j.spelresolver.SpelResolver;
+import io.github.resilience4j.spelresolver.autoconfigure.SpelResolverConfigurationOnMissingBean;
 import io.github.resilience4j.utils.ReactorOnClasspathCondition;
 import io.github.resilience4j.utils.RxJava2OnClasspathCondition;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +26,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 import java.util.List;
 
@@ -31,6 +34,7 @@ import java.util.List;
  * {@link Configuration} for {@link FallbackDecorators}.
  */
 @Configuration
+@Import(SpelResolverConfigurationOnMissingBean.class)
 public class FallbackConfigurationOnMissingBean {
 
     private final FallbackConfiguration fallbackConfiguration;
@@ -43,6 +47,12 @@ public class FallbackConfigurationOnMissingBean {
     @ConditionalOnMissingBean
     public FallbackDecorators fallbackDecorators(@Autowired(required = false) List<FallbackDecorator> fallbackDecorators) {
         return fallbackConfiguration.fallbackDecorators(fallbackDecorators);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public FallbackExecutor fallbackExecutor(SpelResolver spelResolver, FallbackDecorators fallbackDecorators) {
+        return fallbackConfiguration.fallbackExecutor(spelResolver, fallbackDecorators);
     }
 
     @Bean

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/ratelimiter/autoconfigure/AbstractRateLimiterConfigurationOnMissingBean.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/ratelimiter/autoconfigure/AbstractRateLimiterConfigurationOnMissingBean.java
@@ -19,7 +19,7 @@ import io.github.resilience4j.common.CompositeCustomizer;
 import io.github.resilience4j.common.ratelimiter.configuration.RateLimiterConfigCustomizer;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
-import io.github.resilience4j.fallback.FallbackDecorators;
+import io.github.resilience4j.fallback.FallbackExecutor;
 import io.github.resilience4j.fallback.autoconfigure.FallbackConfigurationOnMissingBean;
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
@@ -83,12 +83,12 @@ public abstract class AbstractRateLimiterConfigurationOnMissingBean {
         RateLimiterConfigurationProperties rateLimiterProperties,
         RateLimiterRegistry rateLimiterRegistry,
         @Autowired(required = false) List<RateLimiterAspectExt> rateLimiterAspectExtList,
-        FallbackDecorators fallbackDecorators,
+        FallbackExecutor fallbackExecutor,
         SpelResolver spelResolver
     ) {
         return rateLimiterConfiguration
             .rateLimiterAspect(rateLimiterProperties, rateLimiterRegistry, rateLimiterAspectExtList,
-                fallbackDecorators, spelResolver);
+                fallbackExecutor, spelResolver);
     }
 
     @Bean

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/retry/autoconfigure/AbstractRetryConfigurationOnMissingBean.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/retry/autoconfigure/AbstractRetryConfigurationOnMissingBean.java
@@ -20,7 +20,7 @@ import io.github.resilience4j.common.retry.configuration.RetryConfigCustomizer;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
 import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
-import io.github.resilience4j.fallback.FallbackDecorators;
+import io.github.resilience4j.fallback.FallbackExecutor;
 import io.github.resilience4j.fallback.autoconfigure.FallbackConfigurationOnMissingBean;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryRegistry;
@@ -96,13 +96,13 @@ public abstract class AbstractRetryConfigurationOnMissingBean {
         RetryConfigurationProperties retryConfigurationProperties,
         RetryRegistry retryRegistry,
         @Autowired(required = false) List<RetryAspectExt> retryAspectExtList,
-        FallbackDecorators fallbackDecorators,
+        FallbackExecutor fallbackExecutor,
         SpelResolver spelResolver,
         @Autowired(required = false) ContextAwareScheduledThreadPoolExecutor contextAwareScheduledThreadPoolExecutor
     ) {
         return retryConfiguration
             .retryAspect(retryConfigurationProperties, retryRegistry, retryAspectExtList,
-                fallbackDecorators, spelResolver, contextAwareScheduledThreadPoolExecutor);
+                fallbackExecutor, spelResolver, contextAwareScheduledThreadPoolExecutor);
     }
 
     @Bean

--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/timelimiter/autoconfigure/AbstractTimeLimiterConfigurationOnMissingBean.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/timelimiter/autoconfigure/AbstractTimeLimiterConfigurationOnMissingBean.java
@@ -21,7 +21,7 @@ import io.github.resilience4j.common.timelimiter.configuration.TimeLimiterConfig
 import io.github.resilience4j.consumer.EventConsumerRegistry;
 import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
-import io.github.resilience4j.fallback.FallbackDecorators;
+import io.github.resilience4j.fallback.FallbackExecutor;
 import io.github.resilience4j.fallback.autoconfigure.FallbackConfigurationOnMissingBean;
 import io.github.resilience4j.spelresolver.SpelResolver;
 import io.github.resilience4j.spelresolver.autoconfigure.SpelResolverConfigurationOnMissingBean;
@@ -83,12 +83,12 @@ public abstract class AbstractTimeLimiterConfigurationOnMissingBean {
         TimeLimiterConfigurationProperties timeLimiterProperties,
         TimeLimiterRegistry timeLimiterRegistry,
         @Autowired(required = false) List<TimeLimiterAspectExt> timeLimiterAspectExtList,
-        FallbackDecorators fallbackDecorators,
+        FallbackExecutor fallbackExecutor,
         SpelResolver spelResolver,
         @Autowired(required = false) ContextAwareScheduledThreadPoolExecutor contextAwareScheduledThreadPoolExecutor
     ) {
         return timeLimiterConfiguration.timeLimiterAspect(
-            timeLimiterProperties, timeLimiterRegistry, timeLimiterAspectExtList, fallbackDecorators, spelResolver, contextAwareScheduledThreadPoolExecutor);
+            timeLimiterProperties, timeLimiterRegistry, timeLimiterAspectExtList, fallbackExecutor, spelResolver, contextAwareScheduledThreadPoolExecutor);
     }
 
     @Bean

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/SpringBootCommonTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/SpringBootCommonTest.java
@@ -32,6 +32,7 @@ import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.core.registry.CompositeRegistryEventConsumer;
 import io.github.resilience4j.fallback.CompletionStageFallbackDecorator;
 import io.github.resilience4j.fallback.FallbackDecorators;
+import io.github.resilience4j.fallback.FallbackExecutor;
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
 import io.github.resilience4j.ratelimiter.autoconfigure.AbstractRateLimiterConfigurationOnMissingBean;
 import io.github.resilience4j.ratelimiter.configure.RateLimiterConfigurationProperties;
@@ -75,12 +76,14 @@ public class SpringBootCommonTest {
                     ThreadPoolBulkheadConfigCustomizer.of("backend", builder -> builder.coreThreadPoolSize(10)))))).isNotNull();
         assertThat(bulkheadConfigurationOnMissingBean.reactorBulkHeadAspectExt()).isNotNull();
         assertThat(bulkheadConfigurationOnMissingBean.rxJava2BulkHeadAspectExt()).isNotNull();
+        final DefaultSpelResolver spelResolver = new DefaultSpelResolver(new SpelExpressionParser(), new StandardReflectionParameterNameDiscoverer(), new GenericApplicationContext());
+        final FallbackDecorators fallbackDecorators = new FallbackDecorators(Collections.singletonList(new CompletionStageFallbackDecorator()));
         assertThat(bulkheadConfigurationOnMissingBean
             .bulkheadAspect(new BulkheadConfigurationProperties(),
                 ThreadPoolBulkheadRegistry.ofDefaults(), BulkheadRegistry.ofDefaults(),
                 Collections.emptyList(),
-                new FallbackDecorators(Arrays.asList(new CompletionStageFallbackDecorator())),
-            new DefaultSpelResolver(new SpelExpressionParser(), new StandardReflectionParameterNameDiscoverer(), new GenericApplicationContext()))).isNotNull();
+                new FallbackExecutor(spelResolver, fallbackDecorators),
+                spelResolver)).isNotNull();
         assertThat(
             bulkheadConfigurationOnMissingBean.bulkheadRegistryEventConsumer(Optional.empty())).isNotNull();
     }
@@ -94,10 +97,12 @@ public class SpringBootCommonTest {
         assertThat(circuitBreakerConfig.circuitBreakerRegistry(new DefaultEventConsumerRegistry<>(),
             new CompositeRegistryEventConsumer<>(Collections.emptyList()),
             new CompositeCustomizer<>(Collections.singletonList(new TestCustomizer())))).isNotNull();
+        final DefaultSpelResolver spelResolver = new DefaultSpelResolver(new SpelExpressionParser(), new StandardReflectionParameterNameDiscoverer(), new GenericApplicationContext());
+        final FallbackDecorators fallbackDecorators = new FallbackDecorators(Collections.singletonList(new CompletionStageFallbackDecorator()));
         assertThat(circuitBreakerConfig
             .circuitBreakerAspect(CircuitBreakerRegistry.ofDefaults(), Collections.emptyList(),
-                new FallbackDecorators(Arrays.asList(new CompletionStageFallbackDecorator())),
-            new DefaultSpelResolver(new SpelExpressionParser(), new StandardReflectionParameterNameDiscoverer(), new GenericApplicationContext()))).isNotNull();
+                new FallbackExecutor(spelResolver, fallbackDecorators),
+                spelResolver)).isNotNull();
         assertThat(circuitBreakerConfig.circuitBreakerRegistryEventConsumer(Optional.empty())).isNotNull();
     }
 
@@ -110,11 +115,13 @@ public class SpringBootCommonTest {
             .retryRegistry(new RetryConfigurationProperties(), new DefaultEventConsumerRegistry<>(),
                 new CompositeRegistryEventConsumer<>(Collections.emptyList()),
                 new CompositeCustomizer<>(Collections.emptyList()))).isNotNull();
+        final DefaultSpelResolver spelResolver = new DefaultSpelResolver(new SpelExpressionParser(), new StandardReflectionParameterNameDiscoverer(), new GenericApplicationContext());
+        final FallbackDecorators fallbackDecorators = new FallbackDecorators(Collections.singletonList(new CompletionStageFallbackDecorator()));
         assertThat(retryConfigurationOnMissingBean
             .retryAspect(new RetryConfigurationProperties(), RetryRegistry.ofDefaults(),
                 Collections.emptyList(),
-                new FallbackDecorators(Arrays.asList(new CompletionStageFallbackDecorator())),
-                new DefaultSpelResolver(new SpelExpressionParser(), new StandardReflectionParameterNameDiscoverer(), new GenericApplicationContext()), null)).isNotNull();
+                new FallbackExecutor(spelResolver, fallbackDecorators),
+                spelResolver, null)).isNotNull();
         assertThat(retryConfigurationOnMissingBean.retryRegistryEventConsumer(Optional.empty())).isNotNull();
     }
 
@@ -128,11 +135,13 @@ public class SpringBootCommonTest {
                 new DefaultEventConsumerRegistry<>(),
                 new CompositeRegistryEventConsumer<>(Collections.emptyList()),
                 new CompositeCustomizer<>(Collections.emptyList()))).isNotNull();
+        final FallbackDecorators fallbackDecorators = new FallbackDecorators(Arrays.asList(new CompletionStageFallbackDecorator()));
+        final DefaultSpelResolver spelResolver = new DefaultSpelResolver(new SpelExpressionParser(), new StandardReflectionParameterNameDiscoverer(), new GenericApplicationContext());
         assertThat(rateLimiterConfigurationOnMissingBean
             .rateLimiterAspect(new RateLimiterConfigurationProperties(),
                 RateLimiterRegistry.ofDefaults(), Collections.emptyList(),
-                new FallbackDecorators(Arrays.asList(new CompletionStageFallbackDecorator())),
-                new DefaultSpelResolver(new SpelExpressionParser(), new StandardReflectionParameterNameDiscoverer(), new GenericApplicationContext()))).isNotNull();
+                new FallbackExecutor(spelResolver, fallbackDecorators),
+                spelResolver)).isNotNull();
         assertThat(rateLimiterConfigurationOnMissingBean
             .rateLimiterRegistryEventConsumer(Optional.empty())).isNotNull();
     }
@@ -149,11 +158,13 @@ public class SpringBootCommonTest {
                 new CompositeCustomizer<>(Collections.singletonList(
                     TimeLimiterConfigCustomizer.of("backend", builder -> builder.timeoutDuration(
                         Duration.ofSeconds(10))))))).isNotNull();
+        final DefaultSpelResolver spelResolver = new DefaultSpelResolver(new SpelExpressionParser(), new StandardReflectionParameterNameDiscoverer(), new GenericApplicationContext());
+        final FallbackDecorators fallbackDecorators = new FallbackDecorators(Arrays.asList(new CompletionStageFallbackDecorator()));
         assertThat(timeLimiterConfigurationOnMissingBean
             .timeLimiterAspect(new TimeLimiterConfigurationProperties(),
                 TimeLimiterRegistry.ofDefaults(), Collections.emptyList(),
-                new FallbackDecorators(Arrays.asList(new CompletionStageFallbackDecorator())),
-                new DefaultSpelResolver(new SpelExpressionParser(), new StandardReflectionParameterNameDiscoverer(), new GenericApplicationContext()),
+                new FallbackExecutor(spelResolver, fallbackDecorators),
+                spelResolver,
                 null)).isNotNull();
         assertThat(timeLimiterConfigurationOnMissingBean
             .timeLimiterRegistryEventConsumer(Optional.empty())).isNotNull();

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/bulkhead/autoconfigure/BulkheadConfigurationOnMissingBeanTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/bulkhead/autoconfigure/BulkheadConfigurationOnMissingBeanTest.java
@@ -24,7 +24,7 @@ import io.github.resilience4j.bulkhead.configure.BulkheadConfiguration;
 import io.github.resilience4j.bulkhead.event.BulkheadEvent;
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
-import io.github.resilience4j.fallback.FallbackDecorators;
+import io.github.resilience4j.fallback.FallbackExecutor;
 import io.github.resilience4j.spelresolver.SpelResolver;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -95,12 +95,12 @@ public class BulkheadConfigurationOnMissingBeanTest {
             BulkheadRegistry bulkheadRegistry,
             ThreadPoolBulkheadRegistry threadPoolBulkheadRegistry,
             @Autowired(required = false) List<BulkheadAspectExt> bulkheadAspectExts,
-            FallbackDecorators fallbackDecorators,
+            FallbackExecutor fallbackExecutor,
             SpelResolver spelResolver
         ) {
             bulkheadAspect = new BulkheadAspect(new BulkheadProperties(),
                 threadPoolBulkheadRegistry, bulkheadRegistry, bulkheadAspectExts,
-                fallbackDecorators, spelResolver);
+                fallbackExecutor, spelResolver);
             return bulkheadAspect;
         }
 

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/circuitbreaker/autoconfigure/CircuitBreakerConfigurationOnMissingBeanTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/circuitbreaker/autoconfigure/CircuitBreakerConfigurationOnMissingBeanTest.java
@@ -8,7 +8,7 @@ import io.github.resilience4j.circuitbreaker.configure.CircuitBreakerConfigurati
 import io.github.resilience4j.circuitbreaker.event.CircuitBreakerEvent;
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
-import io.github.resilience4j.fallback.FallbackDecorators;
+import io.github.resilience4j.fallback.FallbackExecutor;
 import io.github.resilience4j.spelresolver.SpelResolver;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -81,10 +81,10 @@ public class CircuitBreakerConfigurationOnMissingBeanTest {
         public CircuitBreakerAspect circuitBreakerAspect(
             CircuitBreakerRegistry circuitBreakerRegistry,
             @Autowired(required = false) List<CircuitBreakerAspectExt> circuitBreakerAspectExtList,
-            FallbackDecorators recoveryDecorators,
+            FallbackExecutor fallbackExecutor,
             SpelResolver spelResolver) {
             circuitBreakerAspect = new CircuitBreakerAspect(new CircuitBreakerProperties(),
-                circuitBreakerRegistry, circuitBreakerAspectExtList, recoveryDecorators, spelResolver);
+                circuitBreakerRegistry, circuitBreakerAspectExtList, fallbackExecutor, spelResolver);
             return circuitBreakerAspect;
         }
 

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/ratelimiter/autoconfigure/RateLimiterConfigurationOnMissingBeanTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/ratelimiter/autoconfigure/RateLimiterConfigurationOnMissingBeanTest.java
@@ -3,7 +3,7 @@ package io.github.resilience4j.ratelimiter.autoconfigure;
 import io.github.resilience4j.TestUtils;
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
-import io.github.resilience4j.fallback.FallbackDecorators;
+import io.github.resilience4j.fallback.FallbackExecutor;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
 import io.github.resilience4j.ratelimiter.configure.RateLimiterAspect;
@@ -83,14 +83,14 @@ public class RateLimiterConfigurationOnMissingBeanTest {
         public RateLimiterAspect rateLimiterAspect(
             RateLimiterRegistry rateLimiterRegistry,
             @Autowired(required = false) List<RateLimiterAspectExt> rateLimiterAspectExtList,
-            FallbackDecorators fallbackDecorators,
+            FallbackExecutor fallbackExecutor,
             SpelResolver spelResolver
         ) {
             rateLimiterAspect = new RateLimiterAspect(
                 rateLimiterRegistry,
                 new RateLimiterConfigurationProperties(),
                 rateLimiterAspectExtList,
-                fallbackDecorators,
+                fallbackExecutor,
                 spelResolver
             );
             return rateLimiterAspect;

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/retry/autoconfigure/RetryConfigurationOnMissingBeanTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/retry/autoconfigure/RetryConfigurationOnMissingBeanTest.java
@@ -19,7 +19,7 @@ import io.github.resilience4j.TestUtils;
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
 import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
-import io.github.resilience4j.fallback.FallbackDecorators;
+import io.github.resilience4j.fallback.FallbackExecutor;
 import io.github.resilience4j.retry.RetryRegistry;
 import io.github.resilience4j.retry.configure.RetryAspect;
 import io.github.resilience4j.retry.configure.RetryAspectExt;
@@ -93,12 +93,12 @@ public class RetryConfigurationOnMissingBeanTest {
         public RetryAspect retryAspect(
             RetryRegistry retryRegistry,
             @Autowired(required = false) List<RetryAspectExt> retryAspectExts,
-            FallbackDecorators fallbackDecorators,
+            FallbackExecutor fallbackExecutor,
             SpelResolver spelResolver,
             @Autowired(required = false) ContextAwareScheduledThreadPoolExecutor contextAwareScheduledThreadPoolExecutor
         ) {
             this.retryAspect = new RetryAspect(new RetryProperties(), retryRegistry,
-                retryAspectExts, fallbackDecorators, spelResolver, contextAwareScheduledThreadPoolExecutor);
+                retryAspectExts, fallbackExecutor, spelResolver, contextAwareScheduledThreadPoolExecutor);
             return retryAspect;
         }
 

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/bulkhead/configure/BulkheadConfiguration.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/bulkhead/configure/BulkheadConfiguration.java
@@ -28,7 +28,7 @@ import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
 import io.github.resilience4j.core.registry.CompositeRegistryEventConsumer;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
-import io.github.resilience4j.fallback.FallbackDecorators;
+import io.github.resilience4j.fallback.FallbackExecutor;
 import io.github.resilience4j.fallback.configure.FallbackConfiguration;
 import io.github.resilience4j.spelresolver.SpelResolver;
 import io.github.resilience4j.spelresolver.configure.SpelResolverConfiguration;
@@ -141,11 +141,11 @@ public class BulkheadConfiguration {
         ThreadPoolBulkheadRegistry threadPoolBulkheadRegistry,
         BulkheadRegistry bulkheadRegistry,
         @Autowired(required = false) List<BulkheadAspectExt> bulkHeadAspectExtList,
-        FallbackDecorators fallbackDecorators,
+        FallbackExecutor fallbackExecutor,
         SpelResolver spelResolver
     ) {
         return new BulkheadAspect(bulkheadConfigurationProperties, threadPoolBulkheadRegistry,
-            bulkheadRegistry, bulkHeadAspectExtList, fallbackDecorators, spelResolver);
+            bulkheadRegistry, bulkHeadAspectExtList, fallbackExecutor, spelResolver);
     }
 
     @Bean

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/circuitbreaker/configure/CircuitBreakerConfiguration.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/circuitbreaker/configure/CircuitBreakerConfiguration.java
@@ -26,17 +26,16 @@ import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
 import io.github.resilience4j.core.registry.CompositeRegistryEventConsumer;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
-import io.github.resilience4j.fallback.FallbackDecorators;
+import io.github.resilience4j.fallback.FallbackExecutor;
+import io.github.resilience4j.fallback.configure.FallbackConfiguration;
 import io.github.resilience4j.spelresolver.SpelResolver;
+import io.github.resilience4j.spelresolver.configure.SpelResolverConfiguration;
 import io.github.resilience4j.utils.AspectJOnClasspathCondition;
 import io.github.resilience4j.utils.ReactorOnClasspathCondition;
 import io.github.resilience4j.utils.RxJava2OnClasspathCondition;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -49,6 +48,7 @@ import java.util.stream.Collectors;
  * resilience4j-circuitbreaker.
  */
 @Configuration
+@Import({FallbackConfiguration.class, SpelResolverConfiguration.class})
 public class CircuitBreakerConfiguration {
 
     private final CircuitBreakerConfigurationProperties circuitBreakerProperties;
@@ -93,11 +93,11 @@ public class CircuitBreakerConfiguration {
     public CircuitBreakerAspect circuitBreakerAspect(
         CircuitBreakerRegistry circuitBreakerRegistry,
         @Autowired(required = false) List<CircuitBreakerAspectExt> circuitBreakerAspectExtList,
-        FallbackDecorators fallbackDecorators,
+        FallbackExecutor fallbackExecutor,
         SpelResolver spelResolver
     ) {
         return new CircuitBreakerAspect(circuitBreakerProperties, circuitBreakerRegistry,
-            circuitBreakerAspectExtList, fallbackDecorators, spelResolver);
+            circuitBreakerAspectExtList, fallbackExecutor, spelResolver);
     }
 
 

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/fallback/FallbackExecutor.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/fallback/FallbackExecutor.java
@@ -1,0 +1,28 @@
+package io.github.resilience4j.fallback;
+
+import io.github.resilience4j.spelresolver.SpelResolver;
+import io.vavr.CheckedFunction0;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.util.StringUtils;
+
+import java.lang.reflect.Method;
+
+public class FallbackExecutor {
+    private final SpelResolver spelResolver;
+    private final FallbackDecorators fallbackDecorators;
+
+    public FallbackExecutor(SpelResolver spelResolver, FallbackDecorators fallbackDecorators) {
+        this.spelResolver = spelResolver;
+        this.fallbackDecorators = fallbackDecorators;
+    }
+
+    public Object execute(ProceedingJoinPoint proceedingJoinPoint, Method method, String fallbackMethodValue, CheckedFunction0<Object> primaryFunction) throws Throwable {
+        String fallbackMethodName = spelResolver.resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue);
+        if (StringUtils.isEmpty(fallbackMethodName)) {
+            return primaryFunction.apply();
+        }
+        FallbackMethod fallbackMethod = FallbackMethod
+            .create(fallbackMethodName, method, proceedingJoinPoint.getArgs(), proceedingJoinPoint.getTarget());
+        return fallbackDecorators.decorate(fallbackMethod, primaryFunction).apply();
+    }
+}

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/fallback/configure/FallbackConfiguration.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/fallback/configure/FallbackConfiguration.java
@@ -16,12 +16,15 @@
 package io.github.resilience4j.fallback.configure;
 
 import io.github.resilience4j.fallback.*;
+import io.github.resilience4j.spelresolver.SpelResolver;
+import io.github.resilience4j.spelresolver.configure.SpelResolverConfiguration;
 import io.github.resilience4j.utils.ReactorOnClasspathCondition;
 import io.github.resilience4j.utils.RxJava2OnClasspathCondition;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 import java.util.List;
 
@@ -29,6 +32,7 @@ import java.util.List;
  * {@link Configuration} for {@link FallbackDecorators}.
  */
 @Configuration
+@Import(SpelResolverConfiguration.class)
 public class FallbackConfiguration {
 
     @Bean
@@ -51,5 +55,10 @@ public class FallbackConfiguration {
     @Bean
     public FallbackDecorators fallbackDecorators(@Autowired(required = false) List<FallbackDecorator> fallbackDecorator) {
         return new FallbackDecorators(fallbackDecorator);
+    }
+
+    @Bean
+    public FallbackExecutor fallbackExecutor(SpelResolver spelResolver, FallbackDecorators fallbackDecorators) {
+        return new FallbackExecutor(spelResolver, fallbackDecorators);
     }
 }

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/ratelimiter/configure/RateLimiterConfiguration.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/ratelimiter/configure/RateLimiterConfiguration.java
@@ -23,21 +23,20 @@ import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
 import io.github.resilience4j.core.registry.CompositeRegistryEventConsumer;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
-import io.github.resilience4j.fallback.FallbackDecorators;
+import io.github.resilience4j.fallback.FallbackExecutor;
+import io.github.resilience4j.fallback.configure.FallbackConfiguration;
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
 import io.github.resilience4j.ratelimiter.event.RateLimiterEvent;
 import io.github.resilience4j.spelresolver.SpelResolver;
+import io.github.resilience4j.spelresolver.configure.SpelResolverConfiguration;
 import io.github.resilience4j.utils.AspectJOnClasspathCondition;
 import io.github.resilience4j.utils.ReactorOnClasspathCondition;
 import io.github.resilience4j.utils.RxJava2OnClasspathCondition;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.*;
 import org.springframework.lang.Nullable;
 
 import java.util.ArrayList;
@@ -51,6 +50,7 @@ import java.util.stream.Collectors;
  * ratelimiter.
  */
 @Configuration
+@Import({FallbackConfiguration.class, SpelResolverConfiguration.class})
 public class RateLimiterConfiguration {
 
     @Bean
@@ -144,11 +144,11 @@ public class RateLimiterConfiguration {
         RateLimiterConfigurationProperties rateLimiterProperties,
         RateLimiterRegistry rateLimiterRegistry,
         @Autowired(required = false) List<RateLimiterAspectExt> rateLimiterAspectExtList,
-        FallbackDecorators fallbackDecorators,
+        FallbackExecutor fallbackExecutor,
         SpelResolver spelResolver
     ) {
         return new RateLimiterAspect(rateLimiterRegistry, rateLimiterProperties,
-            rateLimiterAspectExtList, fallbackDecorators, spelResolver);
+            rateLimiterAspectExtList, fallbackExecutor, spelResolver);
     }
 
     @Bean

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/retry/configure/RetryConfiguration.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/retry/configure/RetryConfiguration.java
@@ -23,21 +23,20 @@ import io.github.resilience4j.consumer.EventConsumerRegistry;
 import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
 import io.github.resilience4j.core.registry.CompositeRegistryEventConsumer;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
-import io.github.resilience4j.fallback.FallbackDecorators;
+import io.github.resilience4j.fallback.FallbackExecutor;
+import io.github.resilience4j.fallback.configure.FallbackConfiguration;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.retry.RetryRegistry;
 import io.github.resilience4j.retry.event.RetryEvent;
 import io.github.resilience4j.spelresolver.SpelResolver;
+import io.github.resilience4j.spelresolver.configure.SpelResolverConfiguration;
 import io.github.resilience4j.utils.AspectJOnClasspathCondition;
 import io.github.resilience4j.utils.ReactorOnClasspathCondition;
 import io.github.resilience4j.utils.RxJava2OnClasspathCondition;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -49,6 +48,7 @@ import java.util.stream.Collectors;
  * {@link Configuration Configuration} for resilience4j-retry.
  */
 @Configuration
+@Import({FallbackConfiguration.class, SpelResolverConfiguration.class})
 public class RetryConfiguration {
 
 
@@ -145,12 +145,12 @@ public class RetryConfiguration {
         RetryConfigurationProperties retryConfigurationProperties,
         RetryRegistry retryRegistry,
         @Autowired(required = false) List<RetryAspectExt> retryAspectExtList,
-        FallbackDecorators fallbackDecorators,
+        FallbackExecutor fallbackExecutor,
         SpelResolver spelResolver,
         @Autowired(required = false) ContextAwareScheduledThreadPoolExecutor contextAwareScheduledThreadPoolExecutor
     ) {
         return new RetryAspect(retryConfigurationProperties, retryRegistry, retryAspectExtList,
-            fallbackDecorators, spelResolver, contextAwareScheduledThreadPoolExecutor);
+            fallbackExecutor, spelResolver, contextAwareScheduledThreadPoolExecutor);
     }
 
     @Bean

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/timelimiter/configure/TimeLimiterConfiguration.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/timelimiter/configure/TimeLimiterConfiguration.java
@@ -24,8 +24,10 @@ import io.github.resilience4j.consumer.EventConsumerRegistry;
 import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
 import io.github.resilience4j.core.registry.CompositeRegistryEventConsumer;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
-import io.github.resilience4j.fallback.FallbackDecorators;
+import io.github.resilience4j.fallback.FallbackExecutor;
+import io.github.resilience4j.fallback.configure.FallbackConfiguration;
 import io.github.resilience4j.spelresolver.SpelResolver;
+import io.github.resilience4j.spelresolver.configure.SpelResolverConfiguration;
 import io.github.resilience4j.timelimiter.TimeLimiter;
 import io.github.resilience4j.timelimiter.TimeLimiterConfig;
 import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
@@ -36,10 +38,7 @@ import io.github.resilience4j.utils.RxJava2OnClasspathCondition;
 import io.vavr.collection.HashMap;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -51,6 +50,7 @@ import java.util.stream.Collectors;
  * {@link Configuration} for resilience4j-timelimiter.
  */
 @Configuration
+@Import({FallbackConfiguration.class, SpelResolverConfiguration.class})
 public class TimeLimiterConfiguration {
 
     @Bean
@@ -88,11 +88,11 @@ public class TimeLimiterConfiguration {
         TimeLimiterConfigurationProperties timeLimiterConfigurationProperties,
         TimeLimiterRegistry timeLimiterRegistry,
         @Autowired(required = false) List<TimeLimiterAspectExt> timeLimiterAspectExtList,
-        FallbackDecorators fallbackDecorators,
+        FallbackExecutor fallbackExecutor,
         SpelResolver spelResolver,
         @Autowired(required = false) ContextAwareScheduledThreadPoolExecutor contextAwareScheduledThreadPoolExecutor
     ) {
-        return new TimeLimiterAspect(timeLimiterRegistry, timeLimiterConfigurationProperties, timeLimiterAspectExtList, fallbackDecorators, spelResolver, contextAwareScheduledThreadPoolExecutor);
+        return new TimeLimiterAspect(timeLimiterRegistry, timeLimiterConfigurationProperties, timeLimiterAspectExtList, fallbackExecutor, spelResolver, contextAwareScheduledThreadPoolExecutor);
     }
 
     @Bean

--- a/resilience4j-spring/src/test/java/io/github/resilience4j/bulkhead/configure/BulkHeadConfigurationSpringTest.java
+++ b/resilience4j-spring/src/test/java/io/github/resilience4j/bulkhead/configure/BulkHeadConfigurationSpringTest.java
@@ -22,7 +22,7 @@ import io.github.resilience4j.bulkhead.event.BulkheadEvent;
 import io.github.resilience4j.common.bulkhead.configuration.ThreadPoolBulkheadConfigurationProperties;
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
-import io.github.resilience4j.fallback.FallbackDecorators;
+import io.github.resilience4j.fallback.FallbackExecutor;
 import io.github.resilience4j.spelresolver.SpelResolver;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -95,12 +95,12 @@ public class BulkHeadConfigurationSpringTest {
             BulkheadRegistry bulkheadRegistry,
             ThreadPoolBulkheadRegistry threadPoolBulkheadRegistry,
             @Autowired(required = false) List<BulkheadAspectExt> bulkheadAspectExts,
-            FallbackDecorators fallbackDecorators,
+            FallbackExecutor fallbackExecutor,
             SpelResolver spelResolver
         ) {
             bulkheadAspect = new BulkheadAspect(bulkheadConfigurationProperties(),
                 threadPoolBulkheadRegistry, bulkheadRegistry, bulkheadAspectExts,
-                fallbackDecorators, spelResolver);
+                fallbackExecutor, spelResolver);
             return bulkheadAspect;
         }
 

--- a/resilience4j-spring/src/test/java/io/github/resilience4j/ratelimiter/configure/RateLimiterConfigurationSpringTest.java
+++ b/resilience4j-spring/src/test/java/io/github/resilience4j/ratelimiter/configure/RateLimiterConfigurationSpringTest.java
@@ -17,7 +17,7 @@ package io.github.resilience4j.ratelimiter.configure;
 
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
-import io.github.resilience4j.fallback.FallbackDecorators;
+import io.github.resilience4j.fallback.FallbackExecutor;
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
 import io.github.resilience4j.ratelimiter.event.RateLimiterEvent;
 import io.github.resilience4j.spelresolver.SpelResolver;
@@ -76,11 +76,11 @@ public class RateLimiterConfigurationSpringTest {
         public RateLimiterAspect rateLimiterAspect(
             RateLimiterRegistry rateLimiterRegistry,
             @Autowired(required = false) List<RateLimiterAspectExt> rateLimiterAspectExts,
-            FallbackDecorators recoveryDecorators,
+            FallbackExecutor fallbackExecutor,
             SpelResolver spelResolver
         ) {
             rateLimiterAspect = new RateLimiterAspect(rateLimiterRegistry,
-                rateLimiterConfigurationProperties(), rateLimiterAspectExts, recoveryDecorators, spelResolver);
+                rateLimiterConfigurationProperties(), rateLimiterAspectExts, fallbackExecutor, spelResolver);
             return rateLimiterAspect;
         }
 

--- a/resilience4j-spring/src/test/java/io/github/resilience4j/retry/configure/RetryConfigurationSpringTest.java
+++ b/resilience4j-spring/src/test/java/io/github/resilience4j/retry/configure/RetryConfigurationSpringTest.java
@@ -18,7 +18,7 @@ package io.github.resilience4j.retry.configure;
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
 import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
-import io.github.resilience4j.fallback.FallbackDecorators;
+import io.github.resilience4j.fallback.FallbackExecutor;
 import io.github.resilience4j.fallback.configure.FallbackConfiguration;
 import io.github.resilience4j.retry.RetryRegistry;
 import io.github.resilience4j.retry.event.RetryEvent;
@@ -81,11 +81,11 @@ public class RetryConfigurationSpringTest {
         public RetryAspect retryAspect(
             RetryRegistry retryRegistry,
             @Autowired(required = false) List<RetryAspectExt> retryAspectExts,
-            FallbackDecorators fallbackDecorators,
+            FallbackExecutor fallbackExecutor,
             SpelResolver spelResolver
         ) {
             retryAspect = new RetryAspect(retryConfigurationProperties(), retryRegistry,
-                retryAspectExts, fallbackDecorators, spelResolver,contextAwareScheduledThreadPoolExecutor);
+                retryAspectExts, fallbackExecutor, spelResolver,contextAwareScheduledThreadPoolExecutor);
             return retryAspect;
         }
 

--- a/resilience4j-spring/src/test/java/io/github/resilience4j/timelimiter/configure/TimeLimiterConfigurationSpringTest.java
+++ b/resilience4j-spring/src/test/java/io/github/resilience4j/timelimiter/configure/TimeLimiterConfigurationSpringTest.java
@@ -3,7 +3,7 @@ package io.github.resilience4j.timelimiter.configure;
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
 import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
-import io.github.resilience4j.fallback.FallbackDecorators;
+import io.github.resilience4j.fallback.FallbackExecutor;
 import io.github.resilience4j.spelresolver.SpelResolver;
 import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
 import io.github.resilience4j.timelimiter.event.TimeLimiterEvent;
@@ -67,10 +67,10 @@ public class TimeLimiterConfigurationSpringTest {
         public TimeLimiterAspect timeLimiterAspect(
             TimeLimiterRegistry timeLimiterRegistry,
             @Autowired(required = false) List<TimeLimiterAspectExt> timeLimiterAspectExtList,
-            FallbackDecorators fallbackDecorators,
+            FallbackExecutor fallbackExecutor,
             SpelResolver spelResolver
         ) {
-            timeLimiterAspect = new TimeLimiterAspect(timeLimiterRegistry, timeLimiterConfigurationProperties(), timeLimiterAspectExtList, fallbackDecorators, spelResolver, contextAwareScheduledThreadPoolExecutor);
+            timeLimiterAspect = new TimeLimiterAspect(timeLimiterRegistry, timeLimiterConfigurationProperties(), timeLimiterAspectExtList, fallbackExecutor, spelResolver, contextAwareScheduledThreadPoolExecutor);
             return timeLimiterAspect;
         }
 


### PR DESCRIPTION
Eliminated duplicate code around fallback method handling in following classes

1. CircuitBreakerAspect
2. RateLimiterAspect
3. BulkheadAspect
4. TimeLimiterAspect
5. RetryAspect

Extracted duplicate code for following and put in FallbackMethodExecutor class; replaced FallbackMethodDecorators dependency with FallbackMethodExecutor in all *Aspect classes
 - Resolving fallback method
- execution path when fallback method exists
- execution path when fallback method name is empty