### PR TITLE
Fixed CircuitBreakerConfigurationPropertiesTest failing test

### DIFF
--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationPropertiesTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationPropertiesTest.java
@@ -343,7 +343,7 @@ public class CircuitBreakerConfigurationPropertiesTest {
     @Test(expected = IllegalArgumentException.class)
     public void testIllegalArgumentOnWaitDurationInHalfOpenState() {
         CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
-        defaultProperties.setMaxWaitDurationInHalfOpenState(Duration.ZERO);
+        defaultProperties.setMaxWaitDurationInHalfOpenState(Duration.ofMillis(-1));
     }
 
     @Test


### PR DESCRIPTION
sorry.

An error occurred in [#1789](https://github.com/resilience4j/resilience4j/pull/1789) because the test code was not corrected.

---
Error
https://github.com/resilience4j/resilience4j/actions/runs/3243173372/jobs/5332211985

```
io.github.resilience4j.common.circuitbreaker.configuration.CircuitBreakerConfigurationPropertiesTest > testIllegalArgumentOnWaitDurationInHalfOpenState FAILED
    java.lang.AssertionError at ExpectException.java:32

io.github.resilience4j.common.circuitbreaker.configuration.CircuitBreakerConfigurationPropertiesTest > testIllegalArgumentOnWaitDurationInHalfOpenState FAILED
    java.lang.AssertionError at ExpectException.java:32

io.github.resilience4j.common.circuitbreaker.configuration.CircuitBreakerConfigurationPropertiesTest > testIllegalArgumentOnWaitDurationInHalfOpenState FAILED
    java.lang.AssertionError at ExpectException.java:32

io.github.resilience4j.common.circuitbreaker.configuration.CircuitBreakerConfigurationPropertiesTest > testIllegalArgumentOnWaitDurationInHalfOpenState FAILED
    java.lang.AssertionError at ExpectException.java:32
```