### PR TITLE
fix spring boot3 customizer application order

### DIFF
--- a/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/SpringBootCommonTest.java
+++ b/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/SpringBootCommonTest.java
@@ -73,7 +73,7 @@ public class SpringBootCommonTest {
                 new DefaultEventConsumerRegistry<>(),
                 new CompositeRegistryEventConsumer<>(Collections.emptyList()),
                 new CompositeCustomizer<>(Collections.singletonList(
-                    ThreadPoolBulkheadConfigCustomizer.of("backend", builder -> builder.coreThreadPoolSize(10)))))).isNotNull();
+                    ThreadPoolBulkheadConfigCustomizer.of("backend", builder -> builder.coreThreadPoolSize(10).maxThreadPoolSize(11)))))).isNotNull();
         assertThat(bulkheadConfigurationOnMissingBean.reactorBulkHeadAspectExt()).isNotNull();
         assertThat(bulkheadConfigurationOnMissingBean.rxJava2BulkHeadAspectExt()).isNotNull();
         assertThat(bulkheadConfigurationOnMissingBean.rxJava3BulkHeadAspectExt()).isNotNull();

--- a/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/bulkhead/autoconfigure/BulkheadAutoConfigurationCustomizerTest.java
+++ b/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/bulkhead/autoconfigure/BulkheadAutoConfigurationCustomizerTest.java
@@ -1,0 +1,195 @@
+package io.github.resilience4j.springboot3.bulkhead.autoconfigure;
+
+import io.github.resilience4j.bulkhead.BulkheadConfig;
+import io.github.resilience4j.bulkhead.BulkheadRegistry;
+import io.github.resilience4j.common.bulkhead.configuration.BulkheadConfigCustomizer;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests combinations of config properties ({@code resilience4j.bulkhead.configs.<name>.*}),
+ * instance properties ({@code resilience4j.bulkhead.instances.<name>.*}) and {@link BulkheadConfigCustomizer}.
+ * <p>
+ * To make this test easier to follow it always uses different magnitude of values for different ways to configure a bulkhead:
+ * <ul>
+ *     <li>config properties - N * 10</li>
+ *     <li>instance properties - N * 100</li>
+ *     <li>customizer - N * 1000</li>
+ * </ul>
+ * where N is index of the config. This way when asserting value {@code 200} it is guaranteed to be coming from instance properties.
+ */
+public class BulkheadAutoConfigurationCustomizerTest {
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(BulkheadAutoConfiguration.class))
+        .withPropertyValues(
+            "resilience4j.bulkhead.configs.default.writableStackTraceEnabled: true",
+            "resilience4j.bulkhead.configs.default.maxConcurrentCalls: 10",
+            "resilience4j.bulkhead.configs.default.maxWaitDuration: 10ms",
+            "resilience4j.bulkhead.configs.sharedConfig.writableStackTraceEnabled: false",
+            "resilience4j.bulkhead.configs.sharedConfig.maxConcurrentCalls: 20",
+            "resilience4j.bulkhead.configs.sharedConfig.maxWaitDuration: 20ms"
+        );
+
+    @Test
+    public void testUserConfigShouldBeAbleToProvideCustomizers() {
+        // Given
+        contextRunner.withUserConfiguration(CustomizerConfiguration.class)
+            .withPropertyValues(
+                "resilience4j.bulkhead.instances.backendWithoutSharedConfig.writableStackTraceEnabled: false",
+                "resilience4j.bulkhead.instances.backendWithSharedConfig.baseConfig: sharedConfig",
+                "resilience4j.bulkhead.instances.backendWithSharedConfig.writableStackTraceEnabled: true"
+            )
+            .run(context -> {
+                // Then
+                assertThat(context).hasSingleBean(BulkheadRegistry.class);
+                BulkheadRegistry registry = context.getBean(BulkheadRegistry.class);
+
+                BulkheadConfig backendWithoutSharedConfig = registry.bulkhead("backendWithoutSharedConfig").getBulkheadConfig();
+                // from default config
+                assertThat(backendWithoutSharedConfig.getMaxWaitDuration()).isEqualTo(Duration.ofMillis(10));
+                // from instance config
+                assertThat(backendWithoutSharedConfig.isWritableStackTraceEnabled()).isEqualTo(false);
+                // from customizer
+                assertThat(backendWithoutSharedConfig.getMaxConcurrentCalls()).isEqualTo(1000);
+
+                BulkheadConfig backendWithSharedConfig = registry.bulkhead("backendWithSharedConfig").getBulkheadConfig();
+                // from default config
+                assertThat(backendWithSharedConfig.getMaxWaitDuration()).isEqualTo(Duration.ofMillis(20));
+                // from instance config
+                assertThat(backendWithSharedConfig.isWritableStackTraceEnabled()).isEqualTo(true);
+                // from customizer
+                assertThat(backendWithSharedConfig.getMaxConcurrentCalls()).isEqualTo(2000);
+
+                BulkheadConfig backendWithoutInstanceConfig = registry.bulkhead("backendWithoutInstanceConfig").getBulkheadConfig();
+                // from default config
+                assertThat(backendWithoutInstanceConfig.getMaxWaitDuration()).isEqualTo(Duration.ofMillis(10));
+                // from default config
+                assertThat(backendWithoutInstanceConfig.isWritableStackTraceEnabled()).isEqualTo(true);
+                // from customizer
+                assertThat(backendWithoutInstanceConfig.getMaxConcurrentCalls()).isEqualTo(3000);
+            });
+    }
+
+    @Test
+    public void testCustomizersShouldOverrideProperties() {
+        // Given
+        contextRunner.withUserConfiguration(CustomizerConfiguration.class)
+            .withPropertyValues(
+                "resilience4j.bulkhead.instances.backendWithoutSharedConfig.maxConcurrentCalls: 100"
+            )
+            .run(context -> {
+                // Then
+                assertThat(context).hasSingleBean(BulkheadRegistry.class);
+                BulkheadRegistry registry = context.getBean(BulkheadRegistry.class);
+
+                BulkheadConfig backendWithoutSharedConfig = registry.bulkhead("backendWithoutSharedConfig").getBulkheadConfig();
+                // from default config
+                assertThat(backendWithoutSharedConfig.getMaxWaitDuration()).isEqualTo(Duration.ofMillis(10));
+                // from default config
+                assertThat(backendWithoutSharedConfig.isWritableStackTraceEnabled()).isEqualTo(true);
+                // from customizer
+                assertThat(backendWithoutSharedConfig.getMaxConcurrentCalls()).isEqualTo(1000);
+            });
+    }
+
+    @Test
+    public void testCustomizersAreAppliedOnConfigs() {
+        // Given
+        contextRunner.withUserConfiguration(ConfigCustomizerConfiguration.class)
+            .withPropertyValues(
+                "resilience4j.bulkhead.instances.backendWithoutSharedConfig.writableStackTraceEnabled: false",
+                "resilience4j.bulkhead.instances.backendWithSharedConfig.baseConfig: sharedConfig",
+                "resilience4j.bulkhead.instances.backendWithSharedConfig.writableStackTraceEnabled: true"
+            )
+            .run(context -> {
+                // Then
+                assertThat(context).hasSingleBean(BulkheadRegistry.class);
+                BulkheadRegistry registry = context.getBean(BulkheadRegistry.class);
+
+                BulkheadConfig defaultConfig = registry.getConfiguration("default").orElseThrow();
+                // from customizer
+                assertThat(defaultConfig.getMaxWaitDuration()).isEqualTo(Duration.ofMillis(1000));
+                // from customizer
+                assertThat(defaultConfig.isWritableStackTraceEnabled()).isEqualTo(true);
+                // from customizer
+                assertThat(defaultConfig.getMaxConcurrentCalls()).isEqualTo(1000);
+
+                BulkheadConfig backendWithoutSharedConfig = registry.bulkhead("backendWithoutSharedConfig").getBulkheadConfig();
+                // from default config customizer
+                assertThat(backendWithoutSharedConfig.getMaxWaitDuration()).isEqualTo(Duration.ofMillis(1000));
+                // from instance config
+                assertThat(backendWithoutSharedConfig.isWritableStackTraceEnabled()).isEqualTo(false);
+                // from default config customizer
+                assertThat(backendWithoutSharedConfig.getMaxConcurrentCalls()).isEqualTo(1000);
+
+
+                BulkheadConfig backendWithSharedConfig = registry.bulkhead("backendWithSharedConfig").getBulkheadConfig();
+                // from shared config customizer
+                assertThat(backendWithSharedConfig.getMaxWaitDuration()).isEqualTo(Duration.ofMillis(2000));
+                // from instance config
+                assertThat(backendWithSharedConfig.isWritableStackTraceEnabled()).isEqualTo(true);
+                // from shared config customizer
+                assertThat(backendWithSharedConfig.getMaxConcurrentCalls()).isEqualTo(2000);
+
+                BulkheadConfig backendWithoutInstanceConfig = registry.bulkhead("backendWithoutInstanceConfig").getBulkheadConfig();
+                // from default config customizer
+                assertThat(backendWithoutInstanceConfig.getMaxWaitDuration()).isEqualTo(Duration.ofMillis(1000));
+                // from default config customizer
+                assertThat(backendWithoutInstanceConfig.isWritableStackTraceEnabled()).isEqualTo(true);
+                // from default config customizer
+                assertThat(backendWithoutInstanceConfig.getMaxConcurrentCalls()).isEqualTo(1000);
+            });
+    }
+
+    @Configuration
+    public static class CustomizerConfiguration {
+        @Bean
+        public BulkheadConfigCustomizer backendWithoutSharedConfigCustomizer() {
+            return BulkheadConfigCustomizer.of("backendWithoutSharedConfig",
+                builder -> builder.maxConcurrentCalls(1000)
+            );
+        }
+
+        @Bean
+        public BulkheadConfigCustomizer backendWithSharedConfigCustomizer() {
+            return BulkheadConfigCustomizer.of("backendWithSharedConfig",
+                builder -> builder.maxConcurrentCalls(2000)
+            );
+        }
+
+        @Bean
+        public BulkheadConfigCustomizer backendWithoutInstanceConfigCustomizer() {
+            return BulkheadConfigCustomizer.of("backendWithoutInstanceConfig",
+                builder -> builder.maxConcurrentCalls(3000)
+            );
+        }
+    }
+
+    @Configuration
+    public static class ConfigCustomizerConfiguration {
+        @Bean
+        public BulkheadConfigCustomizer defaultCustomizer() {
+            return BulkheadConfigCustomizer.of("default",
+                builder -> builder.writableStackTraceEnabled(true)
+                    .maxConcurrentCalls(1000)
+                    .maxWaitDuration(Duration.ofMillis(1000))
+            );
+        }
+
+        @Bean
+        public BulkheadConfigCustomizer sharedConfigCustomizer() {
+            return BulkheadConfigCustomizer.of("sharedConfig",
+                builder -> builder.writableStackTraceEnabled(false)
+                    .maxConcurrentCalls(2000)
+                    .maxWaitDuration(Duration.ofMillis(2000))
+            );
+        }
+    }
+}

