### PR TITLE
Update Feign version

### DIFF
--- a/libraries.gradle
+++ b/libraries.gradle
@@ -22,7 +22,7 @@ ext {
     springBoot3Version = '3.0.0'
     springCloudContext2Version = '3.1.5'
     spockVersion = '1.3-groovy-2.5'
-    feignVersion = '12.0'
+    feignVersion = '13.2.1'
     reactiveStreamsVersion = '1.0.2'
     micrometerVersion = '1.10.0'
     hibernateValidatorVersion = '6.0.18.Final'

--- a/resilience4j-feign/src/main/java/io/github/resilience4j/feign/Resilience4jFeign.java
+++ b/resilience4j-feign/src/main/java/io/github/resilience4j/feign/Resilience4jFeign.java
@@ -57,11 +57,11 @@ public final class Resilience4jFeign {
         }
 
         @Override
-        public Feign build() {
+        public Feign internalBuild() {
             super.invocationHandlerFactory(
                 (target, dispatch) -> new DecoratorInvocationHandler(target, dispatch,
                     invocationDecorator));
-            return super.build();
+            return super.internalBuild();
         }
 
     }


### PR DESCRIPTION
Update to the latest Feign version (13.2.1).

Fix `Resilience4jFeign`: Feign 12.5 introduced a change to the `Builder` type, making the `build()` method `final` and instead adding `abstract internalBuild()` that now has to be overridden. 