### PR TITLE
Set thread interrupted when interrupted from sleep

### DIFF
--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/internal/RetryImpl.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/internal/RetryImpl.java
@@ -253,6 +253,9 @@ public class RetryImpl<T> implements Retry {
                 () -> new RetryOnRetryEvent(getName(), currentNumOfAttempts, either.swap().getOrNull(), interval));
             try {
                 sleepFunction.accept(interval);
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+                throw lastException.get();
             } catch (Throwable ex) {
                 throw lastException.get();
             }


### PR DESCRIPTION
Sets the current thread as interrupted when interrupted from sleep. Fixes https://github.com/resilience4j/resilience4j/issues/1856