### PR TITLE
Issue #2278: Added ThreadPoolBulkhead to some Decorators

### DIFF
--- a/resilience4j-all/src/test/java/io/github/resilience4j/decorators/DecoratorsTest.java
+++ b/resilience4j-all/src/test/java/io/github/resilience4j/decorators/DecoratorsTest.java
@@ -21,6 +21,8 @@ package io.github.resilience4j.decorators;
 import io.github.resilience4j.bulkhead.Bulkhead;
 import io.github.resilience4j.bulkhead.BulkheadFullException;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
+import io.github.resilience4j.bulkhead.ThreadPoolBulkheadConfig;
+import io.github.resilience4j.bulkhead.ThreadPoolBulkheadRegistry;
 import io.github.resilience4j.cache.Cache;
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
@@ -55,10 +57,8 @@ import java.util.function.Supplier;
 import static com.jayway.awaitility.Awaitility.matches;
 import static com.jayway.awaitility.Awaitility.waitAtMost;
 import static java.util.Arrays.asList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.*;
 
 public class DecoratorsTest {
@@ -407,6 +407,62 @@ public class DecoratorsTest {
     }
 
     @Test
+    public void testDecorateCheckedSupplierWithThreadPoolBulkheadSucceeds() throws Exception {
+        String expected = "Hello world";
+        given(helloWorldService.returnHelloWorldWithException()).willReturn(expected);
+        ThreadPoolBulkhead threadPoolBulkhead = ThreadPoolBulkhead.ofDefaults("helloBackend");
+
+        CompletionStage<String> completionStage = Decorators
+                .ofCheckedSupplier(() -> helloWorldService.returnHelloWorldWithException())
+                .withThreadPoolBulkhead(threadPoolBulkhead)
+                .get();
+
+        // make sure normal execution is successful
+        String actual = completionStage.toCompletableFuture().get();
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void testDecorateCheckedSupplierWithThreadPoolBulkheadWithExceptionThrown() throws Exception {
+        IOException exception = new IOException("thrown from mock");
+        given(helloWorldService.returnHelloWorldWithException()).willThrow(exception);
+        ThreadPoolBulkhead threadPoolBulkhead = ThreadPoolBulkhead.ofDefaults("helloBackend");
+
+        CompletionStage<String> completionStage = Decorators
+                .ofCheckedSupplier(() -> helloWorldService.returnHelloWorldWithException())
+                .withThreadPoolBulkhead(threadPoolBulkhead)
+                .get();
+
+        try {
+            completionStage.toCompletableFuture().get();
+            fail("expected exception");
+        } catch (Exception ex) {
+            assertThat(ex.getCause()).isEqualTo(exception);
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testDecorateCheckedSupplierWithThreadPoolBulkheadFull() throws Exception {
+        given(helloWorldService.returnHelloWorldWithException()).willReturn("Hello world");
+        ThreadPoolBulkhead threadPoolBulkheadMock = mock(ThreadPoolBulkhead.class, RETURNS_DEEP_STUBS);
+
+        willThrow(BulkheadFullException.createBulkheadFullException(threadPoolBulkheadMock)).given(threadPoolBulkheadMock).submit(isA(Callable.class));
+        willDoNothing().given(helloWorldService).sayHelloWorldWithException();
+
+        CompletionStage<String> completionStage = Decorators
+                .ofCheckedSupplier(() -> helloWorldService.returnHelloWorldWithException())
+                .withThreadPoolBulkhead(threadPoolBulkheadMock)
+                .get();
+        try {
+            completionStage.toCompletableFuture().get();
+            fail("expected BulkheadFullException");
+        } catch (Exception ex) {
+            assertThat(ex.getCause()).isInstanceOf(BulkheadFullException.class);
+        }
+    }
+
+    @Test
     public void testDecorateCallableWithFallback() throws Throwable {
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
         circuitBreaker.transitionToOpenState();
@@ -566,6 +622,57 @@ public class DecoratorsTest {
         then(helloWorldService).should(times(1)).sayHelloWorldWithException();
     }
 
+    @Test
+    public void testDecorateCheckedRunnableWithThreadPoolBulkheadSucceeds() throws Exception {
+        willDoNothing().given(helloWorldService).sayHelloWorldWithException();
+        ThreadPoolBulkhead threadPoolBulkhead = ThreadPoolBulkhead.ofDefaults("helloBackend");
+
+        CompletionStage<Void> completionStage = Decorators
+                .ofCheckedRunnable(() -> helloWorldService.sayHelloWorldWithException())
+                .withThreadPoolBulkhead(threadPoolBulkhead)
+                .get();
+
+        // make sure normal execution is successful
+        completionStage.toCompletableFuture().get();
+    }
+
+    @Test
+    public void testDecorateCheckedRunnableWithThreadPoolBulkheadWithExceptionThrown() throws Exception {
+        IOException exception = new IOException("thrown from mock");
+        willThrow(exception).given(helloWorldService).sayHelloWorldWithException();
+        ThreadPoolBulkhead threadPoolBulkhead = ThreadPoolBulkhead.ofDefaults("helloBackend");
+
+        CompletionStage<Void> completionStage = Decorators
+                .ofCheckedRunnable(() -> helloWorldService.sayHelloWorldWithException())
+                .withThreadPoolBulkhead(threadPoolBulkhead)
+                .get();
+
+        try {
+            completionStage.toCompletableFuture().get();
+            fail("expected exception");
+        } catch (Exception ex) {
+            assertThat(ex.getCause()).isEqualTo(exception);
+        }
+    }
+
+    @Test
+    public void testDecorateCheckedRunnableWithThreadPoolBulkheadFull() throws Exception {
+        ThreadPoolBulkhead threadPoolBulkheadMock = mock(ThreadPoolBulkhead.class, RETURNS_DEEP_STUBS);
+
+        willThrow(BulkheadFullException.createBulkheadFullException(threadPoolBulkheadMock)).given(threadPoolBulkheadMock).submit(any(Runnable.class));
+        willDoNothing().given(helloWorldService).sayHelloWorldWithException();
+
+        CompletionStage<Void> completionStage = Decorators
+                .ofCheckedRunnable(() -> helloWorldService.sayHelloWorldWithException())
+                .withThreadPoolBulkhead(threadPoolBulkheadMock)
+                .get();
+        try {
+            completionStage.toCompletableFuture().get();
+            fail("expected BulkheadFullException");
+        } catch (Exception ex) {
+            assertThat(ex.getCause()).isInstanceOf(BulkheadFullException.class);
+        }
+    }
 
     @Test
     public void testDecorateCompletionStage() throws ExecutionException, InterruptedException {

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/functions/CheckedBiFunction.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/functions/CheckedBiFunction.java
@@ -26,4 +26,19 @@ import java.util.function.BiFunction;
 @FunctionalInterface
 public interface CheckedBiFunction<T, U, R> {
     R apply(T t, U u) throws Throwable;
+
+    default BiFunction<T, U, R> unchecked() {
+        return (t, u) -> {
+            try {
+                return apply(t, u);
+            } catch (Throwable x) {
+                return sneakyThrow(x);
+            }
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T extends Throwable, R> R sneakyThrow(Throwable t) throws T {
+        throw (T) t;
+    }
 }


### PR DESCRIPTION
This commit adds two new features to the `Decorators` class such that the
- `DecorateCheckedSupplier<T>` will have a new `DecorateCompletionStage<T> withThreadPoolBulkhead(ThreadPoolBulkhead threadPoolBulkhead)`  method 
- `DecorateCheckedRunnable` will have a new `DecorateCompletionStage<Void> withThreadPoolBulkhead(ThreadPoolBulkhead threadPoolBulkhead)` method

Additionally a new default `unchecked()` method has been added to the `CheckedBiFunction` interface to facilitate conversion to standard `BiFunction` similarly to what is provided by the other `Checked*` interfaces.

Fixes #2278 