### PR TITLE
lock free metrics

### DIFF
--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/AbstractAggregation.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/AbstractAggregation.java
@@ -19,34 +19,32 @@
 package io.github.resilience4j.core.metrics;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
 
 class AbstractAggregation {
 
-    long totalDurationInMillis = 0;
-    int numberOfSlowCalls = 0;
-    int numberOfSlowFailedCalls = 0;
-    int numberOfFailedCalls = 0;
-    int numberOfCalls = 0;
+    LongAdder totalDurationInMillis = new LongAdder();
+    LongAdder numberOfSlowCalls = new LongAdder();
+    LongAdder numberOfSlowFailedCalls = new LongAdder();
+    LongAdder numberOfFailedCalls = new LongAdder();
+    LongAdder numberOfCalls = new LongAdder();
 
     void record(long duration, TimeUnit durationUnit, Metrics.Outcome outcome) {
-        this.numberOfCalls++;
-        this.totalDurationInMillis += durationUnit.toMillis(duration);
+        this.numberOfCalls.add(1);
+        this.totalDurationInMillis.add(durationUnit.toMillis(duration));
         switch (outcome) {
             case SLOW_SUCCESS:
-                numberOfSlowCalls++;
+                numberOfSlowCalls.add(1);
                 break;
 
             case SLOW_ERROR:
-                numberOfSlowCalls++;
-                numberOfFailedCalls++;
-                numberOfSlowFailedCalls++;
+                numberOfSlowCalls.add(1);
+                numberOfFailedCalls.add(1);
+                numberOfSlowFailedCalls.add(1);
                 break;
 
             case ERROR:
-                numberOfFailedCalls++;
-                break;
-
-            default:
+                numberOfFailedCalls.add(1);
                 break;
         }
     }

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/FixedSizeSlidingWindowMetrics.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/FixedSizeSlidingWindowMetrics.java
@@ -21,7 +21,6 @@ package io.github.resilience4j.core.metrics;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReferenceArray;
 
 /**
  * A {@link Metrics} implementation is backed by a sliding window that aggregates only the last
@@ -42,7 +41,7 @@ public class FixedSizeSlidingWindowMetrics implements Metrics {
 
     private final int windowSize;
     private final TotalAggregation totalAggregation;
-    private final AtomicReferenceArray<Measurement> measurements;
+    private final Measurement[] measurements;
     final AtomicInteger headIndex;
 
     /**
@@ -52,10 +51,10 @@ public class FixedSizeSlidingWindowMetrics implements Metrics {
      */
     public FixedSizeSlidingWindowMetrics(int windowSize) {
         this.windowSize = windowSize;
-        this.measurements = new AtomicReferenceArray<>(this.windowSize);
+        this.measurements = new Measurement[this.windowSize];
         this.headIndex = new AtomicInteger();
         for (int i = 0; i < this.windowSize; i++) {
-            measurements.set(i, new Measurement());
+            measurements[i] = new Measurement();
         }
         this.totalAggregation = new TotalAggregation();
     }
@@ -73,7 +72,7 @@ public class FixedSizeSlidingWindowMetrics implements Metrics {
 
     private Measurement moveWindowByOne() {
         int lastIndex = moveHeadIndexByOne();
-        Measurement latestMeasurement = measurements.get(lastIndex);
+        Measurement latestMeasurement = measurements[lastIndex];
         totalAggregation.removeBucket(latestMeasurement);
         return latestMeasurement;
     }

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/FixedSizeSlidingWindowMetrics.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/FixedSizeSlidingWindowMetrics.java
@@ -63,7 +63,7 @@ public class FixedSizeSlidingWindowMetrics implements Metrics {
     @Override
     public Snapshot record(long duration, TimeUnit durationUnit, Outcome outcome) {
         totalAggregation.record(duration, durationUnit, outcome);
-        moveWindowByOne(duration, durationUnit, outcome);
+        moveWindowByOne().record(duration, durationUnit, outcome);
         return new SnapshotImpl(totalAggregation);
     }
 
@@ -71,10 +71,11 @@ public class FixedSizeSlidingWindowMetrics implements Metrics {
         return new SnapshotImpl(totalAggregation);
     }
 
-    private void moveWindowByOne(long duration, TimeUnit durationUnit, Outcome outcome) {
-        int lastIndex = moveHeadIndexByOne();
-        Measurement latestMeasurement = measurements.getAndSet(lastIndex, new Measurement(duration, durationUnit, outcome));
+    private Measurement moveWindowByOne() {
+        int lastIndex = headIndex.getAndUpdate(index -> (index + 1) % windowSize);
+        Measurement latestMeasurement = measurements.get(lastIndex);
         totalAggregation.removeBucket(latestMeasurement);
+        return latestMeasurement;
     }
 
     /**

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/FixedSizeSlidingWindowMetrics.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/FixedSizeSlidingWindowMetrics.java
@@ -72,7 +72,7 @@ public class FixedSizeSlidingWindowMetrics implements Metrics {
     }
 
     private Measurement moveWindowByOne() {
-        int lastIndex = headIndex.getAndUpdate(index -> (index + 1) % windowSize);
+        int lastIndex = moveHeadIndexByOne();
         Measurement latestMeasurement = measurements.get(lastIndex);
         totalAggregation.removeBucket(latestMeasurement);
         return latestMeasurement;

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/Measurement.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/Measurement.java
@@ -18,14 +18,24 @@
  */
 package io.github.resilience4j.core.metrics;
 
+import java.util.concurrent.TimeUnit;
+
 class Measurement extends AbstractAggregation {
 
+    public Measurement() {
+
+    }
+
+    public Measurement(long duration, TimeUnit durationUnit, Metrics.Outcome outcome) {
+        record(duration, durationUnit, outcome);
+    }
+
     void reset() {
-        this.totalDurationInMillis = 0;
-        this.numberOfSlowCalls = 0;
-        this.numberOfFailedCalls = 0;
-        this.numberOfSlowFailedCalls = 0;
-        this.numberOfCalls = 0;
+        this.totalDurationInMillis.reset();
+        this.numberOfSlowCalls.reset();
+        this.numberOfFailedCalls.reset();
+        this.numberOfSlowFailedCalls.reset();
+        this.numberOfCalls.reset();
     }
 
 }

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/Measurement.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/Measurement.java
@@ -18,24 +18,7 @@
  */
 package io.github.resilience4j.core.metrics;
 
-import java.util.concurrent.TimeUnit;
 
 class Measurement extends AbstractAggregation {
-
-    public Measurement() {
-
-    }
-
-    public Measurement(long duration, TimeUnit durationUnit, Metrics.Outcome outcome) {
-        record(duration, durationUnit, outcome);
-    }
-
-    void reset() {
-        this.totalDurationInMillis.reset();
-        this.numberOfSlowCalls.reset();
-        this.numberOfFailedCalls.reset();
-        this.numberOfSlowFailedCalls.reset();
-        this.numberOfCalls.reset();
-    }
 
 }

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/PartialAggregation.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/PartialAggregation.java
@@ -18,24 +18,26 @@
  */
 package io.github.resilience4j.core.metrics;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 public class PartialAggregation extends AbstractAggregation {
 
-    private long epochSecond;
+    private final AtomicLong epochSecond;
 
     PartialAggregation(long epochSecond) {
-        this.epochSecond = epochSecond;
+        this.epochSecond = new AtomicLong(epochSecond);
     }
 
     void reset(long epochSecond) {
-        this.epochSecond = epochSecond;
-        this.totalDurationInMillis = 0;
-        this.numberOfSlowCalls = 0;
-        this.numberOfFailedCalls = 0;
-        this.numberOfSlowFailedCalls = 0;
-        this.numberOfCalls = 0;
+        this.epochSecond.set(epochSecond);
+        this.totalDurationInMillis.reset();
+        this.numberOfSlowCalls.reset();
+        this.numberOfFailedCalls.reset();
+        this.numberOfSlowFailedCalls.reset();
+        this.numberOfCalls.reset();
     }
 
     public long getEpochSecond() {
-        return epochSecond;
+        return epochSecond.get();
     }
 }

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/PartialAggregation.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/PartialAggregation.java
@@ -28,13 +28,8 @@ public class PartialAggregation extends AbstractAggregation {
         this.epochSecond = new AtomicLong(epochSecond);
     }
 
-    void reset(long epochSecond) {
+    void setEpochSecond(long epochSecond) {
         this.epochSecond.set(epochSecond);
-        this.totalDurationInMillis.reset();
-        this.numberOfSlowCalls.reset();
-        this.numberOfFailedCalls.reset();
-        this.numberOfSlowFailedCalls.reset();
-        this.numberOfCalls.reset();
     }
 
     public long getEpochSecond() {

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/SlidingTimeWindowMetrics.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/SlidingTimeWindowMetrics.java
@@ -23,7 +23,6 @@ import java.time.Clock;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReferenceArray;
 
 /**
  * A {@link Metrics} implementation is backed by a sliding time window that aggregates only the
@@ -48,7 +47,7 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
  */
 public class SlidingTimeWindowMetrics implements Metrics {
 
-    final AtomicReferenceArray<PartialAggregation> partialAggregations;
+    final PartialAggregation[] partialAggregations;
     private final int timeWindowSizeInSeconds;
     private final TotalAggregation totalAggregation;
     private final Clock clock;
@@ -65,11 +64,11 @@ public class SlidingTimeWindowMetrics implements Metrics {
     public SlidingTimeWindowMetrics(int timeWindowSizeInSeconds, Clock clock) {
         this.clock = clock;
         this.timeWindowSizeInSeconds = timeWindowSizeInSeconds;
-        this.partialAggregations = new AtomicReferenceArray<>(timeWindowSizeInSeconds);
+        this.partialAggregations = new PartialAggregation[timeWindowSizeInSeconds];
         this.headIndex = new AtomicInteger();
         long epochSecond = clock.instant().getEpochSecond();
         for (int i = 0; i < timeWindowSizeInSeconds; i++) {
-            partialAggregations.set(i, new PartialAggregation(epochSecond));
+            partialAggregations[i] = new PartialAggregation(epochSecond);
             epochSecond++;
         }
         this.totalAggregation = new TotalAggregation();
@@ -132,7 +131,7 @@ public class SlidingTimeWindowMetrics implements Metrics {
      * @return the head partial aggregation of the circular array
      */
     private PartialAggregation getLatestPartialAggregation() {
-        return partialAggregations.get(headIndex.get());
+        return partialAggregations[headIndex.get()];
     }
 
     /**

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/SlidingTimeWindowMetrics.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/SlidingTimeWindowMetrics.java
@@ -76,13 +76,13 @@ public class SlidingTimeWindowMetrics implements Metrics {
     }
 
     @Override
-    public synchronized Snapshot record(long duration, TimeUnit durationUnit, Outcome outcome) {
+    public Snapshot record(long duration, TimeUnit durationUnit, Outcome outcome) {
         totalAggregation.record(duration, durationUnit, outcome);
         moveWindowToCurrentEpochSecond().record(duration, durationUnit, outcome);
         return new SnapshotImpl(totalAggregation);
     }
 
-    public synchronized Snapshot getSnapshot() {
+    public Snapshot getSnapshot() {
         moveWindowToCurrentEpochSecond();
         return new SnapshotImpl(totalAggregation);
     }
@@ -96,7 +96,7 @@ public class SlidingTimeWindowMetrics implements Metrics {
      *
      * @param latestPartialAggregation the latest partial aggregation of the circular array
      */
-    private  PartialAggregation moveWindowToCurrentEpochSecond() {
+    private PartialAggregation moveWindowToCurrentEpochSecond() {
         long currentEpochSecond = clock.instant().getEpochSecond();
         PartialAggregation latestPartialAggregation = getLatestPartialAggregation();
         long differenceInSeconds = currentEpochSecond - latestPartialAggregation.getEpochSecond();
@@ -117,7 +117,7 @@ public class SlidingTimeWindowMetrics implements Metrics {
                 moveHeadIndexByOne();
                 currentPartialAggregation = getLatestPartialAggregation();
                 totalAggregation.removeBucket(currentPartialAggregation);
-                currentPartialAggregation.reset(currentEpochSecond - secondsToMoveTheWindow);
+                currentPartialAggregation.setEpochSecond(currentEpochSecond - secondsToMoveTheWindow);
             } while (secondsToMoveTheWindow > 0);
             return currentPartialAggregation;
         } finally {

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/SnapshotImpl.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/SnapshotImpl.java
@@ -29,11 +29,11 @@ public class SnapshotImpl implements Snapshot {
     private final int totalNumberOfCalls;
 
     SnapshotImpl(TotalAggregation totalAggregation) {
-        this.totalDurationInMillis = totalAggregation.totalDurationInMillis;
-        this.totalNumberOfSlowCalls = totalAggregation.numberOfSlowCalls;
-        this.totalNumberOfSlowFailedCalls = totalAggregation.numberOfSlowFailedCalls;
-        this.totalNumberOfFailedCalls = totalAggregation.numberOfFailedCalls;
-        this.totalNumberOfCalls = totalAggregation.numberOfCalls;
+        this.totalDurationInMillis = totalAggregation.totalDurationInMillis.sum();
+        this.totalNumberOfSlowCalls = totalAggregation.numberOfSlowCalls.intValue();
+        this.totalNumberOfSlowFailedCalls = totalAggregation.numberOfSlowFailedCalls.intValue();
+        this.totalNumberOfFailedCalls = totalAggregation.numberOfFailedCalls.intValue();
+        this.totalNumberOfCalls = totalAggregation.numberOfCalls.intValue();
 
     }
 

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/TotalAggregation.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/TotalAggregation.java
@@ -21,10 +21,10 @@ package io.github.resilience4j.core.metrics;
 class TotalAggregation extends AbstractAggregation {
 
     void removeBucket(AbstractAggregation bucket) {
-        this.totalDurationInMillis.add(-bucket.totalDurationInMillis.sum());
-        this.numberOfSlowCalls.add(-bucket.numberOfSlowCalls.sum());
-        this.numberOfSlowFailedCalls.add(-bucket.numberOfSlowFailedCalls.sum());
-        this.numberOfFailedCalls.add(-bucket.numberOfFailedCalls.sum());
-        this.numberOfCalls.add(-bucket.numberOfCalls.sum());
+        this.totalDurationInMillis.add(-bucket.totalDurationInMillis.sumThenReset());
+        this.numberOfSlowCalls.add(-bucket.numberOfSlowCalls.sumThenReset());
+        this.numberOfSlowFailedCalls.add(-bucket.numberOfSlowFailedCalls.sumThenReset());
+        this.numberOfFailedCalls.add(-bucket.numberOfFailedCalls.sumThenReset());
+        this.numberOfCalls.add(-bucket.numberOfCalls.sumThenReset());
     }
 }

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/TotalAggregation.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/TotalAggregation.java
@@ -21,10 +21,10 @@ package io.github.resilience4j.core.metrics;
 class TotalAggregation extends AbstractAggregation {
 
     void removeBucket(AbstractAggregation bucket) {
-        this.totalDurationInMillis -= bucket.totalDurationInMillis;
-        this.numberOfSlowCalls -= bucket.numberOfSlowCalls;
-        this.numberOfSlowFailedCalls -= bucket.numberOfSlowFailedCalls;
-        this.numberOfFailedCalls -= bucket.numberOfFailedCalls;
-        this.numberOfCalls -= bucket.numberOfCalls;
+        this.totalDurationInMillis.add(-bucket.totalDurationInMillis.sum());
+        this.numberOfSlowCalls.add(-bucket.numberOfSlowCalls.sum());
+        this.numberOfSlowFailedCalls.add(-bucket.numberOfSlowFailedCalls.sum());
+        this.numberOfFailedCalls.add(-bucket.numberOfFailedCalls.sum());
+        this.numberOfCalls.add(-bucket.numberOfCalls.sum());
     }
 }

--- a/resilience4j-core/src/test/java/io/github/resilience4j/core/metrics/FixedSizeSlidingWindowMetricsTest.java
+++ b/resilience4j-core/src/test/java/io/github/resilience4j/core/metrics/FixedSizeSlidingWindowMetricsTest.java
@@ -117,23 +117,23 @@ public class FixedSizeSlidingWindowMetricsTest {
     public void testMoveHeadIndexByOne() {
         FixedSizeSlidingWindowMetrics metrics = new FixedSizeSlidingWindowMetrics(3);
 
-        assertThat(metrics.headIndex).isZero();
+        assertThat(metrics.headIndex.get()).isZero();
 
         metrics.moveHeadIndexByOne();
 
-        assertThat(metrics.headIndex).isEqualTo(1);
+        assertThat(metrics.headIndex.get()).isEqualTo(1);
 
         metrics.moveHeadIndexByOne();
 
-        assertThat(metrics.headIndex).isEqualTo(2);
+        assertThat(metrics.headIndex.get()).isEqualTo(2);
 
         metrics.moveHeadIndexByOne();
 
-        assertThat(metrics.headIndex).isZero();
+        assertThat(metrics.headIndex.get()).isZero();
 
         metrics.moveHeadIndexByOne();
 
-        assertThat(metrics.headIndex).isEqualTo(1);
+        assertThat(metrics.headIndex.get()).isEqualTo(1);
 
     }
 

--- a/resilience4j-core/src/test/java/io/github/resilience4j/core/metrics/SlidingTimeWindowMetricsTest.java
+++ b/resilience4j-core/src/test/java/io/github/resilience4j/core/metrics/SlidingTimeWindowMetricsTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 
 import java.time.ZoneId;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReferenceArray;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -34,11 +33,11 @@ public class SlidingTimeWindowMetricsTest {
         MockClock clock = MockClock.at(2019, 8, 4, 12, 0, 0, ZoneId.of("UTC"));
         SlidingTimeWindowMetrics metrics = new SlidingTimeWindowMetrics(5, clock);
 
-        AtomicReferenceArray<PartialAggregation> buckets = metrics.partialAggregations;
+        PartialAggregation[] buckets = metrics.partialAggregations;
 
         long epochSecond = clock.instant().getEpochSecond();
-        for (int i = 0; i < buckets.length(); i++) {
-            PartialAggregation bucket = buckets.get(i);
+        for (int i = 0; i < buckets.length; i++) {
+            PartialAggregation bucket = buckets[i];
             assertThat(bucket.getEpochSecond()).isEqualTo(epochSecond + i);
         }
 

--- a/resilience4j-core/src/test/java/io/github/resilience4j/core/metrics/SlidingTimeWindowMetricsTest.java
+++ b/resilience4j-core/src/test/java/io/github/resilience4j/core/metrics/SlidingTimeWindowMetricsTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import java.time.ZoneId;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -33,11 +34,11 @@ public class SlidingTimeWindowMetricsTest {
         MockClock clock = MockClock.at(2019, 8, 4, 12, 0, 0, ZoneId.of("UTC"));
         SlidingTimeWindowMetrics metrics = new SlidingTimeWindowMetrics(5, clock);
 
-        PartialAggregation[] buckets = metrics.partialAggregations;
+        AtomicReferenceArray<PartialAggregation> buckets = metrics.partialAggregations;
 
         long epochSecond = clock.instant().getEpochSecond();
-        for (int i = 0; i < buckets.length; i++) {
-            PartialAggregation bucket = buckets[i];
+        for (int i = 0; i < buckets.length(); i++) {
+            PartialAggregation bucket = buckets.get(i);
             assertThat(bucket.getEpochSecond()).isEqualTo(epochSecond + i);
         }
 
@@ -134,23 +135,23 @@ public class SlidingTimeWindowMetricsTest {
         MockClock clock = MockClock.at(2019, 8, 4, 12, 0, 0, ZoneId.of("UTC"));
         SlidingTimeWindowMetrics metrics = new SlidingTimeWindowMetrics(3, clock);
 
-        assertThat(metrics.headIndex).isZero();
+        assertThat(metrics.headIndex.get()).isZero();
 
         metrics.moveHeadIndexByOne();
 
-        assertThat(metrics.headIndex).isEqualTo(1);
+        assertThat(metrics.headIndex.get()).isEqualTo(1);
 
         metrics.moveHeadIndexByOne();
 
-        assertThat(metrics.headIndex).isEqualTo(2);
+        assertThat(metrics.headIndex.get()).isEqualTo(2);
 
         metrics.moveHeadIndexByOne();
 
-        assertThat(metrics.headIndex).isZero();
+        assertThat(metrics.headIndex.get()).isZero();
 
         metrics.moveHeadIndexByOne();
 
-        assertThat(metrics.headIndex).isEqualTo(1);
+        assertThat(metrics.headIndex.get()).isEqualTo(1);
 
     }
 


### PR DESCRIPTION
as mentioned in #2151 

Each field in `Aggregation` is replaced by longAdder, and sumThenReset is used when `removeBucket`is called.
In theory, all data changes should not be lost. The only problem is all these fields in `Aggregation` not guaranteed to update at same time, so `checkIfThresholdsExceeded` may not 100% accurate as synchronized style.
