### PR TITLE
:zap: Gradle optimizations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,6 +130,7 @@ task jacocoMergeTest(type: JacocoMerge) {
 }
 
 task jacocoRootTestReport(type: JacocoReport) {
+    dependsOn test
 
     coreProjects.each { dependsOn("${it.name}:test") }
     coreProjects.each { dependsOn("${it.name}:jacocoTestReport") }

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,10 @@ allprojects {
     }
 }
 
+asciidoctorj {
+    noDefaultRepositories = true
+}
+
 ext {
     coreProjects = subprojects.findAll {
         p -> !p.name.endsWith("-bom")

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ configure(project.coreProjects) {
 
     jacocoTestReport {
         reports {
-            xml.enabled true
+            xml.required.set(true)
         }
     }
 
@@ -149,10 +149,10 @@ task jacocoRootTestReport(type: JacocoReport) {
     }
 
     reports {
-        xml.enabled true
+        xml.required.set(true)
         xml.destination file(allTestCoverageFile)
-        html.enabled true
-        csv.enabled false
+        html.required.set(true)
+        csv.required.set(false)
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 kotlin.code.style=official
 systemProp.file.encoding=UTF-8
 systemProp.sun.jnu.encoding=UTF-8
+org.gradle.caching=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip

--- a/publishing.gradle
+++ b/publishing.gradle
@@ -9,6 +9,15 @@ ext {
 def projectArtifactId = 'resilience4j'
 def url = "https://resilience4j.readme.io"
 
+normalization {
+    runtimeClasspath {
+        metaInf {
+            ignoreAttribute("Build-Time")
+            ignoreAttribute("Build-Date")
+        }
+    }
+}
+
 jar {
     manifest {
         attributes(

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,7 @@
+buildCache {
+    local { enabled = true }
+}
+
 rootProject.name = 'resilience4j'
 include 'resilience4j-test'
 include 'resilience4j-core'


### PR DESCRIPTION
fixes #1688 

- upgrades Gradle
- resolves deprecation errors by disabling  asciidoctor plugin adding jcenter as a repository
- enables caching
- fix implicit dependency warning between  jacocoRootTestReport and test task
- configure gradle to ignore changes in certain manifest attributes on the runtime classpath as reasons to rerun tasks. This means that the `test` task can now be "up to date" and not rerun when no changes have been detected