### PR TITLE
Issue #1875: add copyright information to jar

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -1,0 +1,7 @@
+Copyright 2020 Robert Winkler, Bohdan Storozhuk, Mahmoud Romeh, Dan Maas and others
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/build.gradle
+++ b/build.gradle
@@ -120,6 +120,7 @@ configure(project.coreProjects) {
         jar {
             from('../') {
                 include 'COPYRIGHT.txt'
+                include 'LICENSE.txt'
             }
 
             inputs.property('moduleName', moduleName)

--- a/build.gradle
+++ b/build.gradle
@@ -118,6 +118,10 @@ configure(project.coreProjects) {
 
     afterEvaluate {
         jar {
+            from('../') {
+                include 'COPYRIGHT.txt'
+            }
+
             inputs.property('moduleName', moduleName)
             manifest.attributes(
                     'Automatic-Module-Name': moduleName


### PR DESCRIPTION
For a customer project an OpenSource report has to be generated. Therefore a scanner was created to extract the copyright and licence information from our dependencies. This scanner can extract all informaton from the Jar File. Therefore it would be great to have the copyright information included in the Jar File as COPYRIGHT File.