### PR TITLE
2.0 branch - Add support for Fegin 12.5+

### DIFF
--- a/libraries.gradle
+++ b/libraries.gradle
@@ -22,7 +22,7 @@ ext {
     ratpackVersion = '1.7.6'
     spockVersion = '1.3-groovy-2.5'
     retrofitVersion = '2.5.0'
-    feignVersion = '10.2.0'
+    feignVersion = '10.9'
     prometheusSimpleClientVersion = '0.9.0'
     reactiveStreamsVersion = '1.0.2'
     micrometerVersion = '1.5.1'

--- a/resilience4j-feign/README.adoc
+++ b/resilience4j-feign/README.adoc
@@ -14,8 +14,9 @@ resilience4j-feign makes it easy to incorporate "fault tolerance" patterns into 
  
 == Decorating Feign Interfaces
 
-The `Resilience4jFeign.builder` is the main class for creating fault tolerance instances of feign. 
-It extends the `Feign.builder` and can be configured in the same way with the exception of adding a custom 
+The `Resilience4jFeign.capability` is the main class for creating fault tolerance instances of feign.
+It proves a mechanism to bind feign with resilience4j using the capabilities api implemented in feign 10.9.
+Previous releases relied on Resilience4jFeign.builder, which used a mechanism that is no longer working since feign 12.5.
 `InvocationHandlerFactory`. Resilience4jFeign uses its own `InvocationHandlerFactory` to apply the decorators.
 Decorators can be built using the `FeignDecorators` class. Multiple decorators can be combined  
 
@@ -35,7 +36,9 @@ The following example shows how to decorate a feign interface with a RateLimiter
                                          .withRateLimiter(rateLimiter)
                                          .withCircuitBreaker(circuitBreaker)
                                          .build();
-        MyService myService = Resilience4jFeign.builder(decorators).target(MyService.class, "http://localhost:8080/");
+        MyService myService = Feign.builder()
+                                .addCapability(Resilience4jFeign.capability(decorators))
+                                .target(MyService.class, "http://localhost:8080/");
 ```
 
 Calling any method of the `MyService` instance will invoke a CircuitBreaker and then a RateLimiter.
@@ -82,7 +85,9 @@ Fallbacks can be defined that are called when Exceptions are thrown. Exceptions 
                                          .withFallback(requestFailedFallback, FeignException.class)
                                          .withFallback(circuitBreakerFallback, CallNotPermittedException.class)
                                          .build();
-        MyService myService = Resilience4jFeign.builder(decorators).target(MyService.class, "http://localhost:8080/", fallback);
+        MyService myService = Feign.builder()
+                                .addCapability(Resilience4jFeign.capability(decorators))
+                                .target(MyService.class, "http://localhost:8080/", fallback);
 ```
 In this example, the `requestFailedFallback` is called when a `FeignException` is thrown (usually when the HTTP request fails), whereas
  the `circuitBreakerFallback` is only called in the case of a `CallNotPermittedException`.

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignBuilderBackwardsComplianceTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignBuilderBackwardsComplianceTest.java
@@ -1,0 +1,33 @@
+package io.github.resilience4j.feign;
+
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import feign.Feign;
+import io.github.resilience4j.feign.test.TestService;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Resilience4jFeignBuilderBackwardsComplianceTest {
+    @ClassRule
+    public static final WireMockClassRule WIRE_MOCK_RULE = new WireMockClassRule(8080);
+
+    @Test
+    public void fallbackIsWorkingInBothConfigurationMechanisms() {
+        FeignDecorators decorators = FeignDecorators.builder()
+                .withFallback((TestService) () -> "fallback").build();
+
+        TestService testServiceA = Feign.builder()
+                .addCapability(Resilience4jFeign.capability(decorators))
+                .target(TestService.class, "http://localhost:8080/");
+
+        TestService testServiceB = Resilience4jFeign.builder(decorators)
+                .target(TestService.class, "http://localhost:8080/");
+
+        String resultA = testServiceA.greeting();
+        String resultB = testServiceB.greeting();
+
+        assertThat(resultA).isEqualTo("fallback");
+        assertThat(resultA).isEqualTo(resultB);
+    }
+}

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignBulkheadTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignBulkheadTest.java
@@ -2,6 +2,7 @@ package io.github.resilience4j.feign;
 
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import feign.Feign;
 import feign.FeignException;
 import io.github.resilience4j.bulkhead.Bulkhead;
 import io.github.resilience4j.bulkhead.BulkheadConfig;
@@ -33,7 +34,8 @@ public class Resilience4jFeignBulkheadTest {
         final FeignDecorators decorators = FeignDecorators.builder()
                 .withBulkhead(bulkhead)
                 .build();
-        testService = Resilience4jFeign.builder(decorators)
+        testService = Feign.builder()
+                .addCapability(Resilience4jFeign.capability(decorators))
                 .target(TestService.class, MOCK_URL);
 
     }

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignCircuitBreakerTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignCircuitBreakerTest.java
@@ -17,6 +17,7 @@
 package io.github.resilience4j.feign;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import feign.Feign;
 import feign.FeignException;
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
@@ -50,7 +51,8 @@ public class Resilience4jFeignCircuitBreakerTest {
         circuitBreaker = CircuitBreaker.of("test", circuitBreakerConfig);
         final FeignDecorators decorators = FeignDecorators.builder()
             .withCircuitBreaker(circuitBreaker).build();
-        testService = Resilience4jFeign.builder(decorators)
+        testService = Feign.builder()
+            .addCapability(Resilience4jFeign.capability(decorators))
             .target(TestService.class, "http://localhost:8080/");
     }
 

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignFallbackFactoryTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignFallbackFactoryTest.java
@@ -17,6 +17,7 @@
 package io.github.resilience4j.feign;
 
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import feign.Feign;
 import feign.FeignException;
 import io.github.resilience4j.feign.test.TestService;
 import io.github.resilience4j.feign.test.TestServiceFallbackThrowingException;
@@ -49,7 +50,9 @@ public class Resilience4jFeignFallbackFactoryTest {
         FeignDecorators decorators = FeignDecorators.builder()
             .withFallbackFactory(fallbackSupplier)
             .build();
-        return Resilience4jFeign.builder(decorators).target(TestService.class, MOCK_URL);
+        return Feign.builder()
+            .addCapability(Resilience4jFeign.capability(decorators))
+            .target(TestService.class, MOCK_URL);
     }
 
     private static void setupStub(int responseCode) {
@@ -90,7 +93,7 @@ public class Resilience4jFeignFallbackFactoryTest {
         String result = testService.greeting();
 
         assertThat(result)
-            .isEqualTo("Message from exception: status 400 reading TestService#greeting()");
+            .startsWith("Message from exception: [400 Bad Request]");
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
     }
 
@@ -122,7 +125,7 @@ public class Resilience4jFeignFallbackFactoryTest {
         String result = testService.greeting();
 
         assertThat(result)
-            .isEqualTo("Message from exception: status 400 reading TestService#greeting()");
+            .startsWith("Message from exception: [400 Bad Request]");
         verify(uselessFallback, times(0)).greeting();
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
     }
@@ -142,7 +145,7 @@ public class Resilience4jFeignFallbackFactoryTest {
         String result = testService.greeting();
 
         assertThat(result)
-            .isEqualTo("Message from exception: status 400 reading TestService#greeting()");
+            .startsWith("Message from exception: [400 Bad Request]");
         verify(uselessFallback, times(0)).greeting();
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
     }
@@ -163,7 +166,7 @@ public class Resilience4jFeignFallbackFactoryTest {
         String result = testService.greeting();
 
         assertThat(result)
-            .isEqualTo("Message from exception: status 400 reading TestService#greeting()");
+            .startsWith("Message from exception: [400 Bad Request]");
         verify(uselessFallback, times(0)).greeting();
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
     }
@@ -183,7 +186,7 @@ public class Resilience4jFeignFallbackFactoryTest {
         String result = testService.greeting();
 
         assertThat(result)
-            .isEqualTo("Message from exception: status 400 reading TestService#greeting()");
+            .startsWith("Message from exception: [400 Bad Request]");
         verify(uselessFallback, times(0)).greeting();
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
     }

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignFallbackLambdaTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignFallbackLambdaTest.java
@@ -17,6 +17,7 @@
 package io.github.resilience4j.feign;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import feign.Feign;
 import io.github.resilience4j.feign.test.Issue560;
 import io.github.resilience4j.feign.test.TestService;
 import org.junit.Before;
@@ -44,7 +45,8 @@ public class Resilience4jFeignFallbackLambdaTest {
             .withFallback(Issue560.createLambdaFallback())
             .build();
 
-        this.testService = Resilience4jFeign.builder(decorators)
+        this.testService = Feign.builder()
+            .addCapability(Resilience4jFeign.capability(decorators))
             .target(TestService.class, MOCK_URL);
     }
 

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignFallbackTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignFallbackTest.java
@@ -17,6 +17,7 @@
 package io.github.resilience4j.feign;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import feign.Feign;
 import feign.FeignException;
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.feign.test.TestService;
@@ -52,7 +53,9 @@ public class Resilience4jFeignFallbackTest {
             .withFallback(testServiceFallback)
             .build();
 
-        testService = Resilience4jFeign.builder(decorators).target(TestService.class, MOCK_URL);
+        testService = Feign.builder()
+            .addCapability(Resilience4jFeign.capability(decorators))
+            .target(TestService.class, MOCK_URL);
     }
 
     @Test

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignRateLimiterTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignRateLimiterTest.java
@@ -17,6 +17,7 @@
 package io.github.resilience4j.feign;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import feign.Feign;
 import feign.FeignException;
 import io.github.resilience4j.feign.test.TestService;
 import io.github.resilience4j.ratelimiter.RateLimiter;
@@ -48,7 +49,8 @@ public class Resilience4jFeignRateLimiterTest {
         final FeignDecorators decorators = FeignDecorators.builder()
             .withRateLimiter(rateLimiter)
             .build();
-        testService = Resilience4jFeign.builder(decorators)
+        testService = Feign.builder()
+            .addCapability(Resilience4jFeign.capability(decorators))
             .target(TestService.class, MOCK_URL);
     }
 

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignRetryTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignRetryTest.java
@@ -18,6 +18,7 @@ package io.github.resilience4j.feign;
 
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import feign.Feign;
 import feign.FeignException;
 import io.github.resilience4j.feign.test.TestService;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
@@ -51,7 +52,8 @@ public class Resilience4jFeignRetryTest {
         final FeignDecorators decorators = FeignDecorators.builder()
             .withRetry(retry)
             .build();
-        testService = Resilience4jFeign.builder(decorators)
+        testService = Feign.builder()
+            .addCapability(Resilience4jFeign.capability(decorators))
             .target(TestService.class, MOCK_URL);
     }
 


### PR DESCRIPTION
Follow-up for 2.0 branch for https://github.com/resilience4j/resilience4j/pull/2127

Cherry picked 4274ac47991eadc2336b99b865bf3bce52dc3f53 without issues

building the whole thing I got random timeout errors and didnt try until success, so guess its not the most stable build state in this branch..?

Building just feign module works though so dont think its related to my changes:
```
./gradlew  :resilience4j-feign:build
> Task :resilience4j-core:compileJava UP-TO-DATE
> Task :resilience4j-core:processResources NO-SOURCE
> Task :resilience4j-core:classes UP-TO-DATE
> Task :resilience4j-core:osgiClasses UP-TO-DATE
> Task :resilience4j-core:jar
> Task :resilience4j-bulkhead:compileJava UP-TO-DATE
> Task :resilience4j-bulkhead:processResources NO-SOURCE
> Task :resilience4j-bulkhead:classes UP-TO-DATE
> Task :resilience4j-bulkhead:osgiClasses UP-TO-DATE
> Task :resilience4j-bulkhead:jar
> Task :resilience4j-circuitbreaker:compileJava UP-TO-DATE
> Task :resilience4j-circuitbreaker:processResources NO-SOURCE
> Task :resilience4j-circuitbreaker:classes UP-TO-DATE
> Task :resilience4j-circuitbreaker:osgiClasses UP-TO-DATE
> Task :resilience4j-circuitbreaker:jar
> Task :resilience4j-ratelimiter:compileJava UP-TO-DATE
> Task :resilience4j-ratelimiter:processResources NO-SOURCE
> Task :resilience4j-ratelimiter:classes UP-TO-DATE
> Task :resilience4j-ratelimiter:osgiClasses UP-TO-DATE
> Task :resilience4j-ratelimiter:jar
> Task :resilience4j-retry:compileJava UP-TO-DATE
> Task :resilience4j-retry:processResources NO-SOURCE
> Task :resilience4j-retry:classes UP-TO-DATE
> Task :resilience4j-retry:osgiClasses UP-TO-DATE
> Task :resilience4j-retry:jar
> Task :resilience4j-feign:compileJava UP-TO-DATE
> Task :resilience4j-feign:processResources NO-SOURCE
> Task :resilience4j-feign:classes UP-TO-DATE
> Task :resilience4j-feign:osgiClasses UP-TO-DATE
> Task :resilience4j-feign:jar

> Task :resilience4j-feign:javadoc
/resilience4j/resilience4j-feign/src/main/java/io/github/resilience4j/feign/FeignDecorator.java:41: warning: no @param for target
    CheckedFunction<Object[], Object> decorate(CheckedFunction<Object[], Object> invocationCall,
                                      ^
/resilience4j/resilience4j-feign/src/main/java/io/github/resilience4j/feign/Resilience4jFeign.java:48: warning: no @param for invocationDecorator
    public static Builder builder(FeignDecorator invocationDecorator) {
                          ^
/resilience4j/resilience4j-feign/src/main/java/io/github/resilience4j/feign/Resilience4jFeign.java:48: warning: no @return
    public static Builder builder(FeignDecorator invocationDecorator) {
                          ^
3 warnings

> Task :resilience4j-feign:javadocJar
> Task :resilience4j-feign:sourcesJar UP-TO-DATE
> Task :resilience4j-feign:assemble
> Task :resilience4j-feign:compileTestJava UP-TO-DATE
> Task :resilience4j-feign:processTestResources NO-SOURCE
> Task :resilience4j-feign:testClasses UP-TO-DATE
> Task :resilience4j-feign:test
> Task :resilience4j-feign:check
> Task :resilience4j-feign:build

Deprecated Gradle features were used in this build, making it incompatible with Gradle 6.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/5.3.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 6s
23 actionable tasks: 9 executed, 14 up-to-date
```