--- a/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/circuitbreaker/autoconfigure/CircuitBreakerAutoConfigurationCustomizerTest.java
+++ b/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/circuitbreaker/autoconfigure/CircuitBreakerAutoConfigurationCustomizerTest.java
@@ -1,0 +1,195 @@
+package io.github.resilience4j.springboot3.circuitbreaker.autoconfigure;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.common.circuitbreaker.configuration.CircuitBreakerConfigCustomizer;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests combinations of config properties ({@code resilience4j.circuitbreaker.configs.<name>.*}),
+ * instance properties ({@code resilience4j.circuitbreaker.instances.<name>.*}) and {@link CircuitBreakerConfigCustomizer}.
+ * <p>
+ * To make this test easier to follow it always uses different magnitude of values for different ways to configure a circuit breaker:
+ * <ul>
+ *     <li>config properties - N * 10</li>
+ *     <li>instance properties - N * 100</li>
+ *     <li>customizer - N * 1000</li>
+ * </ul>
+ * where N is index of the config. This way when asserting value {@code 200} it is guaranteed to be coming from instance properties.
+ */
+public class CircuitBreakerAutoConfigurationCustomizerTest {
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(CircuitBreakerAutoConfiguration.class))
+        .withPropertyValues(
+            "resilience4j.circuitbreaker.configs.default.slidingWindowSize: 10",
+            "resilience4j.circuitbreaker.configs.default.permittedNumberOfCallsInHalfOpenState: 10",
+            "resilience4j.circuitbreaker.configs.default.slowCallDurationThreshold: 10ms",
+            "resilience4j.circuitbreaker.configs.sharedConfig.slidingWindowSize: 20",
+            "resilience4j.circuitbreaker.configs.sharedConfig.permittedNumberOfCallsInHalfOpenState: 20",
+            "resilience4j.circuitbreaker.configs.sharedConfig.slowCallDurationThreshold: 20ms"
+        );
+
+    @Test
+    public void testUserConfigShouldBeAbleToProvideCustomizers() {
+        // Given
+        contextRunner.withUserConfiguration(CustomizerConfiguration.class)
+            .withPropertyValues(
+                "resilience4j.circuitbreaker.instances.backendWithoutSharedConfig.slidingWindowSize: 100",
+                "resilience4j.circuitbreaker.instances.backendWithSharedConfig.baseConfig: sharedConfig",
+                "resilience4j.circuitbreaker.instances.backendWithSharedConfig.slidingWindowSize: 200"
+            )
+            .run(context -> {
+                // Then
+                assertThat(context).hasSingleBean(CircuitBreakerRegistry.class);
+                CircuitBreakerRegistry registry = context.getBean(CircuitBreakerRegistry.class);
+
+                CircuitBreakerConfig backendWithoutSharedConfig = registry.circuitBreaker("backendWithoutSharedConfig").getCircuitBreakerConfig();
+                // from default config
+                assertThat(backendWithoutSharedConfig.getSlowCallDurationThreshold()).isEqualTo(Duration.ofMillis(10));
+                // from instance config
+                assertThat(backendWithoutSharedConfig.getSlidingWindowSize()).isEqualTo(100);
+                // from customizer
+                assertThat(backendWithoutSharedConfig.getPermittedNumberOfCallsInHalfOpenState()).isEqualTo(1000);
+
+                CircuitBreakerConfig backendWithSharedConfig = registry.circuitBreaker("backendWithSharedConfig").getCircuitBreakerConfig();
+                // from default config
+                assertThat(backendWithSharedConfig.getSlowCallDurationThreshold()).isEqualTo(Duration.ofMillis(20));
+                // from instance config
+                assertThat(backendWithSharedConfig.getSlidingWindowSize()).isEqualTo(200);
+                // from customizer
+                assertThat(backendWithSharedConfig.getPermittedNumberOfCallsInHalfOpenState()).isEqualTo(2000);
+
+                CircuitBreakerConfig backendWithoutInstanceConfig = registry.circuitBreaker("backendWithoutInstanceConfig").getCircuitBreakerConfig();
+                // from default config
+                assertThat(backendWithoutInstanceConfig.getSlowCallDurationThreshold()).isEqualTo(Duration.ofMillis(10));
+                // from default config
+                assertThat(backendWithoutInstanceConfig.getSlidingWindowSize()).isEqualTo(10);
+                // from customizer
+                assertThat(backendWithoutInstanceConfig.getPermittedNumberOfCallsInHalfOpenState()).isEqualTo(3000);
+            });
+    }
+
+    @Test
+    public void testCustomizersShouldOverrideProperties() {
+        // Given
+        contextRunner.withUserConfiguration(CustomizerConfiguration.class)
+            .withPropertyValues(
+                "resilience4j.circuitbreaker.instances.backendWithoutSharedConfig.permittedNumberOfCallsInHalfOpenState: 100"
+            )
+            .run(context -> {
+                // Then
+                assertThat(context).hasSingleBean(CircuitBreakerRegistry.class);
+                CircuitBreakerRegistry registry = context.getBean(CircuitBreakerRegistry.class);
+
+                CircuitBreakerConfig backendWithoutSharedConfig = registry.circuitBreaker("backendWithoutSharedConfig").getCircuitBreakerConfig();
+                // from default config
+                assertThat(backendWithoutSharedConfig.getSlowCallDurationThreshold()).isEqualTo(Duration.ofMillis(10));
+                // from default config
+                assertThat(backendWithoutSharedConfig.getSlidingWindowSize()).isEqualTo(10);
+                // from customizer
+                assertThat(backendWithoutSharedConfig.getPermittedNumberOfCallsInHalfOpenState()).isEqualTo(1000);
+            });
+    }
+
+    @Test
+    public void testCustomizersAreAppliedOnConfigs() {
+        // Given
+        contextRunner.withUserConfiguration(ConfigCustomizerConfiguration.class)
+            .withPropertyValues(
+                "resilience4j.circuitbreaker.instances.backendWithoutSharedConfig.slidingWindowSize: 100",
+                "resilience4j.circuitbreaker.instances.backendWithSharedConfig.baseConfig: sharedConfig",
+                "resilience4j.circuitbreaker.instances.backendWithSharedConfig.slidingWindowSize: 200"
+            )
+            .run(context -> {
+                // Then
+                assertThat(context).hasSingleBean(CircuitBreakerRegistry.class);
+                CircuitBreakerRegistry registry = context.getBean(CircuitBreakerRegistry.class);
+
+                CircuitBreakerConfig defaultConfig = registry.getConfiguration("default").orElseThrow();
+                // from customizer
+                assertThat(defaultConfig.getSlowCallDurationThreshold()).isEqualTo(Duration.ofMillis(1000));
+                // from customizer
+                assertThat(defaultConfig.getSlidingWindowSize()).isEqualTo(1000);
+                // from customizer
+                assertThat(defaultConfig.getPermittedNumberOfCallsInHalfOpenState()).isEqualTo(1000);
+
+                CircuitBreakerConfig backendWithoutSharedConfig = registry.circuitBreaker("backendWithoutSharedConfig").getCircuitBreakerConfig();
+                // from default config customizer
+                assertThat(backendWithoutSharedConfig.getSlowCallDurationThreshold()).isEqualTo(Duration.ofMillis(1000));
+                // from instance config
+                assertThat(backendWithoutSharedConfig.getSlidingWindowSize()).isEqualTo(100);
+                // from default config customizer
+                assertThat(backendWithoutSharedConfig.getPermittedNumberOfCallsInHalfOpenState()).isEqualTo(1000);
+
+
+                CircuitBreakerConfig backendWithSharedConfig = registry.circuitBreaker("backendWithSharedConfig").getCircuitBreakerConfig();
+                // from shared config customizer
+                assertThat(backendWithSharedConfig.getSlowCallDurationThreshold()).isEqualTo(Duration.ofMillis(2000));
+                // from instance config
+                assertThat(backendWithSharedConfig.getSlidingWindowSize()).isEqualTo(200);
+                // from shared config customizer
+                assertThat(backendWithSharedConfig.getPermittedNumberOfCallsInHalfOpenState()).isEqualTo(2000);
+
+                CircuitBreakerConfig backendWithoutInstanceConfig = registry.circuitBreaker("backendWithoutInstanceConfig").getCircuitBreakerConfig();
+                // from default config customizer
+                assertThat(backendWithoutInstanceConfig.getSlowCallDurationThreshold()).isEqualTo(Duration.ofMillis(1000));
+                // from default config customizer
+                assertThat(backendWithoutInstanceConfig.getSlidingWindowSize()).isEqualTo(1000);
+                // from default config customizer
+                assertThat(backendWithoutInstanceConfig.getPermittedNumberOfCallsInHalfOpenState()).isEqualTo(1000);
+            });
+    }
+
+    @Configuration
+    public static class CustomizerConfiguration {
+        @Bean
+        public CircuitBreakerConfigCustomizer backendWithoutSharedConfigCustomizer() {
+            return CircuitBreakerConfigCustomizer.of("backendWithoutSharedConfig",
+                builder -> builder.permittedNumberOfCallsInHalfOpenState(1000)
+            );
+        }
+
+        @Bean
+        public CircuitBreakerConfigCustomizer backendWithSharedConfigCustomizer() {
+            return CircuitBreakerConfigCustomizer.of("backendWithSharedConfig",
+                builder -> builder.permittedNumberOfCallsInHalfOpenState(2000)
+            );
+        }
+
+        @Bean
+        public CircuitBreakerConfigCustomizer backendWithoutInstanceConfigCustomizer() {
+            return CircuitBreakerConfigCustomizer.of("backendWithoutInstanceConfig",
+                builder -> builder.permittedNumberOfCallsInHalfOpenState(3000)
+            );
+        }
+    }
+
+    @Configuration
+    public static class ConfigCustomizerConfiguration {
+        @Bean
+        public CircuitBreakerConfigCustomizer defaultCustomizer() {
+            return CircuitBreakerConfigCustomizer.of("default",
+                builder -> builder.slidingWindowSize(1000)
+                    .permittedNumberOfCallsInHalfOpenState(1000)
+                    .slowCallDurationThreshold(Duration.ofMillis(1000))
+            );
+        }
+
+        @Bean
+        public CircuitBreakerConfigCustomizer sharedConfigCustomizer() {
+            return CircuitBreakerConfigCustomizer.of("sharedConfig",
+                builder -> builder.slidingWindowSize(2000)
+                    .permittedNumberOfCallsInHalfOpenState(2000)
+                    .slowCallDurationThreshold(Duration.ofMillis(2000))
+            );
+        }
+    }
+}

