### PR TITLE
Removing stale retry configurations from configuration map #2037

### DIFF
--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/Registry.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/Registry.java
@@ -89,6 +89,14 @@ public interface Registry<E, C> {
     EventPublisher<E> getEventPublisher();
 
     /**
+     +     * Removes a configuration from the registry
+     +     *
+     +     * @param configName    the configuration name
+     +     * @return configuration mapped to the configName.
+     +     */
+    C removeConfiguration(String configName);
+
+    /**
      * An EventPublisher can be used to register event consumers.
      */
     interface EventPublisher<E> extends io.github.resilience4j.core.EventPublisher<RegistryEvent> {

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/registry/AbstractRegistry.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/registry/AbstractRegistry.java
@@ -140,6 +140,15 @@ public class AbstractRegistry<E, C> implements Registry<E, C> {
     }
 
     @Override
+    public C removeConfiguration(String configName) {
+        if (configName.equals(DEFAULT_CONFIG)) {
+            throw new IllegalArgumentException(
+                "You cannot remove the default configuration");
+        }
+        return this.configurations.remove(configName);
+    }
+
+    @Override
     public C getDefaultConfig() {
         return configurations.get(DEFAULT_CONFIG);
     }

--- a/resilience4j-core/src/test/java/io/github/resilience4j/core/registry/AbstractRegistryTest.java
+++ b/resilience4j-core/src/test/java/io/github/resilience4j/core/registry/AbstractRegistryTest.java
@@ -41,6 +41,22 @@ public class AbstractRegistryTest {
     }
 
     @Test
+    public void shouldRemoveCustomConfiguration() {
+        TestRegistry testRegistry = new TestRegistry();
+        testRegistry.addConfiguration("customRemovable", "test");
+        testRegistry.removeConfiguration("customRemovable");
+        assertThat(testRegistry.getConfiguration("customRemovable").isPresent()).isEqualTo(false);
+    }
+
+    @Test
+    public void shouldNotAllowToRemoveDefaultConfiguration() {
+        TestRegistry testRegistry = new TestRegistry();
+
+        assertThatThrownBy(() -> testRegistry.removeConfiguration("default"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
     public void shouldConsumeRegistryEvents() {
         List<RegistryEvent> consumedEvents = new ArrayList<>();
         List<EntryAddedEvent<String>> addedEvents = new ArrayList<>();


### PR DESCRIPTION
Exposing a method in Registry.java - removeConfiguration(String) to remove any entry except the default entry from the configurations map.