### PR TITLE
Master branch - Add support for Fegin 12.5+

### DIFF
--- a/resilience4j-feign/README.adoc
+++ b/resilience4j-feign/README.adoc
@@ -14,8 +14,9 @@ resilience4j-feign makes it easy to incorporate "fault tolerance" patterns into 
  
 == Decorating Feign Interfaces
 
-The `Resilience4jFeign.builder` is the main class for creating fault tolerance instances of feign. 
-It extends the `Feign.builder` and can be configured in the same way with the exception of adding a custom 
+The `Resilience4jFeign.capability` is the main class for creating fault tolerance instances of feign.
+It proves a mechanism to bind feign with resilience4j using the capabilities api implemented in feign 10.9.
+Previous releases relied on Resilience4jFeign.builder, which used a mechanism that is no longer working since feign 12.5.
 `InvocationHandlerFactory`. Resilience4jFeign uses its own `InvocationHandlerFactory` to apply the decorators.
 Decorators can be built using the `FeignDecorators` class. Multiple decorators can be combined  
 
@@ -35,7 +36,9 @@ The following example shows how to decorate a feign interface with a RateLimiter
                                          .withRateLimiter(rateLimiter)
                                          .withCircuitBreaker(circuitBreaker)
                                          .build();
-        MyService myService = Resilience4jFeign.builder(decorators).target(MyService.class, "http://localhost:8080/");
+        MyService myService = Feign.builder()
+                                .addCapability(Resilience4jFeign.capability(decorators))
+                                .target(MyService.class, "http://localhost:8080/");
 ```
 
 Calling any method of the `MyService` instance will invoke a CircuitBreaker and then a RateLimiter.
@@ -82,7 +85,9 @@ Fallbacks can be defined that are called when Exceptions are thrown. Exceptions 
                                          .withFallback(requestFailedFallback, FeignException.class)
                                          .withFallback(circuitBreakerFallback, CallNotPermittedException.class)
                                          .build();
-        MyService myService = Resilience4jFeign.builder(decorators).target(MyService.class, "http://localhost:8080/", fallback);
+        MyService myService = Feign.builder()
+                                .addCapability(Resilience4jFeign.capability(decorators))
+                                .target(MyService.class, "http://localhost:8080/", fallback);
 ```
 In this example, the `requestFailedFallback` is called when a `FeignException` is thrown (usually when the HTTP request fails), whereas
  the `circuitBreakerFallback` is only called in the case of a `CallNotPermittedException`.

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignBuilderBackwardsComplianceTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignBuilderBackwardsComplianceTest.java
@@ -1,0 +1,33 @@
+package io.github.resilience4j.feign;
+
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import feign.Feign;
+import io.github.resilience4j.feign.test.TestService;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Resilience4jFeignBuilderBackwardsComplianceTest {
+    @ClassRule
+    public static final WireMockClassRule WIRE_MOCK_RULE = new WireMockClassRule(8080);
+
+    @Test
+    public void fallbackIsWorkingInBothConfigurationMechanisms() {
+        FeignDecorators decorators = FeignDecorators.builder()
+                .withFallback((TestService) () -> "fallback").build();
+
+        TestService testServiceA = Feign.builder()
+                .addCapability(Resilience4jFeign.capability(decorators))
+                .target(TestService.class, "http://localhost:8080/");
+
+        TestService testServiceB = Resilience4jFeign.builder(decorators)
+                .target(TestService.class, "http://localhost:8080/");
+
+        String resultA = testServiceA.greeting();
+        String resultB = testServiceB.greeting();
+
+        assertThat(resultA).isEqualTo("fallback");
+        assertThat(resultA).isEqualTo(resultB);
+    }
+}

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignBulkheadTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignBulkheadTest.java
@@ -2,6 +2,7 @@ package io.github.resilience4j.feign;
 
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import feign.Feign;
 import feign.FeignException;
 import io.github.resilience4j.bulkhead.Bulkhead;
 import io.github.resilience4j.bulkhead.BulkheadConfig;
