### PR TITLE
Added param recordResultPredicate to CircuitBreaker configurations properties

### DIFF
--- a/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationProperties.java
+++ b/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationProperties.java
@@ -102,6 +102,11 @@ public class CircuitBreakerConfigurationProperties extends CommonProperties {
             builder.writableStackTraceEnabled(properties.getWritableStackTraceEnabled());
         }
 
+        if (properties.getRecordResultPredicate() != null) {
+            Predicate<Object> predicate = ClassUtils.instantiatePredicateClass(properties.getRecordResultPredicate());
+            builder.recordResult(predicate);
+        }
+
         if (properties.getSlowCallRateThreshold() != null) {
             builder.slowCallRateThreshold(properties.getSlowCallRateThreshold());
         }
@@ -305,6 +310,9 @@ public class CircuitBreakerConfigurationProperties extends CommonProperties {
 
         @Nullable
         private Class<Predicate<Throwable>> recordFailurePredicate;
+
+        @Nullable
+        private Class<Predicate<Object>> recordResultPredicate;
 
         @Nullable
         private Class<? extends Throwable>[] recordExceptions;
@@ -551,6 +559,17 @@ public class CircuitBreakerConfigurationProperties extends CommonProperties {
         @Nullable
         public Class<Predicate<Throwable>> getRecordFailurePredicate() {
             return recordFailurePredicate;
+        }
+
+        @Nullable
+        public Class<Predicate<Object>> getRecordResultPredicate() {
+            return this.recordResultPredicate;
+        }
+
+        public InstanceProperties setRecordResultPredicate(
+                Class<Predicate<Object>> recordResultPredicate) {
+           this.recordResultPredicate = recordResultPredicate;
+            return this;
         }
 
         public InstanceProperties setRecordFailurePredicate(

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/RecordResultPredicate.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/RecordResultPredicate.java
@@ -1,0 +1,11 @@
+package io.github.resilience4j.common;
+
+import java.util.function.Predicate;
+
+public class RecordResultPredicate implements Predicate<String> {
+
+    @Override
+    public boolean test(String object) {
+        return object.equals("failure");
+    }
+}

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationPropertiesTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationPropertiesTest.java
@@ -18,6 +18,7 @@ package io.github.resilience4j.common.circuitbreaker.configuration;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.github.resilience4j.common.CompositeCustomizer;
 import io.github.resilience4j.common.RecordFailurePredicate;
+import io.github.resilience4j.common.RecordResultPredicate;
 import io.github.resilience4j.core.ConfigurationNotFoundException;
 import org.junit.Test;
 
@@ -59,6 +60,7 @@ public class CircuitBreakerConfigurationPropertiesTest {
         instanceProperties1.setRecordExceptions(new Class[]{IllegalStateException.class});
         //noinspection unchecked
         instanceProperties1.setRecordFailurePredicate((Class) RecordFailurePredicate.class);
+        instanceProperties1.setRecordResultPredicate((Class) RecordResultPredicate.class);
 
         CircuitBreakerConfigurationProperties.InstanceProperties instanceProperties2 = new CircuitBreakerConfigurationProperties.InstanceProperties();
         instanceProperties2.setSlidingWindowSize(1337);
@@ -87,6 +89,7 @@ public class CircuitBreakerConfigurationPropertiesTest {
         assertThat(circuitBreaker1.getWaitIntervalFunctionInOpenState().apply(1)).isEqualTo(100);
         assertThat(circuitBreaker1.isAutomaticTransitionFromOpenToHalfOpenEnabled()).isTrue();
         assertThat(circuitBreaker1.isWritableStackTraceEnabled()).isFalse();
+        assertThat(circuitBreaker1.getRecordResultPredicate().getClass()).isEqualTo(RecordResultPredicate.class);
 
         final CircuitBreakerConfigurationProperties.InstanceProperties backend1 = circuitBreakerConfigurationProperties
             .getBackendProperties("backend1");

--- a/resilience4j-micronaut/src/test/groovy/io/github/resilience4j/micronaut/circuitbreaker/CircuitBreakerRegistrySpec.groovy
+++ b/resilience4j-micronaut/src/test/groovy/io/github/resilience4j/micronaut/circuitbreaker/CircuitBreakerRegistrySpec.groovy
@@ -35,6 +35,7 @@ import javax.inject.Inject
 @Property(name = "resilience4j.circuitbreaker.instances.backendA.baseConfig", value = "default")
 @Property(name = "resilience4j.circuitbreaker.instances.backendB.baseConfig", value = "default")
 @Property(name = "resilience4j.circuitbreaker.instances.backendB.recordFailurePredicate", value = "io.github.resilience4j.micronaut.circuitbreaker.RecordFailurePredicate")
+@Property(name = "resilience4j.circuitbreaker.instances.backendB.recordResultPredicate", value = "io.github.resilience4j.micronaut.circuitbreaker.RecordResultPredicate")
 @Property(name = "resilience4j.circuitbreaker.instances.backendB.recordExceptions[0]", value = "io.github.resilience4j.micronaut.circuitbreaker.RecordedException")
 @Property(name = "resilience4j.circuitbreaker.instances.backendB.ignoreExceptions[0]", value = "io.github.resilience4j.micronaut.circuitbreaker.IgnoredException")
 class CircuitBreakerRegistrySpec extends Specification {
@@ -92,5 +93,7 @@ class CircuitBreakerRegistrySpec extends Specification {
         instanceProperties.ignoreExceptions.first() == IgnoredException.class
 
         instanceProperties.recordFailurePredicate == RecordFailurePredicate.class
+
+        instanceProperties.recordResultPredicate == RecordResultPredicate.class
     }
 }

--- a/resilience4j-micronaut/src/test/groovy/io/github/resilience4j/micronaut/circuitbreaker/RecordResultPredicate.java
+++ b/resilience4j-micronaut/src/test/groovy/io/github/resilience4j/micronaut/circuitbreaker/RecordResultPredicate.java
@@ -1,0 +1,11 @@
+package io.github.resilience4j.micronaut.circuitbreaker;
+
+import java.util.function.Predicate;
+
+public class RecordResultPredicate implements Predicate<String> {
+
+    @Override
+    public boolean test(String text) {
+        return text.equals("failure");
+    }
+}


### PR DESCRIPTION
As we discussed in https://github.com/resilience4j/resilience4j/issues/1955, it is currently not possible to add a predicate result in the application environment variable configuration files. With this PR, it will be possible to customize it using YAML/properties.

![image](https://github.com/resilience4j/resilience4j/assets/66184422/268cf286-5a5b-488c-abde-3a1cd3ffc34a)
