### PR TITLE
Use `CircuitBreaker.getCurrentTimestamp` instead of `System.nanoTime`in Kotlin suspend functions

### DIFF
--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/CircuitBreaker.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/CircuitBreaker.kt
@@ -36,22 +36,23 @@ suspend fun <T> CircuitBreaker.executeSuspendFunction(
  * Decorates and executes the given suspend function [block].
  * Release permission without recording error if [ignoreThrowablePredicate] is true.
  */
+@Suppress("UsePropertyAccessSyntax") // current timestamp is not a property of CB
 suspend fun <T> CircuitBreaker.executeSuspendFunction(
     ignoreThrowablePredicate: (Throwable, CoroutineContext) -> Boolean,
     block: suspend () -> T
 ): T {
     acquirePermission()
-    val start = System.nanoTime()
+    val start = getCurrentTimestamp()
     try {
         val result = block()
-        val durationInNanos = System.nanoTime() - start
+        val durationInNanos = getCurrentTimestamp() - start
         onResult(durationInNanos, TimeUnit.NANOSECONDS, result)
         return result
     } catch (exception: Throwable) {
         if (ignoreThrowablePredicate(exception, coroutineContext)) {
             releasePermission()
         } else {
-            val durationInNanos = System.nanoTime() - start
+            val durationInNanos = getCurrentTimestamp() - start
             onError(durationInNanos, TimeUnit.NANOSECONDS, exception)
         }
         throw exception


### PR DESCRIPTION
## Why

Clocks injected in circuit breakers via `CircuitBreakerConfig` are not used by `CircuitBreaker` within Kotlin's suspend-functions.

This change makes the Kotlin module consistent with the core circuit breaker behavior. See #734 for the context.

## What

Replaced calls to `System.nanoTime()` with `CircuitBreaker.getCurrentTimestamp()` in the `CircuitBreaker` extension functions in Kotlin module.