@@ -33,7 +34,8 @@ public class Resilience4jFeignBulkheadTest {
         final FeignDecorators decorators = FeignDecorators.builder()
                 .withBulkhead(bulkhead)
                 .build();
-        testService = Resilience4jFeign.builder(decorators)
+        testService = Feign.builder()
+                .addCapability(Resilience4jFeign.capability(decorators))
                 .target(TestService.class, MOCK_URL);
 
     }

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignCircuitBreakerTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignCircuitBreakerTest.java
@@ -17,6 +17,7 @@
 package io.github.resilience4j.feign;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import feign.Feign;
 import feign.FeignException;
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
@@ -50,7 +51,8 @@ public class Resilience4jFeignCircuitBreakerTest {
         circuitBreaker = CircuitBreaker.of("test", circuitBreakerConfig);
         final FeignDecorators decorators = FeignDecorators.builder()
             .withCircuitBreaker(circuitBreaker).build();
-        testService = Resilience4jFeign.builder(decorators)
+        testService = Feign.builder()
+            .addCapability(Resilience4jFeign.capability(decorators))
             .target(TestService.class, "http://localhost:8080/");
     }
 

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignFallbackFactoryTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignFallbackFactoryTest.java
@@ -17,6 +17,7 @@
 package io.github.resilience4j.feign;
 
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import feign.Feign;
 import feign.FeignException;
 import io.github.resilience4j.feign.test.TestService;
 import io.github.resilience4j.feign.test.TestServiceFallbackThrowingException;
