### PR TITLE
max randomization factor can be 1, refactor randomization function

### DIFF
--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/IntervalFunction.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/IntervalFunction.java
@@ -235,12 +235,13 @@ final class IntervalFunctionCompanion {
     }
 
     @SuppressWarnings("squid:S2245") // this is not security-sensitive code
+    // Given randomizationFactor is restricted by checkRandomizationFactor the return value => 0.0 <= x < 2 * current
     static double randomize(final double current, final double randomizationFactor) {
         final double delta = randomizationFactor * current;
-        final double min = current - delta;
-        final double max = current + delta;
-
-        return (min + (Math.random() * (max - min + 1)));
+        final double min = current - delta; // 0.0 <= min <= current
+        final double max = current + delta; // current <= max <= 2 * current
+        final double random = Math.random(); // 0.0 >= random < 1.0
+        return min + random * (max - min); // min <= return < max, 0.0 <= return < 2 * current
     }
 
     static void checkInterval(long intervalMillis) {

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/IntervalFunction.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/IntervalFunction.java
@@ -251,7 +251,7 @@ final class IntervalFunctionCompanion {
     }
 
     static void checkRandomizationFactor(double randomizationFactor) {
-        if (randomizationFactor < 0.0 || randomizationFactor >= 1.0) {
+        if (randomizationFactor < 0.0 || randomizationFactor > 1.0) {
             throw new IllegalArgumentException(
                 "Illegal argument randomizationFactor: " + randomizationFactor);
         }


### PR DESCRIPTION
TLDR: Nice to have but not important, this could have impacts on code that expects values returned from an interval function to be greater than zero.

This PR proposes two changes:

1. Allow randomization factor to be 1.0.
2. Refactor randomize() in IntervalFunction to remove `+1` and to specify its contract.

## Randomization factor to be 1.0

Largely cosmetic, however it does have the consequence of allowing interval functions to now return 0. I don't know enough about the rest of the codebase outside of Retry to know if this will have any negative consequences. If this is accepted I would also propose a new constructor `ofExponentialFullRandomBackoff` that defaults to a value of 1.0 for randomization. Full random or full jitter is generally a desirable characteristic for backoff functions: https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/

## Refactor randomize()

Randomize currently includes a `+ 1` which seems out of place. This +1 has no effect on large intervals since it extends the range by an insignificant amount and when the interval is 0 it forces the `randomize` function to produce values between 0 and 1.

My proposal is to refactor randomize so that it produces values between `0.0 <= x < 2 * current`.