--- a/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/ratelimiter/autoconfigure/RateLimiterAutoConfigurationCustomizerTest.java
+++ b/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/ratelimiter/autoconfigure/RateLimiterAutoConfigurationCustomizerTest.java
@@ -1,0 +1,195 @@
+package io.github.resilience4j.springboot3.ratelimiter.autoconfigure;
+
+import io.github.resilience4j.ratelimiter.RateLimiterConfig;
+import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
+import io.github.resilience4j.common.ratelimiter.configuration.RateLimiterConfigCustomizer;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests combinations of config properties ({@code resilience4j.ratelimiter.configs.<name>.*}),
+ * instance properties ({@code resilience4j.ratelimiter.instances.<name>.*}) and {@link RateLimiterConfigCustomizer}.
+ * <p>
+ * To make this test easier to follow it always uses different magnitude of values for different ways to configure a rate limiter:
+ * <ul>
+ *     <li>config properties - N * 10</li>
+ *     <li>instance properties - N * 100</li>
+ *     <li>customizer - N * 1000</li>
+ * </ul>
+ * where N is index of the config. This way when asserting value {@code 200} it is guaranteed to be coming from instance properties.
+ */
+public class RateLimiterAutoConfigurationCustomizerTest {
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(RateLimiterAutoConfiguration.class))
+        .withPropertyValues(
+            "resilience4j.ratelimiter.configs.default.limitForPeriod: 10",
+            "resilience4j.ratelimiter.configs.default.timeoutDuration: 10ms",
+            "resilience4j.ratelimiter.configs.default.limitRefreshPeriod: 10ms",
+            "resilience4j.ratelimiter.configs.sharedConfig.limitForPeriod: 20",
+            "resilience4j.ratelimiter.configs.sharedConfig.timeoutDuration: 20ms",
+            "resilience4j.ratelimiter.configs.sharedConfig.limitRefreshPeriod: 20ms"
+        );
+
+    @Test
+    public void testUserConfigShouldBeAbleToProvideCustomizers() {
+        // Given
+        contextRunner.withUserConfiguration(CustomizerConfiguration.class)
+            .withPropertyValues(
+                "resilience4j.ratelimiter.instances.backendWithoutSharedConfig.limitForPeriod: 100",
+                "resilience4j.ratelimiter.instances.backendWithSharedConfig.baseConfig: sharedConfig",
+                "resilience4j.ratelimiter.instances.backendWithSharedConfig.limitForPeriod: 200"
+            )
+            .run(context -> {
+                // Then
+                assertThat(context).hasSingleBean(RateLimiterRegistry.class);
+                RateLimiterRegistry registry = context.getBean(RateLimiterRegistry.class);
+
+                RateLimiterConfig backendWithoutSharedConfig = registry.rateLimiter("backendWithoutSharedConfig").getRateLimiterConfig();
+                // from default config
+                assertThat(backendWithoutSharedConfig.getLimitRefreshPeriod()).isEqualTo(Duration.ofMillis(10));
+                // from instance config
+                assertThat(backendWithoutSharedConfig.getLimitForPeriod()).isEqualTo(100);
+                // from customizer
+                assertThat(backendWithoutSharedConfig.getTimeoutDuration()).isEqualTo(Duration.ofMillis(1000));
+
+                RateLimiterConfig backendWithSharedConfig = registry.rateLimiter("backendWithSharedConfig").getRateLimiterConfig();
+                // from default config
+                assertThat(backendWithSharedConfig.getLimitRefreshPeriod()).isEqualTo(Duration.ofMillis(20));
+                // from instance config
+                assertThat(backendWithSharedConfig.getLimitForPeriod()).isEqualTo(200);
+                // from customizer
+                assertThat(backendWithSharedConfig.getTimeoutDuration()).isEqualTo(Duration.ofMillis(2000));
+
+                RateLimiterConfig backendWithoutInstanceConfig = registry.rateLimiter("backendWithoutInstanceConfig").getRateLimiterConfig();
+                // from default config
+                assertThat(backendWithoutInstanceConfig.getLimitRefreshPeriod()).isEqualTo(Duration.ofMillis(10));
+                // from default config
+                assertThat(backendWithoutInstanceConfig.getLimitForPeriod()).isEqualTo(10);
+                // from customizer
+                assertThat(backendWithoutInstanceConfig.getTimeoutDuration()).isEqualTo(Duration.ofMillis(3000));
+            });
+    }
+
+    @Test
+    public void testCustomizersShouldOverrideProperties() {
+        // Given
+        contextRunner.withUserConfiguration(CustomizerConfiguration.class)
+            .withPropertyValues(
+                "resilience4j.ratelimiter.instances.backendWithoutSharedConfig.timeoutDuration: 100ms"
+            )
+            .run(context -> {
+                // Then
+                assertThat(context).hasSingleBean(RateLimiterRegistry.class);
+                RateLimiterRegistry registry = context.getBean(RateLimiterRegistry.class);
+
+                RateLimiterConfig backendWithoutSharedConfig = registry.rateLimiter("backendWithoutSharedConfig").getRateLimiterConfig();
+                // from default config
+                assertThat(backendWithoutSharedConfig.getLimitRefreshPeriod()).isEqualTo(Duration.ofMillis(10));
+                // from default config
+                assertThat(backendWithoutSharedConfig.getLimitForPeriod()).isEqualTo(10);
+                // from customizer
+                assertThat(backendWithoutSharedConfig.getTimeoutDuration()).isEqualTo(Duration.ofMillis(1000));
+            });
+    }
+
+    @Test
+    public void testCustomizersAreAppliedOnConfigs() {
+        // Given
+        contextRunner.withUserConfiguration(ConfigCustomizerConfiguration.class)
+            .withPropertyValues(
+                "resilience4j.ratelimiter.instances.backendWithoutSharedConfig.limitForPeriod: 100",
+                "resilience4j.ratelimiter.instances.backendWithSharedConfig.baseConfig: sharedConfig",
+                "resilience4j.ratelimiter.instances.backendWithSharedConfig.limitForPeriod: 200"
+            )
+            .run(context -> {
+                // Then
+                assertThat(context).hasSingleBean(RateLimiterRegistry.class);
+                RateLimiterRegistry registry = context.getBean(RateLimiterRegistry.class);
+
+                RateLimiterConfig defaultConfig = registry.getConfiguration("default").orElseThrow();
+                // from customizer
+                assertThat(defaultConfig.getLimitRefreshPeriod()).isEqualTo(Duration.ofMillis(1000));
+                // from customizer
+                assertThat(defaultConfig.getLimitForPeriod()).isEqualTo(1000);
+                // from customizer
+                assertThat(defaultConfig.getTimeoutDuration()).isEqualTo(Duration.ofMillis(1000));
+
+                RateLimiterConfig backendWithoutSharedConfig = registry.rateLimiter("backendWithoutSharedConfig").getRateLimiterConfig();
+                // from default config customizer
+                assertThat(backendWithoutSharedConfig.getLimitRefreshPeriod()).isEqualTo(Duration.ofMillis(1000));
+                // from instance config
+                assertThat(backendWithoutSharedConfig.getLimitForPeriod()).isEqualTo(100);
+                // from default config customizer
+                assertThat(backendWithoutSharedConfig.getTimeoutDuration()).isEqualTo(Duration.ofMillis(1000));
+
+
+                RateLimiterConfig backendWithSharedConfig = registry.rateLimiter("backendWithSharedConfig").getRateLimiterConfig();
+                // from shared config customizer
+                assertThat(backendWithSharedConfig.getLimitRefreshPeriod()).isEqualTo(Duration.ofMillis(2000));
+                // from instance config
+                assertThat(backendWithSharedConfig.getLimitForPeriod()).isEqualTo(200);
+                // from shared config customizer
+                assertThat(backendWithSharedConfig.getTimeoutDuration()).isEqualTo(Duration.ofMillis(2000));
+
+                RateLimiterConfig backendWithoutInstanceConfig = registry.rateLimiter("backendWithoutInstanceConfig").getRateLimiterConfig();
+                // from default config customizer
+                assertThat(backendWithoutInstanceConfig.getLimitRefreshPeriod()).isEqualTo(Duration.ofMillis(1000));
+                // from default config customizer
+                assertThat(backendWithoutInstanceConfig.getLimitForPeriod()).isEqualTo(1000);
+                // from default config customizer
+                assertThat(backendWithoutInstanceConfig.getTimeoutDuration()).isEqualTo(Duration.ofMillis(1000));
+            });
+    }
+
+    @Configuration
+    public static class CustomizerConfiguration {
+        @Bean
+        public RateLimiterConfigCustomizer backendWithoutSharedConfigCustomizer() {
+            return RateLimiterConfigCustomizer.of("backendWithoutSharedConfig",
+                builder -> builder.timeoutDuration(Duration.ofMillis(1000))
+            );
+        }
+
+        @Bean
+        public RateLimiterConfigCustomizer backendWithSharedConfigCustomizer() {
+            return RateLimiterConfigCustomizer.of("backendWithSharedConfig",
+                    builder -> builder.timeoutDuration(Duration.ofMillis(2000))
+            );
+        }
+
+        @Bean
+        public RateLimiterConfigCustomizer backendWithoutInstanceConfigCustomizer() {
+            return RateLimiterConfigCustomizer.of("backendWithoutInstanceConfig",
+                builder -> builder.timeoutDuration(Duration.ofMillis(3000))
+            );
+        }
+    }
+
+    @Configuration
+    public static class ConfigCustomizerConfiguration {
+        @Bean
+        public RateLimiterConfigCustomizer defaultCustomizer() {
+            return RateLimiterConfigCustomizer.of("default",
+                builder -> builder.limitForPeriod(1000)
+                    .timeoutDuration(Duration.ofMillis(1000))
+                    .limitRefreshPeriod(Duration.ofMillis(1000))
+            );
+        }
+
+        @Bean
+        public RateLimiterConfigCustomizer sharedConfigCustomizer() {
+            return RateLimiterConfigCustomizer.of("sharedConfig",
+                builder -> builder.limitForPeriod(2000)
+                    .timeoutDuration(Duration.ofMillis(2000))
+                    .limitRefreshPeriod(Duration.ofMillis(2000))
+            );
+        }
+    }
+}

