### PR TITLE
Feature: add fallback decorator to reactor operators

### DIFF
--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/ReactorOperatorFallbackDecorator.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/ReactorOperatorFallbackDecorator.java
@@ -1,0 +1,133 @@
+package io.github.resilience4j.reactor;
+
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.reactor.circuitbreaker.operator.CircuitBreakerOperator;
+import io.github.resilience4j.reactor.retry.RetryOperator;
+import io.github.resilience4j.reactor.timelimiter.TimeLimiterOperator;
+import io.github.resilience4j.retry.MaxRetriesExceededException;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
+/**
+ * A decorator that applies the fallback logic for reactive operator.
+ * Users need to call {@link #decorate(UnaryOperator)} and provide the operator to decorate after instantiating
+ * a {@link ReactorOperatorFallbackDecorator } with the desired fallback publisher.
+ *
+ * @param <T> the value type of the upstream and downstream
+ */
+public class ReactorOperatorFallbackDecorator<T> implements UnaryOperator<Publisher<T>> {
+
+    private final Map<Class<? extends Throwable>, Publisher<T>> FALLBACK_PUBLISHER_CACHE = new HashMap<>();
+
+
+    private ReactorOperatorFallbackDecorator(Class<? extends Throwable> throwableType, Publisher<T> fallback) {
+        FALLBACK_PUBLISHER_CACHE.put(throwableType, fallback);
+    }
+
+    /**
+     * Adds a fallback publisher that will be used if the underline publisher completes with on error of this fallbackThrowable type
+     *
+     * @param throwableType the type of throwable that triggers the fallback
+     * @param fallback      the publisher to subscribe to when a Throwable of type throwableClass is thrown
+     * @return the function to apply to the stream (typically by calling {{@link Mono#transformDeferred(Function)}} or {@link Flux#transformDeferred(Function)}
+     */
+    public ReactorOperatorFallbackDecorator<T> withFallback(Class<? extends Throwable> throwableType, Publisher<T> fallback) {
+        FALLBACK_PUBLISHER_CACHE.put(throwableType, fallback);
+        return this;
+    }
+
+    /**
+     * Initializes a {@link ReactorOperatorFallbackDecorator} that will fallback when the publisher finishes with an error of the provided class.
+     *
+     * @param throwableType the type of throwable that triggers the fallback
+     * @param fallback      the publisher to subscribe to when a Throwable of type throwableClass is thrown
+     * @param <T>           the value type of the upstream and downstream
+     * @return ReactorOperatorFallbackDecorator that can be used to decorate an operator with fallback
+     * @see #decorate(UnaryOperator)
+     */
+    public static <T> ReactorOperatorFallbackDecorator<T> of(Class<? extends Throwable> throwableType, Publisher<T> fallback) {
+        return new ReactorOperatorFallbackDecorator<>(throwableType, fallback);
+    }
+
+    @Override
+    public Publisher<T> apply(Publisher<T> publisher) {
+        if (publisher instanceof Mono) {
+            Mono<T> upstream = (Mono<T>) publisher;
+            if (!FALLBACK_PUBLISHER_CACHE.isEmpty()) {
+                for (Map.Entry<Class<? extends Throwable>, Publisher<T>> classPublisherEntry : FALLBACK_PUBLISHER_CACHE.entrySet()) {
+                    upstream = upstream.onErrorResume(classPublisherEntry.getKey(),
+                            throwable -> (Mono<? extends T>) classPublisherEntry.getValue());
+                }
+            }
+            return upstream;
+        } else if (publisher instanceof Flux) {
+            Flux<T> upstream = (Flux<T>) publisher;
+            if (!FALLBACK_PUBLISHER_CACHE.isEmpty()) {
+                for (Map.Entry<Class<? extends Throwable>, Publisher<T>> classPublisherEntry : FALLBACK_PUBLISHER_CACHE.entrySet()) {
+                    upstream = upstream.onErrorResume(classPublisherEntry.getKey(), throwable -> classPublisherEntry.getValue());
+                }
+            }
+            return upstream;
+        }
+        else {
+            throw new IllegalPublisherException(publisher);
+        }
+    }
+
+    /**
+     * Applies the fallback behavior to the provided operator
+     *
+     * @param operator the operator to decorate with this fallback
+     * @return the function to apply to the stream, typically by calling {@link Mono#transformDeferred(Function)} or {@link Flux#transformDeferred(Function)}
+     */
+    public Function<Publisher<T>, Publisher<T>> decorate(UnaryOperator<Publisher<T>> operator){
+        return compose(operator);
+    }
+
+
+    /**
+     * a convenience method that initializes a default retry fallback behavior (after {@link MaxRetriesExceededException} is thrown
+     *
+     * @param retryOperator     the operator to decorate with fallbackPublisher
+     * @param fallbackPublisher the publisher to use when {@link MaxRetriesExceededException} is thrown
+     * @param <T>               the value type of the upstream and downstream
+     * @return the function to apply to the stream, typically by calling {@link Mono#transformDeferred(Function)} or {@link Flux#transformDeferred(Function)}
+     */
+    public static<T> Function<Publisher<T>, Publisher<T>> decorateRetry(RetryOperator<T> retryOperator, Publisher<T> fallbackPublisher){
+        return of(MaxRetriesExceededException.class, fallbackPublisher)
+                .decorate(retryOperator);
+    }
+
+    /**
+     * a convenience method that initializes a default circuitbreaker fallback behavior (after {@link CallNotPermittedException} is thrown
+     *
+     * @param circuitBreakerOperator the operator to decorate with fallbackPublisher
+     * @param fallbackPublisher      the publisher to use when {@link CallNotPermittedException} is thrown
+     * @param <T>                    the value type of the upstream and downstream
+     * @return the function to apply to the stream, typically by calling {@link Mono#transformDeferred(Function)} or {@link Flux#transformDeferred(Function)}
+     */
+    public static<T> Function<Publisher<T>, Publisher<T>> decorateCircuitBreaker(CircuitBreakerOperator<T> circuitBreakerOperator, Publisher<T> fallbackPublisher){
+        return of(CallNotPermittedException.class, fallbackPublisher)
+                .decorate(circuitBreakerOperator);
+    }
+
+    /**
+     * a convenience method that initializes a default timelimiter fallback behavior (after {@link TimeoutException} is thrown
+     *
+     * @param timeLimiterOperator the operator to decorate with fallbackPublisher
+     * @param fallbackPublisher   the publisher to use when {@link TimeoutException} is thrown
+     * @param <T>                 the value type of the upstream and downstream
+     * @return the function to apply to the stream, typically by calling {@link Mono#transformDeferred(Function)} or {@link Flux#transformDeferred(Function)}
+     */
+    public static<T> Function<Publisher<T>, Publisher<T>> decorateTimeLimiter(TimeLimiterOperator<T> timeLimiterOperator, Publisher<T> fallbackPublisher){
+        return of(TimeoutException.class, fallbackPublisher)
+                .decorate(timeLimiterOperator);
+    }
+}

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/ReactorOperatorFallbackDecoratorTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/ReactorOperatorFallbackDecoratorTest.java
@@ -37,6 +37,7 @@ public class ReactorOperatorFallbackDecoratorTest {
 
     private CircuitBreaker circuitBreaker;
 
+    private final TimeLimiter timeLimiter = mock(TimeLimiter.class);
 
     @Before
     public void setUp() {
@@ -105,8 +106,6 @@ public class ReactorOperatorFallbackDecoratorTest {
         assertThat(metrics.getNumberOfFailedCallsWithoutRetryAttempt()).isZero();
         assertThat(metrics.getNumberOfFailedCallsWithRetryAttempt()).isEqualTo(1);
     }
-
-    private final TimeLimiter timeLimiter = mock(TimeLimiter.class);
 
     @Test
     public void shouldFallbackOntimeoutUsingMono() {

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/ReactorOperatorFallbackDecoratorTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/ReactorOperatorFallbackDecoratorTest.java
@@ -1,0 +1,169 @@
+package io.github.resilience4j.reactor;
+
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.reactor.circuitbreaker.operator.CircuitBreakerOperator;
+import io.github.resilience4j.reactor.retry.RetryOperator;
+import io.github.resilience4j.reactor.timelimiter.TimeLimiterOperator;
+import io.github.resilience4j.retry.MaxRetriesExceededException;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryConfig;
+import io.github.resilience4j.test.HelloWorldException;
+import io.github.resilience4j.test.HelloWorldService;
+import io.github.resilience4j.timelimiter.TimeLimiter;
+import io.github.resilience4j.timelimiter.TimeLimiterConfig;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.*;
+
+
+public class ReactorOperatorFallbackDecoratorTest {
+
+    private HelloWorldService helloWorldService;
+
+    private CircuitBreaker circuitBreaker;
+
+
+    @Before
+    public void setUp() {
+        helloWorldService = mock(HelloWorldService.class);
+        circuitBreaker=mock(CircuitBreaker.class, RETURNS_DEEP_STUBS);
+    }
+
+    @Test
+    @Ignore("when mono completes with onError, onComplete is not triggered and no MaxRetriesExceededException is thrown so this test fails")
+    public void shouldFallbackOnRetriesExceededUsingMono() {
+        RetryConfig config = RetryConfig.custom()
+                .waitDuration(Duration.ofMillis(10))
+                .failAfterMaxAttempts(true)
+                .build();
+        Retry retry = Retry.of("testName", config);
+        RetryOperator<String> retryOperator = RetryOperator.of(retry);
+        Function<Publisher<String>, Publisher<String>> decorate =
+                ReactorOperatorFallbackDecorator.decorateRetry(retryOperator, Mono.just("Fallback"));
+//                ReactorOperatorFallbackDecorator.of(MaxRetriesExceededException.class, Mono.just("Fallback"))
+//                        .decorate(retryOperator);
+        given(helloWorldService.returnHelloWorld())
+                .willReturn("Hello world")
+                .willThrow(new HelloWorldException())
+                .willThrow(new HelloWorldException())
+                .willThrow(new HelloWorldException())
+                .willReturn("Hello world");
+
+        StepVerifier.create(Mono.fromCallable(helloWorldService::returnHelloWorld)
+                        .transformDeferred(decorate))
+                .expectNext("Hello world")
+                .expectComplete()
+                .verify(Duration.ofSeconds(1));
+        StepVerifier.create(Mono.fromCallable(helloWorldService::returnHelloWorld)
+                        .transformDeferred(decorate))
+                .expectNext("Fallback")
+                .expectComplete()
+                .verify(Duration.ofSeconds(1));
+
+        then(helloWorldService).should(times(4)).returnHelloWorld();
+        Retry.Metrics metrics = retry.getMetrics();
+        assertThat(metrics.getNumberOfSuccessfulCallsWithoutRetryAttempt()).isEqualTo(1);
+        assertThat(metrics.getNumberOfSuccessfulCallsWithRetryAttempt()).isEqualTo(0);
+        assertThat(metrics.getNumberOfFailedCallsWithRetryAttempt()).isEqualTo(2L);
+        assertThat(metrics.getNumberOfFailedCallsWithoutRetryAttempt()).isZero();
+    }
+
+    @Test
+    public void shouldFallbackOnRetriesExceededUsingFlux() {
+        RetryConfig config = RetryConfig.<String>custom()
+                .retryOnResult("retry"::equals)
+                .waitDuration(Duration.ofMillis(10))
+                .maxAttempts(3)
+                .failAfterMaxAttempts(true)
+                .build();
+        Retry retry = Retry.of("testName", config);
+
+        StepVerifier.create(Flux.just("retry")
+                        .log()
+                        .transformDeferred(ReactorOperatorFallbackDecorator.decorateRetry(
+                                        RetryOperator.of(retry), Mono.just("Fallback"))))
+                .expectSubscription()
+                .expectNextCount(1)
+                .expectNext("Fallback")
+                .verifyComplete();
+
+        Retry.Metrics metrics = retry.getMetrics();
+        assertThat(metrics.getNumberOfFailedCallsWithoutRetryAttempt()).isZero();
+        assertThat(metrics.getNumberOfFailedCallsWithRetryAttempt()).isEqualTo(1);
+    }
+
+    private final TimeLimiter timeLimiter = mock(TimeLimiter.class);
+
+    @Test
+    public void shouldFallbackOntimeoutUsingMono() {
+        given(timeLimiter.getTimeLimiterConfig())
+                .willReturn(TimeLimiterConfig.custom()
+                        .timeoutDuration(Duration.ofMillis(1))
+                        .build());
+
+        Mono<?> mono = Mono.delay(Duration.ofMinutes(1))
+                .transformDeferred(
+                        ReactorOperatorFallbackDecorator.decorateTimeLimiter(TimeLimiterOperator.of(timeLimiter),Mono.just(-1L)));
+
+        StepVerifier.create(mono)
+                .expectNextMatches(o -> o instanceof Long && ((long) o) == -1L)
+                .expectComplete()
+                .verify(Duration.ofMinutes(1));
+        then(timeLimiter).should()
+                .onError(any(TimeoutException.class));
+    }
+
+    @Test
+    public void shouldFallbackOnTimeoutUsingFlux() {
+        given(timeLimiter.getTimeLimiterConfig())
+                .willReturn(TimeLimiterConfig.custom()
+                        .timeoutDuration(Duration.ofMillis(1))
+                        .build());
+
+        Flux<?> flux = Flux.interval(Duration.ofSeconds(1))
+                .transformDeferred(
+                        ReactorOperatorFallbackDecorator.decorateTimeLimiter(TimeLimiterOperator.of(timeLimiter),Mono.just(-1L)));
+
+        StepVerifier.create(flux)
+                .expectNextMatches(o -> o instanceof Long && ((long) o) == -1L)
+                .expectComplete()
+                .verify(Duration.ofMinutes(1));
+        then(timeLimiter).should()
+                .onError(any(TimeoutException.class));
+    }
+
+    @Test
+    public void shouldFallbackOnCircuitOpen() {
+        given(circuitBreaker.tryAcquirePermission()).willReturn(false);
+
+        StepVerifier.create(
+                        Flux.<String>error(new IOException("BAM!"))
+                                .transformDeferred(
+                                        ReactorOperatorFallbackDecorator.decorateCircuitBreaker(CircuitBreakerOperator.of(circuitBreaker),Mono.just("Fallback")))
+                                )
+                .expectNext("Fallback")
+                .expectComplete()
+                .verify(Duration.ofSeconds(1));
+
+        verify(circuitBreaker, never()).onResult(anyLong(), any(TimeUnit.class), any());
+    }
+
+
+}

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/ReactorOperatorFallbackDecoratorTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/ReactorOperatorFallbackDecoratorTest.java
@@ -57,8 +57,7 @@ public class ReactorOperatorFallbackDecoratorTest {
         RetryOperator<String> retryOperator = RetryOperator.of(retry);
         Function<Publisher<String>, Publisher<String>> decorate =
                 ReactorOperatorFallbackDecorator.decorateRetry(retryOperator, Mono.just("Fallback"));
-//                ReactorOperatorFallbackDecorator.of(MaxRetriesExceededException.class, Mono.just("Fallback"))
-//                        .decorate(retryOperator);
+
         given(helloWorldService.returnHelloWorld())
                 .willReturn("Hello world")
                 .willThrow(new HelloWorldException())

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/ReactorOperatorFallbackDecoratorTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/ReactorOperatorFallbackDecoratorTest.java
@@ -1,11 +1,9 @@
 package io.github.resilience4j.reactor;
 
-import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.reactor.circuitbreaker.operator.CircuitBreakerOperator;
 import io.github.resilience4j.reactor.retry.RetryOperator;
 import io.github.resilience4j.reactor.timelimiter.TimeLimiterOperator;
-import io.github.resilience4j.retry.MaxRetriesExceededException;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.test.HelloWorldException;


### PR DESCRIPTION
Issue #1723 Add fallback decorator to reactor operators.

Added the class and it's tests. 
No changes to existing code made.
