### PR TITLE
Issue #201 timeUnit replaced by currentTimestamp

### DIFF
--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/adaptive/AdaptiveBulkheadConfig.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/adaptive/AdaptiveBulkheadConfig.java
@@ -64,7 +64,6 @@ public class AdaptiveBulkheadConfig implements Serializable {
     private static final Predicate<Object> DEFAULT_RECORD_RESULT_PREDICATE = (Object object) -> false;
     private static final boolean DEFAULT_RESET_METRICS_ON_TRANSITION = false;
 
-
     @SuppressWarnings("unchecked")
     private Class<? extends Throwable>[] recordExceptions = new Class[0];
     @SuppressWarnings("unchecked")

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/adaptive/AdaptiveBulkheadRegistry.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/adaptive/AdaptiveBulkheadRegistry.java
@@ -19,12 +19,12 @@
 package io.github.resilience4j.bulkhead.adaptive;
 
 
+import io.github.resilience4j.bulkhead.adaptive.internal.InMemoryAdaptiveBulkheadRegistry;
+import io.github.resilience4j.core.Registry;
+
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
-
-import io.github.resilience4j.bulkhead.adaptive.internal.InMemoryAdaptiveBulkheadRegistry;
-import io.github.resilience4j.core.Registry;
 
 /**
  * The {@link AdaptiveBulkheadRegistry} is a factory to create AdaptiveBulkhead instances which stores all bulkhead instances in a registry.

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/adaptive/internal/InMemoryAdaptiveBulkheadRegistry.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/adaptive/internal/InMemoryAdaptiveBulkheadRegistry.java
@@ -18,17 +18,17 @@
  */
 package io.github.resilience4j.bulkhead.adaptive.internal;
 
-import java.util.Map;
-import java.util.Set;
-import java.util.HashSet;
-import java.util.Objects;
-import java.util.function.Supplier;
-
 import io.github.resilience4j.bulkhead.adaptive.AdaptiveBulkhead;
 import io.github.resilience4j.bulkhead.adaptive.AdaptiveBulkheadConfig;
 import io.github.resilience4j.bulkhead.adaptive.AdaptiveBulkheadRegistry;
 import io.github.resilience4j.core.ConfigurationNotFoundException;
 import io.github.resilience4j.core.registry.AbstractRegistry;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * Bulkhead instance manager;

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/adaptive/internal/AdaptiveBulkheadDurationTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/adaptive/internal/AdaptiveBulkheadDurationTest.java
@@ -34,7 +34,7 @@ public class AdaptiveBulkheadDurationTest {
         long startTime = bulkhead.getCurrentTimestamp();
         clock.advanceByMillis(2);
 
-        bulkhead.onResult(startTime, bulkhead.getTimestampUnit(), 400);
+        bulkhead.onResult(startTime, 400);
 
         Snapshot snapshot = ((AdaptiveBulkheadMetrics) bulkhead.getMetrics()).getSnapshot();
         assertThat(snapshot.getNumberOfFailedCalls()).isOne();
@@ -50,7 +50,7 @@ public class AdaptiveBulkheadDurationTest {
         long startTime = bulkhead.getCurrentTimestamp();
         clock.advanceBySeconds(2);
 
-        bulkhead.onResult(startTime, bulkhead.getTimestampUnit(), 200);
+        bulkhead.onResult(startTime, 200);
 
         Snapshot snapshot = ((AdaptiveBulkheadMetrics) bulkhead.getMetrics()).getSnapshot();
         assertThat(snapshot.getNumberOfSuccessfulCalls()).isOne();
@@ -71,8 +71,8 @@ public class AdaptiveBulkheadDurationTest {
         int seconds = (int) (slowCallDurationThreshold.getSeconds() - 1);
         clock.advanceBySeconds(seconds);
 
-        bulkhead.onError(startTime, bulkhead.getTimestampUnit(), failure);
-        bulkhead.onError(startTime, bulkhead.getTimestampUnit(), failure);
+        bulkhead.onError(startTime, failure);
+        bulkhead.onError(startTime, failure);
 
         Snapshot snapshot = ((AdaptiveBulkheadMetrics) bulkhead.getMetrics()).getSnapshot();
         assertThat(snapshot.getNumberOfFailedCalls()).isEqualTo(2);
@@ -88,7 +88,7 @@ public class AdaptiveBulkheadDurationTest {
         AdaptiveBulkheadStateMachine bulkhead = bulkhead(clock);
         long startTime = bulkhead.getCurrentTimestamp() - TimeUnit.SECONDS.toMillis(2);
 
-        bulkhead.onError(startTime, bulkhead.getTimestampUnit(), failure);
+        bulkhead.onError(startTime, failure);
 
         Snapshot snapshot = ((AdaptiveBulkheadMetrics) bulkhead.getMetrics()).getSnapshot();
         assertThat(snapshot.getNumberOfFailedCalls()).isOne();
@@ -107,8 +107,8 @@ public class AdaptiveBulkheadDurationTest {
         int seconds = (int) (slowCallDurationThreshold.getSeconds() + 1);
         clock.advanceBySeconds(seconds);
 
-        bulkhead.onError(startTime, bulkhead.getTimestampUnit(), failure);
-        bulkhead.onError(startTime, bulkhead.getTimestampUnit(), failure);
+        bulkhead.onError(startTime, failure);
+        bulkhead.onError(startTime, failure);
 
         Snapshot snapshot = ((AdaptiveBulkheadMetrics) bulkhead.getMetrics()).getSnapshot();
         assertThat(snapshot.getNumberOfFailedCalls()).isEqualTo(2);
@@ -125,7 +125,7 @@ public class AdaptiveBulkheadDurationTest {
         long startTime = bulkhead.getCurrentTimestamp();
         clock.advanceByDays(2);
 
-        bulkhead.onError(startTime, bulkhead.getTimestampUnit(), failure);
+        bulkhead.onError(startTime, failure);
 
         Snapshot snapshot = ((AdaptiveBulkheadMetrics) bulkhead.getMetrics()).getSnapshot();
         assertThat(snapshot.getNumberOfFailedCalls()).isOne();
@@ -141,7 +141,7 @@ public class AdaptiveBulkheadDurationTest {
         AdaptiveBulkheadStateMachine bulkhead = bulkhead(clock);
         long startTime = bulkhead.getCurrentTimestamp();
 
-        bulkhead.onError(startTime, bulkhead.getTimestampUnit(), failure);
+        bulkhead.onError(startTime, failure);
 
         Snapshot snapshot = ((AdaptiveBulkheadMetrics) bulkhead.getMetrics()).getSnapshot();
         assertThat(snapshot.getNumberOfFailedCalls()).isOne();
@@ -156,7 +156,7 @@ public class AdaptiveBulkheadDurationTest {
         long startTime = bulkhead.getCurrentTimestamp();
         clock.advanceByMillis(2);
 
-        bulkhead.onError(startTime + 600, bulkhead.getTimestampUnit(), failure);
+        bulkhead.onError(startTime + 600, failure);
 
         Snapshot snapshot = ((AdaptiveBulkheadMetrics) bulkhead.getMetrics()).getSnapshot();
         assertThat(snapshot.getNumberOfFailedCalls()).isOne();

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/adaptive/internal/AdaptiveBulkheadEventPublisherTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/adaptive/internal/AdaptiveBulkheadEventPublisherTest.java
@@ -59,7 +59,7 @@ public class AdaptiveBulkheadEventPublisherTest {
 		adaptiveBulkhead.getEventPublisher()
 				.onSuccess(this::logEventType);
 
-		adaptiveBulkhead.onSuccess(1000, TimeUnit.NANOSECONDS);
+		adaptiveBulkhead.onSuccess(1000);
 
 		then(logger).should(times(1)).info("SUCCESS");
 	}
@@ -69,7 +69,7 @@ public class AdaptiveBulkheadEventPublisherTest {
 		adaptiveBulkhead.getEventPublisher()
 				.onError(this::logEventType);
 
-		adaptiveBulkhead.onError(1000, TimeUnit.NANOSECONDS, new IOException("BAM!"));
+		adaptiveBulkhead.onError(1000, new IOException("BAM!"));
 
 		then(logger).should(times(1)).info("ERROR");
 	}
@@ -90,7 +90,7 @@ public class AdaptiveBulkheadEventPublisherTest {
 		adaptiveBulkhead.getEventPublisher()
 				.onIgnoredError(this::logEventType);
 
-		adaptiveBulkhead.onError(10000, TimeUnit.NANOSECONDS, new IOException("BAM!"));
+		adaptiveBulkhead.onError(10000, new IOException("BAM!"));
 
 		then(logger).should(times(1)).info("IGNORED_ERROR");
 	}

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/adaptive/internal/AdaptiveBulkheadGraphTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/adaptive/internal/AdaptiveBulkheadGraphTest.java
@@ -55,7 +55,7 @@ public class AdaptiveBulkheadGraphTest {
     @Test
     public void testSlowCalls() {
         for (int i = 0; i < CALLS; i++) {
-            bulkhead.onSuccess(nextLatency(), TimeUnit.MILLISECONDS);
+            bulkhead.onSuccess(nextLatency());
         }
         drawGraph("testSlowCalls");
     }
@@ -66,9 +66,9 @@ public class AdaptiveBulkheadGraphTest {
 
         for (int i = 0; i < CALLS; i++) {
             if (nextErrorOccurred()) {
-                bulkhead.onError(1, TimeUnit.MILLISECONDS, failure);
+                bulkhead.onError(1, failure);
             } else {
-                bulkhead.onSuccess(1, TimeUnit.MILLISECONDS);
+                bulkhead.onSuccess(1);
             }
         }
         drawGraph("testFailedCalls");
@@ -79,7 +79,7 @@ public class AdaptiveBulkheadGraphTest {
         Throwable failure = new Throwable();
 
         for (int i = 0; i < CALLS; i++) {
-            bulkhead.onError(1, TimeUnit.MILLISECONDS, failure);
+            bulkhead.onError(1, failure);
         }
         drawGraph("testFailedCallsOnly");
     }
@@ -87,7 +87,7 @@ public class AdaptiveBulkheadGraphTest {
     @Test
     public void testSuccessfulCallsOnly() {
         for (int i = 0; i < CALLS; i++) {
-            bulkhead.onSuccess(1, TimeUnit.MILLISECONDS);
+            bulkhead.onSuccess(1);
         }
         drawGraph("testSuccessfulCallsOnly");
     }
@@ -113,10 +113,10 @@ public class AdaptiveBulkheadGraphTest {
 
         for (int j = 0; j < 3; j++) {
             for (int i = 0; i < 5; i++) {
-                bulkhead.onSuccess(1, TimeUnit.MILLISECONDS);
+                bulkhead.onSuccess(1);
             }
             for (int i = 0; i < 3; i++) {
-                bulkhead.onError(System.currentTimeMillis(), TimeUnit.MILLISECONDS, failure);
+                bulkhead.onError(System.currentTimeMillis(), failure);
             }
         }
         drawGraph("WithLowMinConcurrentCalls");

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/adaptive/internal/AdaptiveBulkheadStateMachineTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/adaptive/internal/AdaptiveBulkheadStateMachineTest.java
@@ -47,11 +47,11 @@ public class AdaptiveBulkheadStateMachineTest {
     }
 
     private void onSuccess() {
-        bulkhead.onSuccess(bulkhead.getCurrentTimestamp(), bulkhead.getTimestampUnit());
+        bulkhead.onSuccess(bulkhead.getCurrentTimestamp());
     }
 
     private void onError() {
-        bulkhead.onError(bulkhead.getCurrentTimestamp(), bulkhead.getTimestampUnit(), ERROR);
+        bulkhead.onError(bulkhead.getCurrentTimestamp(), ERROR);
     }
 
     @Test

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/adaptive/internal/AdaptiveBulkheadStateMachineTransitionsTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/adaptive/internal/AdaptiveBulkheadStateMachineTransitionsTest.java
@@ -41,11 +41,11 @@ public class AdaptiveBulkheadStateMachineTransitionsTest {
     }
 
     private void onSuccess() {
-        bulkhead.onSuccess(bulkhead.getCurrentTimestamp(), bulkhead.getTimestampUnit());
+        bulkhead.onSuccess(bulkhead.getCurrentTimestamp());
     }
 
     private void onError() {
-        bulkhead.onError(bulkhead.getCurrentTimestamp(), bulkhead.getTimestampUnit(), ERROR);
+        bulkhead.onError(bulkhead.getCurrentTimestamp(), ERROR);
     }
 
     @Test

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/adaptive/internal/AdaptiveBulkheadThresholdResultHandlingTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/adaptive/internal/AdaptiveBulkheadThresholdResultHandlingTest.java
@@ -19,11 +19,11 @@ public class AdaptiveBulkheadThresholdResultHandlingTest {
             .build());
 
         assertThat(circuitBreaker.tryAcquirePermission()).isTrue();
-        circuitBreaker.onResult(0, TimeUnit.NANOSECONDS, "success");
+        circuitBreaker.onResult(0, "success");
 
         // Call 2 is a failure
         assertThat(circuitBreaker.tryAcquirePermission()).isTrue();
-        circuitBreaker.onResult(0, TimeUnit.NANOSECONDS, "failure");
+        circuitBreaker.onResult(0, "failure");
 
         assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls()).isEqualTo(1);
         assertThat(circuitBreaker.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(1);
@@ -40,11 +40,11 @@ public class AdaptiveBulkheadThresholdResultHandlingTest {
             .build());
 
         assertThat(circuitBreaker.tryAcquirePermission()).isTrue();
-        circuitBreaker.onResult(0, TimeUnit.NANOSECONDS, Either.left("accepted fail"));
+        circuitBreaker.onResult(0, Either.left("accepted fail"));
 
         // Call 2 is a failure
         assertThat(circuitBreaker.tryAcquirePermission()).isTrue();
-        circuitBreaker.onResult(0, TimeUnit.NANOSECONDS, Either.left("failure"));
+        circuitBreaker.onResult(0, Either.left("failure"));
 
         assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls()).isEqualTo(1);
         assertThat(circuitBreaker.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(1);

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/adaptive/internal/ConcurrencyLimitTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/adaptive/internal/ConcurrencyLimitTest.java
@@ -23,11 +23,11 @@ public class ConcurrencyLimitTest {
     }
 
     private void onSuccess() {
-        bulkhead.onSuccess(bulkhead.getCurrentTimestamp(), bulkhead.getTimestampUnit());
+        bulkhead.onSuccess(bulkhead.getCurrentTimestamp());
     }
 
     private void onError() {
-        bulkhead.onError(bulkhead.getCurrentTimestamp(), bulkhead.getTimestampUnit(), ERROR);
+        bulkhead.onError(bulkhead.getCurrentTimestamp(), ERROR);
     }
 
     @Test


### PR DESCRIPTION
Because of the currentTimestampFunction and MockClock it's still testable eg. AdaptiveBulkheadDurationTest
