### PR TITLE
Added CheckedSupplierUtils and deprecated CheckedFunctionUtils

### DIFF
--- a/resilience4j-all/src/main/java/io/github/resilience4j/decorators/Decorators.java
+++ b/resilience4j-all/src/main/java/io/github/resilience4j/decorators/Decorators.java
@@ -5,10 +5,7 @@ import io.github.resilience4j.bulkhead.BulkheadFullException;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
 import io.github.resilience4j.cache.Cache;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
-import io.github.resilience4j.core.CallableUtils;
-import io.github.resilience4j.core.CheckedFunctionUtils;
-import io.github.resilience4j.core.CompletionStageUtils;
-import io.github.resilience4j.core.SupplierUtils;
+import io.github.resilience4j.core.*;
 import io.github.resilience4j.core.functions.*;
 import io.github.resilience4j.micrometer.Timer;
 import io.github.resilience4j.ratelimiter.RateLimiter;
@@ -428,27 +425,27 @@ public interface Decorators {
         }
 
         public DecorateCheckedSupplier<T> withFallback(CheckedBiFunction<T, Throwable, T> handler) {
-            supplier = CheckedFunctionUtils.andThen(supplier, handler);
+            supplier = CheckedSupplierUtils.andThen(supplier, handler);
             return this;
         }
 
         public DecorateCheckedSupplier<T> withFallback(Predicate<T> resultPredicate, CheckedFunction<T, T> resultHandler) {
-            supplier = CheckedFunctionUtils.recover(supplier, resultPredicate, resultHandler);
+            supplier = CheckedSupplierUtils.recover(supplier, resultPredicate, resultHandler);
             return this;
         }
 
         public DecorateCheckedSupplier<T> withFallback(List<Class<? extends Throwable>> exceptionTypes, CheckedFunction<Throwable, T> exceptionHandler) {
-            supplier = CheckedFunctionUtils.recover(supplier, exceptionTypes, exceptionHandler);
+            supplier = CheckedSupplierUtils.recover(supplier, exceptionTypes, exceptionHandler);
             return this;
         }
 
         public DecorateCheckedSupplier<T> withFallback(CheckedFunction<Throwable, T> exceptionHandler) {
-            supplier = CheckedFunctionUtils.recover(supplier, exceptionHandler);
+            supplier = CheckedSupplierUtils.recover(supplier, exceptionHandler);
             return this;
         }
 
         public <X extends Throwable> DecorateCheckedSupplier<T> withFallback(Class<X> exceptionType, CheckedFunction<Throwable, T> exceptionHandler) {
-            supplier = CheckedFunctionUtils.recover(supplier, exceptionType, exceptionHandler);
+            supplier = CheckedSupplierUtils.recover(supplier, exceptionType, exceptionHandler);
             return this;
         }
 

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/CheckedFunctionUtils.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/CheckedFunctionUtils.java
@@ -23,7 +23,6 @@ import io.github.resilience4j.core.functions.CheckedFunction;
 import io.github.resilience4j.core.functions.CheckedSupplier;
 
 import java.util.List;
