### PR TITLE
FallbackMethod supports AOP

### DIFF
--- a/resilience4j-spring/src/main/java/io/github/resilience4j/fallback/FallbackExecutor.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/fallback/FallbackExecutor.java
@@ -28,7 +28,7 @@ public class FallbackExecutor {
         if (StringUtils.hasLength(fallbackMethodName)) {
             try {
                 fallbackMethod = FallbackMethod
-                    .create(fallbackMethodName, method, proceedingJoinPoint.getArgs(), proceedingJoinPoint.getTarget());
+                    .create(fallbackMethodName, method, proceedingJoinPoint.getArgs(), proceedingJoinPoint.getTarget().getClass(), proceedingJoinPoint.getThis());
             } catch (NoSuchMethodException ex) {
                 logger.warn("No fallback method match found", ex);
             }

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/fallback/FallbackMethod.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/fallback/FallbackMethod.java
@@ -72,22 +72,23 @@ public class FallbackMethod {
      * @param fallbackMethodName the configured fallback method name
      * @param originalMethod     the original method which has fallback method configured
      * @param args               the original method arguments
-     * @param target             the target class that own the original method and fallback method
+     * @param originalType       the original type
+     * @param proxy              the proxy that own the original method and fallback method
      * @return FallbackMethod instance
      */
     public static FallbackMethod create(String fallbackMethodName, Method originalMethod,
-        Object[] args, Object target) throws NoSuchMethodException {
+        Object[] args, Class<?> originalType, Object proxy) throws NoSuchMethodException {
         MethodMeta methodMeta = new MethodMeta(
             fallbackMethodName,
             originalMethod.getParameterTypes(),
             originalMethod.getReturnType(),
-            target.getClass());
+            originalType);
 
         Map<Class<?>, Method> methods = FALLBACK_METHODS_CACHE
             .computeIfAbsent(methodMeta, FallbackMethod::extractMethods);
 
         if (!methods.isEmpty()) {
-            return new FallbackMethod(methods, originalMethod.getReturnType(), args, target);
+            return new FallbackMethod(methods, originalMethod.getReturnType(), args, proxy);
         } else {
             throw new NoSuchMethodException(String.format("%s %s.%s(%s,%s)",
                 methodMeta.returnType, methodMeta.targetClass, methodMeta.fallbackMethodName,

--- a/resilience4j-spring/src/test/java/io/github/resilience4j/fallback/FallbackAspectTest.java
+++ b/resilience4j-spring/src/test/java/io/github/resilience4j/fallback/FallbackAspectTest.java
@@ -1,0 +1,83 @@
+package io.github.resilience4j.fallback;
+
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.CircuitBreakerDummyService;
+import io.github.resilience4j.TestApplication;
+import io.github.resilience4j.TestDummyService;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = {TestApplication.class, FallbackAspectTest.TestConfig.class})
+public class FallbackAspectTest {
+
+    @Autowired
+    @Qualifier("fallbackTestDummyService")
+    TestDummyService testDummyService;
+
+
+    @Test
+    public void testFallbackAspect() {
+        assertThat(testDummyService.sync()).isEqualTo("aspect");
+    }
+
+    @Component
+    public static class FallbackTestDummyService extends CircuitBreakerDummyService {
+        @Override
+        @CircuitBreaker(name = BACKEND, fallbackMethod = "fallback")
+        public String sync() {
+            return syncError();
+        }
+
+        @TestAround
+        public String fallback(RuntimeException throwable) {
+            return "recovery";
+        }
+    }
+
+    @Configuration
+    static class TestConfig {
+
+        @Bean
+        public FallbackTestDummyService fallbackTestDummyService() {
+            return new FallbackTestDummyService();
+        }
+
+        @Bean
+        public TestAspect testAspect() {
+            return new TestAspect();
+        }
+    }
+
+    @Aspect
+    static class TestAspect {
+
+        @Around("@annotation(FallbackAspectTest.TestAround)")
+        public Object around(ProceedingJoinPoint joinPoint) throws Throwable {
+            joinPoint.proceed();
+            return "aspect";
+        }
+    }
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface TestAround {
+    }
+}

--- a/resilience4j-spring/src/test/java/io/github/resilience4j/fallback/FallbackMethodParentTest.java
+++ b/resilience4j-spring/src/test/java/io/github/resilience4j/fallback/FallbackMethodParentTest.java
@@ -47,7 +47,7 @@ public class FallbackMethodParentTest {
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
 
         FallbackMethod fallbackMethod = FallbackMethod
-            .create("fallbackParent", testMethod, new Object[]{"test"}, target);
+            .create("fallbackParent", testMethod, new Object[]{"test"}, target.getClass(), target);
 
         assertThat(fallbackMethod.fallback(new IllegalStateException("err")))
             .isEqualTo("proxy-recovered");
@@ -59,7 +59,7 @@ public class FallbackMethodParentTest {
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
 
         FallbackMethod fallbackMethod = FallbackMethod
-            .create("fallbackInterface", testMethod, new Object[]{"test"}, target);
+            .create("fallbackInterface", testMethod, new Object[]{"test"}, target.getClass(), target);
 
         assertThat(fallbackMethod.fallback(new IllegalArgumentException("err")))
             .isEqualTo("proxy-recovered");
@@ -71,7 +71,7 @@ public class FallbackMethodParentTest {
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
 
         FallbackMethod fallbackMethod = FallbackMethod
-            .create("fallbackOnlyInterface", testMethod, new Object[]{"test"}, target);
+            .create("fallbackOnlyInterface", testMethod, new Object[]{"test"}, target.getClass(), target);
 
         assertThat(fallbackMethod.fallback(new IllegalArgumentException("err")))
             .isEqualTo("only-interface-recovered");
@@ -83,7 +83,7 @@ public class FallbackMethodParentTest {
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
 
         assertThatThrownBy(() -> FallbackMethod
-            .create("ambiguousFallback", testMethod, new Object[]{"test"}, target))
+            .create("ambiguousFallback", testMethod, new Object[]{"test"}, target.getClass(), target))
             .isInstanceOf(IllegalStateException.class)
             .hasMessage("You have more that one fallback method that cover the same exception type "
                 + IOException.class.getName());

--- a/resilience4j-spring/src/test/java/io/github/resilience4j/fallback/FallbackMethodTest.java
+++ b/resilience4j-spring/src/test/java/io/github/resilience4j/fallback/FallbackMethodTest.java
@@ -31,7 +31,7 @@ public class FallbackMethodTest {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
         FallbackMethod fallbackMethod = FallbackMethod
-            .create("fallbackMethod", testMethod, new Object[]{"test"}, target);
+            .create("fallbackMethod", testMethod, new Object[]{"test"}, target.getClass(), target);
         assertThat(fallbackMethod.fallback(new RuntimeException("err")))
             .isEqualTo("recovered-RuntimeException");
     }
@@ -41,7 +41,7 @@ public class FallbackMethodTest {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testFutureMethod", String.class);
         FallbackMethod fallbackMethod = FallbackMethod
-            .create("futureFallbackMethod", testMethod, new Object[]{"test"}, target);        
+            .create("futureFallbackMethod", testMethod, new Object[]{"test"}, target.getClass(), target);
         CompletableFuture future = (CompletableFuture) fallbackMethod.fallback(new IllegalStateException("err"));
         assertThat(future.get()).isEqualTo("recovered-IllegalStateException");
     }
@@ -51,7 +51,7 @@ public class FallbackMethodTest {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
         FallbackMethod fallbackMethod = FallbackMethod
-            .create("fallbackMethod", testMethod, new Object[]{"test"}, target);
+            .create("fallbackMethod", testMethod, new Object[]{"test"}, target.getClass(), target);
         assertThat(fallbackMethod.fallback(new IllegalStateException("err")))
             .isEqualTo("recovered-IllegalStateException");
     }
@@ -62,7 +62,7 @@ public class FallbackMethodTest {
         Method testMethod = target.getClass().getMethod("multipleParameterTestMethod", String.class, String.class);
 
         FallbackMethod fallbackMethod = FallbackMethod
-            .create("fallbackMethod", testMethod, new Object[]{"test", "test"}, target);
+            .create("fallbackMethod", testMethod, new Object[]{"test", "test"}, target.getClass(), target);
 
         assertThat(fallbackMethod.fallback(new IllegalStateException("err")))
             .isEqualTo("recovered-IllegalStateException");
@@ -73,7 +73,7 @@ public class FallbackMethodTest {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
         FallbackMethod fallbackMethod = FallbackMethod
-            .create("fallbackMethod", testMethod, new Object[]{"test"}, target);
+            .create("fallbackMethod", testMethod, new Object[]{"test"}, target.getClass(), target);
         assertThat(fallbackMethod.fallback(new NumberFormatException("err")))
             .isEqualTo("recovered-IllegalArgumentException");
     }
@@ -83,7 +83,7 @@ public class FallbackMethodTest {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
         FallbackMethod fallbackMethod = FallbackMethod
-            .create("fallbackMethod", testMethod, new Object[]{"test"}, target);
+            .create("fallbackMethod", testMethod, new Object[]{"test"}, target.getClass(), target);
         Throwable unrecoverableThrown = new Throwable("err");
         assertThatThrownBy(() -> fallbackMethod.fallback(unrecoverableThrown))
             .isEqualTo(unrecoverableThrown);
@@ -94,7 +94,7 @@ public class FallbackMethodTest {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
         FallbackMethod fallbackMethod = FallbackMethod
-            .create("privateFallback", testMethod, new Object[]{"test"}, target);
+            .create("privateFallback", testMethod, new Object[]{"test"}, target.getClass(), target);
         assertThat(fallbackMethod.fallback(new RuntimeException("err")))
             .isEqualTo("recovered-privateMethod");
     }
@@ -105,7 +105,7 @@ public class FallbackMethodTest {
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
 
         assertThatThrownBy(() -> FallbackMethod
-            .create("duplicateException", testMethod, new Object[]{"test"}, target))
+            .create("duplicateException", testMethod, new Object[]{"test"}, target.getClass(), target))
             .isInstanceOf(IllegalStateException.class)
             .hasMessage(
                 "You have more that one fallback method that cover the same exception type java.lang.IllegalArgumentException");
@@ -116,7 +116,7 @@ public class FallbackMethodTest {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
         assertThatThrownBy(() -> FallbackMethod
-            .create("returnMismatchFallback", testMethod, new Object[]{"test"}, target))
+            .create("returnMismatchFallback", testMethod, new Object[]{"test"}, target.getClass(), target))
             .isInstanceOf(NoSuchMethodException.class)
             .hasMessage(
                 "class java.lang.String class io.github.resilience4j.fallback.FallbackMethodTest.returnMismatchFallback(class java.lang.String,class java.lang.Throwable)");
@@ -127,7 +127,7 @@ public class FallbackMethodTest {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
         assertThatThrownBy(
-            () -> FallbackMethod.create("noMethod", testMethod, new Object[]{"test"}, target))
+            () -> FallbackMethod.create("noMethod", testMethod, new Object[]{"test"}, target.getClass(), target))
             .isInstanceOf(NoSuchMethodException.class)
             .hasMessage(
                 "class java.lang.String class io.github.resilience4j.fallback.FallbackMethodTest.noMethod(class java.lang.String,class java.lang.Throwable)");
@@ -138,7 +138,7 @@ public class FallbackMethodTest {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
         FallbackMethod fallbackMethod = FallbackMethod
-            .create("rethrowingFallbackMethod", testMethod, new Object[]{"test"}, target);
+            .create("rethrowingFallbackMethod", testMethod, new Object[]{"test"}, target.getClass(), target);
         RethrowException exception = new RethrowException();
         assertThatThrownBy(() -> fallbackMethod.fallback(exception)).isSameAs(exception);
     }
@@ -148,7 +148,7 @@ public class FallbackMethodTest {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
         FallbackMethod fallbackMethod = FallbackMethod
-            .create("rethrowingFallbackMethodChecked", testMethod, new Object[]{"test"}, target);
+            .create("rethrowingFallbackMethodChecked", testMethod, new Object[]{"test"}, target.getClass(), target);
         RethrowCheckedException exception = new RethrowCheckedException();
         assertThatThrownBy(() -> fallbackMethod.fallback(exception)).isSameAs(exception);
     }

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/fallback/FallbackExecutor.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/fallback/FallbackExecutor.java
@@ -28,7 +28,7 @@ public class FallbackExecutor {
         if (StringUtils.hasLength(fallbackMethodName)) {
             try {
                 fallbackMethod = FallbackMethod
-                    .create(fallbackMethodName, method, proceedingJoinPoint.getArgs(), proceedingJoinPoint.getTarget());
+                    .create(fallbackMethodName, method, proceedingJoinPoint.getArgs(), proceedingJoinPoint.getTarget().getClass(), proceedingJoinPoint.getThis());
             } catch (NoSuchMethodException ex) {
                 logger.warn("No fallback method match found", ex);
             }

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/fallback/FallbackMethod.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/fallback/FallbackMethod.java
@@ -72,22 +72,23 @@ public class FallbackMethod {
      * @param fallbackMethodName the configured fallback method name
      * @param originalMethod     the original method which has fallback method configured
      * @param args               the original method arguments
-     * @param target             the target class that own the original method and fallback method
+     * @param originalType       the original type
+     * @param proxy              the proxy that own the original method and fallback method
      * @return FallbackMethod instance
      */
     public static FallbackMethod create(String fallbackMethodName, Method originalMethod,
-        Object[] args, Object target) throws NoSuchMethodException {
+        Object[] args, Class<?> originalType, Object proxy) throws NoSuchMethodException {
         MethodMeta methodMeta = new MethodMeta(
             fallbackMethodName,
             originalMethod.getParameterTypes(),
             originalMethod.getReturnType(),
-            target.getClass());
+            originalType);
 
         Map<Class<?>, Method> methods = FALLBACK_METHODS_CACHE
             .computeIfAbsent(methodMeta, FallbackMethod::extractMethods);
 
         if (!methods.isEmpty()) {
-            return new FallbackMethod(methods, originalMethod.getReturnType(), args, target);
+            return new FallbackMethod(methods, originalMethod.getReturnType(), args, proxy);
         } else {
             throw new NoSuchMethodException(String.format("%s %s.%s(%s,%s)",
                 methodMeta.returnType, methodMeta.targetClass, methodMeta.fallbackMethodName,

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/fallback/FallbackAspectTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/fallback/FallbackAspectTest.java
@@ -1,0 +1,83 @@
+package io.github.resilience4j.spring6.fallback;
+
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.spring6.CircuitBreakerDummyService;
+import io.github.resilience4j.spring6.TestApplication;
+import io.github.resilience4j.spring6.TestDummyService;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = {TestApplication.class, FallbackAspectTest.TestConfig.class})
+public class FallbackAspectTest {
+
+    @Autowired
+    @Qualifier("fallbackTestDummyService")
+    TestDummyService testDummyService;
+
+
+    @Test
+    public void testFallbackAspect() {
+        assertThat(testDummyService.sync()).isEqualTo("aspect");
+    }
+
+    @Component
+    public static class FallbackTestDummyService extends CircuitBreakerDummyService {
+        @Override
+        @CircuitBreaker(name = BACKEND, fallbackMethod = "fallback")
+        public String sync() {
+            return syncError();
+        }
+
+        @TestAround
+        public String fallback(RuntimeException throwable) {
+            return "recovery";
+        }
+    }
+
+    @Configuration
+    static class TestConfig {
+
+        @Bean
+        public FallbackTestDummyService fallbackTestDummyService() {
+            return new FallbackTestDummyService();
+        }
+
+        @Bean
+        public TestAspect testAspect() {
+            return new TestAspect();
+        }
+    }
+
+    @Aspect
+    static class TestAspect {
+
+        @Around("@annotation(io.github.resilience4j.spring6.fallback.FallbackAspectTest.TestAround)")
+        public Object around(ProceedingJoinPoint joinPoint) throws Throwable {
+            joinPoint.proceed();
+            return "aspect";
+        }
+    }
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface TestAround {
+    }
+}

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/fallback/FallbackMethodParentTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/fallback/FallbackMethodParentTest.java
@@ -47,7 +47,7 @@ public class FallbackMethodParentTest {
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
 
         FallbackMethod fallbackMethod = FallbackMethod
-            .create("fallbackParent", testMethod, new Object[]{"test"}, target);
+            .create("fallbackParent", testMethod, new Object[]{"test"}, target.getClass(), target);
 
         assertThat(fallbackMethod.fallback(new IllegalStateException("err")))
             .isEqualTo("proxy-recovered");
@@ -59,7 +59,7 @@ public class FallbackMethodParentTest {
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
 
         FallbackMethod fallbackMethod = FallbackMethod
-            .create("fallbackInterface", testMethod, new Object[]{"test"}, target);
+            .create("fallbackInterface", testMethod, new Object[]{"test"}, target.getClass(), target);
 
         assertThat(fallbackMethod.fallback(new IllegalArgumentException("err")))
             .isEqualTo("proxy-recovered");
@@ -71,7 +71,7 @@ public class FallbackMethodParentTest {
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
 
         FallbackMethod fallbackMethod = FallbackMethod
-            .create("fallbackOnlyInterface", testMethod, new Object[]{"test"}, target);
+            .create("fallbackOnlyInterface", testMethod, new Object[]{"test"}, target.getClass(), target);
 
         assertThat(fallbackMethod.fallback(new IllegalArgumentException("err")))
             .isEqualTo("only-interface-recovered");
@@ -83,7 +83,7 @@ public class FallbackMethodParentTest {
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
 
         assertThatThrownBy(() -> FallbackMethod
-            .create("ambiguousFallback", testMethod, new Object[]{"test"}, target))
+            .create("ambiguousFallback", testMethod, new Object[]{"test"}, target.getClass(), target))
             .isInstanceOf(IllegalStateException.class)
             .hasMessage("You have more that one fallback method that cover the same exception type "
                 + IOException.class.getName());

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/fallback/FallbackMethodTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/fallback/FallbackMethodTest.java
@@ -31,7 +31,7 @@ public class FallbackMethodTest {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
         FallbackMethod fallbackMethod = FallbackMethod
-            .create("fallbackMethod", testMethod, new Object[]{"test"}, target);
+            .create("fallbackMethod", testMethod, new Object[]{"test"}, target.getClass(), target);
         assertThat(fallbackMethod.fallback(new RuntimeException("err")))
             .isEqualTo("recovered-RuntimeException");
     }
@@ -41,7 +41,7 @@ public class FallbackMethodTest {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testFutureMethod", String.class);
         FallbackMethod fallbackMethod = FallbackMethod
-            .create("futureFallbackMethod", testMethod, new Object[]{"test"}, target);        
+            .create("futureFallbackMethod", testMethod, new Object[]{"test"}, target.getClass(), target);
         CompletableFuture future = (CompletableFuture) fallbackMethod.fallback(new IllegalStateException("err"));
         assertThat(future.get()).isEqualTo("recovered-IllegalStateException");
     }
@@ -51,7 +51,7 @@ public class FallbackMethodTest {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
         FallbackMethod fallbackMethod = FallbackMethod
-            .create("fallbackMethod", testMethod, new Object[]{"test"}, target);
+            .create("fallbackMethod", testMethod, new Object[]{"test"}, target.getClass(), target);
         assertThat(fallbackMethod.fallback(new IllegalStateException("err")))
             .isEqualTo("recovered-IllegalStateException");
     }
@@ -62,7 +62,7 @@ public class FallbackMethodTest {
         Method testMethod = target.getClass().getMethod("multipleParameterTestMethod", String.class, String.class);
 
         FallbackMethod fallbackMethod = FallbackMethod
-            .create("fallbackMethod", testMethod, new Object[]{"test", "test"}, target);
+            .create("fallbackMethod", testMethod, new Object[]{"test", "test"}, target.getClass(), target);
 
         assertThat(fallbackMethod.fallback(new IllegalStateException("err")))
             .isEqualTo("recovered-IllegalStateException");
@@ -73,7 +73,7 @@ public class FallbackMethodTest {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
         FallbackMethod fallbackMethod = FallbackMethod
-            .create("fallbackMethod", testMethod, new Object[]{"test"}, target);
+            .create("fallbackMethod", testMethod, new Object[]{"test"}, target.getClass(), target);
         assertThat(fallbackMethod.fallback(new NumberFormatException("err")))
             .isEqualTo("recovered-IllegalArgumentException");
     }
@@ -83,7 +83,7 @@ public class FallbackMethodTest {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
         FallbackMethod fallbackMethod = FallbackMethod
-            .create("fallbackMethod", testMethod, new Object[]{"test"}, target);
+            .create("fallbackMethod", testMethod, new Object[]{"test"}, target.getClass(), target);
         Throwable unrecoverableThrown = new Throwable("err");
         assertThatThrownBy(() -> fallbackMethod.fallback(unrecoverableThrown))
             .isEqualTo(unrecoverableThrown);
@@ -94,7 +94,7 @@ public class FallbackMethodTest {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
         FallbackMethod fallbackMethod = FallbackMethod
-            .create("privateFallback", testMethod, new Object[]{"test"}, target);
+            .create("privateFallback", testMethod, new Object[]{"test"}, target.getClass(), target);
         assertThat(fallbackMethod.fallback(new RuntimeException("err")))
             .isEqualTo("recovered-privateMethod");
     }
@@ -105,7 +105,7 @@ public class FallbackMethodTest {
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
 
         assertThatThrownBy(() -> FallbackMethod
-            .create("duplicateException", testMethod, new Object[]{"test"}, target))
+            .create("duplicateException", testMethod, new Object[]{"test"}, target.getClass(), target))
             .isInstanceOf(IllegalStateException.class)
             .hasMessage(
                 "You have more that one fallback method that cover the same exception type java.lang.IllegalArgumentException");
@@ -116,7 +116,7 @@ public class FallbackMethodTest {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
         assertThatThrownBy(() -> FallbackMethod
-            .create("returnMismatchFallback", testMethod, new Object[]{"test"}, target))
+            .create("returnMismatchFallback", testMethod, new Object[]{"test"}, target.getClass(), target))
             .isInstanceOf(NoSuchMethodException.class)
             .hasMessage(
                 "class java.lang.String class io.github.resilience4j.spring6.fallback.FallbackMethodTest.returnMismatchFallback(class java.lang.String,class java.lang.Throwable)");
@@ -127,7 +127,7 @@ public class FallbackMethodTest {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
         assertThatThrownBy(
-            () -> FallbackMethod.create("noMethod", testMethod, new Object[]{"test"}, target))
+            () -> FallbackMethod.create("noMethod", testMethod, new Object[]{"test"}, target.getClass(), target))
             .isInstanceOf(NoSuchMethodException.class)
             .hasMessage(
                 "class java.lang.String class io.github.resilience4j.spring6.fallback.FallbackMethodTest.noMethod(class java.lang.String,class java.lang.Throwable)");
@@ -138,7 +138,7 @@ public class FallbackMethodTest {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
         FallbackMethod fallbackMethod = FallbackMethod
-            .create("rethrowingFallbackMethod", testMethod, new Object[]{"test"}, target);
+            .create("rethrowingFallbackMethod", testMethod, new Object[]{"test"}, target.getClass(), target);
         RethrowException exception = new RethrowException();
         assertThatThrownBy(() -> fallbackMethod.fallback(exception)).isSameAs(exception);
     }
@@ -148,7 +148,7 @@ public class FallbackMethodTest {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
         FallbackMethod fallbackMethod = FallbackMethod
-            .create("rethrowingFallbackMethodChecked", testMethod, new Object[]{"test"}, target);
+            .create("rethrowingFallbackMethodChecked", testMethod, new Object[]{"test"}, target.getClass(), target);
         RethrowCheckedException exception = new RethrowCheckedException();
         assertThatThrownBy(() -> fallbackMethod.fallback(exception)).isSameAs(exception);
     }


### PR DESCRIPTION
FallbackMethod supports AOP (CircuitBreaker, Cacheable, etc...)

**Motivation**
Fallback method must be supported AOP

**Solution**
 Fallback method changed to use proxy instead of using original object

~~~java
    @CircuitBreaker(name = "test", fallbackMethod = "fallback")
    public String test(String arg) {
        if (arg == null) {
            throw new NullPointerException();
        }
        return "SUCCESS";
    }

    @Cacheable(cacheNames = "fallback")
    public String fallback(NullPointerException e) {
        return "SUCCESS";
    }

    @CircuitBreaker(name = "fallback")
    public String fallback(Exception e) {
        throw new RuntimeException("test..!!");
    }
~~~

