### PR TITLE
[asciidoctor] bump asciidoctor to 2.4.0

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -55,13 +55,13 @@ NOTE: We use https://guides.github.com/introduction/flow/index.html[Github Flow]
 
 Pull Requests are the best way to propose changes to the codebase:
 
-. Fork the repo and create your branch from `master`.
+. Fork the repo and create your branch from `+master+`.
 . If you added code, add tests.
-. Don't forget about backward compatibility and `Javadoc` for public methods.
+. Don't forget about backward compatibility and `+Javadoc+` for public methods.
 . Apply out Twitter based coding style link:.editorconfig[.editorconfig]
 (https://blog.jetbrains.com/idea/2019/06/managing-code-style-on-a-directory-level-with-editorconfig/[Idea])
 and https://gist.github.com/wojteklu/73c6914cc446146b8b533c0988cf8d29[Clean Code] rules.
-. Use our commit message format: `Issue #699: Fixed/Added bla bla`
+. Use our commit message format: `+Issue #699: Fixed/Added bla bla+`
 . Send that Pull Request and participate in a code review.
 . After a merge update the documentation especially if you've changed API (public methods).
 
@@ -73,7 +73,7 @@ and static imports for them.
 Please write test body in the _Arrange-Act-Assert_ manner.
 Keep _Act (When)_ section as small as possible.
 
-TIP: Instead of `//Given` `//When` `//Then` comments separate sections by a new line.
+TIP: Instead of `+//Given+` `+//When+` `+//Then+` comments separate sections by a new line.
 For complex _Given_ setup you can extract private methods.
 
 

--- a/README.adoc
+++ b/README.adoc
@@ -113,7 +113,7 @@ There are also add-on modules for metrics, Feign, Kotlin, Spring, Ratpack, Vertx
 
 NOTE: Find out full list of modules in our *https://resilience4j.readme.io/docs#section-modularization[User Guide]*.
 
-TIP: For core modules package or `Decorators` builder see *https://mvnrepository.com/artifact/io.github.resilience4j/resilience4j-all[resilience4j-all]*.
+TIP: For core modules package or `+Decorators+` builder see *https://mvnrepository.com/artifact/io.github.resilience4j/resilience4j-all[resilience4j-all]*.
 
 == Resilience patterns
 
@@ -231,7 +231,7 @@ Observable.fromCallable(backendService::doSomething)
     .compose(CircuitBreakerOperator.of(circuitBreaker))
 ----
 
-NOTE: Resilience4j also provides RxJava operators for `RateLimiter`, `Bulkhead`, `TimeLimiter` and `Retry`.
+NOTE: Resilience4j also provides RxJava operators for `+RateLimiter+`, `+Bulkhead+`, `+TimeLimiter+` and `+Retry+`.
 Find out more in our *https://resilience4j.readme.io/docs/getting-started-2[User Guide]*.
 
 ==== CircuitBreaker and Spring Reactor
@@ -245,7 +245,7 @@ Mono.fromCallable(backendService::doSomething)
     .transformDeferred(CircuitBreakerOperator.of(circuitBreaker))
 ----
 
-NOTE: Resilience4j also provides Reactor operators for `RateLimiter`, `Bulkhead`, `TimeLimiter` and `Retry`.
+NOTE: Resilience4j also provides Reactor operators for `+RateLimiter+`, `+Bulkhead+`, `+TimeLimiter+` and `+Retry+`.
 Find out more in our *https://resilience4j.readme.io/docs/getting-started-1[User Guide]*.
 
 [[ratelimiter]]
@@ -328,12 +328,12 @@ CompletionStage<String> execution = bulkhead
 [[events]]
 == Consume emitted events
 
-`CircuitBreaker`, `RateLimiter`, `Cache`, `Bulkhead`, `TimeLimiter` and `Retry` components emit a stream of events.
+`+CircuitBreaker+`, `+RateLimiter+`, `+Cache+`, `+Bulkhead+`, `+TimeLimiter+` and `+Retry+` components emit a stream of events.
 It can be consumed for logging, assertions and any other purpose.
 
 === Examples
 
-A `CircuitBreakerEvent` can be a state transition, a circuit breaker reset, a successful call, a recorded error or an ignored error.
+A `+CircuitBreakerEvent+` can be a state transition, a circuit breaker reset, a successful call, a recorded error or an ignored error.
 All events contains additional information like event creation time and processing duration of the call.
 If you want to consume events, you have to register an event consumer.
 
@@ -350,8 +350,8 @@ circuitBreaker.getEventPublisher()
     .onEvent(event -> logger.info(...));
 ----
 
-You can use RxJava or Spring Reactor Adapters to convert the `EventPublisher` into a Reactive Stream.
-The advantage of a Reactive Stream is that you can use RxJava's `observeOn` operator to specify a different Scheduler that the CircuitBreaker will use to send notifications to its observers/consumers.
+You can use RxJava or Spring Reactor Adapters to convert the `+EventPublisher+` into a Reactive Stream.
+The advantage of a Reactive Stream is that you can use RxJava's `+observeOn+` operator to specify a different Scheduler that the CircuitBreaker will use to send notifications to its observers/consumers.
 
 [source,java]
 ----

--- a/RELEASENOTES.adoc
+++ b/RELEASENOTES.adoc
@@ -39,7 +39,7 @@
 * CircuitBreakerRegistry has a new method which takes a Supplier of a CircuitBreakerConfig so that the CircuitBreakerConfig is only created when needed.
 
 === Version 0.3.3
-* CircuitBreaker has a new method `getCircuitBreakerConfig` which allows to retrieve the CircuitBreakerConfig of the CircuitBreaker.
+* CircuitBreaker has a new method `+getCircuitBreakerConfig+` which allows to retrieve the CircuitBreakerConfig of the CircuitBreaker.
 * Renamed the state HALF_CLOSED to HALF_OPEN to match the pattern description of Martin Fowler.
 
 === Version 0.3.4
@@ -133,7 +133,7 @@ NOTE: Breaking changes:
 * PR #166: Bulkhead metrics for Dropwizard metrics module
 * PR #176: Retrofit enqueue support for circuit breaker and rate limiter
 * PR #177: Dynamic rate limiter configuration
-* PR #181: RxJava bulkhead operator for `Maybe` and `Completable`
+* PR #181: RxJava bulkhead operator for `+Maybe+` and `+Completable+`
 * PR #169: Bulkhead integration with Ratpack and call finished metric for bulkhead
 * PR #184: Dynamic bulkhead configuration
 
@@ -331,7 +331,7 @@ NOTE: Breaking changes:
 === Enhancements
 * RetryConfig.DEFAULT_MAX_ATTEMPTS should be public [#1180](https://github.com/resilience4j/resilience4j/issues/1180)
 * Circuitbreaker doesn't open when nested TimeLimiter throws TimeOutCancellationException [#1123](https://github.com/resilience4j/resilience4j/issues/1123)
-* Enhance Server Side Events  `/circuitbreaker/events`  [#1076](https://github.com/resilience4j/resilience4j/issues/1076)
+* Enhance Server Side Events  `+/circuitbreaker/events+`  [#1076](https://github.com/resilience4j/resilience4j/issues/1076)
 * CallNotPermittedException should contain circuit breaker name (and possibly other information) [#1062](https://github.com/resilience4j/resilience4j/issues/1062)
 * Retry: Exponential backoff with constant behaviour after certain time [#1044](https://github.com/resilience4j/resilience4j/issues/1044)
 * Respecting the clock set in the CircuitBreakerStateMachine for detecting slow calls [#734](https://github.com/resilience4j/resilience4j/issues/734)
@@ -401,12 +401,12 @@ Issue #1414: SpEL expressions support passing runtime method arguments to bean m
 * Issue #1787: Apply Spring Boot customizers even if there is no instance entry in the config file
 * Removed deprecated configuration properties [#1188](https://github.com/resilience4j/resilience4j/pull/1188)
 ** Circutbreaker:
-*** `ringBufferSizeInClosedState` replaced by `slidingWindowSize`
-*** `ringBufferSizeInHalfOpenState` replaced by `permittedNumberOfCallsInHalfOpenState`
+*** `+ringBufferSizeInClosedState+` replaced by `+slidingWindowSize+`
+*** `+ringBufferSizeInHalfOpenState+` replaced by `+permittedNumberOfCallsInHalfOpenState+`
 ** Retry:
-*** `maxRetryAttempts` replaced by `maxAttempts`
+*** `+maxRetryAttempts+` replaced by `+maxAttempts+`
 ** Bulkhead:
-*** `contextPropagator` list replaced by `contextPropagators`
+*** `+contextPropagator+` list replaced by `+contextPropagators+`
 
 ==== Bugs
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "org.sonarqube" version "3.5.0.2730"
-    id 'org.asciidoctor.convert' version '1.6.0'
+    id 'org.asciidoctor.jvm.convert' version '2.4.0'
     id "org.gradle.test-retry" version "1.5.0"
     id "io.github.gradle-nexus.publish-plugin"  version "1.1.0"
     id "me.champeau.jmh" version "0.6.8"
@@ -25,10 +25,6 @@ allprojects {
     jacoco {
         toolVersion = "0.8.8"
     }
-}
-
-asciidoctorj {
-    noDefaultRepositories = true
 }
 
 ext {

--- a/resilience4j-feign/README.adoc
+++ b/resilience4j-feign/README.adoc
@@ -14,11 +14,11 @@ resilience4j-feign makes it easy to incorporate "fault tolerance" patterns into 
  
 == Decorating Feign Interfaces
 
-The `Resilience4jFeign.capability` is the main class for creating fault tolerance instances of feign.
+The `+Resilience4jFeign.capability+` is the main class for creating fault tolerance instances of feign.
 It proves a mechanism to bind feign with resilience4j using the capabilities api implemented in feign 10.9.
 Previous releases relied on Resilience4jFeign.builder, which used a mechanism that is no longer working since feign 12.5.
-`InvocationHandlerFactory`. Resilience4jFeign uses its own `InvocationHandlerFactory` to apply the decorators.
-Decorators can be built using the `FeignDecorators` class. Multiple decorators can be combined  
+`+InvocationHandlerFactory+`. Resilience4jFeign uses its own `+InvocationHandlerFactory+` to apply the decorators.
+Decorators can be built using the `+FeignDecorators+` class. Multiple decorators can be combined
 
 The following example shows how to decorate a feign interface with a RateLimiter and CircuitBreaker:
 ``` java
@@ -41,8 +41,8 @@ The following example shows how to decorate a feign interface with a RateLimiter
                                 .target(MyService.class, "http://localhost:8080/");
 ```
 
-Calling any method of the `MyService` instance will invoke a CircuitBreaker and then a RateLimiter.
-If one of these mechanisms take effect, then the corresponding RuntimeException will be thrown, for example, `CallNotPermittedException` or `RequestNotPermitted` (Hint: These do not extend the `FeignException` class).
+Calling any method of the `+MyService+` instance will invoke a CircuitBreaker and then a RateLimiter.
+If one of these mechanisms take effect, then the corresponding RuntimeException will be thrown, for example, `+CallNotPermittedException+` or `+RequestNotPermitted+` (Hint: These do not extend the `+FeignException+` class).
 
 The following diagram illustrates how the decorators are stacked:
 image::feign-decorators.png[]
@@ -50,7 +50,7 @@ image::feign-decorators.png[]
 
 == Ordering of Decorators
 The order in which decorators are applied correspond to the order in which they are declared. 
-When building `FeignDecorators`, it is important to be wary of this, since the order affects the resulting behavior.
+When building `+FeignDecorators+`, it is important to be wary of this, since the order affects the resulting behavior.
 
 For example,
 ``` java
@@ -65,12 +65,12 @@ For example,
                                          .build();
 ```        
 
-With `decoratorsA` the RateLimiter will be called before the CircuitBreaker. That means that even if the CircuitBreaker is open, the RateLimiter will still limit the rate of calls.
-`decoratorsB` applies the reserve order. Meaning that once the CircuitBreaker is open, the RateLimiter will no longer be in affect.
+With `+decoratorsA+` the RateLimiter will be called before the CircuitBreaker. That means that even if the CircuitBreaker is open, the RateLimiter will still limit the rate of calls.
+`+decoratorsB+` applies the reserve order. Meaning that once the CircuitBreaker is open, the RateLimiter will no longer be in affect.
 
 
 == Fallback
-Fallbacks can be defined that are called when Exceptions are thrown. Exceptions can occur when the HTTP request fails, but also when one of the `FeignDecorators` activates, for example, the CircuitBreaker.
+Fallbacks can be defined that are called when Exceptions are thrown. Exceptions can occur when the HTTP request fails, but also when one of the `+FeignDecorators+` activates, for example, the CircuitBreaker.
 
 ``` java
         public interface MyService {
@@ -89,9 +89,9 @@ Fallbacks can be defined that are called when Exceptions are thrown. Exceptions 
                                 .addCapability(Resilience4jFeign.capability(decorators))
                                 .target(MyService.class, "http://localhost:8080/", fallback);
 ```
-In this example, the `requestFailedFallback` is called when a `FeignException` is thrown (usually when the HTTP request fails), whereas
- the `circuitBreakerFallback` is only called in the case of a `CallNotPermittedException`.
- Check the `FeignDecorators` class for more ways to filter fallbacks.
+In this example, the `+requestFailedFallback+` is called when a `+FeignException+` is thrown (usually when the HTTP request fails), whereas
+ the `+circuitBreakerFallback+` is only called in the case of a `+CallNotPermittedException+`.
+ Check the `+FeignDecorators+` class for more ways to filter fallbacks.
 
 All fallbacks must implement the same interface that is declared in the "target" (Resilience4jFeign.Builder#target) method, otherwise an IllegalArgumentException will be thrown.
 Multiple fallbacks can be assigned to handle the same Exception with the next fallback being called when the previous one fails.


### PR DESCRIPTION
Couldn't run tests locally due to the `0.10` grolifant dep no longer being available on maven. Bumping adoc fixed the issue. I'm aware this is being bumped across a major version.

I ran:
```
~/projects/resilience4j jack-bump-adoc !1                                                                                                                                                                                                                                                                 10s 14:11:39
❯ ./gradlew asciidoctor --warning-mode=all

BUILD SUCCESSFUL in 641ms
```

With no issues which is nice.

However: https://docs.asciidoctor.org/asciidoctor/latest/migrate/upgrade/ indicates that there are some syntax changes that need to be updated. I couldn't find any violations except for monospace.

Then again I have no idea what I'm doing, just want to run tests
