### PR TITLE
Add support for custom permits in reactor RateLimiterOperators

### DIFF
--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/ratelimiter/operator/CorePublisherRateLimiterOperator.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/ratelimiter/operator/CorePublisherRateLimiterOperator.java
@@ -29,14 +29,16 @@ class CorePublisherRateLimiterOperator<T> {
 
     private final CorePublisher<? extends T> source;
     private final RateLimiter rateLimiter;
+    private final int permits;
 
-    CorePublisherRateLimiterOperator(CorePublisher<? extends T> source, RateLimiter rateLimiter) {
+    CorePublisherRateLimiterOperator(CorePublisher<? extends T> source, RateLimiter rateLimiter, int permits) {
         this.source = source;
         this.rateLimiter = rateLimiter;
+        this.permits = permits;
     }
 
     void subscribe(CoreSubscriber<? super T> actual) {
-        long waitDuration = rateLimiter.reservePermission();
+        long waitDuration = rateLimiter.reservePermission(permits);
         if (waitDuration >= 0) {
             if (waitDuration > 0) {
                 delaySubscription(actual, waitDuration);

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/ratelimiter/operator/FluxRateLimiter.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/ratelimiter/operator/FluxRateLimiter.java
@@ -24,9 +24,9 @@ class FluxRateLimiter<T> extends FluxOperator<T, T> {
 
     private final CorePublisherRateLimiterOperator<T> operator;
 
-    FluxRateLimiter(Flux<? extends T> source, RateLimiter rateLimiter) {
+    FluxRateLimiter(Flux<? extends T> source, RateLimiter rateLimiter, int permits) {
         super(source);
-        this.operator = new CorePublisherRateLimiterOperator<T>(source, rateLimiter);
+        this.operator = new CorePublisherRateLimiterOperator<T>(source, rateLimiter, permits);
     }
 
     @Override

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/ratelimiter/operator/MonoRateLimiter.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/ratelimiter/operator/MonoRateLimiter.java
@@ -24,9 +24,9 @@ class MonoRateLimiter<T> extends MonoOperator<T, T> {
 
     private final CorePublisherRateLimiterOperator<T> operator;
 
-    MonoRateLimiter(Mono<? extends T> source, RateLimiter rateLimiter) {
+    MonoRateLimiter(Mono<? extends T> source, RateLimiter rateLimiter, int permits) {
         super(source);
-        this.operator = new CorePublisherRateLimiterOperator<T>(source, rateLimiter);
+        this.operator = new CorePublisherRateLimiterOperator<T>(source, rateLimiter, permits);
     }
 
     @Override


### PR DESCRIPTION
Issue: https://github.com/resilience4j/resilience4j/issues/1757

Add possibility for custom weight to rate limiters used in reactor way.