### PR TITLE
allow any backoff multiplier

### DIFF
--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/IntervalFunction.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/IntervalFunction.java
@@ -108,7 +108,6 @@ public interface IntervalFunction extends Function<Integer, Long> {
     }
 
     static IntervalFunction ofExponentialBackoff(long initialIntervalMillis, double multiplier) {
-        checkMultiplier(multiplier);
         return of(initialIntervalMillis, x -> (long) (x * multiplier));
     }
 
@@ -149,7 +148,6 @@ public interface IntervalFunction extends Function<Integer, Long> {
         double randomizationFactor
     ) {
         checkInterval(initialIntervalMillis);
-        checkMultiplier(multiplier);
         checkRandomizationFactor(randomizationFactor);
         return attempt -> {
             checkAttempt(attempt);
@@ -249,12 +247,6 @@ final class IntervalFunctionCompanion {
         if (intervalMillis < 1) {
             throw new IllegalArgumentException(
                 "Illegal argument interval: " + intervalMillis + " millis is less than 1");
-        }
-    }
-
-    static void checkMultiplier(double multiplier) {
-        if (multiplier < 1.0) {
-            throw new IllegalArgumentException("Illegal argument multiplier: " + multiplier);
         }
     }
 

--- a/resilience4j-core/src/test/java/io/github/resilience4j/core/IntervalFunctionTest.java
+++ b/resilience4j-core/src/test/java/io/github/resilience4j/core/IntervalFunctionTest.java
@@ -128,22 +128,6 @@ public class IntervalFunctionTest {
     }
 
     @Test
-    public void shouldRejectOutOfBoundsMultiplier() {
-        final Duration duration = Duration.ofMillis(100);
-        final float lessThenOneMultiplier = 0.9999f;
-
-        final List<Try<IntervalFunction>> tries = List.of(
-            Try.of(() -> IntervalFunction.ofExponentialBackoff(duration, lessThenOneMultiplier)),
-            Try.of(
-                () -> IntervalFunction.ofExponentialRandomBackoff(duration, lessThenOneMultiplier))
-        );
-
-        assertThat(tries.forAll(Try::isFailure)).isTrue();
-        assertThat(tries.map(Try::getCause).forAll(t -> t instanceof IllegalArgumentException))
-            .isTrue();
-    }
-
-    @Test
     public void shouldPassPositiveMultiplier() {
         final Duration duration = Duration.ofMillis(100);
         final float greaterThanOneMultiplier = 1.0001f;


### PR DESCRIPTION
Issue #1810 

no reason to limit backoff mulitplier to numbers > 1.0 Negative and numbers < 1.0 should be allowed too. 