--- a/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/retry/autoconfigure/RetryAutoConfigurationCustomizerTest.java
+++ b/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/retry/autoconfigure/RetryAutoConfigurationCustomizerTest.java
@@ -1,0 +1,195 @@
+package io.github.resilience4j.springboot3.retry.autoconfigure;
+
+import io.github.resilience4j.retry.RetryConfig;
+import io.github.resilience4j.retry.RetryRegistry;
+import io.github.resilience4j.common.retry.configuration.RetryConfigCustomizer;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests combinations of config properties ({@code resilience4j.retry.configs.<name>.*}),
+ * instance properties ({@code resilience4j.retry.instances.<name>.*}) and {@link RetryConfigCustomizer}.
+ * <p>
+ * To make this test easier to follow it always uses different magnitude of values for different ways to configure a retry:
+ * <ul>
+ *     <li>config properties - N * 10</li>
+ *     <li>instance properties - N * 100</li>
+ *     <li>customizer - N * 1000</li>
+ * </ul>
+ * where N is index of the config. This way when asserting value {@code 200} it is guaranteed to be coming from instance properties.
+ */
+public class RetryAutoConfigurationCustomizerTest {
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(RetryAutoConfiguration.class))
+        .withPropertyValues(
+            "resilience4j.retry.configs.default.maxAttempts: 10",
+            "resilience4j.retry.configs.default.writableStackTraceEnabled: true",
+            "resilience4j.retry.configs.default.waitDuration: 10ms",
+            "resilience4j.retry.configs.sharedConfig.maxAttempts: 20",
+            "resilience4j.retry.configs.sharedConfig.writableStackTraceEnabled: false",
+            "resilience4j.retry.configs.sharedConfig.waitDuration: 20ms"
+        );
+
+    @Test
+    public void testUserConfigShouldBeAbleToProvideCustomizers() {
+        // Given
+        contextRunner.withUserConfiguration(CustomizerConfiguration.class)
+            .withPropertyValues(
+                "resilience4j.retry.instances.backendWithoutSharedConfig.maxAttempts: 100",
+                "resilience4j.retry.instances.backendWithSharedConfig.baseConfig: sharedConfig",
+                "resilience4j.retry.instances.backendWithSharedConfig.maxAttempts: 200"
+            )
+            .run(context -> {
+                // Then
+                assertThat(context).hasSingleBean(RetryRegistry.class);
+                RetryRegistry registry = context.getBean(RetryRegistry.class);
+
+                RetryConfig backendWithoutSharedConfig = registry.retry("backendWithoutSharedConfig").getRetryConfig();
+                // from default config
+                assertThat(backendWithoutSharedConfig.getIntervalBiFunction().apply(0, null)).isEqualTo(10);
+                // from instance config
+                assertThat(backendWithoutSharedConfig.getMaxAttempts()).isEqualTo(100);
+                // from customizer
+                assertThat(backendWithoutSharedConfig.isWritableStackTraceEnabled()).isEqualTo(true);
+
+                RetryConfig backendWithSharedConfig = registry.retry("backendWithSharedConfig").getRetryConfig();
+                // from default config
+                assertThat(backendWithSharedConfig.getIntervalBiFunction().apply(0, null)).isEqualTo(20);
+                // from instance config
+                assertThat(backendWithSharedConfig.getMaxAttempts()).isEqualTo(200);
+                // from customizer
+                assertThat(backendWithSharedConfig.isWritableStackTraceEnabled()).isEqualTo(false);
+
+                RetryConfig backendWithoutInstanceConfig = registry.retry("backendWithoutInstanceConfig").getRetryConfig();
+                // from default config
+                assertThat(backendWithoutInstanceConfig.getIntervalBiFunction().apply(0, null)).isEqualTo(10);
+                // from default config
+                assertThat(backendWithoutInstanceConfig.getMaxAttempts()).isEqualTo(10);
+                // from customizer
+                assertThat(backendWithoutInstanceConfig.isWritableStackTraceEnabled()).isEqualTo(true);
+            });
+    }
+
+    @Test
+    public void testCustomizersShouldOverrideProperties() {
+        // Given
+        contextRunner.withUserConfiguration(CustomizerConfiguration.class)
+            .withPropertyValues(
+                "resilience4j.retry.instances.backendWithoutSharedConfig.writableStackTraceEnabled: false"
+            )
+            .run(context -> {
+                // Then
+                assertThat(context).hasSingleBean(RetryRegistry.class);
+                RetryRegistry registry = context.getBean(RetryRegistry.class);
+
+                RetryConfig backendWithoutSharedConfig = registry.retry("backendWithoutSharedConfig").getRetryConfig();
+                // from default config
+                assertThat(backendWithoutSharedConfig.getIntervalBiFunction().apply(0, null)).isEqualTo(10);
+                // from default config
+                assertThat(backendWithoutSharedConfig.getMaxAttempts()).isEqualTo(10);
+                // from customizer
+                assertThat(backendWithoutSharedConfig.isWritableStackTraceEnabled()).isEqualTo(true);
+            });
+    }
+
+    @Test
+    public void testCustomizersAreAppliedOnConfigs() {
+        // Given
+        contextRunner.withUserConfiguration(ConfigCustomizerConfiguration.class)
+            .withPropertyValues(
+                "resilience4j.retry.instances.backendWithoutSharedConfig.maxAttempts: 100",
+                "resilience4j.retry.instances.backendWithSharedConfig.baseConfig: sharedConfig",
+                "resilience4j.retry.instances.backendWithSharedConfig.maxAttempts: 200"
+            )
+            .run(context -> {
+                // Then
+                assertThat(context).hasSingleBean(RetryRegistry.class);
+                RetryRegistry registry = context.getBean(RetryRegistry.class);
+
+                RetryConfig defaultConfig = registry.getConfiguration("default").orElseThrow();
+                // from customizer
+                assertThat(defaultConfig.getIntervalBiFunction().apply(0, null)).isEqualTo(1000);
+                // from customizer
+                assertThat(defaultConfig.getMaxAttempts()).isEqualTo(1000);
+                // from customizer
+                assertThat(defaultConfig.isWritableStackTraceEnabled()).isEqualTo(true);
+
+                RetryConfig backendWithoutSharedConfig = registry.retry("backendWithoutSharedConfig").getRetryConfig();
+                // from default config customizer
+                assertThat(backendWithoutSharedConfig.getIntervalBiFunction().apply(0, null)).isEqualTo(1000);
+                // from instance config
+                assertThat(backendWithoutSharedConfig.getMaxAttempts()).isEqualTo(100);
+                // from default config customizer
+                assertThat(backendWithoutSharedConfig.isWritableStackTraceEnabled()).isEqualTo(true);
+
+
+                RetryConfig backendWithSharedConfig = registry.retry("backendWithSharedConfig").getRetryConfig();
+                // from shared config customizer
+                assertThat(backendWithSharedConfig.getIntervalBiFunction().apply(0, null)).isEqualTo(2000);
+                // from instance config
+                assertThat(backendWithSharedConfig.getMaxAttempts()).isEqualTo(200);
+                // from shared config customizer
+                assertThat(backendWithSharedConfig.isWritableStackTraceEnabled()).isEqualTo(false);
+
+                RetryConfig backendWithoutInstanceConfig = registry.retry("backendWithoutInstanceConfig").getRetryConfig();
+                // from default config customizer
+                assertThat(backendWithoutInstanceConfig.getIntervalBiFunction().apply(0, null)).isEqualTo(1000);
+                // from default config customizer
+                assertThat(backendWithoutInstanceConfig.getMaxAttempts()).isEqualTo(1000);
+                // from default config customizer
+                assertThat(backendWithoutInstanceConfig.isWritableStackTraceEnabled()).isEqualTo(true);
+            });
+    }
+
+    @Configuration
+    public static class CustomizerConfiguration {
+        @Bean
+        public RetryConfigCustomizer backendWithoutSharedConfigCustomizer() {
+            return RetryConfigCustomizer.of("backendWithoutSharedConfig",
+                builder -> builder.writableStackTraceEnabled(true)
+            );
+        }
+
+        @Bean
+        public RetryConfigCustomizer backendWithSharedConfigCustomizer() {
+            return RetryConfigCustomizer.of("backendWithSharedConfig",
+                builder -> builder.writableStackTraceEnabled(false)
+            );
+        }
+
+        @Bean
+        public RetryConfigCustomizer backendWithoutInstanceConfigCustomizer() {
+            return RetryConfigCustomizer.of("backendWithoutInstanceConfig",
+                builder -> builder.writableStackTraceEnabled(true)
+            );
+        }
+    }
+
+    @Configuration
+    public static class ConfigCustomizerConfiguration {
+        @Bean
+        public RetryConfigCustomizer defaultCustomizer() {
+            return RetryConfigCustomizer.of("default",
+                builder -> builder.maxAttempts(1000)
+                    .writableStackTraceEnabled(true)
+                    .waitDuration(Duration.ofMillis(1000))
+            );
+        }
+
+        @Bean
+        public RetryConfigCustomizer sharedConfigCustomizer() {
+            return RetryConfigCustomizer.of("sharedConfig",
+                builder -> builder.maxAttempts(2000)
+                    .writableStackTraceEnabled(false)
+                    .waitDuration(Duration.ofMillis(2000))
+            );
+        }
+    }
+}

