### PR TITLE
avoid to add  duplicate consumer

### DIFF
--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/EventProcessor.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/EventProcessor.java
@@ -20,14 +20,14 @@ package io.github.resilience4j.core;
 
 import io.github.resilience4j.core.lang.Nullable;
 
-import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 public class EventProcessor<T> implements EventPublisher<T> {
 
-    final List<EventConsumer<T>> onEventConsumers = new CopyOnWriteArrayList<>();
+    final Set<EventConsumer<T>> onEventConsumers = new CopyOnWriteArraySet<>();
     final ConcurrentMap<String, List<EventConsumer<T>>> eventConsumerMap = new ConcurrentHashMap<>();
     private boolean consumerRegistered;
 
@@ -39,7 +39,7 @@ public class EventProcessor<T> implements EventPublisher<T> {
     public synchronized void registerConsumer(String className, EventConsumer<? extends T> eventConsumer) {
         this.eventConsumerMap.compute(className, (k, consumers) -> {
             if (consumers == null) {
-                consumers = new CopyOnWriteArrayList<>();
+                consumers = new CopyOnWriteArraySet<>();
                 consumers.add((EventConsumer<T>) eventConsumer);
                 return consumers;
             } else {
@@ -60,7 +60,7 @@ public class EventProcessor<T> implements EventPublisher<T> {
         }
 
         if (!eventConsumerMap.isEmpty()) {
-            final List<EventConsumer<T>> consumers = this.eventConsumerMap.get(event.getClass().getName());
+            final Set<EventConsumer<T>> consumers = this.eventConsumerMap.get(event.getClass().getName());
             if (consumers != null && !consumers.isEmpty()) {
                 for (EventConsumer<T> consumer : consumers) {
                     consumer.consumeEvent(event);

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/EventProcessor.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/EventProcessor.java
@@ -20,6 +20,7 @@ package io.github.resilience4j.core;
 
 import io.github.resilience4j.core.lang.Nullable;
 
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -28,7 +29,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
 public class EventProcessor<T> implements EventPublisher<T> {
 
     final Set<EventConsumer<T>> onEventConsumers = new CopyOnWriteArraySet<>();
-    final ConcurrentMap<String, List<EventConsumer<T>>> eventConsumerMap = new ConcurrentHashMap<>();
+    final ConcurrentMap<String, Set<EventConsumer<T>>> eventConsumerMap = new ConcurrentHashMap<>();
     private boolean consumerRegistered;
 
     public boolean hasConsumers() {

--- a/resilience4j-core/src/test/java/io/github/resilience4j/core/EventProcessorTest.java
+++ b/resilience4j-core/src/test/java/io/github/resilience4j/core/EventProcessorTest.java
@@ -50,9 +50,9 @@ public class EventProcessorTest {
         eventProcessor.onEvent(eventConsumer);
         eventProcessor.onEvent(eventConsumer);
 
-        assertThat(eventProcessor.onEventConsumers).hasSize(2);
+        assertThat(eventProcessor.onEventConsumers).hasSize(1);
         boolean consumed = eventProcessor.processEvent(1);
-        then(logger).should(times(2)).info("1");
+        then(logger).should(times(1)).info("1");
         assertThat(consumed).isTrue();
     }
 
@@ -65,9 +65,9 @@ public class EventProcessorTest {
         eventProcessor.registerConsumer(Integer.class.getName(), eventConsumer);
 
         assertThat(eventProcessor.eventConsumerMap).hasSize(1);
-        assertThat(eventProcessor.eventConsumerMap.get(Integer.class.getName())).hasSize(2);
+        assertThat(eventProcessor.eventConsumerMap.get(Integer.class.getName())).hasSize(1);
         boolean consumed = eventProcessor.processEvent(1);
-        then(logger).should(times(2)).info("1");
+        then(logger).should(times(1)).info("1");
         assertThat(consumed).isTrue();
     }
 


### PR DESCRIPTION
CopyOnWriteArrayList may lead to add same eventConsumer and repeatedly publish events

