### PR TITLE
Specify required RateLimiter permits on annotation

### DIFF
--- a/resilience4j-annotations/src/main/java/io/github/resilience4j/ratelimiter/annotation/RateLimiter.java
+++ b/resilience4j-annotations/src/main/java/io/github/resilience4j/ratelimiter/annotation/RateLimiter.java
@@ -45,4 +45,11 @@ public @interface RateLimiter {
      * @return fallbackMethod method name.
      */
     String fallbackMethod() default "";
+
+    /**
+     * Number of permits that this call requires.
+     *
+     * @return the number of permits that this call requires.
+     */
+    int permits() default 1;
 }

--- a/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/RateLimiter.java
+++ b/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/RateLimiter.java
@@ -536,7 +536,19 @@ public interface RateLimiter {
      * @return the decorated CompletionStage.
      */
     default <T> CompletionStage<T> executeCompletionStage(Supplier<CompletionStage<T>> supplier) {
-        return decorateCompletionStage(this, supplier).get();
+        return executeCompletionStage(1, supplier);
+    }
+
+    /**
+     * Decorates and executes the decorated CompletionStage.
+     *
+     * @param permits  number of permits that this call requires
+     * @param supplier the original CompletionStage
+     * @param <T>      the type of results supplied by this supplier
+     * @return the decorated CompletionStage.
+     */
+    default <T> CompletionStage<T> executeCompletionStage(int permits, Supplier<CompletionStage<T>> supplier) {
+        return decorateCompletionStage(this, permits, supplier).get();
     }
 
     /**

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/service/test/DummyService.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/service/test/DummyService.java
@@ -14,4 +14,7 @@ public interface DummyService {
     CompletableFuture<String> longDoSomethingAsync() throws InterruptedException;
 
     CompletableFuture<String> doSomethingAsync(boolean throwException) throws IOException;
+
+    void doSomethingExpensive();
+
 }

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/service/test/DummyServiceImpl.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/service/test/DummyServiceImpl.java
@@ -42,4 +42,9 @@ public class DummyServiceImpl implements DummyService {
         Try.run(() -> Thread.sleep(2000));
         return CompletableFuture.completedFuture("Test result");
     }
+
+    @RateLimiter(name = BACKEND, permits = 10)
+    @Override
+    public void doSomethingExpensive() {
+    }
 }


### PR DESCRIPTION
With this change you can specify the number of required permits for a ratelimiter on the annotation level