-import java.util.function.BiFunction;
 import java.util.function.Predicate;
 
 public class CheckedFunctionUtils {
@@ -33,115 +32,48 @@ public class CheckedFunctionUtils {
 
 
     /**
-     * Returns a composed supplier that first executes the supplier and optionally recovers from an
-     * exception.
-     *
-     * @param <T>              return type of after
-     * @param supplier the supplier which should be recovered from a certain exception
-     * @param exceptionHandler the exception handler
-     * @return a supplier composed of callable and exceptionHandler
+     * @deprecated use {@link CheckedSupplierUtils#recover(CheckedSupplier, CheckedFunction)}
      */
+    @Deprecated
     public static <T> CheckedSupplier<T> recover(CheckedSupplier<T> supplier,
                                                  CheckedFunction<Throwable, T> exceptionHandler) {
-        return () -> {
-            try {
-                return supplier.get();
-            } catch (Throwable throwable) {
-                return exceptionHandler.apply(throwable);
-            }
-        };
+        return CheckedSupplierUtils.recover(supplier, exceptionHandler);
     }
 
     /**
-     * Returns a composed supplier that first applies the supplier and then applies {@linkplain
-     * BiFunction} {@code after} to the result.
-     *
-     * @param <T>     return type of callable
-     * @param <R>     return type of handler
-     * @param supplier the supplier
-     * @param handler the supplier applied after callable
-     * @return a supplier composed of supplier and handler
+     * @deprecated use {@link CheckedSupplierUtils#andThen(CheckedSupplier, CheckedBiFunction)}
      */
+    @Deprecated
     public static <T, R> CheckedSupplier<R> andThen(CheckedSupplier<T> supplier,
         CheckedBiFunction<T, Throwable, R> handler) {
-        return () -> {
-            try {
-                return handler.apply(supplier.get(), null);
-            } catch (Throwable throwable) {
-                return handler.apply(null, throwable);
-            }
-        };
+        return CheckedSupplierUtils.andThen(supplier, handler);
     }
 
     /**
-     * Returns a composed supplier that first executes the supplier and optionally recovers from a specific result.
-     *
-     * @param <T>              return type of after
-     * @param supplier the supplier
-     * @param resultPredicate the result predicate
-     * @param resultHandler the result handler
-     * @return a supplier composed of supplier and exceptionHandler
+     * @deprecated use {@link CheckedSupplierUtils#recover(CheckedSupplier, Predicate, CheckedFunction)}
      */
+    @Deprecated
     public static <T> CheckedSupplier<T> recover(CheckedSupplier<T> supplier,
         Predicate<T> resultPredicate, CheckedFunction<T, T> resultHandler) {
-        return () -> {
-            T result = supplier.get();
-            if(resultPredicate.test(result)){
-                return resultHandler.apply(result);
-            }
-            return result;
-        };
+        return CheckedSupplierUtils.recover(supplier, resultPredicate, resultHandler);
     }
 
     /**
-     * Returns a composed supplier that first executes the supplier and optionally recovers from an
-     * exception.
-     *
-     * @param <T>              return type of after
-     * @param supplier the supplier which should be recovered from a certain exception
-     * @param exceptionTypes the specific exception types that should be recovered
-     * @param exceptionHandler the exception handler
-     * @return a supplier composed of supplier and exceptionHandler
+     * @deprecated use {@link CheckedSupplierUtils#recover(CheckedSupplier, List, CheckedFunction)}
      */
+    @Deprecated
     public static <T> CheckedSupplier<T> recover(CheckedSupplier<T> supplier,
         List<Class<? extends Throwable>> exceptionTypes,
         CheckedFunction<Throwable, T> exceptionHandler) {
-        return () -> {
-            try {
-                return supplier.get();
-            } catch (Exception exception) {
-                if(exceptionTypes.stream().anyMatch(exceptionType -> exceptionType.isAssignableFrom(exception.getClass()))){
-                    return exceptionHandler.apply(exception);
-                }else{
-                    throw exception;
-                }
-            }
-        };
+        return CheckedSupplierUtils.recover(supplier, exceptionTypes, exceptionHandler);
     }
 
     /**
-     * Returns a composed supplier that first executes the supplier and optionally recovers from an
-     * exception.
-     *
-     * @param <T>              return type of after
-     * @param supplier the supplier which should be recovered from a certain exception
-     * @param exceptionType the specific exception type that should be recovered
-     * @param exceptionHandler the exception handler
-     * @return a supplier composed of callable and exceptionHandler
+     * @deprecated use {@link CheckedSupplierUtils#recover(CheckedSupplier, Class, CheckedFunction)}
      */
     public static <X extends Throwable, T> CheckedSupplier<T> recover(CheckedSupplier<T> supplier,
         Class<X> exceptionType,
         CheckedFunction<Throwable, T> exceptionHandler) {
-        return () -> {
-            try {
-                return supplier.get();
-            } catch (Throwable throwable) {
-                if(exceptionType.isAssignableFrom(throwable.getClass())) {
-                    return exceptionHandler.apply(throwable);
-                }else{
-                    throw throwable;
-                }
-            }
-        };
+        return CheckedSupplierUtils.recover(supplier, exceptionType, exceptionHandler);
     }
 }

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/CheckedSupplierUtils.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/CheckedSupplierUtils.java
@@ -1,0 +1,128 @@
+package io.github.resilience4j.core;
+
+import io.github.resilience4j.core.functions.CheckedBiFunction;
+import io.github.resilience4j.core.functions.CheckedFunction;
+import io.github.resilience4j.core.functions.CheckedSupplier;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+public class CheckedSupplierUtils {
+
+    private CheckedSupplierUtils() {
+    }
+
+
+    /**
+     * Returns a composed supplier that first executes the supplier and optionally recovers from an
+     * exception.
+     *
+     * @param <T>              return type of after
+     * @param supplier the supplier which should be recovered from a certain exception
+     * @param exceptionHandler the exception handler
+     * @return a supplier composed of callable and exceptionHandler
+     */
+    public static <T> CheckedSupplier<T> recover(CheckedSupplier<T> supplier,
+                                                 CheckedFunction<Throwable, T> exceptionHandler) {
+        return () -> {
+            try {
+                return supplier.get();
+            } catch (Throwable throwable) {
+                return exceptionHandler.apply(throwable);
+            }
+        };
+    }
+
+    /**
+     * Returns a composed supplier that first applies the supplier and then applies {@linkplain
+     * CheckedBiFunction} {@code after} to the result.
+     *
+     * @param <T>     return type of callable
+     * @param <R>     return type of handler
+     * @param supplier the supplier
+     * @param handler the supplier applied after callable
+     * @return a supplier composed of supplier and handler
+     */
+    public static <T, R> CheckedSupplier<R> andThen(CheckedSupplier<T> supplier,
+        CheckedBiFunction<T, Throwable, R> handler) {
+        return () -> {
+            try {
+                return handler.apply(supplier.get(), null);
+            } catch (Throwable throwable) {
+                return handler.apply(null, throwable);
+            }
+        };
+    }
+
+    /**
+     * Returns a composed supplier that first executes the supplier and optionally recovers from a specific result.
+     *
+     * @param <T>              return type of after
+     * @param supplier the supplier
+     * @param resultPredicate the result predicate
+     * @param resultHandler the result handler
+     * @return a supplier composed of supplier and exceptionHandler
+     */
+    public static <T> CheckedSupplier<T> recover(CheckedSupplier<T> supplier,
+        Predicate<T> resultPredicate, CheckedFunction<T, T> resultHandler) {
+        return () -> {
+            T result = supplier.get();
+            if(resultPredicate.test(result)){
+                return resultHandler.apply(result);
+            }
+            return result;
+        };
+    }
+
+    /**
+     * Returns a composed supplier that first executes the supplier and optionally recovers from an
+     * exception.
+     *
+     * @param <T>              return type of after
+     * @param supplier the supplier which should be recovered from a certain exception
+     * @param exceptionTypes the specific exception types that should be recovered
+     * @param exceptionHandler the exception handler
+     * @return a supplier composed of supplier and exceptionHandler
+     */
+    public static <T> CheckedSupplier<T> recover(CheckedSupplier<T> supplier,
+        List<Class<? extends Throwable>> exceptionTypes,
+        CheckedFunction<Throwable, T> exceptionHandler) {
+        return () -> {
+            try {
+                return supplier.get();
+            } catch (Exception exception) {
+                if(exceptionTypes.stream().anyMatch(exceptionType -> exceptionType.isAssignableFrom(exception.getClass()))){
+                    return exceptionHandler.apply(exception);
+                }else{
+                    throw exception;
+                }
+            }
+        };
+    }
+
+    /**
+     * Returns a composed supplier that first executes the supplier and optionally recovers from an
+     * exception.
+     *
+     * @param <T>              return type of after
+     * @param supplier the supplier which should be recovered from a certain exception
+     * @param exceptionType the specific exception type that should be recovered
+     * @param exceptionHandler the exception handler
+     * @return a supplier composed of callable and exceptionHandler
+     */
+    public static <X extends Throwable, T> CheckedSupplier<T> recover(CheckedSupplier<T> supplier,
+        Class<X> exceptionType,
+        CheckedFunction<Throwable, T> exceptionHandler) {
+        return () -> {
+            try {
+                return supplier.get();
+            } catch (Throwable throwable) {
+                if(exceptionType.isAssignableFrom(throwable.getClass())) {
+                    return exceptionHandler.apply(throwable);
+                }else{
+                    throw throwable;
+                }
+            }
+        };
+    }
+}

--- a/resilience4j-core/src/test/java/io/github/resilience4j/core/CheckedSupplierUtilsTest.java
+++ b/resilience4j-core/src/test/java/io/github/resilience4j/core/CheckedSupplierUtilsTest.java
@@ -1,0 +1,105 @@
+package io.github.resilience4j.core;
+
+import io.github.resilience4j.core.functions.CheckedSupplier;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CheckedSupplierUtilsTest {
+
+    @Test
+    public void shouldRecoverFromException() throws Throwable {
+        CheckedSupplier<String> callable = () -> {
+            throw new IOException("BAM!");
+        };
+        CheckedSupplier<String> callableWithRecovery = CheckedSupplierUtils.recover(callable, (ex) -> "Bla");
+
+        String result = callableWithRecovery.get();
+
+        assertThat(result).isEqualTo("Bla");
+    }
+
+    @Test
+    public void shouldRecoverFromSpecificExceptions() throws Throwable {
+        CheckedSupplier<String> callable = () -> {
+            throw new IOException("BAM!");
+        };
+
+        CheckedSupplier<String> callableWithRecovery = CheckedSupplierUtils.recover(callable,
+            asList(IllegalArgumentException.class, IOException.class),
+            (ex) -> "Bla");
+
+        String result = callableWithRecovery.get();
+
+        assertThat(result).isEqualTo("Bla");
+    }
+
+    @Test
+    public void shouldRecoverFromResult() throws Throwable {
+        CheckedSupplier<String> callable = () -> "Wrong Result";
+
+        CheckedSupplier<String> callableWithRecovery = CheckedSupplierUtils.andThen(callable, (result, ex) -> {
+            if(result.equals("Wrong Result")){
+                return "Bla";
+            }
+            return result;
+        });
+
+        String result = callableWithRecovery.get();
+
+        assertThat(result).isEqualTo("Bla");
+    }
+
+    @Test
+    public void shouldRecoverFromException2() throws Throwable {
+        CheckedSupplier<String> callable = () -> {
+            throw new IllegalArgumentException("BAM!");
+        };
+        CheckedSupplier<String> callableWithRecovery = CheckedSupplierUtils.andThen(callable, (result, ex) -> {
+            if(ex instanceof IllegalArgumentException){
+                return "Bla";
+            }
+            return result;
+        });
+
+        String result = callableWithRecovery.get();
+
+        assertThat(result).isEqualTo("Bla");
+    }
+
+    @Test
+    public void shouldRecoverFromSpecificResult() throws Throwable {
+        CheckedSupplier<String> supplier = () -> "Wrong Result";
+
+        CheckedSupplier<String> callableWithRecovery = CheckedSupplierUtils.recover(supplier, (result) -> result.equals("Wrong Result"), (r) -> "Bla");
+        String result = callableWithRecovery.get();
+
+        assertThat(result).isEqualTo("Bla");
+    }
+
+
+    @Test(expected = RuntimeException.class)
+    public void shouldRethrowException() throws Throwable {
+        CheckedSupplier<String> callable = () -> {
+            throw new IOException("BAM!");
+        };
+        CheckedSupplier<String> callableWithRecovery = CheckedSupplierUtils.recover(callable, (ex) -> {
+            throw new RuntimeException();
+        });
+
+        callableWithRecovery.get();
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void shouldRethrowException2() throws Throwable {
+        CheckedSupplier<String> callable = () -> {
+            throw new RuntimeException("BAM!");
+        };
+        CheckedSupplier<String> callableWithRecovery = CheckedSupplierUtils.recover(callable, IllegalArgumentException.class, (ex) -> "Bla");
+
+        callableWithRecovery.get();
+    }
+}


### PR DESCRIPTION
The existing `CheckedFunctionUtils` class name is misleading, because all methods deals with `CheckedSupplier` and not `CheckedFunction`

Consequently, this PR:
- Adds a new class `CheckedSupplierUtils` that is a copy/paste of the existing `CheckedFunctionUtils`.
- Adds a new test class `CheckedSupplierUtilsTest` by copy/paste the existing `CheckedFunctionsUtilsTest` but use the new class.
- Replaces all usages of `CheckedFunctionUtils` in `Decorators` with the new class.
- Updates existing methods in the `CheckedFunctionUtils` to delegate to the new class and adds `@Deprecation` annotations so that existing integrations will continue to work, but with deprecation warnings.