@@ -49,7 +50,9 @@ public class Resilience4jFeignFallbackFactoryTest {
         FeignDecorators decorators = FeignDecorators.builder()
             .withFallbackFactory(fallbackSupplier)
             .build();
-        return Resilience4jFeign.builder(decorators).target(TestService.class, MOCK_URL);
+        return Feign.builder()
+            .addCapability(Resilience4jFeign.capability(decorators))
+            .target(TestService.class, MOCK_URL);
     }
 
     private static void setupStub(int responseCode) {
@@ -90,7 +93,7 @@ public class Resilience4jFeignFallbackFactoryTest {
         String result = testService.greeting();
 
         assertThat(result)
-            .isEqualTo("Message from exception: [400 Bad Request] during [GET] to [http://localhost:8080/greeting] [TestService#greeting()]: [Hello, world!]");
+            .startsWith("Message from exception: [400 Bad Request]");
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
     }
 
@@ -122,7 +125,7 @@ public class Resilience4jFeignFallbackFactoryTest {
         String result = testService.greeting();
 
         assertThat(result)
-            .isEqualTo("Message from exception: [400 Bad Request] during [GET] to [http://localhost:8080/greeting] [TestService#greeting()]: [Hello, world!]");
+            .startsWith("Message from exception: [400 Bad Request]");
         verify(uselessFallback, times(0)).greeting();
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
     }
@@ -142,7 +145,7 @@ public class Resilience4jFeignFallbackFactoryTest {
         String result = testService.greeting();
 
         assertThat(result)
-            .isEqualTo("Message from exception: [400 Bad Request] during [GET] to [http://localhost:8080/greeting] [TestService#greeting()]: [Hello, world!]");
+            .startsWith("Message from exception: [400 Bad Request]");
         verify(uselessFallback, times(0)).greeting();
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
     }
@@ -163,7 +166,7 @@ public class Resilience4jFeignFallbackFactoryTest {
         String result = testService.greeting();
 
         assertThat(result)
-            .isEqualTo("Message from exception: [400 Bad Request] during [GET] to [http://localhost:8080/greeting] [TestService#greeting()]: [Hello, world!]");
+            .startsWith("Message from exception: [400 Bad Request]");
         verify(uselessFallback, times(0)).greeting();
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
     }
@@ -183,7 +186,7 @@ public class Resilience4jFeignFallbackFactoryTest {
         String result = testService.greeting();
 
         assertThat(result)
-            .isEqualTo("Message from exception: [400 Bad Request] during [GET] to [http://localhost:8080/greeting] [TestService#greeting()]: [Hello, world!]");
+            .startsWith("Message from exception: [400 Bad Request]");
         verify(uselessFallback, times(0)).greeting();
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
     }

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignFallbackLambdaTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignFallbackLambdaTest.java
@@ -17,6 +17,7 @@
 package io.github.resilience4j.feign;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import feign.Feign;
 import io.github.resilience4j.feign.test.Issue560;
 import io.github.resilience4j.feign.test.TestService;
 import org.junit.Before;
@@ -44,7 +45,8 @@ public class Resilience4jFeignFallbackLambdaTest {
             .withFallback(Issue560.createLambdaFallback())
             .build();
 
-        this.testService = Resilience4jFeign.builder(decorators)
+        this.testService = Feign.builder()
+            .addCapability(Resilience4jFeign.capability(decorators))
             .target(TestService.class, MOCK_URL);
     }
 

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignFallbackTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignFallbackTest.java
@@ -17,6 +17,7 @@
 package io.github.resilience4j.feign;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import feign.Feign;
 import feign.FeignException;
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.feign.test.TestService;
@@ -52,7 +53,9 @@ public class Resilience4jFeignFallbackTest {
             .withFallback(testServiceFallback)
             .build();
 
-        testService = Resilience4jFeign.builder(decorators).target(TestService.class, MOCK_URL);
+        testService = Feign.builder()
+            .addCapability(Resilience4jFeign.capability(decorators))
+            .target(TestService.class, MOCK_URL);
     }
 
     @Test

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignRateLimiterTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignRateLimiterTest.java
@@ -17,6 +17,7 @@
 package io.github.resilience4j.feign;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import feign.Feign;
 import feign.FeignException;
 import io.github.resilience4j.feign.test.TestService;
 import io.github.resilience4j.ratelimiter.RateLimiter;
@@ -47,7 +48,8 @@ public class Resilience4jFeignRateLimiterTest {
         final FeignDecorators decorators = FeignDecorators.builder()
             .withRateLimiter(rateLimiter)
             .build();
-        testService = Resilience4jFeign.builder(decorators)
+        testService = Feign.builder()
+            .addCapability(Resilience4jFeign.capability(decorators))
             .target(TestService.class, MOCK_URL);
     }
 

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignRetryTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignRetryTest.java
@@ -17,6 +17,7 @@
 package io.github.resilience4j.feign;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import feign.Feign;
 import feign.FeignException;
 import io.github.resilience4j.feign.test.TestService;
 import io.github.resilience4j.retry.Retry;
@@ -47,7 +48,8 @@ public class Resilience4jFeignRetryTest {
         final FeignDecorators decorators = FeignDecorators.builder()
             .withRetry(retry)
             .build();
-        testService = Resilience4jFeign.builder(decorators)
+        testService = Feign.builder()
+            .addCapability(Resilience4jFeign.capability(decorators))
             .target(TestService.class, MOCK_URL);
     }
 


### PR DESCRIPTION
Follow up from https://github.com/resilience4j/resilience4j/pull/2127

Cherry picked and addressed merge conflicts, TLDR; 
* you had bumped feign to 12.0 so no need for me to modify libraries
* Test file had conflict where you had previously copied the entire long exception where I went for startsWith()

```
BUILD SUCCESSFUL in 5m 21s
214 actionable tasks: 214 executed
```

Feign 12.5 made the builder.build() method final, and started internally clone it...

This breaks resilience4j integration with feign and renders resilience4j completely unused by feign.

In version 10.9 they introduced an api to add "capabilities" to the feign client.

Here I have made changed to the 1.7 branch (the release I need) that implements this new pattern instead, and provides a fallback using old pattern for backwards compatibility down to 10.9.

Merging this means minimum version of feign to use would be 10.9. and works with latest