### PR TITLE
Fix StackOverflowError after scheduled future interruption

### DIFF
--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachine.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachine.java
@@ -815,8 +815,8 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
         }
 
         private void cancelAutomaticTransitionToHalfOpen() {
-            if (transitionToHalfOpenFuture != null && !transitionToHalfOpenFuture.isDone()) {
-                transitionToHalfOpenFuture.cancel(true);
+            if (transitionToHalfOpenFuture != null) {
+                transitionToHalfOpenFuture.cancel(false);
             }
         }
 

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerAutoTransitionStateMachineTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerAutoTransitionStateMachineTest.java
@@ -95,7 +95,7 @@ public class CircuitBreakerAutoTransitionStateMachineTest {
         circuitBreaker.transitionToForcedOpenState();
 
         // Verify scheduled future is canceled
-        then(mockFuture).should(times(1)).cancel(true);
+        then(mockFuture).should(times(1)).cancel(false);
     }
 
     @Test


### PR DESCRIPTION
[issue](https://github.com/resilience4j/resilience4j/issues/2038)

Changes:

1. Do not interrupt future if it is running
2. Remove `synchronized`, because code already synchronized with atomic change gate (REVERTED)