### PR TITLE
add withFallback() methods to DecorateFunction

### DIFF
--- a/resilience4j-all/src/main/java/io/github/resilience4j/decorators/Decorators.java
+++ b/resilience4j-all/src/main/java/io/github/resilience4j/decorators/Decorators.java
@@ -527,6 +527,31 @@ public interface Decorators {
             return this;
         }
 
+        public DecorateCheckedFunction<T, R> withFallback(BiFunction<R, Throwable, R> handler) {
+            function = CheckedFunctionUtils.andThen(function, handler);
+            return this;
+        }
+
+        public DecorateCheckedFunction<T, R> withFallback(Predicate<R> resultPredicate, UnaryOperator<R> resultHandler) {
+            function = CheckedFunctionUtils.recover(function, resultPredicate, resultHandler);
+            return this;
+        }
+
+        public DecorateCheckedFunction<T, R> withFallback(List<Class<? extends Throwable>> exceptionTypes, CheckedFunction<Throwable, R> exceptionHandler) {
+            function = CheckedFunctionUtils.recover(function, exceptionTypes, exceptionHandler);
+            return this;
+        }
+
+        public DecorateCheckedFunction<T, R> withFallback(CheckedFunction<Throwable, R> exceptionHandler) {
+            function = CheckedFunctionUtils.recover(function, exceptionHandler);
+            return this;
+        }
+
+        public <X extends Throwable> DecorateCheckedFunction<T, R> withFallback(Class<X> exceptionType, CheckedFunction<Throwable, R> exceptionHandler) {
+            function = CheckedFunctionUtils.recover(function, exceptionType, exceptionHandler);
+            return this;
+        }
+
         public CheckedFunction<T, R> decorate() {
             return function;
         }

--- a/resilience4j-all/src/main/java/io/github/resilience4j/decorators/Decorators.java
+++ b/resilience4j-all/src/main/java/io/github/resilience4j/decorators/Decorators.java
@@ -5,10 +5,7 @@ import io.github.resilience4j.bulkhead.BulkheadFullException;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
 import io.github.resilience4j.cache.Cache;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
-import io.github.resilience4j.core.CallableUtils;
-import io.github.resilience4j.core.CheckedFunctionUtils;
-import io.github.resilience4j.core.CompletionStageUtils;
-import io.github.resilience4j.core.SupplierUtils;
+import io.github.resilience4j.core.*;
 import io.github.resilience4j.core.functions.*;
 import io.github.resilience4j.micrometer.Timer;
 import io.github.resilience4j.ratelimiter.RateLimiter;
