### PR TITLE
Make `RateLimiter.executeSuspendFunction` respect `drainPermissionsOnResult` in config

### DIFF
--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/ratelimiter/RateLimiter.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/ratelimiter/RateLimiter.kt
@@ -31,7 +31,15 @@ import java.util.concurrent.TimeUnit
  */
 suspend fun <T> RateLimiter.executeSuspendFunction(block: suspend () -> T): T {
     awaitPermission()
-    return block()
+
+    try {
+        val result = block()
+        onResult(result)
+        return result
+    } catch (e: Throwable) {
+        onError(e)
+        throw e
+    }
 }
 
 /**


### PR DESCRIPTION
It closes #2169.

Unlike java version wapper methods like `RateLimiter.executeCallable`, `RateLimiter.executeSuspendFunction` in resillience4j doesn't respect `drainPermissionsOnResult` in the `RateLimiterConfig`, so anything set in `drainPermissionsOnResult` just gets ignored.

Here, we follow the behavior in `RateLimiter.executeCallable/executeSupplier`, add `onResult` and `onError` accordingly to `executeSuspendFunction`:
https://github.com/resilience4j/resilience4j/blob/eeaf57a8217ded7fe14bad511454f263f9e6f06d/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/RateLimiter.java#L214-L227

