### PR TITLE
Issue #2269: Added getCausingRateLimiterName

### DIFF
--- a/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/RequestNotPermitted.java
+++ b/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/RequestNotPermitted.java
@@ -24,8 +24,11 @@ package io.github.resilience4j.ratelimiter;
  */
 public class RequestNotPermitted extends RuntimeException {
 
-    private RequestNotPermitted(String message, boolean writableStackTrace) {
+    private final transient String causingRateLimiter;
+
+    private RequestNotPermitted(RateLimiter rateLimiter, String message, boolean writableStackTrace) {
         super(message, null, false, writableStackTrace);
+        this.causingRateLimiter = rateLimiter.getName();
     }
 
     /**
@@ -35,11 +38,20 @@ public class RequestNotPermitted extends RuntimeException {
      */
     public static RequestNotPermitted createRequestNotPermitted(RateLimiter rateLimiter) {
         boolean writableStackTraceEnabled = rateLimiter.getRateLimiterConfig()
-            .isWritableStackTraceEnabled();
+                .isWritableStackTraceEnabled();
 
         String message = String
-            .format("RateLimiter '%s' does not permit further calls", rateLimiter.getName());
+                .format("RateLimiter '%s' does not permit further calls", rateLimiter.getName());
 
-        return new RequestNotPermitted(message, writableStackTraceEnabled);
+        return new RequestNotPermitted(rateLimiter, message, writableStackTraceEnabled);
+    }
+
+    /**
+     * Returns the name of {@link RateLimiter} that caused this exception.
+     *
+     * @return the name of  {@link RateLimiter} that caused this exception.
+     */
+    public String getCausingRateLimiterName() {
+        return this.causingRateLimiter;
     }
 }

--- a/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/RequestNotPermittedExceptionTest.java
+++ b/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/RequestNotPermittedExceptionTest.java
@@ -1,0 +1,19 @@
+package io.github.resilience4j.ratelimiter;
+
+import org.junit.Test;
+
+import static io.github.resilience4j.ratelimiter.RequestNotPermitted.createRequestNotPermitted;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RequestNotPermittedExceptionTest {
+
+    @Test
+    public void shouldReturnCorrectMessageWhenStateIsOpen() {
+        RateLimiter rateLimiter = RateLimiter.ofDefaults("testName");
+        final RequestNotPermitted requestNotPermitted = createRequestNotPermitted(rateLimiter);
+        assertThat(requestNotPermitted.getMessage())
+            .isEqualTo("RateLimiter 'testName' does not permit further calls");
+        assertThat(requestNotPermitted.getCausingRateLimiterName()).isEqualTo(rateLimiter.getName());
+    }
+
+}


### PR DESCRIPTION
Pull Request for [2269](https://github.com/resilience4j/resilience4j/issues/2269), adding `getCausingRateLimiterName` to `RequestNotPermitted`.