@@ -213,6 +210,31 @@ public interface Decorators {
 
         public DecorateFunction<T, R> withBulkhead(Bulkhead bulkhead) {
             function = Bulkhead.decorateFunction(bulkhead, function);
+            return this;
+        }
+
+        public DecorateFunction<T, R> withFallback(BiFunction<R, Throwable, R> handler) {
+            function = FunctionUtils.andThen(function, handler);
+            return this;
+        }
+
+        public DecorateFunction<T, R> withFallback(Predicate<R> resultPredicate, UnaryOperator<R> resultHandler) {
+            function = FunctionUtils.recover(function, resultPredicate, resultHandler);
+            return this;
+        }
+
+        public DecorateFunction<T, R> withFallback(List<Class<? extends Throwable>> exceptionTypes, Function<Throwable, R> exceptionHandler) {
+            function = FunctionUtils.recover(function, exceptionTypes, exceptionHandler);
+            return this;
+        }
+
+        public DecorateFunction<T, R> withFallback(Function<Throwable, R> exceptionHandler) {
+            function = FunctionUtils.recover(function, exceptionHandler);
+            return this;
+        }
+
+        public <X extends Throwable> DecorateFunction<T, R> withFallback(Class<X> exceptionType, Function<Throwable, R> exceptionHandler) {
+            function = FunctionUtils.recover(function, exceptionType, exceptionHandler);
             return this;
         }
 

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/CheckedFunctionUtils.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/CheckedFunctionUtils.java
@@ -24,7 +24,9 @@ import io.github.resilience4j.core.functions.CheckedSupplier;
 
 import java.util.List;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
 
 public class CheckedFunctionUtils {
 
@@ -140,6 +142,163 @@ public class CheckedFunctionUtils {
                     return exceptionHandler.apply(throwable);
                 }else{
                     throw throwable;
+                }
+            }
+        };
+    }
+
+    /**
+     * Returns a composed function that first applies the CheckedFunction and then applies the
+     * resultHandler.
+     *
+     * @param <T>           function parameter type
+     * @param <U>           return type of function
+     * @param <R>           return type of handler
+     * @param function the function
+     * @param resultHandler the function applied after function
+     * @return a function composed of supplier and resultHandler
+     */
+    public static <T, U, R> CheckedFunction<T, R> andThen(CheckedFunction<T, U> function, CheckedFunction<U, R> resultHandler) {
+        return t -> resultHandler.apply(function.apply(t));
+    }
+
+    /**
+     * Returns a composed function that first applies the CheckedFunction and then applies {@linkplain
+     * BiFunction} {@code after} to the result.
+     *
+     * @param <T>           function parameter type
+     * @param <U>           return type of function
+     * @param <R>           return type of handler
+     * @param function the function
+     * @param handler the function applied after function
+     * @return a function composed of supplier and handler
+     */
+    public static <T, U, R> CheckedFunction<T, R> andThen(CheckedFunction<T, U> function,
+                                                   BiFunction<U, Throwable, R> handler) {
+        return t -> {
+            try {
+                U result = function.apply(t);
+                return handler.apply(result, null);
+            } catch (Exception exception) {
+                return handler.apply(null, exception);
+            }
+        };
+    }
+
+    /**
+     * Returns a composed function that first applies the CheckedFunction and then applies either the
+     * resultHandler or exceptionHandler.
+     *
+     * @param <T>           function parameter type
+     * @param <U>           return type of function
+     * @param <R>           return type of handler
+     * @param function the function
+     * @param resultHandler    the function applied after function was successful
+     * @param exceptionHandler the function applied after function has failed
+     * @return a function composed of supplier and handler
+     */
+    public static <T, U, R> CheckedFunction<T, R> andThen(CheckedFunction<T, U> function, CheckedFunction<U, R> resultHandler,
+                                                          CheckedFunction<Throwable, R> exceptionHandler) {
+        return t -> {
+            try {
+                U result = function.apply(t);
+                return resultHandler.apply(result);
+            } catch (Exception exception) {
+                return exceptionHandler.apply(exception);
+            }
+        };
+    }
+
+    /**
+     * Returns a composed function that first executes the CheckedFunction and optionally recovers from an
+     * exception.
+     *
+     * @param <T>           function parameter type
+     * @param <R>           return type of function
+     * @param function the function which should be recovered from a certain exception
+     * @param exceptionHandler the exception handler
+     * @return a function composed of function and exceptionHandler
+     */
+    public static <T, R> CheckedFunction<T, R> recover(CheckedFunction<T, R> function,
+                                                CheckedFunction<Throwable, R> exceptionHandler) {
+        return t -> {
+            try {
+                return function.apply(t);
+            } catch (Exception exception) {
+                return exceptionHandler.apply(exception);
+            }
+        };
+    }
+
+    /**
+     * Returns a composed CheckedFunction that first executes the CheckedFunction and optionally recovers from a specific result.
+     *
+     * @param <T>           function parameter type
+     * @param <R>           return type of function
+     * @param function the function which should be recovered from a certain exception
+     * @param resultPredicate the result predicate
+     * @param resultHandler the result handler
+     * @return a function composed of supplier and exceptionHandler
+     */
+    public static <T, R> CheckedFunction<T, R> recover(CheckedFunction<T, R> function,
+                                                Predicate<R> resultPredicate, UnaryOperator<R> resultHandler) {
+        return t -> {
+            R result = function.apply(t);
+            if(resultPredicate.test(result)){
+                return resultHandler.apply(result);
+            }
+            return result;
+        };
+    }
+
+    /**
+     * Returns a composed function that first executes the CheckedFunction and optionally recovers from an
+     * exception.
+     *
+     * @param <T>           function parameter type
+     * @param <R>           return type of function
+     * @param function the function which should be recovered from a certain exception
+     * @param exceptionTypes the specific exception types that should be recovered
+     * @param exceptionHandler the exception handler
+     * @return a function composed of supplier and exceptionHandler
+     */
+    public static <T, R> CheckedFunction<T, R> recover(CheckedFunction<T, R> function,
+                                                List<Class<? extends Throwable>> exceptionTypes,
+                                                       CheckedFunction<Throwable, R> exceptionHandler) {
+        return t -> {
+            try {
+                return function.apply(t);
+            } catch (Exception exception) {
+                if(exceptionTypes.stream().anyMatch(exceptionType -> exceptionType.isAssignableFrom(exception.getClass()))){
+                    return exceptionHandler.apply(exception);
+                }else{
+                    throw exception;
+                }
+            }
+        };
+    }
+
+    /**
+     * Returns a composed function that first executes the CheckedFunction and optionally recovers from an
+     * exception.
+     *
+     * @param <T>           function parameter type
+     * @param <R>           return type of function
+     * @param exceptionType the specific exception type that should be recovered
+     * @param exceptionHandler the exception handler
+     * @return a function composed of function and exceptionHandler
+     */
+    public static <X extends Throwable, T, R> CheckedFunction<T, R> recover(CheckedFunction<T, R> function,
+                                                                     Class<X> exceptionType,
+                                                                     CheckedFunction<Throwable, R> exceptionHandler) {
+        return t -> {
+            try {
+                return function.apply(t);
+            } catch (Exception exception) {
+                if(exceptionType.isAssignableFrom(exception.getClass())) {
+                    return exceptionHandler.apply(exception);
+                }else{
+                    throw exception;
                 }
             }
         };

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/FunctionUtils.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/FunctionUtils.java
@@ -144,7 +144,7 @@ public class FunctionUtils {
     }
 
     /**
-     * Returns a composed function that first executes the Runnable and optionally recovers from an
+     * Returns a composed function that first executes the Function and optionally recovers from an
      * exception.
      *
      * @param <T>           function parameter type

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/FunctionUtils.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/FunctionUtils.java
@@ -1,0 +1,171 @@
+package io.github.resilience4j.core;
+
+
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+
+public class FunctionUtils {
+
+    private FunctionUtils() {
+    }
+
+    /**
+     * Returns a composed function that first applies the Function and then applies the
+     * resultHandler.
+     *
+     * @param <T>           function parameter type
+     * @param <U>           return type of function
+     * @param <R>           return type of handler
+     * @param function the function
+     * @param resultHandler the function applied after function
+     * @return a function composed of supplier and resultHandler
+     */
+    public static <T, U, R> Function<T, R> andThen(Function<T, U> function, Function<U, R> resultHandler) {
+        return t -> resultHandler.apply(function.apply(t));
+    }
+
+    /**
+     * Returns a composed function that first applies the Function and then applies {@linkplain
+     * BiFunction} {@code after} to the result.
+     *
+     * @param <T>           function parameter type
+     * @param <U>           return type of function
+     * @param <R>           return type of handler
+     * @param function the function
+     * @param handler the function applied after function
+     * @return a function composed of supplier and handler
+     */
+    public static <T, U, R> Function<T, R> andThen(Function<T, U> function,
+        BiFunction<U, Throwable, R> handler) {
+        return t -> {
+            try {
+                U result = function.apply(t);
+                return handler.apply(result, null);
+            } catch (Exception exception) {
+                return handler.apply(null, exception);
+            }
+        };
+    }
+
+    /**
+     * Returns a composed function that first applies the Function and then applies either the
+     * resultHandler or exceptionHandler.
+     *
+     * @param <T>           function parameter type
+     * @param <U>           return type of function
+     * @param <R>           return type of handler
+     * @param function the function
+     * @param resultHandler    the function applied after function was successful
+     * @param exceptionHandler the function applied after function has failed
+     * @return a function composed of supplier and handler
+     */
+    public static <T, U, R> Function<T, R> andThen(Function<T, U> function, Function<U, R> resultHandler,
+        Function<Throwable, R> exceptionHandler) {
+        return t -> {
+            try {
+                U result = function.apply(t);
+                return resultHandler.apply(result);
+            } catch (Exception exception) {
+                return exceptionHandler.apply(exception);
+            }
+        };
+    }
+
+    /**
+     * Returns a composed function that first executes the Function and optionally recovers from an
+     * exception.
+     *
+     * @param <T>           function parameter type
+     * @param <R>           return type of function
+     * @param function the function which should be recovered from a certain exception
+     * @param exceptionHandler the exception handler
+     * @return a function composed of function and exceptionHandler
+     */
+    public static <T, R> Function<T, R> recover(Function<T, R> function,
+        Function<Throwable, R> exceptionHandler) {
+        return t -> {
+            try {
+                return function.apply(t);
+            } catch (Exception exception) {
+                return exceptionHandler.apply(exception);
+            }
+        };
+    }
+
+    /**
+     * Returns a composed Function that first executes the Function and optionally recovers from a specific result.
+     *
+     * @param <T>           function parameter type
+     * @param <R>           return type of function
+     * @param function the function which should be recovered from a certain exception
+     * @param resultPredicate the result predicate
+     * @param resultHandler the result handler
+     * @return a function composed of supplier and exceptionHandler
+     */
+    public static <T, R> Function<T, R> recover(Function<T, R> function,
+        Predicate<R> resultPredicate, UnaryOperator<R> resultHandler) {
+        return t -> {
+            R result = function.apply(t);
+            if(resultPredicate.test(result)){
+                return resultHandler.apply(result);
+            }
+            return result;
+        };
+    }
+
+    /**
+     * Returns a composed function that first executes the Function and optionally recovers from an
+     * exception.
+     *
+     * @param <T>           function parameter type
+     * @param <R>           return type of function
+     * @param function the function which should be recovered from a certain exception
+     * @param exceptionTypes the specific exception types that should be recovered
+     * @param exceptionHandler the exception handler
+     * @return a function composed of supplier and exceptionHandler
+     */
+    public static <T, R> Function<T, R> recover(Function<T, R> function,
+        List<Class<? extends Throwable>> exceptionTypes,
+        Function<Throwable, R> exceptionHandler) {
+        return t -> {
+            try {
+                return function.apply(t);
+            } catch (Exception exception) {
+                if(exceptionTypes.stream().anyMatch(exceptionType -> exceptionType.isAssignableFrom(exception.getClass()))){
+                    return exceptionHandler.apply(exception);
+                }else{
+                    throw exception;
+                }
+            }
+        };
+    }
+
+    /**
+     * Returns a composed function that first executes the Runnable and optionally recovers from an
+     * exception.
+     *
+     * @param <T>           function parameter type
+     * @param <R>           return type of function
+     * @param exceptionType the specific exception type that should be recovered
+     * @param exceptionHandler the exception handler
+     * @return a function composed of function and exceptionHandler
+     */
+    public static <X extends Throwable, T, R> Function<T, R> recover(Function<T, R> function,
+        Class<X> exceptionType,
+        Function<Throwable, R> exceptionHandler) {
+        return t -> {
+            try {
+                return function.apply(t);
+            } catch (Exception exception) {
+                if(exceptionType.isAssignableFrom(exception.getClass())) {
+                    return exceptionHandler.apply(exception);
+                }else{
+                    throw exception;
+                }
+            }
+        };
+    }
+}

