### PR TITLE
fix 2097

### DIFF
--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/RetryConfig.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/RetryConfig.java
@@ -245,7 +245,7 @@ public class RetryConfig implements Serializable {
 
         public Builder<T> waitDuration(Duration waitDuration) {
             if (waitDuration.toMillis() >= 0) {
-                this.intervalBiFunction = (attempt, either) -> waitDuration.toMillis();
+                this.intervalBiFunction((attempt, either) -> waitDuration.toMillis());
             } else {
                 throw new IllegalArgumentException(
                     "waitDuration must be a positive value");
@@ -311,6 +311,7 @@ public class RetryConfig implements Serializable {
          */
         public Builder<T> intervalFunction(IntervalFunction f) {
             this.intervalFunction = f;
+            this.intervalBiFunction = null;
             return this;
         }
 
@@ -322,6 +323,7 @@ public class RetryConfig implements Serializable {
          */
         public Builder<T> intervalBiFunction(IntervalBiFunction<T> f) {
             this.intervalBiFunction = f;
+            this.intervalFunction = null;
             return this;
         }
 

--- a/resilience4j-retry/src/test/java/io/github/resilience4j/retry/RetryConfigBuilderTest.java
+++ b/resilience4j-retry/src/test/java/io/github/resilience4j/retry/RetryConfigBuilderTest.java
@@ -236,7 +236,7 @@ public class RetryConfigBuilderTest {
                 .intervalBiFunction(biFunction)
                 .build();
         assertThat(config).isNotNull();
-        assertThat(config.getIntervalFunction()).isNotNull();
+        assertThat(config.getIntervalFunction()).isNull();
         assertThat(config.getIntervalFunction()).isNotEqualTo(function);
         assertThat(config.getIntervalBiFunction()).isEqualTo(biFunction);
     }

--- a/resilience4j-retry/src/test/java/io/github/resilience4j/retry/RetryConfigBuilderTest.java
+++ b/resilience4j-retry/src/test/java/io/github/resilience4j/retry/RetryConfigBuilderTest.java
@@ -216,11 +216,29 @@ public class RetryConfigBuilderTest {
         assertThat(config1.getMaxAttempts()).isEqualTo(5);
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void intervalFunctionUsedWithIntervalBiFunctionShouldFail() {
-        RetryConfig.custom().intervalBiFunction((attempt, either) -> 100L)
-            .intervalFunction(IntervalFunction.ofDefaults())
-            .build();
+    @Test()
+    public void intervalFunctionClearIntervalBiFunction() {
+        IntervalBiFunction<Object> biFunction = (attempt, either) -> 100L;
+        IntervalFunction function = IntervalFunction.ofDefaults();
+        RetryConfig config = RetryConfig.custom().intervalBiFunction(biFunction)
+                .intervalFunction(function)
+                .build();
+        assertThat(config).isNotNull();
+        assertThat(config.getIntervalFunction()).isEqualTo(function);
+        assertThat(config.getIntervalBiFunction()).isNotEqualTo(biFunction);
+    }
+
+    @Test
+    public void intervalBiFunctionClearIntervalFunction() {
+        IntervalBiFunction<Object> biFunction = (attempt, either) -> 100L;
+        IntervalFunction function = IntervalFunction.ofDefaults();
+        RetryConfig config = RetryConfig.custom().intervalFunction(function)
+                .intervalBiFunction(biFunction)
+                .build();
+        assertThat(config).isNotNull();
+        assertThat(config.getIntervalFunction()).isNotNull();
+        assertThat(config.getIntervalFunction()).isNotEqualTo(function);
+        assertThat(config.getIntervalBiFunction()).isEqualTo(biFunction);
     }
 
     @Test


### PR DESCRIPTION
This PR fixes #2097.

Always update `intervalFunction` and `intervalBiFunction` of `io.github.resilience4j.retry.RetryConfig.Builder` with `setter` method. In the `setter`s, always update one and clear the other.