### PR TITLE
Issue 1788: Change resilience4j.scheduled.executor.corePoolSize prope…

### DIFF
--- a/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/scheduled/threadpool/autoconfigure/ContextAwareScheduledThreadPoolAutoConfiguration.java
+++ b/resilience4j-spring-boot2/src/main/java/io/github/resilience4j/scheduled/threadpool/autoconfigure/ContextAwareScheduledThreadPoolAutoConfiguration.java
@@ -25,7 +25,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ConditionalOnProperty(value = "resilience4j.scheduled.executor.corePoolSize")
+@ConditionalOnProperty(value = "resilience4j.scheduled.executor.core-pool-size")
 @EnableConfigurationProperties({ContextAwareScheduledThreadPoolProperties.class})
 public class ContextAwareScheduledThreadPoolAutoConfiguration {
 

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/ContextAwareScheduledThreadPoolAutoConfigurationTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/ContextAwareScheduledThreadPoolAutoConfigurationTest.java
@@ -1,0 +1,50 @@
+package io.github.resilience4j;
+
+import io.github.resilience4j.scheduled.threadpool.autoconfigure.ContextAwareScheduledThreadPoolAutoConfiguration;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ContextAwareScheduledThreadPoolAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner();
+
+    @Test
+    public void registersBeanWhenConditionalPropertyIsInKebabCase() {
+        assertBeanHasBeenCreated("resilience4j.scheduled.executor.core-pool-size=1");
+    }
+
+    @Test
+    public void registersBeanWhenConditionalPropertyIsInCamelCase() {
+        assertBeanHasBeenCreated("resilience4j.scheduled.executor.corePoolSize=1");
+    }
+
+    @Test
+    public void doesNotRegisterBeanWhenConditionalPropertyNotSpecified() {
+        assertBeanWasNotCreated("randomProperty");
+    }
+
+    private void assertBeanHasBeenCreated(String conditionalProperty) {
+        contextRunner(conditionalProperty).run(context ->
+            assertThat(context).hasSingleBean(ContextAwareScheduledThreadPoolAutoConfiguration.class)
+        );
+    }
+
+    private void assertBeanWasNotCreated(String conditionalProperty) {
+        contextRunner(conditionalProperty).run(context ->
+            assertThat(context).doesNotHaveBean(ContextAwareScheduledThreadPoolAutoConfiguration.class)
+        );
+    }
+
+    private ApplicationContextRunner contextRunner(String conditionalProperty) {
+        return contextRunner
+            .withPropertyValues(conditionalProperty)
+            .withConfiguration(AutoConfigurations.of(
+                ContextAwareScheduledThreadPoolAutoConfiguration.class)
+            );
+    }
+
+
+}


### PR DESCRIPTION
…rty to kebab case

Hello, I've changed property format to "kebab case" so both camelCase and kebab-case are allowed now. 