### PR TITLE
Issue #2235: add retryOnResult support to decorateRunnable and decorateCheckedRunnable

### DIFF
--- a/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/RetryMetricsTest.java
+++ b/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/RetryMetricsTest.java
@@ -62,8 +62,7 @@ public class RetryMetricsTest extends AbstractRetryMetricsTest {
     public void shouldReturnTotalNumberOfRequestsAs1ForSuccessVoid() {
         HelloWorldService helloWorldService = mock(HelloWorldService.class);
 
-        Retry retry = Retry.of("metrics", RetryConfig.<String>custom()
-                .retryOnResult(String::isEmpty)
+        Retry retry = Retry.of("metrics", RetryConfig.custom()
                 .maxAttempts(5)
                 .build());
 

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/Retry.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/Retry.java
@@ -622,10 +622,10 @@ public interface Retry {
         private final CompletableFuture<T> promise;
 
         AsyncRetryBlock(
-                ScheduledExecutorService scheduler,
-                Retry.AsyncContext<T> retryContext,
-                Supplier<CompletionStage<T>> supplier,
-                CompletableFuture<T> promise
+            ScheduledExecutorService scheduler,
+            Retry.AsyncContext<T> retryContext,
+            Supplier<CompletionStage<T>> supplier,
+            CompletableFuture<T> promise
         ) {
             this.scheduler = scheduler;
             this.retryContext = retryContext;

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/Retry.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/Retry.java
@@ -184,8 +184,11 @@ public interface Retry {
             do {
                 try {
                     runnable.run();
-                    context.onComplete();
-                    break;
+                    final boolean validationOfResult = context.onResult(null);
+                    if (!validationOfResult) {
+                        context.onComplete();
+                        break;
+                    }
                 } catch (Exception exception) {
                     context.onError(exception);
                 }
@@ -331,8 +334,11 @@ public interface Retry {
             do {
                 try {
                     runnable.run();
-                    context.onComplete();
-                    break;
+                    final boolean validationOfResult = context.onResult(null);
+                    if (!validationOfResult) {
+                        context.onComplete();
+                        break;
+                    }
                 } catch (RuntimeException runtimeException) {
                     context.onRuntimeError(runtimeException);
                 }
@@ -616,10 +622,10 @@ public interface Retry {
         private final CompletableFuture<T> promise;
 
         AsyncRetryBlock(
-            ScheduledExecutorService scheduler,
-            Retry.AsyncContext<T> retryContext,
-            Supplier<CompletionStage<T>> supplier,
-            CompletableFuture<T> promise
+                ScheduledExecutorService scheduler,
+                Retry.AsyncContext<T> retryContext,
+                Supplier<CompletionStage<T>> supplier,
+                CompletableFuture<T> promise
         ) {
             this.scheduler = scheduler;
             this.retryContext = retryContext;


### PR DESCRIPTION
This feature adds `RetryConfig `.`retryOnResult` config support in `decorateCheckedRunnable` and `decorateRunnable functions`.
For further context, please refer to the related issue: https://github.com/resilience4j/resilience4j/issues/2235