--- a/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/timelimiter/autoconfigure/TimeLimiterAutoConfigurationCustomizerTest.java
+++ b/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/timelimiter/autoconfigure/TimeLimiterAutoConfigurationCustomizerTest.java
@@ -1,0 +1,175 @@
+package io.github.resilience4j.springboot3.timelimiter.autoconfigure;
+
+import io.github.resilience4j.timelimiter.TimeLimiterConfig;
+import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
+import io.github.resilience4j.common.timelimiter.configuration.TimeLimiterConfigCustomizer;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests combinations of config properties ({@code resilience4j.timelimiter.configs.<name>.*}),
+ * instance properties ({@code resilience4j.timelimiter.instances.<name>.*}) and {@link TimeLimiterConfigCustomizer}.
+ * <p>
+ * To make this test easier to follow it always uses different magnitude of values for different ways to configure a time limiter:
+ * <ul>
+ *     <li>config properties - N * 10</li>
+ *     <li>instance properties - N * 100</li>
+ *     <li>customizer - N * 1000</li>
+ * </ul>
+ * where N is index of the config. This way when asserting value {@code 200} it is guaranteed to be coming from instance properties.
+ */
+public class TimeLimiterAutoConfigurationCustomizerTest {
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(TimeLimiterAutoConfiguration.class))
+        .withPropertyValues(
+            "resilience4j.timelimiter.configs.default.cancelRunningFuture: true",
+            "resilience4j.timelimiter.configs.default.timeoutDuration: 10ms",
+            "resilience4j.timelimiter.configs.sharedConfig.cancelRunningFuture: false",
+            "resilience4j.timelimiter.configs.sharedConfig.timeoutDuration: 20ms"
+        );
+
+    @Test
+    public void testUserConfigShouldBeAbleToProvideCustomizers() {
+        // Given
+        contextRunner.withUserConfiguration(CustomizerConfiguration.class)
+            .withPropertyValues(
+                "resilience4j.timelimiter.instances.backendWithoutSharedConfig.cancelRunningFuture: false",
+                "resilience4j.timelimiter.instances.backendWithSharedConfig.baseConfig: sharedConfig",
+                "resilience4j.timelimiter.instances.backendWithSharedConfig.cancelRunningFuture: true"
+            )
+            .run(context -> {
+                // Then
+                assertThat(context).hasSingleBean(TimeLimiterRegistry.class);
+                TimeLimiterRegistry registry = context.getBean(TimeLimiterRegistry.class);
+
+                TimeLimiterConfig backendWithoutSharedConfig = registry.timeLimiter("backendWithoutSharedConfig").getTimeLimiterConfig();
+                // from instance config
+                assertThat(backendWithoutSharedConfig.shouldCancelRunningFuture()).isEqualTo(false);
+                // from customizer
+                assertThat(backendWithoutSharedConfig.getTimeoutDuration()).isEqualTo(Duration.ofMillis(1000));
+
+                TimeLimiterConfig backendWithSharedConfig = registry.timeLimiter("backendWithSharedConfig").getTimeLimiterConfig();
+                // from instance config
+                assertThat(backendWithSharedConfig.shouldCancelRunningFuture()).isEqualTo(true);
+                // from customizer
+                assertThat(backendWithSharedConfig.getTimeoutDuration()).isEqualTo(Duration.ofMillis(2000));
+
+                TimeLimiterConfig backendWithoutInstanceConfig = registry.timeLimiter("backendWithoutInstanceConfig").getTimeLimiterConfig();
+                // from default config
+                assertThat(backendWithoutInstanceConfig.shouldCancelRunningFuture()).isEqualTo(true);
+                // from customizer
+                assertThat(backendWithoutInstanceConfig.getTimeoutDuration()).isEqualTo(Duration.ofMillis(3000));
+            });
+    }
+
+    @Test
+    public void testCustomizersShouldOverrideProperties() {
+        // Given
+        contextRunner.withUserConfiguration(CustomizerConfiguration.class)
+            .withPropertyValues(
+                "resilience4j.timelimiter.instances.backendWithoutSharedConfig.timeoutDuration: 100"
+            )
+            .run(context -> {
+                // Then
+                assertThat(context).hasSingleBean(TimeLimiterRegistry.class);
+                TimeLimiterRegistry registry = context.getBean(TimeLimiterRegistry.class);
+
+                TimeLimiterConfig backendWithoutSharedConfig = registry.timeLimiter("backendWithoutSharedConfig").getTimeLimiterConfig();
+                // from default config
+                assertThat(backendWithoutSharedConfig.shouldCancelRunningFuture()).isEqualTo(true);
+                // from customizer
+                assertThat(backendWithoutSharedConfig.getTimeoutDuration()).isEqualTo(Duration.ofMillis(1000));
+            });
+    }
+
+    @Test
+    public void testCustomizersAreAppliedOnConfigs() {
+        // Given
+        contextRunner.withUserConfiguration(ConfigCustomizerConfiguration.class)
+            .withPropertyValues(
+                "resilience4j.timelimiter.instances.backendWithoutSharedConfig.cancelRunningFuture: false",
+                "resilience4j.timelimiter.instances.backendWithSharedConfig.baseConfig: sharedConfig",
+                "resilience4j.timelimiter.instances.backendWithSharedConfig.cancelRunningFuture: true"
+            )
+            .run(context -> {
+                // Then
+                assertThat(context).hasSingleBean(TimeLimiterRegistry.class);
+                TimeLimiterRegistry registry = context.getBean(TimeLimiterRegistry.class);
+
+                TimeLimiterConfig defaultConfig = registry.getConfiguration("default").orElseThrow();
+                // from customizer
+                assertThat(defaultConfig.getTimeoutDuration()).isEqualTo(Duration.ofMillis(1000));
+                // from customizer
+                assertThat(defaultConfig.shouldCancelRunningFuture()).isEqualTo(true);
+
+                TimeLimiterConfig backendWithoutSharedConfig = registry.timeLimiter("backendWithoutSharedConfig").getTimeLimiterConfig();
+                // from default config customizer
+                assertThat(backendWithoutSharedConfig.getTimeoutDuration()).isEqualTo(Duration.ofMillis(1000));
+                // from instance config
+                assertThat(backendWithoutSharedConfig.shouldCancelRunningFuture()).isEqualTo(false);
+
+
+                TimeLimiterConfig backendWithSharedConfig = registry.timeLimiter("backendWithSharedConfig").getTimeLimiterConfig();
+                // from shared config customizer
+                assertThat(backendWithSharedConfig.getTimeoutDuration()).isEqualTo(Duration.ofMillis(2000));
+                // from instance config
+                assertThat(backendWithSharedConfig.shouldCancelRunningFuture()).isEqualTo(true);
+
+                TimeLimiterConfig backendWithoutInstanceConfig = registry.timeLimiter("backendWithoutInstanceConfig").getTimeLimiterConfig();
+                // from default config customizer
+                assertThat(backendWithoutInstanceConfig.getTimeoutDuration()).isEqualTo(Duration.ofMillis(1000));
+                // from default config customizer
+                assertThat(backendWithoutInstanceConfig.shouldCancelRunningFuture()).isEqualTo(true);
+            });
+    }
+
+    @Configuration
+    public static class CustomizerConfiguration {
+        @Bean
+        public TimeLimiterConfigCustomizer backendWithoutSharedConfigCustomizer() {
+            return TimeLimiterConfigCustomizer.of("backendWithoutSharedConfig",
+                builder -> builder.timeoutDuration(Duration.ofMillis(1000))
+            );
+        }
+
+        @Bean
+        public TimeLimiterConfigCustomizer backendWithSharedConfigCustomizer() {
+            return TimeLimiterConfigCustomizer.of("backendWithSharedConfig",
+                builder -> builder.timeoutDuration(Duration.ofMillis(2000))
+            );
+        }
+
+        @Bean
+        public TimeLimiterConfigCustomizer backendWithoutInstanceConfigCustomizer() {
+            return TimeLimiterConfigCustomizer.of("backendWithoutInstanceConfig",
+                builder -> builder.timeoutDuration(Duration.ofMillis(3000))
+            );
+        }
+    }
+
+    @Configuration
+    public static class ConfigCustomizerConfiguration {
+        @Bean
+        public TimeLimiterConfigCustomizer defaultCustomizer() {
+            return TimeLimiterConfigCustomizer.of("default",
+                builder -> builder.cancelRunningFuture(true)
+                    .timeoutDuration(Duration.ofMillis(1000))
+            );
+        }
+
+        @Bean
+        public TimeLimiterConfigCustomizer sharedConfigCustomizer() {
+            return TimeLimiterConfigCustomizer.of("sharedConfig",
+                builder -> builder.cancelRunningFuture(false)
+                    .timeoutDuration(Duration.ofMillis(2000))
+            );
+        }
+    }
+}

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/retry/configure/RetryConfiguration.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/retry/configure/RetryConfiguration.java
@@ -77,11 +77,25 @@ public class RetryConfiguration {
             retryRegistryEventConsumer, compositeRetryCustomizer);
         registerEventConsumer(retryRegistry, retryEventConsumerRegistry,
             retryConfigurationProperties);
