### PR TITLE
Lock free sliding window for internal CircutBreaker metrics

### DIFF
--- a/libraries.gradle
+++ b/libraries.gradle
@@ -6,6 +6,8 @@ ext {
     rxJava3Version = '3.0.0'
     reactorVersion = '3.4.24'
     junitVersion = '4.12'
+    junitParams = '1.1.1'
+    lincheck='2.34'
     slf4jVersion = '1.7.30'
     assertjVersion = '3.18.1'
     logbackVersion = '1.2.3'
@@ -50,6 +52,7 @@ ext {
 
             // testCompile
             junit: "junit:junit:${junitVersion}",
+            junitParams: "pl.pragmatists:JUnitParams:${junitParams}",
             assertj: "org.assertj:assertj-core:${assertjVersion}",
             logback: "ch.qos.logback:logback-classic:${logbackVersion}",
             mockito: "org.mockito:mockito-core:${mockitoVersion}",
@@ -61,6 +64,7 @@ ext {
             reactive_streams_tck: "org.reactivestreams:reactive-streams-tck:${reactiveStreamsVersion}",
             mock_clock: "com.statemachinesystems:mock-clock:1.0",
             blockhound: "io.projectreactor.tools:blockhound:${blockhoundVersion}",
+            lincheck: "org.jetbrains.kotlinx:lincheck:${lincheck}",
 
             // Vert.x addon
             vertx: "io.vertx:vertx-core:${vertxVersion}",

--- a/resilience4j-circuitbreaker/build.gradle
+++ b/resilience4j-circuitbreaker/build.gradle
@@ -2,5 +2,6 @@ dependencies {
     api project(':resilience4j-core')
     testImplementation project(':resilience4j-test')
     testImplementation(libraries.mock_clock)
+    testImplementation(libraries.junitParams)
 }
 ext.moduleName = 'io.github.resilience4j.circuitbreaker'

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfigTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfigTest.java
@@ -60,7 +60,12 @@ public class CircuitBreakerConfigTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void zeroSlidingWindowSizeShouldFail() {
-        custom().slidingWindow(0, 0, SlidingWindowType.COUNT_BASED).build();
+        custom().slidingWindow(
+            0,
+            0,
+            SlidingWindowType.COUNT_BASED,
+            SlidingWindowSynchronizationStrategy.SYNCHRONIZED
+        ).build();
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -70,7 +75,12 @@ public class CircuitBreakerConfigTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void zeroMinimumNumberOfCallsShouldFail() {
-        custom().slidingWindow(2, 0, SlidingWindowType.COUNT_BASED).build();
+        custom().slidingWindow(
+            2,
+            0,
+            SlidingWindowType.COUNT_BASED,
+            SlidingWindowSynchronizationStrategy.SYNCHRONIZED
+        ).build();
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -112,6 +122,8 @@ public class CircuitBreakerConfigTest {
             .isEqualTo(DEFAULT_PERMITTED_CALLS_IN_HALF_OPEN_STATE);
         then(circuitBreakerConfig.getSlidingWindowSize()).isEqualTo(DEFAULT_SLIDING_WINDOW_SIZE);
         then(circuitBreakerConfig.getSlidingWindowType()).isEqualTo(DEFAULT_SLIDING_WINDOW_TYPE);
+        then(circuitBreakerConfig.getSlidingWindowSynchronizationStrategy())
+            .isEqualTo(DEFAULT_SLIDING_WINDOW_SYNCHRONIZATION_STRATEGY);
         then(circuitBreakerConfig.getMinimumNumberOfCalls())
             .isEqualTo(DEFAULT_MINIMUM_NUMBER_OF_CALLS);
         then(circuitBreakerConfig.getWaitIntervalFunctionInOpenState().apply(1))
@@ -179,7 +191,12 @@ public class CircuitBreakerConfigTest {
     @Test
     public void shouldSetCountBasedSlidingWindowSize() {
         CircuitBreakerConfig circuitBreakerConfig = custom()
-            .slidingWindow(1000, 1000, SlidingWindowType.COUNT_BASED)
+            .slidingWindow(
+                1000,
+                1000,
+                SlidingWindowType.COUNT_BASED,
+                SlidingWindowSynchronizationStrategy.SYNCHRONIZED
+            )
             .build();
         then(circuitBreakerConfig.getSlidingWindowSize()).isEqualTo(1000);
     }
@@ -194,26 +211,42 @@ public class CircuitBreakerConfigTest {
     @Test
     public void shouldReduceMinimumNumberOfCallsToSlidingWindowSize() {
         CircuitBreakerConfig circuitBreakerConfig = custom()
-            .slidingWindow(5, 6, SlidingWindowType.COUNT_BASED).build();
+            .slidingWindow(
+                5,
+                6,
+                SlidingWindowType.COUNT_BASED,
+                SlidingWindowSynchronizationStrategy.SYNCHRONIZED
+            )
+            .build();
         then(circuitBreakerConfig.getMinimumNumberOfCalls()).isEqualTo(5);
         then(circuitBreakerConfig.getSlidingWindowSize()).isEqualTo(5);
         then(circuitBreakerConfig.getSlidingWindowType()).isEqualTo(SlidingWindowType.COUNT_BASED);
+        then(circuitBreakerConfig.getSlidingWindowSynchronizationStrategy())
+            .isEqualTo(SlidingWindowSynchronizationStrategy.SYNCHRONIZED);
     }
 
     @Test
     public void shouldSetSlidingWindowToCountBased() {
         CircuitBreakerConfig circuitBreakerConfig = custom()
-            .slidingWindow(5, 3, SlidingWindowType.COUNT_BASED).build();
+            .slidingWindow(
+                5,
+                3,
+                SlidingWindowType.COUNT_BASED,
+                SlidingWindowSynchronizationStrategy.SYNCHRONIZED
+            )
+            .build();
         then(circuitBreakerConfig.getMinimumNumberOfCalls()).isEqualTo(3);
         then(circuitBreakerConfig.getSlidingWindowSize()).isEqualTo(5);
         then(circuitBreakerConfig.getSlidingWindowType()).isEqualTo(SlidingWindowType.COUNT_BASED);
+        then(circuitBreakerConfig.getSlidingWindowSynchronizationStrategy())
+            .isEqualTo(SlidingWindowSynchronizationStrategy.SYNCHRONIZED);
     }
 
     @Test
     public void shouldSetSlidingWindowToTimeBased() {
         CircuitBreakerConfig circuitBreakerConfig = custom()
-            .slidingWindowType(SlidingWindowType.COUNT_BASED).build();
-        then(circuitBreakerConfig.getSlidingWindowType()).isEqualTo(SlidingWindowType.COUNT_BASED);
+            .slidingWindowType(SlidingWindowType.TIME_BASED).build();
+        then(circuitBreakerConfig.getSlidingWindowType()).isEqualTo(SlidingWindowType.TIME_BASED);
     }
 
     @Test
@@ -231,6 +264,14 @@ public class CircuitBreakerConfigTest {
     }
 
     @Test
+    public void shouldSetSlidingWindowSynchronizationStrategyToLockFree() {
+        CircuitBreakerConfig circuitBreakerConfig = custom()
+            .slidingWindowSynchronizationStrategy(SlidingWindowSynchronizationStrategy.LOCK_FREE).build();
+        then(circuitBreakerConfig.getSlidingWindowSynchronizationStrategy())
+            .isEqualTo(SlidingWindowSynchronizationStrategy.LOCK_FREE);
+    }
+
+    @Test
     public void maxWaitDurationInHalfOpenStateEqualZeroShouldPass() {
         CircuitBreakerConfig circuitBreakerConfig = custom().maxWaitDurationInHalfOpenState(Duration.ZERO).build();
         then(circuitBreakerConfig.getMaxWaitDurationInHalfOpenState().getSeconds()).isEqualTo(0);
@@ -239,7 +280,13 @@ public class CircuitBreakerConfigTest {
     @Test
     public void shouldAllowHighMinimumNumberOfCallsWhenSlidingWindowIsTimeBased() {
         CircuitBreakerConfig circuitBreakerConfig = custom()
-            .slidingWindow(10, 100, SlidingWindowType.TIME_BASED).build();
+            .slidingWindow(
+                10,
+                100,
+                SlidingWindowType.TIME_BASED,
+                SlidingWindowSynchronizationStrategy.SYNCHRONIZED
+            )
+            .build();
         then(circuitBreakerConfig.getMinimumNumberOfCalls()).isEqualTo(100);
         then(circuitBreakerConfig.getSlidingWindowSize()).isEqualTo(10);
         then(circuitBreakerConfig.getSlidingWindowType()).isEqualTo(SlidingWindowType.TIME_BASED);
@@ -433,6 +480,8 @@ public class CircuitBreakerConfigTest {
         CircuitBreakerConfig baseConfig = custom()
             .waitDurationInOpenState(Duration.ofSeconds(100))
             .slidingWindowSize(1000)
+            .slidingWindowType(SlidingWindowType.TIME_BASED)
+            .slidingWindowSynchronizationStrategy(SlidingWindowSynchronizationStrategy.LOCK_FREE)
             .permittedNumberOfCallsInHalfOpenState(100)
             .writableStackTraceEnabled(false)
             .automaticTransitionFromOpenToHalfOpenEnabled(true)
@@ -448,6 +497,9 @@ public class CircuitBreakerConfigTest {
         then(extendedConfig.getSlidingWindowSize()).isEqualTo(1000);
         then(extendedConfig.getPermittedNumberOfCallsInHalfOpenState()).isEqualTo(100);
         then(extendedConfig.isAutomaticTransitionFromOpenToHalfOpenEnabled()).isTrue();
+        then(extendedConfig.getSlidingWindowType()).isEqualTo(SlidingWindowType.TIME_BASED);
+        then(extendedConfig.getSlidingWindowSynchronizationStrategy())
+            .isEqualTo(SlidingWindowSynchronizationStrategy.LOCK_FREE);
     }
 
     @Test
@@ -465,6 +517,7 @@ public class CircuitBreakerConfigTest {
         assertThat(result).contains("recordExceptions=[class java.lang.RuntimeException]");
         assertThat(result).contains("automaticTransitionFromOpenToHalfOpenEnabled=true");
         assertThat(result).contains("slidingWindowType=TIME_BASED");
+        assertThat(result).contains("slidingWindowSynchronizationStrategy=SYNCHRONIZED");
         assertThat(result).endsWith("}");
     }
 

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerAutoTransitionStateMachineTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerAutoTransitionStateMachineTest.java
@@ -43,7 +43,12 @@ public class CircuitBreakerAutoTransitionStateMachineTest {
     public void setUp() {
         CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
             .failureRateThreshold(50)
-            .slidingWindow(5, 5, CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+            .slidingWindow(
+                5,
+                5,
+                CircuitBreakerConfig.SlidingWindowType.COUNT_BASED,
+                CircuitBreakerConfig.SlidingWindowSynchronizationStrategy.SYNCHRONIZED
+            )
             .permittedNumberOfCallsInHalfOpenState(3)
             .automaticTransitionFromOpenToHalfOpenEnabled(true)
             .waitDurationInOpenState(Duration.ofSeconds(2))

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerMetricsTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerMetricsTest.java
@@ -20,21 +20,38 @@ package io.github.resilience4j.circuitbreaker.internal;
 
 import com.statemachinesystems.mockclock.MockClock;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.SlidingWindowSynchronizationStrategy;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static io.github.resilience4j.circuitbreaker.internal.CircuitBreakerMetrics.Result;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(JUnitParamsRunner.class)
 public class CircuitBreakerMetricsTest {
 
+    private List<SlidingWindowSynchronizationStrategy> slidingWindowConfig() {
+        return Arrays.asList(SlidingWindowSynchronizationStrategy.values());
+    }
+
     @Test
-    public void testCircuitBreakerMetrics() {
+    @Parameters(method = "slidingWindowConfig")
+    public void testCircuitBreakerMetrics(SlidingWindowSynchronizationStrategy slidingWindowSynchronizationStrategy) {
         CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
-            .slidingWindow(10, 10, CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
             .clock(MockClock.at(2019, 1, 1, 12, 0, 0, ZoneId.of("UTC")))
+            .slidingWindow(
+                10,
+                10,
+                CircuitBreakerConfig.SlidingWindowType.COUNT_BASED,
+                slidingWindowSynchronizationStrategy
+            )
             .build();
 
         CircuitBreakerMetrics circuitBreakerMetrics = CircuitBreakerMetrics

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachineTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachineTest.java
@@ -79,7 +79,12 @@ public class CircuitBreakerStateMachineTest {
             .slowCallDurationThreshold(Duration.ofSeconds(4))
             .slowCallRateThreshold(50)
             .maxWaitDurationInHalfOpenState(Duration.ofSeconds(1))
-            .slidingWindow(20, 5, SlidingWindowType.TIME_BASED)
+            .slidingWindow(
+                20,
+                5,
+                SlidingWindowType.TIME_BASED,
+                CircuitBreakerConfig.SlidingWindowSynchronizationStrategy.SYNCHRONIZED
+            )
             .waitDurationInOpenState(Duration.ofSeconds(5))
             .ignoreExceptions(NumberFormatException.class)
             .currentTimestampFunction(clock -> clock.instant().toEpochMilli(), TimeUnit.MILLISECONDS)

--- a/resilience4j-core/build.gradle
+++ b/resilience4j-core/build.gradle
@@ -1,5 +1,21 @@
+plugins {
+    id 'org.jetbrains.kotlin.jvm' version '1.9.0'
+}
+
 ext.moduleName = 'io.github.resilience4j.core'
 
 dependencies {
     testImplementation(libraries.mock_clock)
+    testImplementation(libraries.junitParams)
+    testImplementation(libraries.lincheck)
+}
+
+compileTestKotlin {
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+test {
+    jvmArgs '-Xmx2G'
 }

--- a/resilience4j-core/src/jmh/java/io/github/resilience4j/core/MetricsBenchmark.java
+++ b/resilience4j-core/src/jmh/java/io/github/resilience4j/core/MetricsBenchmark.java
@@ -1,0 +1,214 @@
+package io.github.resilience4j.core;
+
+import io.github.resilience4j.core.metrics.*;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.time.Clock;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.Throughput)
+public class MetricsBenchmark {
+    public static final int FORK_COUNT = 1;
+    private static final int WARMUP_COUNT = 3;
+    private static final int ITERATION_COUNT = 3;
+
+    private final int slidingWindowSize = 5;
+
+    private LockFreeFixedSizeSlidingWindowMetrics lockFreeSlidingWindow;
+    private FixedSizeSlidingWindowMetrics slidingWindow;
+
+    private LockFreeSlidingTimeWindowMetrics lockFreeSlidingTimeWindow;
+    private SlidingTimeWindowMetrics slidingTimeWindow;
+
+    public static void main(String[] args) throws RunnerException {
+        Options options = new OptionsBuilder()
+                .include(".*" + MetricsBenchmark.class.getSimpleName() + ".*")
+                .build();
+        new Runner(options).run();
+    }
+
+    @Setup(Level.Iteration)
+    public void setUp() {
+        lockFreeSlidingWindow = new LockFreeFixedSizeSlidingWindowMetrics(slidingWindowSize);
+        slidingWindow = new FixedSizeSlidingWindowMetrics(slidingWindowSize);
+
+        lockFreeSlidingTimeWindow = new LockFreeSlidingTimeWindowMetrics(slidingWindowSize);
+        slidingTimeWindow = new SlidingTimeWindowMetrics(slidingWindowSize, Clock.systemUTC());
+    }
+
+    @Benchmark
+    @Warmup(iterations = WARMUP_COUNT)
+    @Fork(value = FORK_COUNT)
+    @Measurement(iterations = ITERATION_COUNT)
+    @Threads(1)
+    public Snapshot benchmarkLFSW1Thread() throws InterruptedException {
+        long duration = simulateWork();
+        return lockFreeSlidingWindow.record(duration, TimeUnit.MILLISECONDS, Metrics.Outcome.SUCCESS);
+    }
+
+    @Benchmark
+    @Warmup(iterations = WARMUP_COUNT)
+    @Fork(value = FORK_COUNT)
+    @Measurement(iterations = ITERATION_COUNT)
+    @Threads(4)
+    public Snapshot benchmarkLFSW4Threads() throws InterruptedException {
+        long duration = simulateWork();
+        return lockFreeSlidingWindow.record(duration, TimeUnit.MILLISECONDS, Metrics.Outcome.SUCCESS);
+    }
+
+    @Benchmark
+    @Warmup(iterations = WARMUP_COUNT)
+    @Fork(value = FORK_COUNT)
+    @Measurement(iterations = ITERATION_COUNT)
+    @Threads(8)
+    public Snapshot benchmarkLFSW8Threads() throws InterruptedException {
+        long duration = simulateWork();
+        return lockFreeSlidingWindow.record(duration, TimeUnit.MILLISECONDS, Metrics.Outcome.SUCCESS);
+    }
+
+    @Benchmark
+    @Warmup(iterations = WARMUP_COUNT)
+    @Fork(value = FORK_COUNT)
+    @Measurement(iterations = ITERATION_COUNT)
+    @Threads(16)
+    public Snapshot benchmarkLFSW16Threads() throws InterruptedException {
+        long duration = simulateWork();
+        return lockFreeSlidingWindow.record(duration, TimeUnit.MILLISECONDS, Metrics.Outcome.SUCCESS);
+    }
+
+    @Benchmark
+    @Warmup(iterations = WARMUP_COUNT)
+    @Fork(value = FORK_COUNT)
+    @Measurement(iterations = ITERATION_COUNT)
+    @Threads(1)
+    public Snapshot benchmarkSW1Thread() throws InterruptedException {
+        long duration = simulateWork();
+        return slidingWindow.record(duration, TimeUnit.MILLISECONDS, Metrics.Outcome.SUCCESS);
+    }
+
+    @Benchmark
+    @Warmup(iterations = WARMUP_COUNT)
+    @Fork(value = FORK_COUNT)
+    @Measurement(iterations = ITERATION_COUNT)
+    @Threads(4)
+    public Snapshot benchmarkSW4Threads() throws InterruptedException {
+        long duration = simulateWork();
+        return slidingWindow.record(duration, TimeUnit.MILLISECONDS, Metrics.Outcome.SUCCESS);
+    }
+
+    @Benchmark
+    @Warmup(iterations = WARMUP_COUNT)
+    @Fork(value = FORK_COUNT)
+    @Measurement(iterations = ITERATION_COUNT)
+    @Threads(8)
+    public Snapshot benchmarkSW8Threads() throws InterruptedException {
+        long duration = simulateWork();
+        return slidingWindow.record(duration, TimeUnit.MILLISECONDS, Metrics.Outcome.SUCCESS);
+    }
+
+    @Benchmark
+    @Warmup(iterations = WARMUP_COUNT)
+    @Fork(value = FORK_COUNT)
+    @Measurement(iterations = ITERATION_COUNT)
+    @Threads(16)
+    public Snapshot benchmarkSW16Threads() throws InterruptedException {
+        long duration = simulateWork();
+        return slidingWindow.record(duration, TimeUnit.MILLISECONDS, Metrics.Outcome.SUCCESS);
+    }
+
+    @Benchmark
+    @Warmup(iterations = WARMUP_COUNT)
+    @Fork(value = FORK_COUNT)
+    @Measurement(iterations = ITERATION_COUNT)
+    @Threads(1)
+    public Snapshot benchmarkLFSTW1Thread() throws InterruptedException {
+        long duration = simulateWork();
+        return lockFreeSlidingTimeWindow.record(duration, TimeUnit.MILLISECONDS, Metrics.Outcome.SUCCESS);
+    }
+
+    @Benchmark
+    @Warmup(iterations = WARMUP_COUNT)
+    @Fork(value = FORK_COUNT)
+    @Measurement(iterations = ITERATION_COUNT)
+    @Threads(4)
+    public Snapshot benchmarkLFSTW4Threads() throws InterruptedException {
+        long duration = simulateWork();
+        return lockFreeSlidingTimeWindow.record(duration, TimeUnit.MILLISECONDS, Metrics.Outcome.SUCCESS);
+    }
+
+    @Benchmark
+    @Warmup(iterations = WARMUP_COUNT)
+    @Fork(value = FORK_COUNT)
+    @Measurement(iterations = ITERATION_COUNT)
+    @Threads(8)
+    public Snapshot benchmarkLFSTW8Threads() throws InterruptedException {
+        long duration = simulateWork();
+        return lockFreeSlidingTimeWindow.record(duration, TimeUnit.MILLISECONDS, Metrics.Outcome.SUCCESS);
+    }
+
+    @Benchmark
+    @Warmup(iterations = WARMUP_COUNT)
+    @Fork(value = FORK_COUNT)
+    @Measurement(iterations = ITERATION_COUNT)
+    @Threads(16)
+    public Snapshot benchmarkLFSTW16Threads() throws InterruptedException {
+        long duration = simulateWork();
+        return lockFreeSlidingTimeWindow.record(duration, TimeUnit.MILLISECONDS, Metrics.Outcome.SUCCESS);
+    }
+
+    @Benchmark
+    @Warmup(iterations = WARMUP_COUNT)
+    @Fork(value = FORK_COUNT)
+    @Measurement(iterations = ITERATION_COUNT)
+    @Threads(1)
+    public Snapshot benchmarkSTW1Thread() throws InterruptedException {
+        long duration = simulateWork();
+        return slidingTimeWindow.record(duration, TimeUnit.MILLISECONDS, Metrics.Outcome.SUCCESS);
+    }
+
+    @Benchmark
+    @Warmup(iterations = WARMUP_COUNT)
+    @Fork(value = FORK_COUNT)
+    @Measurement(iterations = ITERATION_COUNT)
+    @Threads(4)
+    public Snapshot benchmarkSTW4Threads() throws InterruptedException {
+        long duration = simulateWork();
+        return slidingTimeWindow.record(duration, TimeUnit.MILLISECONDS, Metrics.Outcome.SUCCESS);
+    }
+
+    @Benchmark
+    @Warmup(iterations = WARMUP_COUNT)
+    @Fork(value = FORK_COUNT)
+    @Measurement(iterations = ITERATION_COUNT)
+    @Threads(8)
+    public Snapshot benchmarkSTW8Threads() throws InterruptedException {
+        long duration = simulateWork();
+        return slidingTimeWindow.record(duration, TimeUnit.MILLISECONDS, Metrics.Outcome.SUCCESS);
+    }
+
+    @Benchmark
+    @Warmup(iterations = WARMUP_COUNT)
+    @Fork(value = FORK_COUNT)
+    @Measurement(iterations = ITERATION_COUNT)
+    @Threads(16)
+    public Snapshot benchmarkSTW16Threads() throws InterruptedException {
+        long duration = simulateWork();
+        return slidingTimeWindow.record(duration, TimeUnit.MILLISECONDS, Metrics.Outcome.SUCCESS);
+    }
+
+    public long simulateWork() {
+        long result = 0;
+
+        for (long i = 0; i < 5000; i++) {
+            result += (long) Math.sqrt(i);
+        }
+
+        return result;
+    }
+}

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/Clock.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/Clock.java
@@ -1,0 +1,52 @@
+/*
+ *
+ *  Copyright 2024 Florentin Simion and Rares Vlasceanu
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.core;
+
+/**
+ * A clock abstraction used to measure absolute and relative time.
+ */
+public interface Clock {
+    /**
+     * Current time expressed as milliseconds since the Unix epoch. Should not be used for measuring time,
+     * just for timestamps.
+     *
+     * @return wall time in milliseconds
+     */
+    long wallTime();
+
+    /**
+     * Current monotonic time in nanoseconds. Should be used for measuring time.
+     * The value is not related to the wall time and is not subject to system clock changes.
+     *
+     * @return monotonic time in nanoseconds
+     */
+    long monotonicTime();
+
+    Clock SYSTEM = new Clock() {
+        @Override
+        public long wallTime() {
+            return System.currentTimeMillis();
+        }
+
+        @Override
+        public long monotonicTime() {
+            return System.nanoTime();
+        }
+    };
+}

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/AbstractAggregation.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/AbstractAggregation.java
@@ -20,7 +20,7 @@ package io.github.resilience4j.core.metrics;
 
 import java.util.concurrent.TimeUnit;
 
-class AbstractAggregation {
+abstract class AbstractAggregation implements CumulativeMeasurement {
 
     long totalDurationInMillis = 0;
     int numberOfSlowCalls = 0;
@@ -28,7 +28,32 @@ class AbstractAggregation {
     int numberOfFailedCalls = 0;
     int numberOfCalls = 0;
 
-    void record(long duration, TimeUnit durationUnit, Metrics.Outcome outcome) {
+    @Override
+    public long getTotalDurationInMillis() {
+        return totalDurationInMillis;
+    }
+
+    @Override
+    public int getNumberOfSlowCalls() {
+        return numberOfSlowCalls;
+    }
+
+    @Override
+    public int getNumberOfSlowFailedCalls() {
+        return numberOfSlowFailedCalls;
+    }
+
+    @Override
+    public int getNumberOfFailedCalls() {
+        return numberOfFailedCalls;
+    }
+
+    @Override
+    public int getNumberOfCalls() {
+        return numberOfCalls;
+    }
+
+    public void record(long duration, TimeUnit durationUnit, Metrics.Outcome outcome) {
         this.numberOfCalls++;
         this.totalDurationInMillis += durationUnit.toMillis(duration);
         switch (outcome) {

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/CumulativeMeasurement.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/CumulativeMeasurement.java
@@ -1,0 +1,36 @@
+/*
+ *
+ *  Copyright 2024 Florentin Simion and Rares Vlasceanu
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.core.metrics;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Interface for measurement implementations that accumulate calls durations and outcomes.
+ */
+public interface CumulativeMeasurement extends MeasurementData {
+
+    /**
+     * Records a call duration and its outcome.
+     *
+     * @param duration the call duration
+     * @param durationUnit the time unit of the call duration
+     * @param outcome the outcome of the call
+     */
+    void record(long duration, TimeUnit durationUnit, Metrics.Outcome outcome);
+}

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/LockFreeFixedSizeSlidingWindowMetrics.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/LockFreeFixedSizeSlidingWindowMetrics.java
@@ -1,0 +1,172 @@
+/*
+ *
+ *  Copyright 2024 Florentin Simion and Rares Vlasceanu
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.core.metrics;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Implements a lock-free sliding window using a single linked list, represented by a head and a tail reference.
+ * <p>
+ * The idea is to initialize the list to the window size, where node N represents the stats for the N-th entry. Besides
+ * the stats for the N-th entry, it also contains the stats for the whole window, which are carried over on each new
+ * added entry.
+ *
+ * <p>
+ * When a new record is added, the size of the window is maintained:
+ * <ul>
+ * <ol>1. A new node is added at the tail of the list.</ol>
+ * <ol>2. The head of the list is moved to the next node.</ol>
+ * <ol>3. The tail of the list is moved to the next node.</ol>
+ * </ul>
+ *
+ * <p>
+ * As these operations need to happen atomically, we use the VarHandle API to perform CAS operations on the head, tail
+ * and next references. However, these updates are not atomically happening across these references, so we can end up
+ * that each reference is updated by a different thread.
+ *
+ * <p>
+ * The algorithm is based on the following conditions:
+ * <ul>
+ * <li>if there is no next node -> try to add one </li>
+ * <li>else, if the head and tail represent the same N-th stats -> advance the head</li>
+ * <li>else -> advance the tail</li>
+ * </ul>
+ *
+ * <p>
+ * All these operations are done via compare-and-swap operations.
+ *
+ */
+public class LockFreeFixedSizeSlidingWindowMetrics implements Metrics {
+
+    private static final VarHandle HEAD;
+    private static final VarHandle TAIL;
+
+    private static final VarHandle NEXT;
+
+    static {
+        try {
+            MethodHandles.Lookup l = MethodHandles.lookup();
+
+            HEAD = l.findVarHandle(LockFreeFixedSizeSlidingWindowMetrics.class, "headRef", Node.class);
+            TAIL = l.findVarHandle(LockFreeFixedSizeSlidingWindowMetrics.class, "tailRef", Node.class);
+
+            NEXT = l.findVarHandle(Node.class, "next", Node.class);
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private final int windowSize;
+
+    private volatile Node tailRef;
+    private volatile Node headRef;
+
+    public LockFreeFixedSizeSlidingWindowMetrics(int windowSize) {
+        this.windowSize = windowSize;
+
+        this.headRef = new Node(0, new PackedAggregation(), null);
+        this.tailRef = headRef;
+
+        for (int i = 1; i < this.windowSize; i++) {
+            Node newNode = new Node(i, new PackedAggregation(), null);
+
+            tailRef.next = newNode;
+            tailRef = newNode;
+        }
+    }
+
+    @Override
+    public Snapshot record(long duration, TimeUnit durationUnit, Outcome outcome) {
+        while (true) {
+            Node head = headRef;
+            Node headNext = head.next;
+
+            Node tail = tailRef;
+            Node tailNext = tail.next;
+
+            // This check is necessary to make sure that the head has not fallen off the list.
+            // This can happen when a thread reads the head, it is superseded from the CPU, and other threads
+            // advances the head in the meantime.
+            // Without this check we might end up adding into the queue a new node with incorrect stats.
+            if (head != headRef) {
+                continue;
+            }
+
+            // This check is not actually needed for the well-functioning of the algorithm, it is just an optimization
+            // to avoid unnecessary CAS operations, which are expensive.
+            if (tail != tailRef) {
+                continue;
+            }
+
+            if (tailNext == null) {
+                int nextId = (tail.id + 1) % windowSize;
+
+                PackedAggregation nextStats = tail.stats.copy();
+
+                nextStats.discard(head.stats);
+                nextStats.record(duration, durationUnit, outcome);
+
+                Node nextNode = new Node(nextId, nextStats, null);
+
+                if (NEXT.compareAndSet(tail, null, nextNode)) {
+                    // These operations can fail, as the head/tail might have been advanced by other threads,
+                    // but we will exit anyway, so we can try to move the head/tail with some less-expensive operations.
+                    //
+                    // These operations can fail spuriously, but they are not critical, as the next thread will
+                    // complete the job, by moving them.
+                    if (HEAD.weakCompareAndSet(this, head, headNext)) {
+                        TAIL.weakCompareAndSet(this, tail, nextNode);
+                    }
+
+                    return new SnapshotImpl(nextNode.stats);
+                }
+            } else if (tailNext.id == head.id) {
+                if (HEAD.compareAndSet(this, head, headNext)) {
+                    TAIL.compareAndSet(this, tail, tailNext);
+                }
+            } else {
+                TAIL.compareAndSet(this, tail, tailNext);
+            }
+        }
+    }
+
+    @Override
+    public Snapshot getSnapshot() {
+        Node tail = tailRef;
+        Node tailNext = tail.next;
+
+        // As the tail can lag behind, the next pointer may be the actual tail.
+        return new SnapshotImpl(Objects.requireNonNullElse(tailNext, tail).stats);
+    }
+
+    private static class Node {
+        int id;
+        PackedAggregation stats;
+        volatile Node next;
+
+        Node(int id, PackedAggregation stats, Node next) {
+            this.id = id;
+            this.stats = stats;
+            NEXT.set(this, next);
+        }
+    }
+}

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/LockFreeFixedSizeSlidingWindowMetrics.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/LockFreeFixedSizeSlidingWindowMetrics.java
@@ -32,11 +32,11 @@ import java.util.concurrent.TimeUnit;
  *
  * <p>
  * When a new record is added, the size of the window is maintained:
- * <ul>
- * <ol>1. A new node is added at the tail of the list.</ol>
- * <ol>2. The head of the list is moved to the next node.</ol>
- * <ol>3. The tail of the list is moved to the next node.</ol>
- * </ul>
+ * <ol>
+ * <li>A new node is added at the tail of the list.</li>
+ * <li>The head of the list is moved to the next node.</li>
+ * <li>The tail of the list is moved to the next node.</li>
+ * </ol>
  *
  * <p>
  * As these operations need to happen atomically, we use the VarHandle API to perform CAS operations on the head, tail

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/LockFreeSlidingTimeWindowMetrics.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/LockFreeSlidingTimeWindowMetrics.java
@@ -1,0 +1,258 @@
+/*
+ *
+ *  Copyright 2024 Florentin Simion and Rares Vlasceanu
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.core.metrics;
+
+import io.github.resilience4j.core.Clock;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Implements a lock-free time sliding window using a single linked list, represented by a head and a tail reference.
+ * The algorithm of the sliding window is very similar as for {@link LockFreeFixedSizeSlidingWindowMetrics}.
+ * <p>
+ * Each node of the sliding window represents the aggregated stats across 1 second (time slice). During a time slice,
+ * the algorithm is very simple consisting of a classical CAS-loop, in which the stats are copied, incremented, and
+ * a swap is attempted.
+ * <p>
+ * The complexity of the algorithm comes when the time slice is advanced. The algorithm needs to ensure that only
+ * one thread succeeds in advancing the time slice, i.e. a single time slice is advanced not multiple. This is achieved
+ * via an extra check when adding a new entry to the window, which guarantees that it is added only if it
+ * respects the time order, i.e. ith time slice is added only if it is preceded by the (i-1)th time slice.
+ * <p>
+ * It also needs to ensure that no stats updates are lost by updating a time slice in the past. This is accounted via
+ * a processed flag in the time slice, which marks that no further increments should happen for it.
+ * <p>
+ *
+ */
+public class LockFreeSlidingTimeWindowMetrics implements Metrics {
+    private static final long TIME_SLICE_DURATION_IN_NANOS = TimeUnit.SECONDS.toNanos(1);
+
+    private static final VarHandle HEAD;
+    private static final VarHandle TAIL;
+
+    private static final VarHandle TIME_SLICE;
+    private static final VarHandle NEXT;
+
+    static {
+        try {
+            MethodHandles.Lookup l = MethodHandles.lookup();
+
+            HEAD = l.findVarHandle(LockFreeSlidingTimeWindowMetrics.class, "headRef", Node.class);
+            TAIL = l.findVarHandle(LockFreeSlidingTimeWindowMetrics.class, "tailRef", Node.class);
+
+            TIME_SLICE = l.findVarHandle(Node.class, "timeSlice", TimeSlice.class);
+            NEXT = l.findVarHandle(Node.class, "next", Node.class);
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private final Clock clock;
+    private final int windowSize;
+
+    private volatile Node headRef;
+    private volatile Node tailRef;
+
+    public LockFreeSlidingTimeWindowMetrics(int windowSize, Clock clock) {
+        long time = clock.monotonicTime();
+
+        this.clock = clock;
+        this.windowSize = windowSize;
+
+        this.headRef = new Node(new TimeSlice(0, time, new PackedAggregation(), false), null);
+        this.tailRef = headRef;
+
+        for (int i = 1; i < this.windowSize; i++) {
+            Node newNode = new Node(new TimeSlice(i, time, new PackedAggregation(), false), null);
+
+            tailRef.next = newNode;
+            tailRef = newNode;
+        }
+    }
+
+    public LockFreeSlidingTimeWindowMetrics(int windowSize) {
+        this(windowSize, Clock.SYSTEM);
+    }
+
+    @Override
+    public Snapshot record(long duration, TimeUnit durationUnit, Outcome outcome) {
+        while (true) {
+            advanceTimeSlice();
+
+            Node tail = tailRef;
+            TimeSlice current = tail.timeSlice;
+
+            // The current time slice has been marked as processed, no further updates to it are allowed.
+            if (current.processed) {
+                continue;
+            }
+
+            TimeSlice next = current.copy();
+            next.record(duration, durationUnit, outcome);
+
+            // Updates stats in the current time slice.
+            if (TIME_SLICE.compareAndSet(tail, current, next)) {
+                return new SnapshotImpl(next.stats);
+            }
+        }
+    }
+
+    @Override
+    public Snapshot getSnapshot() {
+        advanceTimeSlice();
+        return new SnapshotImpl(tailRef.timeSlice.stats);
+    }
+
+    private void advanceTimeSlice() {
+        while (true) {
+            Node tail = tailRef;
+            TimeSlice current = tail.timeSlice;
+
+            long now = clock.monotonicTime();
+            long elapsedTime = now - current.time;
+
+            if (elapsedTime < TIME_SLICE_DURATION_IN_NANOS) {
+                return;
+            }
+
+            // This check is an optimization to avoid the below CAS.
+            //
+            // It can happen that the current time slice is already marked as processed by another thread, which
+            // didn't manage it to actually advance the time slice.
+            if (!current.processed) {
+                TimeSlice processed = new TimeSlice(current.second, current.time, current.stats, true);
+
+                // Mark the current time slice as processed so that no further updates are allowed.
+                if (TIME_SLICE.compareAndSet(tail, current, processed)) {
+                    current = processed;
+                } else {
+                    continue;
+                }
+            }
+
+            // The elapsed time slice can be larger than the window size, in which case we need to do
+            // a full window advancement.
+            long elapsedSlices = Math.min(elapsedTime / TIME_SLICE_DURATION_IN_NANOS, windowSize);
+            long elapsedTimeInNextSlice = elapsedTime - (elapsedSlices * TIME_SLICE_DURATION_IN_NANOS);
+
+            // This can happen when the elapsed time is larger than the time tracked by the window, so the time
+            // slice will be relative to the current time. Basically, the next slice time will be the current time.
+            if (elapsedTimeInNextSlice >= TIME_SLICE_DURATION_IN_NANOS) {
+                elapsedTimeInNextSlice = 0;
+            }
+
+            int nextSecond = (current.second + 1) % windowSize;
+            long nextTime = now - (elapsedSlices - 1) * TIME_SLICE_DURATION_IN_NANOS - elapsedTimeInNextSlice;
+
+            // Tries to advance the window to the next time slice, it can fail, as another thread might have already
+            // done so. This is ok, as what is important is that the window is advanced. And all threads will exit once
+            // the window is advanced to the current time.
+            updateWindow(nextSecond, nextTime);
+        }
+    }
+
+    private void updateWindow(int second, long time) {
+        while (true) {
+            Node head = headRef;
+            Node headNext = head.next;
+
+            Node tail = tailRef;
+            Node tailNext = tail.next;
+
+            if (head != headRef) {
+                continue;
+            }
+
+            if (tail != tailRef) {
+                continue;
+            }
+
+            TimeSlice headTimeSlice = head.timeSlice;
+            TimeSlice tailTimeSlice = tail.timeSlice;
+
+            int nextSecond = (tailTimeSlice.second + 1) % windowSize;
+
+            // This guarantees that only one thread advances the time slice.
+            // The time functions as a modification counter, helping us to avoid the ABA problem.
+            if (second != nextSecond || time < tailTimeSlice.time) {
+                return;
+            }
+
+            if (tailNext == null) {
+                PackedAggregation nextStats = tailTimeSlice.stats.copy();
+                nextStats.discard(headTimeSlice.stats);
+
+                TimeSlice nextTimeSlice = new TimeSlice(nextSecond, time, nextStats, false);
+
+                Node nextNode = new Node(nextTimeSlice, null);
+
+                // We need to guarantee that the time slice has been moved, so no early exit is allowed if any of
+                // the last - 1 CAS operations fail. Also, no operations that can spuriously fail are allowed.
+                if (NEXT.compareAndSet(tail, null, nextNode)) {
+                    if (HEAD.compareAndSet(this, head, headNext)) {
+                        // If this fails, it means that the tail has been advanced by another thread,
+                        // so we can still exit.
+                        TAIL.compareAndSet(this, tail, nextNode);
+                        return;
+                    }
+                }
+            } else if (tailNext.timeSlice.second == headTimeSlice.second) {
+                if (HEAD.compareAndSet(this, head, headNext)) {
+                    TAIL.compareAndSet(this, tail, tailNext);
+                }
+            } else {
+                TAIL.compareAndSet(this, tail, tailNext);
+            }
+        }
+    }
+
+    public static class TimeSlice {
+        final int second;
+        final long time;
+        final PackedAggregation stats;
+        final boolean processed;
+
+        public TimeSlice(int second, long time, PackedAggregation stats, boolean processed) {
+            this.second = second;
+            this.time = time;
+            this.stats = stats;
+            this.processed = processed;
+        }
+
+        public TimeSlice copy() {
+            return new TimeSlice(second, time, stats.copy(), processed);
+        }
+
+        public void record(Long duration, TimeUnit durationUnit, Outcome outcome) {
+            stats.record(duration, durationUnit, outcome);
+        }
+    }
+
+    private static class Node {
+        volatile TimeSlice timeSlice;
+        volatile Node next;
+
+        Node(TimeSlice timeSlice, Node next) {
+            TIME_SLICE.set(this, timeSlice);
+            NEXT.set(this, next);
+        }
+    }
+}

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/MeasurementData.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/MeasurementData.java
@@ -1,0 +1,59 @@
+/*
+ *
+ *  Copyright 2024 Florentin Simion and Rares Vlasceanu
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.core.metrics;
+
+/**
+ * Represents a data structure that holds the results of a measurement.
+ */
+public interface MeasurementData {
+    /**
+     * Returns the total duration of all calls in this measurement.
+     *
+     * @return the total duration of all calls
+     */
+    long getTotalDurationInMillis();
+
+    /**
+     * Returns the number of calls in this measurement which were slower than a certain threshold.
+     *
+     * @return the number of calls which were slower than a certain threshold
+     */
+    int getNumberOfSlowCalls();
+
+    /**
+     * Returns the number of failed calls in this measurement which were slower than a certain threshold.
+     *
+     * @return the number of failed calls which were slower than a certain threshold
+     */
+    int getNumberOfSlowFailedCalls();
+
+    /**
+     * Returns the number of failed calls in this measurement.
+     *
+     * @return the number of failed calls
+     */
+    int getNumberOfFailedCalls();
+
+    /**
+     * Returns the total number of all calls in this measurement.
+     *
+     * @return the total number of all calls
+     */
+    int getNumberOfCalls();
+}

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/PackedAggregation.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/PackedAggregation.java
@@ -1,0 +1,147 @@
+/*
+ *
+ *  Copyright 2024 Florentin Simion and Rares Vlasceanu
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.core.metrics;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A measurement implementation used in sliding windows to track the total duration and the number of calls in the
+ * window, along with the duration and number of calls of the current entry/bucket.
+ *
+ * <p>This implementation has the advantage of being cache friendly, benefiting from cache locality when
+ * counting/discarding the tracked metrics.
+ *
+ * <p>Besides this, metrics can also be quickly cloned, which is important for the lock-free algorithms which
+ * are operating with immutable objects.
+ */
+public class PackedAggregation implements CumulativeMeasurement {
+    private long[] durations = new long[2];
+    private int[] counts = new int[8];
+
+    private static final int TOTAL_DURATION_INDEX = 0;
+    private static final int DURATION_INDEX = 1;
+
+    private static final int TOTAL_SLOW_CALLS_INDEX = 0;
+    private static final int TOTAL_FAILED_SLOW_CALLS_INDEX = 1;
+    private static final int TOTAL_FAILED_CALLS_INDEX = 2;
+    private static final int TOTAL_CALLS_INDEX = 3;
+
+    private static final int SLOW_CALLS_INDEX = 4;
+    private static final int FAILED_SLOW_CALLS_INDEX = 5;
+    private static final int FAILED_CALLS_INDEX = 6;
+    private static final int CALLS_INDEX = 7;
+
+    public PackedAggregation() {
+    }
+
+    public PackedAggregation(long[] durations, int[] counts) {
+        this.durations = durations;
+        this.counts = counts;
+    }
+
+    PackedAggregation copy() {
+        return new PackedAggregation(durations.clone(), counts.clone());
+    }
+
+    void discard(PackedAggregation discarded) {
+        durations[TOTAL_DURATION_INDEX] -= discarded.durations[DURATION_INDEX];
+        durations[DURATION_INDEX] = 0;
+
+        counts[TOTAL_SLOW_CALLS_INDEX] -= discarded.counts[SLOW_CALLS_INDEX];
+        counts[TOTAL_FAILED_SLOW_CALLS_INDEX] -= discarded.counts[FAILED_SLOW_CALLS_INDEX];
+        counts[TOTAL_FAILED_CALLS_INDEX] -= discarded.counts[FAILED_CALLS_INDEX];
+        counts[TOTAL_CALLS_INDEX] -= discarded.counts[CALLS_INDEX];
+
+        counts[SLOW_CALLS_INDEX] = 0;
+        counts[FAILED_SLOW_CALLS_INDEX] = 0;
+        counts[FAILED_CALLS_INDEX] = 0;
+        counts[CALLS_INDEX] = 0;
+    }
+
+    @Override
+    public void record(long duration, TimeUnit durationUnit, Metrics.Outcome outcome) {
+        long durationInMillis = durationUnit.toMillis(duration);
+
+        durations[TOTAL_DURATION_INDEX] += durationInMillis;
+        durations[DURATION_INDEX] += durationInMillis;
+
+        counts[TOTAL_CALLS_INDEX]++;
+        counts[CALLS_INDEX]++;
+
+        switch (outcome) {
+            case SLOW_SUCCESS:
+                counts[TOTAL_SLOW_CALLS_INDEX]++;
+                counts[SLOW_CALLS_INDEX]++;
+                break;
+
+            case SLOW_ERROR:
+                counts[TOTAL_SLOW_CALLS_INDEX]++;
+                counts[SLOW_CALLS_INDEX]++;
+
+                counts[TOTAL_FAILED_SLOW_CALLS_INDEX]++;
+                counts[FAILED_SLOW_CALLS_INDEX]++;
+
+                counts[TOTAL_FAILED_CALLS_INDEX]++;
+                counts[FAILED_CALLS_INDEX]++;
+                break;
+
+            case ERROR:
+                counts[TOTAL_FAILED_CALLS_INDEX]++;
+                counts[FAILED_CALLS_INDEX]++;
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    @Override
+    public long getTotalDurationInMillis() {
+        return durations[TOTAL_DURATION_INDEX];
+    }
+
+    @Override
+    public int getNumberOfSlowCalls() {
+        return counts[TOTAL_SLOW_CALLS_INDEX];
+    }
+
+    @Override
+    public int getNumberOfSlowFailedCalls() {
+        return counts[TOTAL_FAILED_SLOW_CALLS_INDEX];
+    }
+
+    @Override
+    public int getNumberOfFailedCalls() {
+        return counts[TOTAL_FAILED_CALLS_INDEX];
+    }
+
+    @Override
+    public int getNumberOfCalls() {
+        return counts[TOTAL_CALLS_INDEX];
+    }
+
+    @Override
+    public String toString() {
+        return "PackedAggregation{" +
+            "durations=" + Arrays.toString(durations) +
+            ", counts=" + Arrays.toString(counts) +
+            '}';
+    }
+}

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/SnapshotImpl.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/metrics/SnapshotImpl.java
@@ -19,6 +19,7 @@
 package io.github.resilience4j.core.metrics;
 
 import java.time.Duration;
+import java.util.Objects;
 
 public class SnapshotImpl implements Snapshot {
 
@@ -28,13 +29,12 @@ public class SnapshotImpl implements Snapshot {
     private final int totalNumberOfFailedCalls;
     private final int totalNumberOfCalls;
 
-    SnapshotImpl(TotalAggregation totalAggregation) {
-        this.totalDurationInMillis = totalAggregation.totalDurationInMillis;
-        this.totalNumberOfSlowCalls = totalAggregation.numberOfSlowCalls;
-        this.totalNumberOfSlowFailedCalls = totalAggregation.numberOfSlowFailedCalls;
-        this.totalNumberOfFailedCalls = totalAggregation.numberOfFailedCalls;
-        this.totalNumberOfCalls = totalAggregation.numberOfCalls;
-
+    SnapshotImpl(MeasurementData measurementData) {
+        this.totalDurationInMillis = measurementData.getTotalDurationInMillis();
+        this.totalNumberOfSlowCalls = measurementData.getNumberOfSlowCalls();
+        this.totalNumberOfSlowFailedCalls = measurementData.getNumberOfSlowFailedCalls();
+        this.totalNumberOfFailedCalls = measurementData.getNumberOfFailedCalls();
+        this.totalNumberOfCalls = measurementData.getNumberOfCalls();
     }
 
     @Override
@@ -94,5 +94,39 @@ public class SnapshotImpl implements Snapshot {
             return Duration.ZERO;
         }
         return Duration.ofMillis(totalDurationInMillis / totalNumberOfCalls);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SnapshotImpl snapshot = (SnapshotImpl) o;
+        return totalDurationInMillis == snapshot.totalDurationInMillis &&
+            totalNumberOfSlowCalls == snapshot.totalNumberOfSlowCalls &&
+            totalNumberOfSlowFailedCalls == snapshot.totalNumberOfSlowFailedCalls &&
+            totalNumberOfFailedCalls == snapshot.totalNumberOfFailedCalls &&
+            totalNumberOfCalls == snapshot.totalNumberOfCalls;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+            totalDurationInMillis,
+            totalNumberOfSlowCalls,
+            totalNumberOfSlowFailedCalls,
+            totalNumberOfFailedCalls,
+            totalNumberOfCalls
+        );
+    }
+
+    @Override
+    public String toString() {
+        return "SnapshotImpl{" +
+            "totalDurationInMillis=" + totalDurationInMillis +
+            ", totalNumberOfSlowCalls=" + totalNumberOfSlowCalls +
+            ", totalNumberOfSlowFailedCalls=" + totalNumberOfSlowFailedCalls +
+            ", totalNumberOfFailedCalls=" + totalNumberOfFailedCalls +
+            ", totalNumberOfCalls=" + totalNumberOfCalls +
+            '}';
     }
 }

--- a/resilience4j-core/src/test/java/io/github/resilience4j/core/JavaClockWrapper.java
+++ b/resilience4j-core/src/test/java/io/github/resilience4j/core/JavaClockWrapper.java
@@ -1,0 +1,42 @@
+/*
+ *
+ *  Copyright 2024 Florentin Simion and Rares Vlasceanu
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.core;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A wrapper used to adapt the Java 8 Clock used in the rest of the project to the new Clock interface.
+ */
+public class JavaClockWrapper implements Clock {
+    private final java.time.Clock clock;
+
+    public JavaClockWrapper(java.time.Clock clock) {
+        this.clock = clock;
+    }
+
+    @Override
+    public long wallTime() {
+        return this.clock.millis();
+    }
+
+    @Override
+    public long monotonicTime() {
+        return TimeUnit.MILLISECONDS.toNanos(this.clock.millis());
+    }
+}

--- a/resilience4j-core/src/test/java/io/github/resilience4j/core/ManualClock.java
+++ b/resilience4j-core/src/test/java/io/github/resilience4j/core/ManualClock.java
@@ -1,0 +1,47 @@
+/*
+ *
+ *  Copyright 2024 Florentin Simion and Rares Vlasceanu
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.core;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A clock that can be manually advanced in time for testing purposes.
+ */
+public class ManualClock implements Clock {
+    private final AtomicLong timeNanos = new AtomicLong(0);
+
+    public void advanceByMillis(long millis) {
+        timeNanos.addAndGet(TimeUnit.MILLISECONDS.toNanos(millis));
+    }
+
+    public void advanceBySeconds(long seconds) {
+        timeNanos.addAndGet(TimeUnit.SECONDS.toNanos(seconds));
+    }
+
+    @Override
+    public long wallTime() {
+        return TimeUnit.NANOSECONDS.toMillis(timeNanos.get());
+    }
+
+    @Override
+    public long monotonicTime() {
+        return timeNanos.get();
+    }
+}

--- a/resilience4j-core/src/test/java/io/github/resilience4j/core/metrics/FixedSizeSlidingWindowMetricsTest.java
+++ b/resilience4j-core/src/test/java/io/github/resilience4j/core/metrics/FixedSizeSlidingWindowMetricsTest.java
@@ -18,18 +18,44 @@
  */
 package io.github.resilience4j.core.metrics;
 
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(JUnitParamsRunner.class)
 public class FixedSizeSlidingWindowMetricsTest {
 
-    @Test
-    public void checkInitialBucketCreation() {
-        FixedSizeSlidingWindowMetrics metrics = new FixedSizeSlidingWindowMetrics(5);
+    private List<Metrics> defaultSlidingWindow() {
+        return Arrays.asList(
+                new FixedSizeSlidingWindowMetrics(5),
+                new LockFreeFixedSizeSlidingWindowMetrics(5)
+        );
+    }
 
+    private List<Metrics> mediumSizeSlidingWindow() {
+        return Arrays.asList(
+                new FixedSizeSlidingWindowMetrics(4),
+                new LockFreeFixedSizeSlidingWindowMetrics(4)
+        );
+    }
+
+    private List<Metrics> smallSizeSlidingWindow() {
+        return Arrays.asList(
+                new FixedSizeSlidingWindowMetrics(2),
+                new LockFreeFixedSizeSlidingWindowMetrics(2)
+        );
+    }
+
+    @Test
+    @Parameters(method = "defaultSlidingWindow")
+    public void checkInitialBucketCreation(Metrics metrics) {
         Snapshot snapshot = metrics.getSnapshot();
 
         assertThat(snapshot.getTotalNumberOfCalls()).isZero();
@@ -44,9 +70,8 @@ public class FixedSizeSlidingWindowMetricsTest {
     }
 
     @Test
-    public void testRecordSuccess() {
-        Metrics metrics = new FixedSizeSlidingWindowMetrics(5);
-
+    @Parameters(method = "defaultSlidingWindow")
+    public void testRecordSuccess(Metrics metrics) {
         Snapshot snapshot = metrics.record(100, TimeUnit.MILLISECONDS, Metrics.Outcome.SUCCESS);
         assertThat(snapshot.getTotalNumberOfCalls()).isEqualTo(1);
         assertThat(snapshot.getNumberOfSuccessfulCalls()).isEqualTo(1);
@@ -60,9 +85,8 @@ public class FixedSizeSlidingWindowMetricsTest {
     }
 
     @Test
-    public void testRecordError() {
-        Metrics metrics = new FixedSizeSlidingWindowMetrics(5);
-
+    @Parameters(method = "defaultSlidingWindow")
+    public void testRecordError(Metrics metrics) {
         Snapshot snapshot = metrics.record(100, TimeUnit.MILLISECONDS, Metrics.Outcome.ERROR);
         assertThat(snapshot.getTotalNumberOfCalls()).isEqualTo(1);
         assertThat(snapshot.getNumberOfSuccessfulCalls()).isZero();
@@ -76,11 +100,9 @@ public class FixedSizeSlidingWindowMetricsTest {
     }
 
     @Test
-    public void testRecordSlowSuccess() {
-        Metrics metrics = new FixedSizeSlidingWindowMetrics(5);
-
-        Snapshot snapshot = metrics
-            .record(100, TimeUnit.MILLISECONDS, Metrics.Outcome.SLOW_SUCCESS);
+    @Parameters(method = "defaultSlidingWindow")
+    public void testRecordSlowSuccess(Metrics metrics) {
+        Snapshot snapshot = metrics.record(100, TimeUnit.MILLISECONDS, Metrics.Outcome.SLOW_SUCCESS);
         assertThat(snapshot.getTotalNumberOfCalls()).isEqualTo(1);
         assertThat(snapshot.getNumberOfSuccessfulCalls()).isEqualTo(1);
         assertThat(snapshot.getNumberOfFailedCalls()).isZero();
@@ -93,9 +115,8 @@ public class FixedSizeSlidingWindowMetricsTest {
     }
 
     @Test
-    public void testSlowCallsPercentage() {
-        Metrics metrics = new FixedSizeSlidingWindowMetrics(5);
-
+    @Parameters(method = "defaultSlidingWindow")
+    public void testSlowCallsPercentage(Metrics metrics) {
         metrics.record(10000, TimeUnit.MILLISECONDS, Metrics.Outcome.SLOW_SUCCESS);
         metrics.record(10000, TimeUnit.MILLISECONDS, Metrics.Outcome.SLOW_ERROR);
         metrics.record(100, TimeUnit.MILLISECONDS, Metrics.Outcome.SUCCESS);
@@ -138,9 +159,8 @@ public class FixedSizeSlidingWindowMetricsTest {
     }
 
     @Test
-    public void testSlidingWindowMetrics() {
-        FixedSizeSlidingWindowMetrics metrics = new FixedSizeSlidingWindowMetrics(4);
-
+    @Parameters(method = "mediumSizeSlidingWindow")
+    public void testSlidingWindowMetrics(Metrics metrics) {
         Snapshot snapshot = metrics.record(100, TimeUnit.MILLISECONDS, Metrics.Outcome.ERROR);
         assertThat(snapshot.getTotalNumberOfCalls()).isEqualTo(1);
         assertThat(snapshot.getNumberOfSuccessfulCalls()).isZero();
@@ -185,9 +205,8 @@ public class FixedSizeSlidingWindowMetricsTest {
     }
 
     @Test
-    public void testSlidingWindowMetricsWithSlowCalls() {
-        FixedSizeSlidingWindowMetrics metrics = new FixedSizeSlidingWindowMetrics(2);
-
+    @Parameters(method = "smallSizeSlidingWindow")
+    public void testSlidingWindowMetricsWithSlowCalls(Metrics metrics) {
         Snapshot snapshot = metrics.record(100, TimeUnit.MILLISECONDS, Metrics.Outcome.SLOW_ERROR);
         assertThat(snapshot.getTotalNumberOfCalls()).isEqualTo(1);
         assertThat(snapshot.getTotalNumberOfSlowCalls()).isEqualTo(1);

--- a/resilience4j-core/src/test/kotlin/io/github/resilience4j/core/metrics/ConcurrencyTests.kt
+++ b/resilience4j-core/src/test/kotlin/io/github/resilience4j/core/metrics/ConcurrencyTests.kt
@@ -1,0 +1,26 @@
+/*
+ *
+ *  Copyright 2024 Florentin Simion and Rares Vlasceanu
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.core.metrics
+
+/**
+ * Interface to reference tests that are related to concurrency. Can be used to include/exclude tests based
+ * on this category.
+ */
+interface ConcurrencyTests {
+}

--- a/resilience4j-core/src/test/kotlin/io/github/resilience4j/core/metrics/LockFreeFixedSizeSlidingWindowMetricsTest.kt
+++ b/resilience4j-core/src/test/kotlin/io/github/resilience4j/core/metrics/LockFreeFixedSizeSlidingWindowMetricsTest.kt
@@ -1,0 +1,57 @@
+/*
+ *
+ *  Copyright 2024 Florentin Simion and Rares Vlasceanu
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.core.metrics
+
+import io.github.resilience4j.core.metrics.Metrics.Outcome
+import org.jetbrains.kotlinx.lincheck.annotations.Operation
+import org.jetbrains.kotlinx.lincheck.check
+import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.ModelCheckingOptions
+import org.jetbrains.kotlinx.lincheck.strategy.stress.StressOptions
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.experimental.categories.Category
+import java.util.concurrent.TimeUnit
+
+/**
+ * Tests the [LockFreeFixedSizeSlidingWindowMetrics] class using the Lincheck framework.
+ *
+ * The model checking test is ignored because it is extremly slow (~3m) and is most useful during development. Also,
+ * to run it you need to disable the Jacoco plugin, as it seems to interfere with the model checking test.
+ *
+ * In contrast, stress testing is faster and can catch rare bugs that require many context switches,
+ * making it suitable for regular builds.
+ */
+@Category(ConcurrencyTests::class)
+class LockFreeFixedSizeSlidingWindowMetricsTest {
+    private val metrics = LockFreeFixedSizeSlidingWindowMetrics(5)
+
+    @Operation
+    fun record(duration: Long, durationUnit: TimeUnit, outcome: Outcome): Snapshot =
+        metrics.record(duration, durationUnit, outcome)
+
+    @Operation
+    fun getSnapshot(): Snapshot = metrics.snapshot
+
+    @Test
+    fun stressTest() = StressOptions().check(this::class)
+
+    @Test
+    @Ignore
+    fun modelCheckingTest() = ModelCheckingOptions().check(this::class)
+}

--- a/resilience4j-core/src/test/kotlin/io/github/resilience4j/core/metrics/LockFreeSlidingTimeWindowMetricsTest.kt
+++ b/resilience4j-core/src/test/kotlin/io/github/resilience4j/core/metrics/LockFreeSlidingTimeWindowMetricsTest.kt
@@ -1,0 +1,88 @@
+/*
+ *
+ *  Copyright 2024 Florentin Simion and Rares Vlasceanu
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.core.metrics
+
+import io.github.resilience4j.core.ManualClock
+import io.github.resilience4j.core.metrics.Metrics.Outcome
+import org.jetbrains.kotlinx.lincheck.annotations.Operation
+import org.jetbrains.kotlinx.lincheck.check
+import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.ModelCheckingOptions
+import org.jetbrains.kotlinx.lincheck.strategy.stress.StressOptions
+import org.junit.AfterClass
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.experimental.categories.Category
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.random.Random
+
+/**
+ * Tests the [LockFreeSlidingTimeWindowMetrics] class using the Lincheck framework.
+ *
+ * Since Lincheck does not account for time, we need to manually and quickly advance the time to ensure
+ * the test validates the sliding behavior of the time window (i.e., sliding the window every second).
+ * We achieve this by using a static timer that advances the time every 10 ms by a value between 1s and 1.25s
+ *
+ * It is important to note that the windowSize must be large enough to prevent records from being discarded.
+ * This is because the sequential version may run faster or slower than the concurrent version,
+ * leading to different results and potential test failures, even if there is no bug in the implementation.
+ * This can be verified by commenting out the line where metrics are discarded, which should make the test pass.
+ * The required window size depends on the machine's speed, so slower machines may need a larger size.
+ *
+ * The model checking test is ignored because it is extremely slow (~3m) and is most useful during development. Also,
+ * to run it you need to disable the Jacoco plugin, as it seems to interfere with the model checking test.
+ *
+ * In contrast, stress testing is faster and can catch rare bugs that require many context switches,
+ * making it suitable for regular builds.
+ */
+@Category(ConcurrencyTests::class)
+class LockFreeSlidingTimeWindowMetricsTest {
+    companion object {
+        private val clock = ManualClock()
+        private val scheduler = Executors.newSingleThreadScheduledExecutor().apply {
+            val interval = 10_000_000L
+
+            scheduleAtFixedRate({
+                clock.advanceByMillis(1000 + Random.nextLong(0, 250))
+            }, interval, interval, TimeUnit.NANOSECONDS)
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun cleanUp() {
+            scheduler.shutdownNow()
+        }
+    }
+
+    private val metrics = LockFreeSlidingTimeWindowMetrics(10, clock)
+
+    @Operation
+    fun record(duration: Long, durationUnit: TimeUnit, outcome: Outcome): Snapshot =
+        metrics.record(duration, durationUnit, outcome)
+
+    @Operation
+    fun getSnapshot(): Snapshot = metrics.snapshot
+
+    @Test
+    fun stressTest() = StressOptions().check(this::class)
+
+    @Test
+    @Ignore
+    fun modelCheckingTest() = ModelCheckingOptions().check(this::class)
+}


### PR DESCRIPTION
Fixes #2151.

This PR introduces lock-free implementations of the count-based and time-based sliding windows used internally by the CircuitBreaker. The changes are organized into five commits for easier review:

- **Measurement small refactor**: A small refactor to provide a common interface and accommodate a new measurement implementation.
- **Packed Measurement Implementation**: Added a compact measurement class designed for use with the lock-free sliding windows.
- **Lock-Free Count Sliding Window**: Implemented the lock-free version of the count-based sliding window.
- **Lock-Free Time Sliding Window**: Implemented the lock-free version of the time-based sliding window.
- **New Public Configuration**: Introduced a new configuration option, slidingWindowSynchronizationStrategy, allowing users to select between SYNCHRONIZED (default) and LOCK_FREE.

The new sliding window implementations are validated using existing unit tests, which were extended to include the new versions. Additionally, the correctness of the algorithms - specifically, their linearizability - is verified using the [Lincheck](https://github.com/JetBrains/lincheck) framework.

One note is that the new time sliding window uses a different Clock implementation in order to have access to a monotonic time source, so that it will not be affected by system clock changes. This implementation may yield a better accuracy, which would make it valauble to extend its usage to the whole circuit breaker logic. (most probably as an addendum, to not extend this PR's scope).

This contribution has been made possible also with support from @raresvla.