### PR TITLE
Issue #1683: SemaphoreBasedRateLimiter could cause memory leak 

### DIFF
--- a/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/RateLimiter.java
+++ b/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/RateLimiter.java
@@ -29,6 +29,7 @@ import io.github.resilience4j.ratelimiter.event.RateLimiterOnFailureEvent;
 import io.github.resilience4j.ratelimiter.event.RateLimiterOnSuccessEvent;
 import io.github.resilience4j.ratelimiter.internal.AtomicRateLimiter;
 
+import java.io.Closeable;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -49,7 +50,7 @@ import static java.util.Collections.emptyMap;
  * necessary until a permit is available, and then takes it. Once acquired, permits need not be
  * released.
  */
-public interface RateLimiter {
+public interface RateLimiter extends Closeable {
 
     /**
      * Creates a RateLimiter with a custom RateLimiter configuration.

--- a/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/internal/AtomicRateLimiter.java
+++ b/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/internal/AtomicRateLimiter.java
@@ -24,6 +24,7 @@ import static java.lang.Thread.currentThread;
 import static java.util.Collections.emptyMap;
 import static java.util.concurrent.locks.LockSupport.parkNanos;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -411,6 +412,11 @@ public class AtomicRateLimiter implements RateLimiter {
             return;
         }
         eventProcessor.consumeEvent(new RateLimiterOnFailureEvent(name, permits));
+    }
+
+    @Override
+    public void close() throws IOException {
+
     }
 
     /**


### PR DESCRIPTION
Resilience4j version:
1.7.1
Java version:
1.8

SemaphoreBasedRateLimiter use scheduledExecutorService to refresh permit, but it didn't provide a way to shut down or close it, even if there are no references  to SemaphoreBasedRateLimiter  instance,  the schedule tasks are still running,  so SemaphoreBasedRateLimiter can't be garbage collected.

> In our use case , we'll create millions of SemaphoreBasedRateLimiter instance, so after some long running,  jvm will be filled with SemaphoreBasedRateLimiter instances, and cause too much full gc, jvm is basically dead

```java

    private void scheduleLimitRefresh() {
        scheduler.scheduleAtFixedRate(
            this::refreshLimit,
            this.rateLimiterConfig.get().getLimitRefreshPeriod().toNanos(),
            this.rateLimiterConfig.get().getLimitRefreshPeriod().toNanos(),
            TimeUnit.NANOSECONDS
        );
    }
```