### PR TITLE
Fix for Issue #2190: Resolve StackOverflowError and Circular Reference in CircuitBreaker Configuration Handling

### DIFF
--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationPropertiesTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationPropertiesTest.java
@@ -526,6 +526,31 @@ public class CircuitBreakerConfigurationPropertiesTest {
         assertThat(circuitBreakerProperties.get().getEventConsumerBufferSize()).isEqualTo(99);
     }
 
+    @Test
+    public void testCreateCircuitBreakerRegistryWithBaseAndDefaultConfig() {
+        CommonCircuitBreakerConfigurationProperties.InstanceProperties baseProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
+        baseProperties.setSlidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED);
+        baseProperties.setSlidingWindowSize(2000);
+        baseProperties.setMaxWaitDurationInHalfOpenState(Duration.ofMillis(100L));
+
+        CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
+        defaultProperties.setSlidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED);
+        defaultProperties.setSlidingWindowSize(1000);
+        defaultProperties.setBaseConfig("baseConfig");
+
+        CommonCircuitBreakerConfigurationProperties circuitBreakerConfigurationProperties = new CommonCircuitBreakerConfigurationProperties();
+        circuitBreakerConfigurationProperties.getConfigs().put("baseConfig", baseProperties);
+        circuitBreakerConfigurationProperties.getConfigs().put("default", defaultProperties);
+
+        CircuitBreakerConfig config = circuitBreakerConfigurationProperties.createCircuitBreakerConfig(
+                "default", defaultProperties, compositeCircuitBreakerCustomizer());
+
+        assertThat(config.getMaxWaitDurationInHalfOpenState()).isEqualTo(baseProperties.getMaxWaitDurationInHalfOpenState());
+        assertThat(config.getSlidingWindowSize()).isEqualTo(defaultProperties.getSlidingWindowSize());
+        assertThat(config.getSlidingWindowType()).isEqualTo(defaultProperties.getSlidingWindowType());
+    }
+
+
     private CompositeCustomizer<CircuitBreakerConfigCustomizer> compositeCircuitBreakerCustomizer() {
         return new CompositeCustomizer<>(Collections.emptyList());
     }

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationPropertiesTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationPropertiesTest.java
@@ -470,6 +470,18 @@ public class CircuitBreakerConfigurationPropertiesTest {
         assertThat(circuitBreakerConfig.getIgnoreExceptionPredicate().test(new NullPointerException())).isFalse();
     }
 
+    @Test(expected = IllegalStateException.class)
+    public void testCircularReferenceInBaseConfigThrowsIllegalStateException() {
+        CommonCircuitBreakerConfigurationProperties circuitBreakerConfigurationProperties = new CommonCircuitBreakerConfigurationProperties();
+
+        CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultConfig = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
+        defaultConfig.setBaseConfig("defaultConfig");
+
+        circuitBreakerConfigurationProperties.getInstances().put("defaultConfig", defaultConfig);
+
+        circuitBreakerConfigurationProperties.createCircuitBreakerConfig("defaultConfig", defaultConfig, compositeCircuitBreakerCustomizer());
+    }
+
     @Test
     public void testFindCircuitBreakerPropertiesWithoutDefaultConfig() {
         //Given

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationPropertiesTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationPropertiesTest.java
@@ -474,12 +474,11 @@ public class CircuitBreakerConfigurationPropertiesTest {
     public void testCircularReferenceInBaseConfigThrowsIllegalStateException() {
         CommonCircuitBreakerConfigurationProperties circuitBreakerConfigurationProperties = new CommonCircuitBreakerConfigurationProperties();
 
-        CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultConfig = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
-        defaultConfig.setBaseConfig("defaultConfig");
+        CommonCircuitBreakerConfigurationProperties.InstanceProperties selfReferencingConfig = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
+        selfReferencingConfig.setBaseConfig("selfReferencingConfig");
+        circuitBreakerConfigurationProperties.getConfigs().put("selfReferencingConfig", selfReferencingConfig);
 
-        circuitBreakerConfigurationProperties.getInstances().put("defaultConfig", defaultConfig);
-
-        circuitBreakerConfigurationProperties.createCircuitBreakerConfig("defaultConfig", defaultConfig, compositeCircuitBreakerCustomizer());
+        circuitBreakerConfigurationProperties.createCircuitBreakerConfig("selfReferencingConfig", selfReferencingConfig, compositeCircuitBreakerCustomizer());
     }
 
     @Test


### PR DESCRIPTION
This PR refactors the ```createCircuitBreakerConfig``` method to address issues related to circular references. The changes ensure that the correct configuration is applied based on the presence of base, direct, or default configurations.

Related Issue: [Issue #2190](https://github.com/resilience4j/resilience4j/issues/2190).

#### Issue Details:
The issue arises from circular references in configuration handling when using properties like ```resilience4j.circuitbreaker.configs.default.base-config```. This caused a ```StackOverflowError``` due to endless recursion when configurations where process. 


## Changes Made:
### Refactored Configuration Handling:
- **Base Config Handling:**
  - Extracted logic for handling for base configurations into a separate ```createBaseConfig``` method.
  - Ensured that circular references are detected and appropriate exceptions are thrown if a base configuration is not found
- **Direct Config Handling:**
  - Extracted logic for handling direct configurations into a separate ```createDirectConfig``` method.
- **Default Config Handling:**
  - Extracted logic for handling default configurations into a separate ```createDefaultConfig``` method.

### How It Address the Fix:
- **Circular Reference Detection:** The refactored ```createBaseConfig``` method properly detects and prevents circular references, which was a key issue.
- **Code Clarity:** The separation of concerns into individual methods improves code readability and maintainability.

### Testing:
- The changes have been tested with various scenarios including:
  - Configurations with base configurations.
  - Configurations with direct mappings.
  - Configurations falling back to default values.
- All relevant unit tests passed successfully without the need of updating them.

