### PR TITLE
chore(ci): use temurin jdk

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Cache SonarCloud packages
         uses: actions/cache@v2.1.6
         if: env.SONAR_TOKEN != null && env.SONAR_TOKEN != ''


### PR DESCRIPTION
https://github.com/actions/setup-java#supported-distributions

NOTE: Adopt OpenJDK got moved to Eclipse Temurin and
won't be updated anymore. It is highly recommended
to migrate workflows from adopt to temurin to keep
receiving software and security updates.