--- a/resilience4j-core/src/test/java/io/github/resilience4j/core/CheckedFunctionUtilsTest.java
+++ b/resilience4j-core/src/test/java/io/github/resilience4j/core/CheckedFunctionUtilsTest.java
@@ -23,7 +23,6 @@ import io.github.resilience4j.core.functions.CheckedSupplier;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.function.Function;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -124,7 +123,7 @@ public class CheckedFunctionUtilsTest {
     }
 
     @Test
-    public void shouldChainCheckedFunctionAndResultHandler() {
+    public void shouldChainCheckedFunctionAndResultHandler() throws Throwable {
         CheckedFunction<String, String> function = ignored -> "foo";
         CheckedFunction<String, String> functionWithRecovery = CheckedFunctionUtils.andThen(function, result -> "bar");
 
@@ -135,7 +134,7 @@ public class CheckedFunctionUtilsTest {
 
 
     @Test
-    public void shouldChainCheckedFunctionAndRecoverFromException() {
+    public void shouldChainCheckedFunctionAndRecoverFromException() throws Throwable {
         CheckedFunction<String, String> function = ignored -> {
             throw new RuntimeException("BAM!");
         };
@@ -148,7 +147,7 @@ public class CheckedFunctionUtilsTest {
     }
 
     @Test
-    public void shouldChainCheckedFunctionAndRecoverWithErrorHandler() {
+    public void shouldChainCheckedFunctionAndRecoverWithErrorHandler() throws Throwable {
         CheckedFunction<String, String> function = ignored -> {
             throw new RuntimeException("BAM!");
         };
@@ -161,7 +160,7 @@ public class CheckedFunctionUtilsTest {
     }
 
     @Test
-    public void shouldRecoverCheckedFunctionFromException() {
+    public void shouldRecoverCheckedFunctionFromException() throws Throwable {
         CheckedFunction<String, String> function = ignored -> {
             throw new RuntimeException("BAM!");
         };
@@ -173,7 +172,7 @@ public class CheckedFunctionUtilsTest {
     }
 
     @Test
-    public void shouldRecoverCheckedFunctionFromSpecificExceptions() {
+    public void shouldRecoverCheckedFunctionFromSpecificExceptions() throws Throwable {
         CheckedFunction<String, String> function = ignored -> {
             throw new IllegalArgumentException("BAM!");
         };
@@ -188,7 +187,7 @@ public class CheckedFunctionUtilsTest {
     }
 
     @Test
-    public void shouldRecoverCheckedFunctionFromSpecificResult() {
+    public void shouldRecoverCheckedFunctionFromSpecificResult() throws Throwable {
         CheckedFunction<String, String> function = ignored -> "Wrong Result";
 
         CheckedFunction<String, String> functionWithRecovery = CheckedFunctionUtils.recover(function, (result) -> result.equals("Wrong Result"), (r) -> "Correct Result");
@@ -198,7 +197,7 @@ public class CheckedFunctionUtilsTest {
     }
 
     @Test(expected = RuntimeException.class)
-    public void shouldRethrowException() {
+    public void shouldRethrowCheckedFunctionException() throws Throwable {
         CheckedFunction<String, String> function = ignored -> {
             throw new IllegalArgumentException("BAM!");
         };
@@ -210,7 +209,7 @@ public class CheckedFunctionUtilsTest {
     }
 
     @Test(expected = RuntimeException.class)
-    public void shouldRethrowException2() throws Exception {
+    public void shouldRethrowCheckedFuntctionException2() throws Throwable {
         CheckedFunction<String, String> function = ignored -> {
             throw new RuntimeException("BAM!");
         };
@@ -218,5 +217,4 @@ public class CheckedFunctionUtilsTest {
 
         functionWithRecovery.apply("bar");
     }
-
 }

--- a/resilience4j-core/src/test/java/io/github/resilience4j/core/FunctionUtilsTest.java
+++ b/resilience4j-core/src/test/java/io/github/resilience4j/core/FunctionUtilsTest.java
@@ -75,7 +75,7 @@ public class FunctionUtilsTest {
     }
 
     @Test
-    public void shouldRecoverCallableFromSpecificResult() {
+    public void shouldRecoverFunctionFromSpecificResult() {
         Function<String, String> function = ignored -> "Wrong Result";
 
         Function<String, String> functionWithRecovery = FunctionUtils.recover(function, (result) -> result.equals("Wrong Result"), (r) -> "Correct Result");

--- a/resilience4j-core/src/test/java/io/github/resilience4j/core/FunctionUtilsTest.java
+++ b/resilience4j-core/src/test/java/io/github/resilience4j/core/FunctionUtilsTest.java
@@ -1,0 +1,108 @@
+package io.github.resilience4j.core;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FunctionUtilsTest {
+
+    @Test
+    public void shouldChainFunctionAndResultHandler() {
+        Function<String, String> function = ignored -> "foo";
+        Function<String, String> functionWithRecovery = FunctionUtils.andThen(function, result -> "bar");
+
+        String result = functionWithRecovery.apply("baz");
+
+        assertThat(result).isEqualTo("bar");
+    }
+
+
+    @Test
+    public void shouldChainFunctionAndRecoverFromException() {
+        Function<String, String> function = ignored -> {
+            throw new RuntimeException("BAM!");
+        };
+        Function<String, String> functionWithRecovery = FunctionUtils
+            .andThen(function, (result, ex) -> "foo");
+
+        String result = functionWithRecovery.apply("bar");
+
+        assertThat(result).isEqualTo("foo");
+    }
+
+    @Test
+    public void shouldChainFunctionAndRecoverWithErrorHandler() {
+        Function<String, String> function = ignored -> {
+            throw new RuntimeException("BAM!");
+        };
+        Function<String, String> functionWithRecovery = FunctionUtils
+            .andThen(function, (result) -> result, ex -> "foo");
+
+        String result = functionWithRecovery.apply("bar");
+
+        assertThat(result).isEqualTo("foo");
+    }
+
+    @Test
+    public void shouldRecoverFunctionFromException() {
+        Function<String, String> function = ignored -> {
+            throw new RuntimeException("BAM!");
+        };
+        Function<String, String> functionWithRecovery = FunctionUtils.recover(function, (ex) -> "foo");
+
+        String result = functionWithRecovery.apply("bar");
+
+        assertThat(result).isEqualTo("foo");
+    }
+
+    @Test
+    public void shouldRecoverFunctionFromSpecificExceptions() {
+        Function<String, String> function = ignored -> {
+            throw new IllegalArgumentException("BAM!");
+        };
+
+        Function<String, String> functionWithRecovery = FunctionUtils.recover(function,
+            asList(IllegalArgumentException.class, IOException.class),
+            (ex) -> "foo");
+
+        String result = functionWithRecovery.apply("bar");
+
+        assertThat(result).isEqualTo("foo");
+    }
+
+    @Test
+    public void shouldRecoverCallableFromSpecificResult() {
+        Function<String, String> function = ignored -> "Wrong Result";
+
+        Function<String, String> functionWithRecovery = FunctionUtils.recover(function, (result) -> result.equals("Wrong Result"), (r) -> "Correct Result");
+        String result = functionWithRecovery.apply("foo");
+
+        assertThat(result).isEqualTo("Correct Result");
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void shouldRethrowException() {
+        Function<String, String> function = ignored -> {
+            throw new IllegalArgumentException("BAM!");
+        };
+        Function<String, String> functionWithRecovery = FunctionUtils.recover(function, (ex) -> {
+            throw new RuntimeException();
+        });
+
+        functionWithRecovery.apply("foo");
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void shouldRethrowException2() throws Exception {
+        Function<String, String> function = ignored -> {
+            throw new RuntimeException("BAM!");
+        };
+        Function<String, String> functionWithRecovery = FunctionUtils.recover(function, IllegalArgumentException.class, (ex) -> "foo");
+
+        functionWithRecovery.apply("bar");
+    }
+}


### PR DESCRIPTION
This PR adds `.withFallback(...)` methods to the `DecoratedFunction` and the `DecoreatedCheckedFunction` classes. Additionally, it also adds a `FunctionUtils` class and new method to the `CheckedFunctionUtils` classes for convenience composition of `Function` and `CheckedFunction`.

fixes #2314