### PR TITLE
Add a Clock to CircuitBreakerConfig, use it in the state machine

### DIFF
--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfig.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfig.java
@@ -56,6 +56,7 @@ public class CircuitBreakerConfig implements Serializable {
     private static final Predicate<Object> DEFAULT_RECORD_RESULT_PREDICATE = (Object object) -> false;
     private static final Function<Either<Object, Throwable>, TransitionCheckResult> DEFAULT_TRANSITION_ON_RESULT
         = any -> TransitionCheckResult.noTransition();
+    private static final Clock DEFAULT_CLOCK = Clock.systemUTC();
     // The default exception predicate counts all exceptions as failures.
 
     private transient Predicate<Throwable> recordExceptionPredicate = DEFAULT_RECORD_EXCEPTION_PREDICATE;
@@ -87,6 +88,7 @@ public class CircuitBreakerConfig implements Serializable {
         .ofSeconds(DEFAULT_SLOW_CALL_DURATION_THRESHOLD);
     private Duration maxWaitDurationInHalfOpenState = Duration
         .ofSeconds(DEFAULT_WAIT_DURATION_IN_HALF_OPEN_STATE);
+    private transient Clock clock = DEFAULT_CLOCK;
 
     private CircuitBreakerConfig() {
     }
@@ -187,6 +189,10 @@ public class CircuitBreakerConfig implements Serializable {
 
     public Duration getMaxWaitDurationInHalfOpenState() {
         return maxWaitDurationInHalfOpenState;
+    }
+
+    public Clock getClock() {
+        return clock;
     }
 
     public enum SlidingWindowType {
@@ -319,6 +325,7 @@ public class CircuitBreakerConfig implements Serializable {
         private Duration maxWaitDurationInHalfOpenState = Duration
             .ofSeconds(DEFAULT_WAIT_DURATION_IN_HALF_OPEN_STATE);
         private byte createWaitIntervalFunctionCounter = 0;
+        private Clock clock = DEFAULT_CLOCK;
 
 
         public Builder(CircuitBreakerConfig baseConfig) {
@@ -341,6 +348,7 @@ public class CircuitBreakerConfig implements Serializable {
             this.maxWaitDurationInHalfOpenState = baseConfig.maxWaitDurationInHalfOpenState;
             this.writableStackTraceEnabled = baseConfig.writableStackTraceEnabled;
             this.recordResultPredicate = baseConfig.recordResultPredicate;
+            this.clock = baseConfig.clock;
         }
 
         public Builder() {
@@ -782,6 +790,22 @@ public class CircuitBreakerConfig implements Serializable {
         }
 
         /**
+         * Configures a custom Clock instance to use for time measurements.
+         * Default value is Clock.systemUTC().
+         *
+         * @param clock the Clock to use
+         * @return the CircuitBreakerConfig.Builder
+         */
+        public Builder clock(Clock clock) {
+            if (clock == null) {
+                this.clock = DEFAULT_CLOCK;
+            } else {
+                this.clock = clock;
+            }
+            return this;
+        }
+
+        /**
          * Builds a CircuitBreakerConfig
          *
          * @return the CircuitBreakerConfig
@@ -808,6 +832,7 @@ public class CircuitBreakerConfig implements Serializable {
             config.currentTimestampFunction = currentTimestampFunction;
             config.timestampUnit = timestampUnit;
             config.recordResultPredicate = recordResultPredicate;
+            config.clock = clock;
             return config;
         }
 

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerMetrics.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerMetrics.java
@@ -43,14 +43,13 @@ class CircuitBreakerMetrics implements CircuitBreaker.Metrics {
 
     private CircuitBreakerMetrics(int slidingWindowSize,
         CircuitBreakerConfig.SlidingWindowType slidingWindowType,
-        CircuitBreakerConfig circuitBreakerConfig,
-        Clock clock) {
+        CircuitBreakerConfig circuitBreakerConfig) {
         if (slidingWindowType == CircuitBreakerConfig.SlidingWindowType.COUNT_BASED) {
             this.metrics = new FixedSizeSlidingWindowMetrics(slidingWindowSize);
             this.minimumNumberOfCalls = Math
                 .min(circuitBreakerConfig.getMinimumNumberOfCalls(), slidingWindowSize);
         } else {
-            this.metrics = new SlidingTimeWindowMetrics(slidingWindowSize, clock);
+            this.metrics = new SlidingTimeWindowMetrics(slidingWindowSize, circuitBreakerConfig.getClock());
             this.minimumNumberOfCalls = circuitBreakerConfig.getMinimumNumberOfCalls();
         }
         this.failureRateThreshold = circuitBreakerConfig.getFailureRateThreshold();
@@ -61,33 +60,33 @@ class CircuitBreakerMetrics implements CircuitBreaker.Metrics {
     }
 
     private CircuitBreakerMetrics(int slidingWindowSize,
-        CircuitBreakerConfig circuitBreakerConfig, Clock clock) {
-        this(slidingWindowSize, circuitBreakerConfig.getSlidingWindowType(), circuitBreakerConfig, clock);
+        CircuitBreakerConfig circuitBreakerConfig) {
+        this(slidingWindowSize, circuitBreakerConfig.getSlidingWindowType(), circuitBreakerConfig);
     }
 
-    static CircuitBreakerMetrics forClosed(CircuitBreakerConfig circuitBreakerConfig, Clock clock) {
+    static CircuitBreakerMetrics forClosed(CircuitBreakerConfig circuitBreakerConfig) {
         return new CircuitBreakerMetrics(circuitBreakerConfig.getSlidingWindowSize(),
-            circuitBreakerConfig, clock);
+            circuitBreakerConfig);
     }
 
     static CircuitBreakerMetrics forHalfOpen(int permittedNumberOfCallsInHalfOpenState,
-        CircuitBreakerConfig circuitBreakerConfig, Clock clock) {
+        CircuitBreakerConfig circuitBreakerConfig) {
         return new CircuitBreakerMetrics(permittedNumberOfCallsInHalfOpenState,
-            CircuitBreakerConfig.SlidingWindowType.COUNT_BASED, circuitBreakerConfig, clock);
+            CircuitBreakerConfig.SlidingWindowType.COUNT_BASED, circuitBreakerConfig);
     }
 
-    static CircuitBreakerMetrics forForcedOpen(CircuitBreakerConfig circuitBreakerConfig, Clock clock) {
+    static CircuitBreakerMetrics forForcedOpen(CircuitBreakerConfig circuitBreakerConfig) {
         return new CircuitBreakerMetrics(0, CircuitBreakerConfig.SlidingWindowType.COUNT_BASED,
-            circuitBreakerConfig, clock);
+            circuitBreakerConfig);
     }
 
-    static CircuitBreakerMetrics forDisabled(CircuitBreakerConfig circuitBreakerConfig, Clock clock) {
+    static CircuitBreakerMetrics forDisabled(CircuitBreakerConfig circuitBreakerConfig) {
         return new CircuitBreakerMetrics(0, CircuitBreakerConfig.SlidingWindowType.COUNT_BASED,
-            circuitBreakerConfig, clock);
+            circuitBreakerConfig);
     }
 
-    static CircuitBreakerMetrics forMetricsOnly(CircuitBreakerConfig circuitBreakerConfig, Clock clock) {
-        return forClosed(circuitBreakerConfig, clock);
+    static CircuitBreakerMetrics forMetricsOnly(CircuitBreakerConfig circuitBreakerConfig) {
+        return forClosed(circuitBreakerConfig);
     }
 
     /**

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerMetricsTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerMetricsTest.java
@@ -34,10 +34,11 @@ public class CircuitBreakerMetricsTest {
     public void testCircuitBreakerMetrics() {
         CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
             .slidingWindow(10, 10, CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+            .clock(MockClock.at(2019, 1, 1, 12, 0, 0, ZoneId.of("UTC")))
             .build();
 
         CircuitBreakerMetrics circuitBreakerMetrics = CircuitBreakerMetrics
-            .forClosed(circuitBreakerConfig, MockClock.at(2019, 1, 1, 12, 0, 0, ZoneId.of("UTC")));
+            .forClosed(circuitBreakerConfig);
 
         circuitBreakerMetrics.onSuccess(0, TimeUnit.NANOSECONDS);
         circuitBreakerMetrics.onSuccess(0, TimeUnit.NANOSECONDS);

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachineTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachineTest.java
@@ -66,7 +66,7 @@ public class CircuitBreakerStateMachineTest {
 
     @Before
     @SuppressWarnings("unchecked")
-    public void setUp() {        
+    public void setUp() {
         mockOnSuccessEventConsumer = (EventConsumer<CircuitBreakerOnSuccessEvent>) mock(EventConsumer.class);
         mockOnErrorEventConsumer = (EventConsumer<CircuitBreakerOnErrorEvent>) mock(EventConsumer.class);
         mockOnStateTransitionEventConsumer = (EventConsumer<CircuitBreakerOnStateTransitionEvent>) mock(EventConsumer.class);
@@ -83,7 +83,8 @@ public class CircuitBreakerStateMachineTest {
             .waitDurationInOpenState(Duration.ofSeconds(5))
             .ignoreExceptions(NumberFormatException.class)
             .currentTimestampFunction(clock -> clock.instant().toEpochMilli(), TimeUnit.MILLISECONDS)
-            .build(), mockClock);
+            .clock(mockClock)
+            .build());
     }
 
     @Test
@@ -427,7 +428,8 @@ public class CircuitBreakerStateMachineTest {
                 .permittedNumberOfCallsInHalfOpenState(4)
                 .waitIntervalFunctionInOpenState(IntervalFunction.ofExponentialBackoff(5000L))
                 .recordException(error -> !(error instanceof NumberFormatException))
-                .build(), mockClock);
+                .clock(mockClock)
+                .build());
 
         // Initially the CircuitBreaker is open
         intervalCircuitBreaker.transitionToOpenState();


### PR DESCRIPTION
This PR adds a `clock(...)` function to `CircuitBreakerConfig`, and uses that clock in `CircuitBreakerStateMachine` and `CircuitBreakerMetrics` - basically, everywhere where we were passing both a config and a clock to a type, the clock parameter is removed and the clock is instead sourced from the configuration.

This is useful because right now, `CircuitBreakerStateMachine` does not respect the current-timestamp function, using the default `Clock.systemUTC()` instance.  This means that there's no way (if one is testing code _using_ circuit breakers) to control the passage of time with a clock in tests.

Fixes #2234