-        retryConfigurationProperties.getInstances()
-            .forEach((name, properties) ->
-                retryRegistry.retry(name, retryConfigurationProperties
-                    .createRetryConfig(name, compositeRetryCustomizer)));
+        initRetryRegistry(retryConfigurationProperties, compositeRetryCustomizer, retryRegistry);
         return retryRegistry;
+    }
+    /**
+     * Initializes the Retry registry with resilience4j instances.
+     *
+     * @param retryRegistry The retry registry.
+     * @param compositeRetryCustomizer customizers for instances and configs
+     */
+    private void initRetryRegistry(RetryConfigurationProperties retryConfigurationProperties,
+        CompositeCustomizer<RetryConfigCustomizer> compositeRetryCustomizer, RetryRegistry retryRegistry) {
+        retryConfigurationProperties.getInstances().forEach((name, properties) ->
+            retryRegistry.retry(name, retryConfigurationProperties.createRetryConfig(name, compositeRetryCustomizer)));
+
+        compositeRetryCustomizer.instanceNames()
+            .stream()
+            .filter(name -> retryRegistry.getConfiguration(name).isEmpty())
+            .forEach(name ->
+                retryRegistry.retry(name, retryConfigurationProperties.createRetryConfig(name, compositeRetryCustomizer)));
     }
 
     @Bean

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterConfiguration.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterConfiguration.java
@@ -144,7 +144,7 @@ public class TimeLimiterConfiguration {
     }
 
     /**
-     * Initializes the TimeLimiter registry.
+     * Initializes the TimeLimiter registry with resilience4j instances.
      *
      * @param timeLimiterRegistry The time limiter registry.
      * @param compositeTimeLimiterCustomizer The Composite time limiter customizer
@@ -154,11 +154,19 @@ public class TimeLimiterConfiguration {
         TimeLimiterConfigurationProperties timeLimiterConfigurationProperties,
         CompositeCustomizer<TimeLimiterConfigCustomizer> compositeTimeLimiterCustomizer) {
 
-        timeLimiterConfigurationProperties.getInstances().forEach(
-            (name, properties) -> timeLimiterRegistry.timeLimiter(name,
+        timeLimiterConfigurationProperties.getInstances().forEach((name, properties) ->
+            timeLimiterRegistry.timeLimiter(name,
                 timeLimiterConfigurationProperties
                     .createTimeLimiterConfig(name, properties, compositeTimeLimiterCustomizer))
         );
+
+        compositeTimeLimiterCustomizer.instanceNames()
+            .stream()
+            .filter(name -> timeLimiterRegistry.getConfiguration(name).isEmpty())
+            .forEach(name ->
+                timeLimiterRegistry.timeLimiter(name, timeLimiterConfigurationProperties
+                    .createTimeLimiterConfig(name, null, compositeTimeLimiterCustomizer))
+            );
     }
     /**
      * Registers the post creation consumer function that registers the consumer events to the timeLimiters.


### PR DESCRIPTION
Ports the fixes for #1787 to resilience4j-spring-boot3 and resilience4j-spring6. Closes #2320 .

Modifies the autoconfiguration logic for registries for spring boot 3 in the same way as the PR for #1787 did for spring boot 2; see b9a6b5f9d for details (PR #1819).

The only difference is there's an additional fix for SpringBootCommonTest where customizers were not actually been triggered, masking a bug in the test code.