### PR TITLE
Improve exception message for failure rate threshold in circuit breaker config

### DIFF
--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfig.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfig.java
@@ -363,7 +363,7 @@ public class CircuitBreakerConfig implements Serializable {
         public Builder failureRateThreshold(float failureRateThreshold) {
             if (failureRateThreshold <= 0 || failureRateThreshold > 100) {
                 throw new IllegalArgumentException(
-                    "failureRateThreshold must be between 1 and 100");
+                    "failureRateThreshold must be greater than 0 and lower than 100, but was " + failureRateThreshold);
             }
             this.failureRateThreshold = failureRateThreshold;
             return this;
@@ -388,7 +388,7 @@ public class CircuitBreakerConfig implements Serializable {
         public Builder slowCallRateThreshold(float slowCallRateThreshold) {
             if (slowCallRateThreshold <= 0 || slowCallRateThreshold > 100) {
                 throw new IllegalArgumentException(
-                    "slowCallRateThreshold must be between 1 and 100");
+                    "slowCallRateThreshold must be greater than 0 and not greater than 100, but was " + slowCallRateThreshold);
             }
             this.slowCallRateThreshold = slowCallRateThreshold;
             return this;

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfigTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfigTest.java
@@ -131,6 +131,13 @@ public class CircuitBreakerConfigTest {
         then(circuitBreakerConfig.getFailureRateThreshold()).isEqualTo(25);
     }
 
+
+    @Test
+    public void shouldSetFailureRateThresholdAsAFloatGreaterThanZero() {
+        CircuitBreakerConfig circuitBreakerConfig = custom().failureRateThreshold(0.5f).build();
+        then(circuitBreakerConfig.getFailureRateThreshold()).isEqualTo(0.5f);
+    }
+
     @Test
     public void shouldSetWaitDurationInHalfOpenState() {
         CircuitBreakerConfig circuitBreakerConfig = custom().maxWaitDurationInHalfOpenState(Duration.ofMillis(1000)).build();
@@ -141,6 +148,12 @@ public class CircuitBreakerConfigTest {
     public void shouldSetSlowCallRateThreshold() {
         CircuitBreakerConfig circuitBreakerConfig = custom().slowCallRateThreshold(25).build();
         then(circuitBreakerConfig.getSlowCallRateThreshold()).isEqualTo(25);
+    }
+
+    @Test
+    public void shouldSetSlowCallRateThresholdAsFloatGreaterThanZero() {
+        CircuitBreakerConfig circuitBreakerConfig = custom().slowCallRateThreshold(0.5f).build();
+        then(circuitBreakerConfig.getSlowCallRateThreshold()).isEqualTo(0.5f);
     }
 
     @Test


### PR DESCRIPTION
Improves messages for failure rate threshold and slow call rate threshold to match documentation.
Fixes https://github.com/resilience4j/resilience4j/issues/2202