### PR TITLE
Feature-2224 : Convert syncronized to ReentrantLock to avoid virtual-thread pinned issues

### DIFF
--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkhead.java
@@ -34,6 +34,7 @@ import io.github.resilience4j.core.lang.Nullable;
 import java.util.Map;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
 import static java.util.Collections.emptyMap;
@@ -52,7 +53,7 @@ public class SemaphoreBulkhead implements Bulkhead {
     private final BulkheadMetrics metrics;
     private final BulkheadEventProcessor eventProcessor;
 
-    private final Object configChangesLock = new Object();
+    private final ReentrantLock lock = new ReentrantLock();
     private final Map<String, String> tags;
     @SuppressWarnings("squid:S3077")
     // this object is immutable and we replace ref entirely during config change.
@@ -123,7 +124,9 @@ public class SemaphoreBulkhead implements Bulkhead {
      */
     @Override
     public void changeConfig(final BulkheadConfig newConfig) {
-        synchronized (configChangesLock) {
+        lock.lock();
+
+        try {
             int delta = newConfig.getMaxConcurrentCalls() - config.getMaxConcurrentCalls();
             if (delta < 0) {
                 semaphore.acquireUninterruptibly(-delta);
@@ -131,6 +134,8 @@ public class SemaphoreBulkhead implements Bulkhead {
                 semaphore.release(delta);
             }
             config = newConfig;
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/SlidingTimeWindowMetrics.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/SlidingTimeWindowMetrics.java
@@ -21,6 +21,7 @@ package io.github.resilience4j.core.metrics;
 
 import java.time.Clock;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * A {@link Metrics} implementation is backed by a sliding time window that aggregates only the
@@ -51,6 +52,8 @@ public class SlidingTimeWindowMetrics implements Metrics {
     private final Clock clock;
     int headIndex;
 
+    private final ReentrantLock lock = new ReentrantLock();
+
     /**
      * Creates a new {@link SlidingTimeWindowMetrics} with the given clock and window of time.
      *
@@ -71,16 +74,28 @@ public class SlidingTimeWindowMetrics implements Metrics {
     }
 
     @Override
-    public synchronized Snapshot record(long duration, TimeUnit durationUnit, Outcome outcome) {
-        totalAggregation.record(duration, durationUnit, outcome);
-        moveWindowToCurrentEpochSecond(getLatestPartialAggregation())
-            .record(duration, durationUnit, outcome);
-        return new SnapshotImpl(totalAggregation);
+    public Snapshot record(long duration, TimeUnit durationUnit, Outcome outcome) {
+        lock.lock();
+
+        try {
+            totalAggregation.record(duration, durationUnit, outcome);
+            moveWindowToCurrentEpochSecond(getLatestPartialAggregation())
+                    .record(duration, durationUnit, outcome);
+            return new SnapshotImpl(totalAggregation);
+        } finally {
+            lock.unlock();
+        }
     }
 
-    public synchronized Snapshot getSnapshot() {
-        moveWindowToCurrentEpochSecond(getLatestPartialAggregation());
-        return new SnapshotImpl(totalAggregation);
+    public Snapshot getSnapshot() {
+        lock.lock();
+
+        try {
+            moveWindowToCurrentEpochSecond(getLatestPartialAggregation());
+            return new SnapshotImpl(totalAggregation);
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**


### PR DESCRIPTION
- This is the first step toward virtual thread support in resilience4j.
- Changed Synchronized to ReentrantLock which was causing a pinned issue in the virtual thread
    - Please check the JEP documentation for the relationship between synchronized and pinned issues -> https://openjdk.org/jeps/444
- I didn't determine if ReentrantLock was the block we needed, I simply changed the part affected by syncronized.