### PR TITLE
Fix: CompletionStage does not complete on user supplied predicate failures

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -3,6 +3,11 @@
     <JetCodeStyleSettings>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
+    <codeStyleSettings language="JAVA">
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
+    </codeStyleSettings>
     <codeStyleSettings language="kotlin">
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </codeStyleSettings>

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -3,11 +3,6 @@
     <JetCodeStyleSettings>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
-    <codeStyleSettings language="JAVA">
-      <indentOptions>
-        <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      </indentOptions>
-    </codeStyleSettings>
     <codeStyleSettings language="kotlin">
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </codeStyleSettings>

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/Retry.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/Retry.java
@@ -642,8 +642,8 @@ public interface Retry {
                     } else {
                         onResult(result);
                     }
-                } catch (Throwable unKnown) {
-                    promise.completeExceptionally(unKnown);
+                } catch (Throwable unknownTh) {
+                    promise.completeExceptionally(unknownTh);
                 }
             });
         }

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/Retry.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/Retry.java
@@ -632,14 +632,18 @@ public interface Retry {
             final CompletionStage<T> stage = supplier.get();
 
             stage.whenComplete((result, throwable) -> {
-                if (throwable != null) {
-                    if (throwable instanceof Exception) {
-                        onError((Exception) throwable);
+                try {
+                    if (throwable != null) {
+                        if (throwable instanceof Exception) {
+                            onError((Exception) throwable);
+                        } else {
+                            promise.completeExceptionally(throwable);
+                        }
                     } else {
-                        promise.completeExceptionally(throwable);
+                        onResult(result);
                     }
-                } else {
-                    onResult(result);
+                } catch (Throwable unKnown) {
+                    promise.completeExceptionally(unKnown);
                 }
             });
         }

--- a/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/CompletionStageRetryTest.java
+++ b/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/CompletionStageRetryTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.times;
 public class CompletionStageRetryTest {
 
     private AsyncHelloWorldService helloWorldService;
-    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    private ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
 
     @Before
     public void setUp() {
@@ -170,16 +170,16 @@ public class CompletionStageRetryTest {
     @Test
     public void shouldStopRetryingAndEmitProperEventsIfIntervalFunctionReturnsLessThanZero() {
         given(helloWorldService.returnHelloWorld())
-            .willReturn(CompletableFuture.failedFuture(new HelloWorldException("Exceptional!")));
+                .willReturn(CompletableFuture.failedFuture(new HelloWorldException("Exceptional!")));
 
         AtomicInteger numberOfTimesIntervalFunctionCalled = new AtomicInteger(0);
         RetryConfig retryConfig = RetryConfig.<String>custom()
-            .intervalFunction((ignored) -> {
-                int numTimesCalled = numberOfTimesIntervalFunctionCalled.incrementAndGet();
-                return numTimesCalled > 1 ? -1L : 0L;
-            })
-            .maxAttempts(3)
-            .build();
+                .intervalFunction((ignored) -> {
+                    int numTimesCalled = numberOfTimesIntervalFunctionCalled.incrementAndGet();
+                    return numTimesCalled > 1 ? -1L : 0L;
+                })
+                .maxAttempts(3)
+                .build();
 
         AtomicInteger numberOfRetryEvents = new AtomicInteger();
         AtomicBoolean onErrorEventOccurred = new AtomicBoolean(false);
@@ -189,17 +189,17 @@ public class CompletionStageRetryTest {
         retry.getEventPublisher().onError((ignored) -> onErrorEventOccurred.set(true));
 
         Supplier<CompletionStage<String>> supplier = Retry.decorateCompletionStage(
-            retry,
-            scheduler,
-            helloWorldService::returnHelloWorld
+                retry,
+                scheduler,
+                helloWorldService::returnHelloWorld
         );
 
         assertThat(supplier.get())
-            .failsWithin(5, TimeUnit.SECONDS)
-            .withThrowableOfType(ExecutionException.class)
-            .havingCause()
-            .isInstanceOf(HelloWorldException.class)
-            .withMessage("Exceptional!");
+                .failsWithin(5, TimeUnit.SECONDS)
+                .withThrowableOfType(ExecutionException.class)
+                .havingCause()
+                .isInstanceOf(HelloWorldException.class)
+                .withMessage("Exceptional!");
         assertThat(numberOfRetryEvents).hasValue(1);
         assertThat(onErrorEventOccurred).isTrue();
         then(helloWorldService).should(times(2)).returnHelloWorld();
@@ -208,16 +208,16 @@ public class CompletionStageRetryTest {
     @Test
     public void shouldContinueRetryingAndEmitProperEventsIfIntervalFunctionReturnsZeroOrMore() {
         given(helloWorldService.returnHelloWorld())
-            .willReturn(CompletableFuture.failedFuture(new HelloWorldException("Exceptional!")));
+                .willReturn(CompletableFuture.failedFuture(new HelloWorldException("Exceptional!")));
 
         AtomicInteger numberOfTimesIntervalFunctionCalled = new AtomicInteger(0);
         RetryConfig retryConfig = RetryConfig.<String>custom()
-            .intervalFunction((ignored) -> {
-                // Returns 0, 1, 2
-                return (long) numberOfTimesIntervalFunctionCalled.getAndIncrement();
-            })
-            .maxAttempts(3)
-            .build();
+                .intervalFunction((ignored) -> {
+                    // Returns 0, 1, 2
+                    return (long) numberOfTimesIntervalFunctionCalled.getAndIncrement();
+                })
+                .maxAttempts(3)
+                .build();
 
         AtomicInteger numberOfRetryEvents = new AtomicInteger();
         AtomicBoolean onErrorEventOccurred = new AtomicBoolean(false);
@@ -227,17 +227,17 @@ public class CompletionStageRetryTest {
         retry.getEventPublisher().onError((ignored) -> onErrorEventOccurred.set(true));
 
         Supplier<CompletionStage<String>> supplier = Retry.decorateCompletionStage(
-            retry,
-            scheduler,
-            helloWorldService::returnHelloWorld
+                retry,
+                scheduler,
+                helloWorldService::returnHelloWorld
         );
 
         assertThat(supplier.get())
-            .failsWithin(5, TimeUnit.SECONDS)
-            .withThrowableOfType(ExecutionException.class)
-            .havingCause()
-            .isInstanceOf(HelloWorldException.class)
-            .withMessage("Exceptional!");
+                .failsWithin(5, TimeUnit.SECONDS)
+                .withThrowableOfType(ExecutionException.class)
+                .havingCause()
+                .isInstanceOf(HelloWorldException.class)
+                .withMessage("Exceptional!");
         assertThat(numberOfRetryEvents).hasValue(2);
         assertThat(onErrorEventOccurred).isTrue();
         then(helloWorldService).should(times(3)).returnHelloWorld();
@@ -283,7 +283,7 @@ public class CompletionStageRetryTest {
     }
 
     private void shouldCompleteFutureAfterAttemptsInCaseOfRetyOnResultAtAsyncStage(int noOfAttempts,
-                                                                                   String retryResponse) {
+        String retryResponse) {
         given(helloWorldService.returnHelloWorld())
             .willReturn(completedFuture("Hello world"));
         Retry retryContext = Retry.of(

--- a/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/CompletionStageRetryTest.java
+++ b/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/CompletionStageRetryTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.times;
 public class CompletionStageRetryTest {
 
     private AsyncHelloWorldService helloWorldService;
-    private ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
 
     @Before
     public void setUp() {
@@ -170,16 +170,16 @@ public class CompletionStageRetryTest {
     @Test
     public void shouldStopRetryingAndEmitProperEventsIfIntervalFunctionReturnsLessThanZero() {
         given(helloWorldService.returnHelloWorld())
-                .willReturn(CompletableFuture.failedFuture(new HelloWorldException("Exceptional!")));
+            .willReturn(CompletableFuture.failedFuture(new HelloWorldException("Exceptional!")));
 
         AtomicInteger numberOfTimesIntervalFunctionCalled = new AtomicInteger(0);
         RetryConfig retryConfig = RetryConfig.<String>custom()
-                .intervalFunction((ignored) -> {
-                    int numTimesCalled = numberOfTimesIntervalFunctionCalled.incrementAndGet();
-                    return numTimesCalled > 1 ? -1L : 0L;
-                })
-                .maxAttempts(3)
-                .build();
+            .intervalFunction((ignored) -> {
+                int numTimesCalled = numberOfTimesIntervalFunctionCalled.incrementAndGet();
+                return numTimesCalled > 1 ? -1L : 0L;
+            })
+            .maxAttempts(3)
+            .build();
 
         AtomicInteger numberOfRetryEvents = new AtomicInteger();
         AtomicBoolean onErrorEventOccurred = new AtomicBoolean(false);
@@ -189,17 +189,17 @@ public class CompletionStageRetryTest {
         retry.getEventPublisher().onError((ignored) -> onErrorEventOccurred.set(true));
 
         Supplier<CompletionStage<String>> supplier = Retry.decorateCompletionStage(
-                retry,
-                scheduler,
-                helloWorldService::returnHelloWorld
+            retry,
+            scheduler,
+            helloWorldService::returnHelloWorld
         );
 
         assertThat(supplier.get())
-                .failsWithin(5, TimeUnit.SECONDS)
-                .withThrowableOfType(ExecutionException.class)
-                .havingCause()
-                .isInstanceOf(HelloWorldException.class)
-                .withMessage("Exceptional!");
+            .failsWithin(5, TimeUnit.SECONDS)
+            .withThrowableOfType(ExecutionException.class)
+            .havingCause()
+            .isInstanceOf(HelloWorldException.class)
+            .withMessage("Exceptional!");
         assertThat(numberOfRetryEvents).hasValue(1);
         assertThat(onErrorEventOccurred).isTrue();
         then(helloWorldService).should(times(2)).returnHelloWorld();
@@ -208,16 +208,16 @@ public class CompletionStageRetryTest {
     @Test
     public void shouldContinueRetryingAndEmitProperEventsIfIntervalFunctionReturnsZeroOrMore() {
         given(helloWorldService.returnHelloWorld())
-                .willReturn(CompletableFuture.failedFuture(new HelloWorldException("Exceptional!")));
+            .willReturn(CompletableFuture.failedFuture(new HelloWorldException("Exceptional!")));
 
         AtomicInteger numberOfTimesIntervalFunctionCalled = new AtomicInteger(0);
         RetryConfig retryConfig = RetryConfig.<String>custom()
-                .intervalFunction((ignored) -> {
-                    // Returns 0, 1, 2
-                    return (long) numberOfTimesIntervalFunctionCalled.getAndIncrement();
-                })
-                .maxAttempts(3)
-                .build();
+            .intervalFunction((ignored) -> {
+                // Returns 0, 1, 2
+                return (long) numberOfTimesIntervalFunctionCalled.getAndIncrement();
+            })
+            .maxAttempts(3)
+            .build();
 
         AtomicInteger numberOfRetryEvents = new AtomicInteger();
         AtomicBoolean onErrorEventOccurred = new AtomicBoolean(false);
@@ -227,17 +227,17 @@ public class CompletionStageRetryTest {
         retry.getEventPublisher().onError((ignored) -> onErrorEventOccurred.set(true));
 
         Supplier<CompletionStage<String>> supplier = Retry.decorateCompletionStage(
-                retry,
-                scheduler,
-                helloWorldService::returnHelloWorld
+            retry,
+            scheduler,
+            helloWorldService::returnHelloWorld
         );
 
         assertThat(supplier.get())
-                .failsWithin(5, TimeUnit.SECONDS)
-                .withThrowableOfType(ExecutionException.class)
-                .havingCause()
-                .isInstanceOf(HelloWorldException.class)
-                .withMessage("Exceptional!");
+            .failsWithin(5, TimeUnit.SECONDS)
+            .withThrowableOfType(ExecutionException.class)
+            .havingCause()
+            .isInstanceOf(HelloWorldException.class)
+            .withMessage("Exceptional!");
         assertThat(numberOfRetryEvents).hasValue(2);
         assertThat(onErrorEventOccurred).isTrue();
         then(helloWorldService).should(times(3)).returnHelloWorld();
@@ -283,7 +283,7 @@ public class CompletionStageRetryTest {
     }
 
     private void shouldCompleteFutureAfterAttemptsInCaseOfRetyOnResultAtAsyncStage(int noOfAttempts,
-        String retryResponse) {
+                                                                                   String retryResponse) {
         given(helloWorldService.returnHelloWorld())
             .willReturn(completedFuture("Hello world"));
         Retry retryContext = Retry.of(
@@ -302,6 +302,28 @@ public class CompletionStageRetryTest {
 
         then(helloWorldService).should(times(noOfAttempts)).returnHelloWorld();
         assertThat(resultTry.isSuccess()).isTrue();
+    }
+
+    @Test
+    public void shouldCompleteExceptionallyWhenRetryOnExPredicateThrows() {
+        given(helloWorldService.returnHelloWorld())
+            .willReturn(CompletableFuture.failedFuture(new HelloWorldException()));
+        final RetryConfig retryConfig = RetryConfig.custom()
+            .retryOnException(__ -> {
+                throw new RuntimeException();
+            })
+            .build();
+        Retry retryContext = Retry.of("id", retryConfig);
+
+        Supplier<CompletionStage<String>> supplier = Retry.decorateCompletionStage(
+            retryContext,
+            scheduler,
+            () -> helloWorldService.returnHelloWorld());
+        Try<String> resultTry = Try.of(() -> awaitResult(supplier.get()));
+
+        then(helloWorldService).should(times(1)).returnHelloWorld();
+        assertThat(resultTry.isFailure()).isTrue();
+        assertThat(resultTry.getCause().getCause()).isInstanceOf(RuntimeException.class);
     }
 
 }


### PR DESCRIPTION
This pr fixes the behaviour where completion stage returned by `Retry.decorateCompletionStage()` never completes successfully or exceptionally when user provided predicate functions can fail.

fixes: #2198 