### PR TITLE
Restore Java 8 compatibility to DropWizards Metrics Module

### DIFF
--- a/resilience4j-metrics/src/main/java/io/github/resilience4j/metrics/BulkheadMetrics.java
+++ b/resilience4j-metrics/src/main/java/io/github/resilience4j/metrics/BulkheadMetrics.java
@@ -22,7 +22,7 @@ import com.codahale.metrics.MetricSet;
 import io.github.resilience4j.bulkhead.Bulkhead;
 import io.github.resilience4j.bulkhead.BulkheadRegistry;
 
-import java.util.List;
+import java.util.Collections;
 import java.util.Map;
 
 import static com.codahale.metrics.MetricRegistry.name;
@@ -133,7 +133,7 @@ public class BulkheadMetrics implements MetricSet {
      * @param bulkhead the circuit breaker
      */
     public static BulkheadMetrics ofBulkhead(Bulkhead bulkhead) {
-        return new BulkheadMetrics(List.of(bulkhead));
+        return new BulkheadMetrics(Collections.singletonList(bulkhead));
     }
 
     @Override

--- a/resilience4j-metrics/src/main/java/io/github/resilience4j/metrics/CircuitBreakerMetrics.java
+++ b/resilience4j-metrics/src/main/java/io/github/resilience4j/metrics/CircuitBreakerMetrics.java
@@ -25,7 +25,7 @@ import com.codahale.metrics.MetricSet;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 
-import java.util.List;
+import java.util.Collections;
 import java.util.Map;
 
 import static com.codahale.metrics.MetricRegistry.name;
@@ -155,7 +155,7 @@ public class CircuitBreakerMetrics implements MetricSet {
      * @param circuitBreaker the circuit breaker
      */
     public static CircuitBreakerMetrics ofCircuitBreaker(CircuitBreaker circuitBreaker) {
-        return new CircuitBreakerMetrics(List.of(circuitBreaker));
+        return new CircuitBreakerMetrics(Collections.singletonList(circuitBreaker));
     }
 
     @Override

--- a/resilience4j-metrics/src/main/java/io/github/resilience4j/metrics/RateLimiterMetrics.java
+++ b/resilience4j-metrics/src/main/java/io/github/resilience4j/metrics/RateLimiterMetrics.java
@@ -25,7 +25,7 @@ import com.codahale.metrics.MetricSet;
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
 
-import java.util.List;
+import java.util.Collections;
 import java.util.Map;
 
 import static com.codahale.metrics.MetricRegistry.name;
@@ -140,7 +140,7 @@ public class RateLimiterMetrics implements MetricSet {
      * @param rateLimiter the rate limiter
      */
     public static RateLimiterMetrics ofRateLimiter(RateLimiter rateLimiter) {
-        return new RateLimiterMetrics(List.of(rateLimiter));
+        return new RateLimiterMetrics(Collections.singletonList(rateLimiter));
     }
 
     @Override

--- a/resilience4j-metrics/src/main/java/io/github/resilience4j/metrics/RetryMetrics.java
+++ b/resilience4j-metrics/src/main/java/io/github/resilience4j/metrics/RetryMetrics.java
@@ -7,7 +7,7 @@ import com.codahale.metrics.MetricSet;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryRegistry;
 
-import java.util.List;
+import java.util.Collections;
 import java.util.Map;
 
 import static com.codahale.metrics.MetricRegistry.name;
@@ -72,7 +72,7 @@ public class RetryMetrics implements MetricSet {
     }
 
     public static RetryMetrics ofRetry(Retry retry) {
-        return new RetryMetrics(List.of(retry));
+        return new RetryMetrics(Collections.singletonList(retry));
     }
 
     @Override

--- a/resilience4j-metrics/src/main/java/io/github/resilience4j/metrics/ThreadPoolBulkheadMetrics.java
+++ b/resilience4j-metrics/src/main/java/io/github/resilience4j/metrics/ThreadPoolBulkheadMetrics.java
@@ -24,7 +24,7 @@ import io.github.resilience4j.bulkhead.BulkheadRegistry;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkheadRegistry;
 
-import java.util.List;
+import java.util.Collections;
 import java.util.Map;
 
 import static com.codahale.metrics.MetricRegistry.name;
@@ -137,7 +137,7 @@ public class ThreadPoolBulkheadMetrics implements MetricSet {
      * @param bulkhead the circuit breaker
      */
     public static ThreadPoolBulkheadMetrics ofBulkhead(ThreadPoolBulkhead bulkhead) {
-        return new ThreadPoolBulkheadMetrics(List.of(bulkhead));
+        return new ThreadPoolBulkheadMetrics(Collections.singletonList(bulkhead));
     }
 
     @Override

--- a/resilience4j-metrics/src/main/java/io/github/resilience4j/metrics/TimeLimiterMetrics.java
+++ b/resilience4j-metrics/src/main/java/io/github/resilience4j/metrics/TimeLimiterMetrics.java
@@ -25,7 +25,7 @@ import com.codahale.metrics.MetricSet;
 import io.github.resilience4j.timelimiter.TimeLimiter;
 import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
 
-import java.util.List;
+import java.util.Collections;
 import java.util.Map;
 
 import static com.codahale.metrics.MetricRegistry.name;
@@ -139,7 +139,7 @@ public class TimeLimiterMetrics implements MetricSet {
      * @param timeLimiter the time limiter
      */
     public static TimeLimiterMetrics ofTimeLimiter(TimeLimiter timeLimiter) {
-        return new TimeLimiterMetrics(List.of(timeLimiter));
+        return new TimeLimiterMetrics(Collections.singletonList(timeLimiter));
     }
 
     @Override


### PR DESCRIPTION
* Replaced usages of `List.of` with `Collections.singletonList`

Other usages of List.of, Set.of, and Map.of are scattered throughout Resilience4j,
however the others are in test classes, so not necessarily a big deal.