### PR TITLE
Issue #2243: DefaultEventConsumerRegistry could cause memory leak

### DIFF
--- a/resilience4j-consumer/src/main/java/io/github/resilience4j/consumer/DefaultEventConsumerRegistry.java
+++ b/resilience4j-consumer/src/main/java/io/github/resilience4j/consumer/DefaultEventConsumerRegistry.java
@@ -41,6 +41,10 @@ public class DefaultEventConsumerRegistry<T> implements EventConsumerRegistry<T>
     }
 
     @Override
+    public CircularEventConsumer<T> removeEventConsumer(String id) {
+        return registry.remove(id);
+    }
+    @Override
     public CircularEventConsumer<T> getEventConsumer(String id) {
         return registry.get(id);
     }

--- a/resilience4j-consumer/src/main/java/io/github/resilience4j/consumer/EventConsumerRegistry.java
+++ b/resilience4j-consumer/src/main/java/io/github/resilience4j/consumer/EventConsumerRegistry.java
@@ -32,6 +32,14 @@ public interface EventConsumerRegistry<T> {
     CircularEventConsumer<T> createEventConsumer(String id, int bufferSize);
 
     /**
+     * remove a EventConsumer  in the registry.
+     *
+     * @param id         the id of the EventConsumer
+     * @return the removed EventConsumer
+     */
+    CircularEventConsumer<T> removeEventConsumer(String id);
+
+    /**
      * Returns the EventConsumer to which the specified id is mapped.
      *
      * @param id the id of the EventConsumer

--- a/resilience4j-consumer/src/test/java/io/github/resilience4j/consumer/EventConsumerRegistryTest.java
+++ b/resilience4j-consumer/src/test/java/io/github/resilience4j/consumer/EventConsumerRegistryTest.java
@@ -36,6 +36,22 @@ public class EventConsumerRegistryTest {
     }
 
     @Test
+    public void shouldRemoveAnEventConsumer() {
+        EventConsumerRegistry<CircuitBreakerEvent> registry = new DefaultEventConsumerRegistry<>();
+        String eventConsumerId = "testName";
+
+        EventConsumer<CircuitBreakerEvent> eventEventConsumerAdded = registry.createEventConsumer(eventConsumerId, 5);
+        assertThat(eventEventConsumerAdded).isNotNull();
+
+        EventConsumer<CircuitBreakerEvent> eventEventConsumerRemoved = registry.removeEventConsumer(eventConsumerId);
+        assertThat(eventEventConsumerRemoved).isNotNull();
+
+        assertThat(eventEventConsumerAdded).isEqualTo(eventEventConsumerRemoved);
+
+        EventConsumer<CircuitBreakerEvent> eventEventConsumer = registry.getEventConsumer(eventConsumerId);
+        assertThat(eventEventConsumer).isNull();
+    }
+    @Test
     public void shouldReturnTheSameEventConsumer() {
         EventConsumerRegistry<CircuitBreakerEvent> registry = new DefaultEventConsumerRegistry<>();
         EventConsumer<CircuitBreakerEvent> eventEventConsumer1 = registry

--- a/resilience4j-micronaut/src/main/java/io/github/resilience4j/micronaut/ratelimiter/RateLimiterRegistryFactory.java
+++ b/resilience4j-micronaut/src/main/java/io/github/resilience4j/micronaut/ratelimiter/RateLimiterRegistryFactory.java
@@ -95,9 +95,14 @@ public class RateLimiterRegistryFactory {
     private void registerEventConsumer(RateLimiterRegistry rateLimiterRegistry,
                                        EventConsumerRegistry<RateLimiterEvent> eventConsumerRegistry,
                                        CommonRateLimiterConfigurationProperties rateLimiterConfigurationProperties) {
-        rateLimiterRegistry.getEventPublisher().onEntryAdded(
-            event -> registerEventConsumer(eventConsumerRegistry, event.getAddedEntry(),
-                rateLimiterConfigurationProperties));
+        rateLimiterRegistry.getEventPublisher()
+            .onEntryAdded(event -> registerEventConsumer(eventConsumerRegistry, event.getAddedEntry(), rateLimiterConfigurationProperties))
+            .onEntryReplaced(event -> registerEventConsumer(eventConsumerRegistry, event.getNewEntry(), rateLimiterConfigurationProperties))
+            .onEntryRemoved(event -> unregisterEventConsumer(eventConsumerRegistry, event.getRemovedEntry()));
+    }
+
+    private void unregisterEventConsumer(EventConsumerRegistry<RateLimiterEvent> eventConsumerRegistry, RateLimiter rateLimiter) {
+        eventConsumerRegistry.removeEventConsumer(rateLimiter.getName());
     }
 
     private void registerEventConsumer(

--- a/resilience4j-micronaut/src/main/java/io/github/resilience4j/micronaut/retry/RetryRegistryFactory.java
+++ b/resilience4j-micronaut/src/main/java/io/github/resilience4j/micronaut/retry/RetryRegistryFactory.java
@@ -96,9 +96,14 @@ public class RetryRegistryFactory {
     private void registerEventConsumer(RetryRegistry retryRegistry,
                                        EventConsumerRegistry<RetryEvent> eventConsumerRegistry,
                                        CommonRetryConfigurationProperties rateLimiterConfigurationProperties) {
-        retryRegistry.getEventPublisher().onEntryAdded(
-            event -> registerEventConsumer(eventConsumerRegistry, event.getAddedEntry(),
-                rateLimiterConfigurationProperties));
+        retryRegistry.getEventPublisher()
+            .onEntryAdded(event -> registerEventConsumer(eventConsumerRegistry, event.getAddedEntry(), rateLimiterConfigurationProperties))
+            .onEntryReplaced(event -> registerEventConsumer(eventConsumerRegistry, event.getNewEntry(), rateLimiterConfigurationProperties))
+            .onEntryRemoved(event -> unregisterEventConsumer(eventConsumerRegistry, event.getRemovedEntry()));
+    }
+
+    private void unregisterEventConsumer(EventConsumerRegistry<RetryEvent> eventConsumerRegistry, Retry retry) {
+        eventConsumerRegistry.removeEventConsumer(retry.getName());
     }
 
     private void registerEventConsumer(

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/bulkhead/configure/BulkheadConfiguration.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/bulkhead/configure/BulkheadConfiguration.java
@@ -136,7 +136,12 @@ public class BulkheadConfiguration {
         BulkheadConfigurationProperties properties) {
         bulkheadRegistry.getEventPublisher()
             .onEntryAdded(event -> registerEventConsumer(eventConsumerRegistry, event.getAddedEntry(), properties))
-            .onEntryReplaced(event -> registerEventConsumer(eventConsumerRegistry, event.getNewEntry(), properties));
+            .onEntryReplaced(event -> registerEventConsumer(eventConsumerRegistry, event.getNewEntry(), properties))
+            .onEntryRemoved(event -> unregisterEventConsumer(eventConsumerRegistry, event.getRemovedEntry()));
+    }
+
+    private void unregisterEventConsumer(EventConsumerRegistry<BulkheadEvent> eventConsumerRegistry, Bulkhead bulkHead) {
+        eventConsumerRegistry.removeEventConsumer(bulkHead.getName());
     }
 
     private void registerEventConsumer(EventConsumerRegistry<BulkheadEvent> eventConsumerRegistry,

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/bulkhead/configure/threadpool/ThreadPoolBulkheadConfiguration.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/bulkhead/configure/threadpool/ThreadPoolBulkheadConfiguration.java
@@ -135,7 +135,12 @@ public class ThreadPoolBulkheadConfiguration {
         CommonThreadPoolBulkheadConfigurationProperties properties) {
         bulkheadRegistry.getEventPublisher()
             .onEntryAdded(event -> registerEventConsumer(eventConsumerRegistry, event.getAddedEntry(), properties))
-            .onEntryReplaced(event -> registerEventConsumer(eventConsumerRegistry, event.getNewEntry(), properties));
+            .onEntryReplaced(event -> registerEventConsumer(eventConsumerRegistry, event.getNewEntry(), properties))
+            .onEntryRemoved(event -> unregisterEventConsumer(eventConsumerRegistry, event.getRemovedEntry()));
+    }
+
+    private void unregisterEventConsumer(EventConsumerRegistry<BulkheadEvent> eventConsumerRegistry, ThreadPoolBulkhead bulkHead) {
+        eventConsumerRegistry.removeEventConsumer(bulkHead.getName());
     }
 
     private void registerEventConsumer(EventConsumerRegistry<BulkheadEvent> eventConsumerRegistry,

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/circuitbreaker/configure/CircuitBreakerConfiguration.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/circuitbreaker/configure/CircuitBreakerConfiguration.java
@@ -180,7 +180,11 @@ public class CircuitBreakerConfiguration {
         circuitBreakerRegistry.getEventPublisher()
             .onEntryAdded(event -> registerEventConsumer(eventConsumerRegistry, event.getAddedEntry()))
             .onEntryReplaced(event -> registerEventConsumer(eventConsumerRegistry, event.getNewEntry()))
-            .onEntryRemoved(event -> unregisterEventConsumer(eventConsumerRegistry, event.getRemovedEntry()))
+            .onEntryRemoved(event -> unregisterEventConsumer(eventConsumerRegistry, event.getRemovedEntry()));
+    }
+
+    private void unregisterEventConsumer(EventConsumerRegistry<CircuitBreakerEvent> eventConsumerRegistry, CircuitBreaker circuitBreaker) {
+        eventConsumerRegistry.removeEventConsumer(circuitBreaker.getName());
     }
 
     private void registerEventConsumer(
@@ -194,7 +198,4 @@ public class CircuitBreakerConfiguration {
             .createEventConsumer(circuitBreaker.getName(), eventConsumerBufferSize));
     }
 
-    private void unregisterEventConsumer(EventConsumerRegistry<CircuitBreakerEvent> eventConsumerRegistry, CircuitBreaker circuitBreaker) {
-        eventConsumerRegistry.removeEventConsumer(circuitBreaker.getName());
-    }
 }

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/circuitbreaker/configure/CircuitBreakerConfiguration.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/circuitbreaker/configure/CircuitBreakerConfiguration.java
@@ -179,7 +179,8 @@ public class CircuitBreakerConfiguration {
                                       EventConsumerRegistry<CircuitBreakerEvent> eventConsumerRegistry) {
         circuitBreakerRegistry.getEventPublisher()
             .onEntryAdded(event -> registerEventConsumer(eventConsumerRegistry, event.getAddedEntry()))
-            .onEntryReplaced(event -> registerEventConsumer(eventConsumerRegistry, event.getNewEntry()));
+            .onEntryReplaced(event -> registerEventConsumer(eventConsumerRegistry, event.getNewEntry()))
+            .onEntryRemoved(event -> unregisterEventConsumer(eventConsumerRegistry, event.getRemovedEntry()))
     }
 
     private void registerEventConsumer(
@@ -191,5 +192,9 @@ public class CircuitBreakerConfiguration {
             .orElse(100);
         circuitBreaker.getEventPublisher().onEvent(eventConsumerRegistry
             .createEventConsumer(circuitBreaker.getName(), eventConsumerBufferSize));
+    }
+
+    private void unregisterEventConsumer(EventConsumerRegistry<CircuitBreakerEvent> eventConsumerRegistry, CircuitBreaker circuitBreaker) {
+        eventConsumerRegistry.removeEventConsumer(circuitBreaker.getName());
     }
 }

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/ratelimiter/configure/RateLimiterConfiguration.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/ratelimiter/configure/RateLimiterConfiguration.java
@@ -137,7 +137,12 @@ public class RateLimiterConfiguration {
         RateLimiterConfigurationProperties properties) {
         rateLimiterRegistry.getEventPublisher()
             .onEntryAdded(event -> registerEventConsumer(eventConsumerRegistry, event.getAddedEntry(), properties))
-            .onEntryReplaced(event -> registerEventConsumer(eventConsumerRegistry, event.getNewEntry(), properties));
+            .onEntryReplaced(event -> registerEventConsumer(eventConsumerRegistry, event.getNewEntry(), properties))
+            .onEntryRemoved(event -> unregisterEventConsumer(eventConsumerRegistry, event.getRemovedEntry()));
+    }
+
+    private void unregisterEventConsumer(EventConsumerRegistry<RateLimiterEvent> eventConsumerRegistry, RateLimiter rateLimiter) {
+        eventConsumerRegistry.removeEventConsumer(rateLimiter.getName());
     }
 
     private void registerEventConsumer(

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/retry/configure/RetryConfiguration.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/retry/configure/RetryConfiguration.java
@@ -135,7 +135,12 @@ public class RetryConfiguration {
         RetryConfigurationProperties properties) {
         retryRegistry.getEventPublisher()
             .onEntryAdded(event -> registerEventConsumer(eventConsumerRegistry, event.getAddedEntry(), properties))
-            .onEntryReplaced(event -> registerEventConsumer(eventConsumerRegistry, event.getNewEntry(), properties));
+            .onEntryReplaced(event -> registerEventConsumer(eventConsumerRegistry, event.getNewEntry(), properties))
+            .onEntryRemoved(event -> unregisterEventConsumer(eventConsumerRegistry, event.getRemovedEntry()));
+    }
+
+    private void unregisterEventConsumer(EventConsumerRegistry<RetryEvent> eventConsumerRegistry, Retry retry) {
+        eventConsumerRegistry.removeEventConsumer(retry.getName());
     }
 
     private void registerEventConsumer(EventConsumerRegistry<RetryEvent> eventConsumerRegistry,

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/timelimiter/configure/TimeLimiterConfiguration.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/timelimiter/configure/TimeLimiterConfiguration.java
@@ -180,7 +180,12 @@ public class TimeLimiterConfiguration {
                                               TimeLimiterConfigurationProperties properties) {
         timeLimiterRegistry.getEventPublisher()
             .onEntryAdded(event -> registerEventConsumer(eventConsumerRegistry, event.getAddedEntry(), properties))
-            .onEntryReplaced(event -> registerEventConsumer(eventConsumerRegistry, event.getNewEntry(), properties));
+            .onEntryReplaced(event -> registerEventConsumer(eventConsumerRegistry, event.getNewEntry(), properties))
+            .onEntryRemoved(event -> unregisterEventConsumer(eventConsumerRegistry, event.getRemovedEntry()));
+    }
+
+    private static void unregisterEventConsumer(EventConsumerRegistry<TimeLimiterEvent> eventConsumerRegistry, TimeLimiter timeLimiter) {
+        eventConsumerRegistry.removeEventConsumer(timeLimiter.getName());
     }
 
     private static void registerEventConsumer(EventConsumerRegistry<TimeLimiterEvent> eventConsumerRegistry, TimeLimiter timeLimiter,

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/bulkhead/configure/BulkheadConfiguration.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/bulkhead/configure/BulkheadConfiguration.java
@@ -15,10 +15,7 @@
  */
 package io.github.resilience4j.spring6.bulkhead.configure;
 
-import io.github.resilience4j.bulkhead.Bulkhead;
-import io.github.resilience4j.bulkhead.BulkheadConfig;
-import io.github.resilience4j.bulkhead.BulkheadRegistry;
-import io.github.resilience4j.bulkhead.ThreadPoolBulkheadRegistry;
+import io.github.resilience4j.bulkhead.*;
 import io.github.resilience4j.spring6.bulkhead.configure.threadpool.ThreadPoolBulkheadConfiguration;
 import io.github.resilience4j.bulkhead.event.BulkheadEvent;
 import io.github.resilience4j.common.CompositeCustomizer;
@@ -121,7 +118,12 @@ public class BulkheadConfiguration {
         BulkheadConfigurationProperties properties) {
         bulkheadRegistry.getEventPublisher()
             .onEntryAdded(event -> registerEventConsumer(eventConsumerRegistry, event.getAddedEntry(), properties))
-            .onEntryReplaced(event -> registerEventConsumer(eventConsumerRegistry, event.getNewEntry(), properties));
+            .onEntryReplaced(event -> registerEventConsumer(eventConsumerRegistry, event.getNewEntry(), properties))
+            .onEntryRemoved(event -> unregisterEventConsumer(eventConsumerRegistry, event.getRemovedEntry()));
+    }
+
+    private void unregisterEventConsumer(EventConsumerRegistry<BulkheadEvent> eventConsumerRegistry, Bulkhead bulkHead) {
+        eventConsumerRegistry.removeEventConsumer(bulkHead.getName());
     }
 
     private void registerEventConsumer(EventConsumerRegistry<BulkheadEvent> eventConsumerRegistry,

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/bulkhead/configure/threadpool/ThreadPoolBulkheadConfiguration.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/bulkhead/configure/threadpool/ThreadPoolBulkheadConfiguration.java
@@ -117,7 +117,12 @@ public class ThreadPoolBulkheadConfiguration {
         CommonThreadPoolBulkheadConfigurationProperties properties) {
         bulkheadRegistry.getEventPublisher()
             .onEntryAdded(event -> registerEventConsumer(eventConsumerRegistry, event.getAddedEntry(), properties))
-            .onEntryReplaced(event -> registerEventConsumer(eventConsumerRegistry, event.getNewEntry(), properties));
+            .onEntryReplaced(event -> registerEventConsumer(eventConsumerRegistry, event.getNewEntry(), properties))
+            .onEntryRemoved(event -> unregisterEventConsumer(eventConsumerRegistry, event.getRemovedEntry()));
+    }
+
+    private void unregisterEventConsumer(EventConsumerRegistry<BulkheadEvent> eventConsumerRegistry, ThreadPoolBulkhead bulkHead) {
+        eventConsumerRegistry.removeEventConsumer(bulkHead.getName());
     }
 
     private void registerEventConsumer(EventConsumerRegistry<BulkheadEvent> eventConsumerRegistry,

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/circuitbreaker/configure/CircuitBreakerConfiguration.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/circuitbreaker/configure/CircuitBreakerConfiguration.java
@@ -179,7 +179,12 @@ public class CircuitBreakerConfiguration {
                                       EventConsumerRegistry<CircuitBreakerEvent> eventConsumerRegistry) {
         circuitBreakerRegistry.getEventPublisher()
             .onEntryAdded(event -> registerEventConsumer(eventConsumerRegistry, event.getAddedEntry()))
-            .onEntryReplaced(event -> registerEventConsumer(eventConsumerRegistry, event.getNewEntry()));
+            .onEntryReplaced(event -> registerEventConsumer(eventConsumerRegistry, event.getNewEntry()))
+            .onEntryRemoved(event -> unregisterEventConsumer(eventConsumerRegistry, event.getRemovedEntry()));
+    }
+
+    private void unregisterEventConsumer(EventConsumerRegistry<CircuitBreakerEvent> eventConsumerRegistry, CircuitBreaker circuitBreaker) {
+        eventConsumerRegistry.removeEventConsumer(circuitBreaker.getName());
     }
 
     private void registerEventConsumer(

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/micrometer/configure/TimerConfiguration.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/micrometer/configure/TimerConfiguration.java
@@ -16,6 +16,8 @@
 
 package io.github.resilience4j.spring6.micrometer.configure;
 
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.event.CircuitBreakerEvent;
 import io.github.resilience4j.common.CompositeCustomizer;
 import io.github.resilience4j.common.micrometer.configuration.CommonTimerConfigurationProperties.InstanceProperties;
 import io.github.resilience4j.common.micrometer.configuration.TimerConfigCustomizer;
@@ -174,7 +176,12 @@ public class TimerConfiguration {
     ) {
         timerRegistry.getEventPublisher()
                 .onEntryAdded(event -> registerEventConsumer(eventConsumerRegistry, event.getAddedEntry(), properties))
-                .onEntryReplaced(event -> registerEventConsumer(eventConsumerRegistry, event.getNewEntry(), properties));
+                .onEntryReplaced(event -> registerEventConsumer(eventConsumerRegistry, event.getNewEntry(), properties))
+                .onEntryRemoved(event -> unregisterEventConsumer(eventConsumerRegistry, event.getRemovedEntry()));
+    }
+
+    private static void unregisterEventConsumer(EventConsumerRegistry<TimerEvent> eventConsumerRegistry, Timer timer) {
+        eventConsumerRegistry.removeEventConsumer(timer.getName());
     }
 
     private static void registerEventConsumer(
@@ -188,4 +195,5 @@ public class TimerConfiguration {
         timer.getEventPublisher().onEvent(
                 eventConsumerRegistry.createEventConsumer(timer.getName(), eventConsumerBufferSize));
     }
+
 }

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/ratelimiter/configure/RateLimiterConfiguration.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/ratelimiter/configure/RateLimiterConfiguration.java
@@ -16,6 +16,8 @@
 package io.github.resilience4j.spring6.ratelimiter.configure;
 
 
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.event.CircuitBreakerEvent;
 import io.github.resilience4j.common.CompositeCustomizer;
 import io.github.resilience4j.common.ratelimiter.configuration.RateLimiterConfigCustomizer;
 import io.github.resilience4j.common.ratelimiter.configuration.CommonRateLimiterConfigurationProperties.InstanceProperties;
@@ -121,7 +123,12 @@ public class RateLimiterConfiguration {
         RateLimiterConfigurationProperties properties) {
         rateLimiterRegistry.getEventPublisher()
             .onEntryAdded(event -> registerEventConsumer(eventConsumerRegistry, event.getAddedEntry(), properties))
-            .onEntryReplaced(event -> registerEventConsumer(eventConsumerRegistry, event.getNewEntry(), properties));
+            .onEntryReplaced(event -> registerEventConsumer(eventConsumerRegistry, event.getNewEntry(), properties))
+            .onEntryRemoved(event -> unregisterEventConsumer(eventConsumerRegistry, event.getRemovedEntry()));
+    }
+
+    private void unregisterEventConsumer(EventConsumerRegistry<RateLimiterEvent> eventConsumerRegistry, RateLimiter rateLimiter) {
+        eventConsumerRegistry.removeEventConsumer(rateLimiter.getName());
     }
 
     private void registerEventConsumer(

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/retry/configure/RetryConfiguration.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/retry/configure/RetryConfiguration.java
@@ -15,6 +15,8 @@
  */
 package io.github.resilience4j.spring6.retry.configure;
 
+import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
+import io.github.resilience4j.bulkhead.event.BulkheadEvent;
 import io.github.resilience4j.common.CompositeCustomizer;
 import io.github.resilience4j.common.retry.configuration.RetryConfigCustomizer;
 import io.github.resilience4j.common.retry.configuration.CommonRetryConfigurationProperties.InstanceProperties;
@@ -121,7 +123,12 @@ public class RetryConfiguration {
         RetryConfigurationProperties properties) {
         retryRegistry.getEventPublisher()
             .onEntryAdded(event -> registerEventConsumer(eventConsumerRegistry, event.getAddedEntry(), properties))
-            .onEntryReplaced(event -> registerEventConsumer(eventConsumerRegistry, event.getNewEntry(), properties));
+            .onEntryReplaced(event -> registerEventConsumer(eventConsumerRegistry, event.getNewEntry(), properties))
+            .onEntryRemoved(event -> unregisterEventConsumer(eventConsumerRegistry, event.getRemovedEntry()));
+    }
+
+    private void unregisterEventConsumer(EventConsumerRegistry<RetryEvent> eventConsumerRegistry, Retry retry) {
+        eventConsumerRegistry.removeEventConsumer(retry.getName());
     }
 
     private void registerEventConsumer(EventConsumerRegistry<RetryEvent> eventConsumerRegistry,

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterConfiguration.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterConfiguration.java
@@ -172,7 +172,12 @@ public class TimeLimiterConfiguration {
                                               TimeLimiterConfigurationProperties properties) {
         timeLimiterRegistry.getEventPublisher()
             .onEntryAdded(event -> registerEventConsumer(eventConsumerRegistry, event.getAddedEntry(), properties))
-            .onEntryReplaced(event -> registerEventConsumer(eventConsumerRegistry, event.getNewEntry(), properties));
+            .onEntryReplaced(event -> registerEventConsumer(eventConsumerRegistry, event.getNewEntry(), properties))
+            .onEntryRemoved(event -> unregisterEventConsumer(eventConsumerRegistry, event.getRemovedEntry()));
+    }
+
+    private static void unregisterEventConsumer(EventConsumerRegistry<TimeLimiterEvent> eventConsumerRegistry, TimeLimiter timeLimiter) {
+        eventConsumerRegistry.removeEventConsumer(timeLimiter.getName());
     }
 
     private static void registerEventConsumer(EventConsumerRegistry<TimeLimiterEvent> eventConsumerRegistry, TimeLimiter timeLimiter,


### PR DESCRIPTION
Fixes #2243

Resilience4j version: 1.3.1 1.7.1 2.2.0

Java version: 8

DefaultEventConsumerRegistry use ConcurrentMap to registry the CircularEventConsumer, but it didn't provide a way to remove it, even if the CircuitBreaker instance were removed, the CircularEventConsumer and CircuitBreakerEvent instances are still holded, so they can't be garbage collected.