### PR TITLE
Provide key for components using SpEL for names

### DIFF
--- a/resilience4j-annotations/src/main/java/io/github/resilience4j/bulkhead/annotation/Bulkhead.java
+++ b/resilience4j-annotations/src/main/java/io/github/resilience4j/bulkhead/annotation/Bulkhead.java
@@ -23,6 +23,12 @@ public @interface Bulkhead {
     String name();
 
     /**
+     * Configuration key to use if name is given as a SpEL expression share the same configuration
+     * @return the configuration key
+     */
+    String configuration() default "";
+
+    /**
      * fallbackMethod method name.
      *
      * @return fallbackMethod method name.

--- a/resilience4j-annotations/src/main/java/io/github/resilience4j/circuitbreaker/annotation/CircuitBreaker.java
+++ b/resilience4j-annotations/src/main/java/io/github/resilience4j/circuitbreaker/annotation/CircuitBreaker.java
@@ -44,6 +44,12 @@ public @interface CircuitBreaker {
     String name();
 
     /**
+     * Configuration key to use if name is given as a SpEL expression share the same configuration
+     * @return the configuration key
+     */
+    String configuration() default "";
+
+    /**
      * fallbackMethod method name.
      *
      * @return fallbackMethod method name.

--- a/resilience4j-annotations/src/main/java/io/github/resilience4j/micrometer/annotation/Timer.java
+++ b/resilience4j-annotations/src/main/java/io/github/resilience4j/micrometer/annotation/Timer.java
@@ -40,6 +40,12 @@ public @interface Timer {
     String name();
 
     /**
+     * Configuration key to use if name is given as a SpEL expression share the same configuration
+     * @return the configuration key
+     */
+    String configuration() default "";
+
+    /**
      * fallbackMethod method name.
      *
      * @return fallbackMethod method name.

--- a/resilience4j-annotations/src/main/java/io/github/resilience4j/ratelimiter/annotation/RateLimiter.java
+++ b/resilience4j-annotations/src/main/java/io/github/resilience4j/ratelimiter/annotation/RateLimiter.java
@@ -40,6 +40,12 @@ public @interface RateLimiter {
     String name();
 
     /**
+     * Configuration key to use if name is given as a SpEL expression share the same configuration
+     * @return the configuration key
+     */
+    String configurationKey() default "";
+
+    /**
      * fallbackMethod method name.
      *
      * @return fallbackMethod method name.

--- a/resilience4j-annotations/src/main/java/io/github/resilience4j/ratelimiter/annotation/RateLimiter.java
+++ b/resilience4j-annotations/src/main/java/io/github/resilience4j/ratelimiter/annotation/RateLimiter.java
@@ -43,7 +43,7 @@ public @interface RateLimiter {
      * Configuration key to use if name is given as a SpEL expression share the same configuration
      * @return the configuration key
      */
-    String configurationKey() default "";
+    String configuration() default "";
 
     /**
      * fallbackMethod method name.

--- a/resilience4j-annotations/src/main/java/io/github/resilience4j/retry/annotation/Retry.java
+++ b/resilience4j-annotations/src/main/java/io/github/resilience4j/retry/annotation/Retry.java
@@ -39,6 +39,12 @@ public @interface Retry {
     String name();
 
     /**
+     * Configuration key to use if name is given as a SpEL expression share the same configuration
+     * @return the configuration key
+     */
+    String configuration() default "";
+
+    /**
      * fallbackMethod method name.
      *
      * @return fallbackMethod method name.

--- a/resilience4j-annotations/src/main/java/io/github/resilience4j/timelimiter/annotation/TimeLimiter.java
+++ b/resilience4j-annotations/src/main/java/io/github/resilience4j/timelimiter/annotation/TimeLimiter.java
@@ -40,6 +40,12 @@ public @interface TimeLimiter {
     String name();
 
     /**
+     * Configuration key to use if name is given as a SpEL expression share the same configuration
+     * @return the configuration key
+     */
+    String configuration() default "";
+
+    /**
      * fallbackMethod method name.
      *
      * @return fallbackMethod method name.

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/bulkhead/configure/BulkheadAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/bulkhead/configure/BulkheadAspect.java
@@ -151,7 +151,7 @@ public class BulkheadAspect implements Ordered {
     private io.github.resilience4j.bulkhead.Bulkhead getOrCreateBulkhead(String methodName,
         String backend, String configKey) {
         BulkheadConfig config = bulkheadRegistry.getConfiguration(configKey)
-            .orElse(bulkheadRegistry.getDefaultConfig());
+            .orElseGet(bulkheadRegistry::getDefaultConfig);
         var bulkhead = bulkheadRegistry.bulkhead(backend, config);
 
         if (logger.isDebugEnabled()) {

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/bulkhead/configure/BulkheadAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/bulkhead/configure/BulkheadAspect.java
@@ -38,6 +38,7 @@ import io.github.resilience4j.bulkhead.BulkheadConfig;
 import io.github.resilience4j.bulkhead.BulkheadFullException;
 import io.github.resilience4j.bulkhead.BulkheadRegistry;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
+import io.github.resilience4j.bulkhead.ThreadPoolBulkheadConfig;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkheadRegistry;
 import io.github.resilience4j.bulkhead.annotation.Bulkhead;
 import io.github.resilience4j.core.functions.CheckedSupplier;
@@ -111,12 +112,12 @@ public class BulkheadAspect implements Ordered {
         }
         Class<?> returnType = method.getReturnType();
         String backend = spelResolver.resolve(method, proceedingJoinPoint.getArgs(), bulkheadAnnotation.name());
+        String configKey = bulkheadAnnotation.configuration().isEmpty() ? backend : bulkheadAnnotation.configuration();
         if (bulkheadAnnotation.type() == Bulkhead.Type.THREADPOOL) {
             final CheckedSupplier<Object> bulkheadExecution =
-                () -> proceedInThreadPoolBulkhead(proceedingJoinPoint, methodName, returnType, backend);
+                () -> proceedInThreadPoolBulkhead(proceedingJoinPoint, methodName, returnType, backend, configKey);
             return fallbackExecutor.execute(proceedingJoinPoint, method, bulkheadAnnotation.fallbackMethod(), bulkheadExecution);
         } else {
-            String configKey = bulkheadAnnotation.configuration().isEmpty() ? backend : bulkheadAnnotation.configuration();
             var bulkhead = getOrCreateBulkhead(methodName, backend, configKey);
             final CheckedSupplier<Object> bulkheadExecution = () -> proceed(proceedingJoinPoint, methodName, bulkhead, returnType);
             return fallbackExecutor.execute(proceedingJoinPoint, method, bulkheadAnnotation.fallbackMethod(), bulkheadExecution);
@@ -159,6 +160,22 @@ public class BulkheadAspect implements Ordered {
                 "Created or retrieved bulkhead '{}' with max concurrent call '{}' and max wait time '{}ms' for method: '{}'",
                 backend, bulkhead.getBulkheadConfig().getMaxConcurrentCalls(),
                 bulkhead.getBulkheadConfig().getMaxWaitDuration().toMillis(), methodName);
+        }
+
+        return bulkhead;
+    }
+
+    private ThreadPoolBulkhead getOrCreateThreadPoolBulkhead(String methodName,
+                                                                         String backend, String configKey) {
+        ThreadPoolBulkheadConfig config = threadPoolBulkheadRegistry.getConfiguration(configKey)
+                .orElseGet(threadPoolBulkheadRegistry::getDefaultConfig);
+        var bulkhead = threadPoolBulkheadRegistry.bulkhead(backend, config);
+
+        if (logger.isDebugEnabled()) {
+            logger.debug(
+                    "Created or retrieved thread pool bulkhead '{}' for key '{}' with max pool size '{}' and max queue size '{}' for method: '{}' and ",
+                    backend, configKey, config.getMaxThreadPoolSize(),
+                    config.getQueueCapacity(), methodName);
         }
 
         return bulkhead;
@@ -227,12 +244,12 @@ public class BulkheadAspect implements Ordered {
      * @throws Throwable
      */
     private Object proceedInThreadPoolBulkhead(ProceedingJoinPoint proceedingJoinPoint,
-        String methodName, Class<?> returnType, String backend) throws Throwable {
+        String methodName, Class<?> returnType, String backend, String configKey) throws Throwable {
         if (logger.isDebugEnabled()) {
             logger.debug("ThreadPool bulkhead invocation for method {} in backend {}", methodName,
                 backend);
         }
-        ThreadPoolBulkhead threadPoolBulkhead = threadPoolBulkheadRegistry.bulkhead(backend);
+        ThreadPoolBulkhead threadPoolBulkhead = getOrCreateThreadPoolBulkhead(methodName, backend, configKey);
         if (CompletionStage.class.isAssignableFrom(returnType)) {
             // threadPoolBulkhead.executeSupplier throws a BulkheadFullException, if the Bulkhead is full.
             // The RuntimeException is converted into an exceptionally completed future

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/circuitbreaker/configure/CircuitBreakerAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/circuitbreaker/configure/CircuitBreakerAspect.java
@@ -130,7 +130,7 @@ public class CircuitBreakerAspect implements Ordered {
     private io.github.resilience4j.circuitbreaker.CircuitBreaker getOrCreateCircuitBreaker(
         String methodName, String backend, String configKey) {
         CircuitBreakerConfig config = circuitBreakerRegistry.getConfiguration(configKey)
-            .orElse(circuitBreakerRegistry.getDefaultConfig());
+            .orElseGet(circuitBreakerRegistry::getDefaultConfig);
         var circuitBreaker = circuitBreakerRegistry.circuitBreaker(backend, config);
 
         if (logger.isDebugEnabled()) {

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/micrometer/configure/TimerAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/micrometer/configure/TimerAspect.java
@@ -103,7 +103,7 @@ public class TimerAspect implements Ordered {
     }
 
     private io.github.resilience4j.micrometer.Timer getOrCreateTimer(String methodName, String name, String configKey) {
-        TimerConfig config = timerRegistry.getConfiguration(configKey).orElse(timerRegistry.getDefaultConfig());
+        TimerConfig config = timerRegistry.getConfiguration(configKey).orElseGet(timerRegistry::getDefaultConfig);
         var timer = timerRegistry.timer(name, config);
         if (logger.isDebugEnabled()) {
             logger.debug("Created or retrieved timer '{}' for method: '{}'", name, methodName);

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/ratelimiter/configure/RateLimiterAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/ratelimiter/configure/RateLimiterAspect.java
@@ -109,9 +109,8 @@ public class RateLimiterAspect implements Ordered {
             return proceedingJoinPoint.proceed();
         }
         String name = spelResolver.resolve(method, proceedingJoinPoint.getArgs(), rateLimiterAnnotation.name());
-        String configKey = rateLimiterAnnotation.configurationKey().isEmpty() ? name : rateLimiterAnnotation.configurationKey();
-        io.github.resilience4j.ratelimiter.RateLimiter rateLimiter = getOrCreateRateLimiter(
-            methodName, name, configKey);
+        String configKey = rateLimiterAnnotation.configuration().isEmpty() ? name : rateLimiterAnnotation.configuration();
+        var rateLimiter = getOrCreateRateLimiter(methodName, name, configKey);
         Class<?> returnType = method.getReturnType();
         final CheckedSupplier<Object> rateLimiterExecution = () -> proceed(proceedingJoinPoint, methodName, returnType, rateLimiter);
         return fallbackExecutor.execute(proceedingJoinPoint, method, rateLimiterAnnotation.fallbackMethod(), rateLimiterExecution);
@@ -138,8 +137,7 @@ public class RateLimiterAspect implements Ordered {
         String name, String configKey) {
         RateLimiterConfig config = rateLimiterRegistry.getConfiguration(configKey)
             .orElse(rateLimiterRegistry.getDefaultConfig());
-        io.github.resilience4j.ratelimiter.RateLimiter rateLimiter = rateLimiterRegistry
-            .rateLimiter(name, config);
+        var rateLimiter = rateLimiterRegistry.rateLimiter(name, config);
 
         if (logger.isDebugEnabled()) {
             RateLimiterConfig rateLimiterConfig = rateLimiter.getRateLimiterConfig();

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/ratelimiter/configure/RateLimiterAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/ratelimiter/configure/RateLimiterAspect.java
@@ -136,7 +136,7 @@ public class RateLimiterAspect implements Ordered {
     private io.github.resilience4j.ratelimiter.RateLimiter getOrCreateRateLimiter(String methodName,
         String name, String configKey) {
         RateLimiterConfig config = rateLimiterRegistry.getConfiguration(configKey)
-            .orElse(rateLimiterRegistry.getDefaultConfig());
+            .orElseGet(rateLimiterRegistry::getDefaultConfig);
         var rateLimiter = rateLimiterRegistry.rateLimiter(name, config);
 
         if (logger.isDebugEnabled()) {

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/retry/configure/RetryAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/retry/configure/RetryAspect.java
@@ -141,7 +141,7 @@ public class RetryAspect implements Ordered, AutoCloseable {
      * @return the configured retry
      */
     private io.github.resilience4j.retry.Retry getOrCreateRetry(String methodName, String backend, String configKey) {
-        RetryConfig config = retryRegistry.getConfiguration(configKey).orElse(retryRegistry.getDefaultConfig());
+        RetryConfig config = retryRegistry.getConfiguration(configKey).orElseGet(retryRegistry::getDefaultConfig);
         var retry = retryRegistry.retry(backend, config);
 
         if (logger.isDebugEnabled()) {

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/retry/configure/RetryAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/retry/configure/RetryAspect.java
@@ -112,7 +112,8 @@ public class RetryAspect implements Ordered, AutoCloseable {
             return proceedingJoinPoint.proceed();
         }
         String backend = spelResolver.resolve(method, proceedingJoinPoint.getArgs(), retryAnnotation.name());
-        io.github.resilience4j.retry.Retry retry = getOrCreateRetry(methodName, backend);
+        String configKey = retryAnnotation.configuration().isEmpty() ? backend : retryAnnotation.configuration();
+        var retry = getOrCreateRetry(methodName, backend, configKey);
         Class<?> returnType = method.getReturnType();
         final CheckedSupplier<Object> retryExecution = () -> proceed(proceedingJoinPoint, methodName, retry, returnType);
         return fallbackExecutor.execute(proceedingJoinPoint, method, retryAnnotation.fallbackMethod(), retryExecution);
@@ -136,11 +137,12 @@ public class RetryAspect implements Ordered, AutoCloseable {
     /**
      * @param methodName the retry method name
      * @param backend    the retry backend name
+     * @param configKey  the configuration key
      * @return the configured retry
      */
-    private io.github.resilience4j.retry.Retry getOrCreateRetry(String methodName, String backend) {
-        RetryConfig config = retryRegistry.getConfiguration(backend).orElse(retryRegistry.getDefaultConfig());
-        io.github.resilience4j.retry.Retry retry = retryRegistry.retry(backend, config);
+    private io.github.resilience4j.retry.Retry getOrCreateRetry(String methodName, String backend, String configKey) {
+        RetryConfig config = retryRegistry.getConfiguration(configKey).orElse(retryRegistry.getDefaultConfig());
+        var retry = retryRegistry.retry(backend, config);
 
         if (logger.isDebugEnabled()) {
             logger.debug(

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterAspect.java
@@ -111,7 +111,7 @@ public class TimeLimiterAspect implements Ordered, AutoCloseable {
     }
 
     private io.github.resilience4j.timelimiter.TimeLimiter getOrCreateTimeLimiter(String methodName, String name, String configKey) {
-        TimeLimiterConfig config = timeLimiterRegistry.getConfiguration(configKey).orElse(timeLimiterRegistry.getDefaultConfig());
+        TimeLimiterConfig config = timeLimiterRegistry.getConfiguration(configKey).orElseGet(timeLimiterRegistry::getDefaultConfig);
         var timeLimiter = timeLimiterRegistry.timeLimiter(name, config);
 
         if (logger.isDebugEnabled()) {

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/BulkheadDummyService.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/BulkheadDummyService.java
@@ -119,4 +119,16 @@ public class BulkheadDummyService implements TestDummyService {
     public String spelSync(String backend) {
         return syncError();
     }
+
+    @Override
+    @Bulkhead(name = "#root.args[0]", fallbackMethod = "#{'recovery'}")
+    public String spelSyncNoCfg(String backend) {
+        return backend;
+    }
+
+    @Override
+    @Bulkhead(name = "#root.args[0]", configuration = BACKEND, fallbackMethod = "#{'recovery'}")
+    public String spelSyncWithCfg(String backend) {
+        return backend;
+    }
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/BulkheadDummyService.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/BulkheadDummyService.java
@@ -131,4 +131,15 @@ public class BulkheadDummyService implements TestDummyService {
     public String spelSyncWithCfg(String backend) {
         return backend;
     }
+
+
+    @Bulkhead(name = "#root.args[0]", fallbackMethod = "#{'recovery'}", type = Bulkhead.Type.THREADPOOL)
+    public CompletionStage<String> spelSyncThreadPoolNoCfg(String backend) {
+        return CompletableFuture.completedFuture(backend);
+    }
+
+    @Bulkhead(name = "#root.args[0]", configuration = BACKEND, fallbackMethod = "#{'recovery'}", type = Bulkhead.Type.THREADPOOL)
+    public CompletionStage<String> spelSyncThreadPoolWithCfg(String backend) {
+        return CompletableFuture.completedFuture(backend);
+    }
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/CircuitBreakerDummyService.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/CircuitBreakerDummyService.java
@@ -118,4 +118,16 @@ public class CircuitBreakerDummyService implements TestDummyService {
     public String spelSync(String backend) {
         return syncError();
     }
+
+    @Override
+    @CircuitBreaker(name = "#root.args[0]", fallbackMethod = "#{'recovery'}")
+    public String spelSyncNoCfg(String backend) {
+        return backend;
+    }
+
+    @Override
+    @CircuitBreaker(name = "#root.args[0]", configuration = BACKEND, fallbackMethod = "#{'recovery'}")
+    public String spelSyncWithCfg(String backend) {
+        return backend;
+    }
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/RateLimiterDummyService.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/RateLimiterDummyService.java
@@ -118,4 +118,16 @@ public class RateLimiterDummyService implements TestDummyService {
     public String spelSync(String backend) {
         return syncError();
     }
+
+    @Override
+    @RateLimiter(name = "#root.args[0]", fallbackMethod = "recovery")
+    public String spelSyncNoCfg(String backend) {
+        return backend;
+    }
+
+    @Override
+    @RateLimiter(name = "#root.args[0]", configuration = BACKEND, fallbackMethod = "recovery")
+    public String spelSyncWithCfg(String backend) {
+        return backend;
+    }
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/RetryDummyService.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/RetryDummyService.java
@@ -125,4 +125,16 @@ public class RetryDummyService implements TestDummyService {
     public String spelSync(String backend) {
         return syncError();
     }
+
+    @Override
+    @Retry(name = "#root.args[0]", fallbackMethod = "#{'recovery'}")
+    public String spelSyncNoCfg(String backend) {
+        return backend;
+    }
+
+    @Override
+    @Retry(name = "#root.args[0]", configuration = BACKEND, fallbackMethod = "#{'recovery'}")
+    public String spelSyncWithCfg(String backend) {
+        return backend;
+    }
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/TestDummyService.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/TestDummyService.java
@@ -65,6 +65,14 @@ public interface TestDummyService {
         return syncError();
     }
 
+    default String spelSyncNoCfg(String backend) {
+        return syncError();
+    }
+
+    default String spelSyncWithCfg(String backend) {
+        return syncError();
+    }
+
     default Mono<String> spelMono(String backend) {
         return monoError(backend);
     }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/TestDummyService.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/TestDummyService.java
@@ -77,6 +77,10 @@ public interface TestDummyService {
         return monoError(backend);
     }
 
+    default Mono<String> spelMonoWithCfg(String backend) {
+        return monoError(backend);
+    }
+
     default String syncError() {
         throw new RuntimeException("Test");
     }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/TimeLimiterDummyService.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/TimeLimiterDummyService.java
@@ -131,4 +131,10 @@ public class TimeLimiterDummyService implements TestDummyService {
     public Mono<String> spelMono(String backend) {
         return monoError(backend);
     }
+
+    @Override
+    @TimeLimiter(name = "#root.args[0]", configuration = BACKEND, fallbackMethod = "${missing.property:monoRecovery}")
+    public Mono<String> spelMonoWithCfg(String backend) {
+        return monoError(backend);
+    }
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/bulkhead/configure/BulkHeadInitializationInAspectTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/bulkhead/configure/BulkHeadInitializationInAspectTest.java
@@ -82,7 +82,7 @@ public class BulkHeadInitializationInAspectTest {
         assertThat(testDummyService.spelSyncWithCfg("foo")).isEqualTo("recovered");
         assertThat(registry.getAllBulkheads()).hasSize(1).first()
                 .matches(bulkhead -> bulkhead.getName().equals("foo"))
-                .matches(bulkhead -> bulkhead.getBulkheadConfig() != registry.getDefaultConfig());
+                .matches(bulkhead -> bulkhead.getBulkheadConfig() == registry.getConfiguration(BACKEND).orElse(null));
     }
 
     @Test

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/bulkhead/configure/BulkHeadInitializationInAspectTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/bulkhead/configure/BulkHeadInitializationInAspectTest.java
@@ -1,8 +1,10 @@
 package io.github.resilience4j.spring6.bulkhead.configure;
 
+import io.github.resilience4j.bulkhead.Bulkhead;
 import io.github.resilience4j.bulkhead.BulkheadConfig;
 import io.github.resilience4j.bulkhead.BulkheadRegistry;
 import io.github.resilience4j.spring6.TestDummyService;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -53,10 +55,40 @@ public class BulkHeadInitializationInAspectTest {
         assertThat(registry.getAllBulkheads()).isEmpty();
     }
 
+    @After
+    public void tearDown() {
+        // could have used DirtiesContext but spawns a springboot for each test
+        registry.getAllBulkheads().stream().map(Bulkhead::getName).forEach(registry::remove);
+    }
+
     @Test
     public void testCorrectConfigIsUsedInAspect() {
-
         // The bulkhead is configured to allow 0 concurrent calls, so the call should be rejected
         assertThat(testDummyService.syncSuccess()).isEqualTo("recovered");
     }
+
+    @Test
+    public void testSpelWithoutMappingConfigurationInAspect() {
+        // Default bulkhead is configured to allow several concurrent calls
+        assertThat(testDummyService.spelSyncNoCfg("foo")).isEqualTo("foo");
+        assertThat(registry.getAllBulkheads()).hasSize(1).first()
+                .matches(bulkhead -> bulkhead.getName().equals("foo"))
+                .matches(bulkhead -> bulkhead.getBulkheadConfig() == registry.getDefaultConfig());
+    }
+
+    @Test
+    public void testSpelWithMappingConfigurationInAspect() {
+        // The bulkhead is configured to allow 0 concurrent calls, so the call should be rejected
+        assertThat(testDummyService.spelSyncWithCfg("foo")).isEqualTo("recovered");
+        assertThat(registry.getAllBulkheads()).hasSize(1).first()
+                .matches(bulkhead -> bulkhead.getName().equals("foo"))
+                .matches(bulkhead -> bulkhead.getBulkheadConfig() != registry.getDefaultConfig());
+    }
+
+    @Test
+    public void testConfigurationKeyIsUsedInAspect() {
+        assertThat(testDummyService.spelSyncWithCfg(BACKEND)).isEqualTo("recovered");
+        assertThat(testDummyService.spelSyncNoCfg(BACKEND)).isEqualTo("recovered");
+    }
+
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/bulkhead/configure/ThreadPoolBulkHeadInitializationInAspectTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/bulkhead/configure/ThreadPoolBulkHeadInitializationInAspectTest.java
@@ -1,0 +1,86 @@
+package io.github.resilience4j.spring6.bulkhead.configure;
+
+import io.github.resilience4j.bulkhead.Bulkhead;
+import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
+import io.github.resilience4j.bulkhead.ThreadPoolBulkheadConfig;
+import io.github.resilience4j.bulkhead.ThreadPoolBulkheadRegistry;
+import io.github.resilience4j.spring6.BulkheadDummyService;
+import io.github.resilience4j.spring6.TestDummyService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static io.github.resilience4j.spring6.TestDummyService.BACKEND;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(properties = {
+        "logging.level.io.github.resilience4j.bulkhead.configure=debug",
+        "spring.main.allow-bean-definition-overriding=true"
+})
+public class ThreadPoolBulkHeadInitializationInAspectTest {
+
+    @TestConfiguration
+    static class TestConfig {
+
+        @Bean
+        public ThreadPoolBulkheadRegistry threadPoolBulkheadRegistry() {
+
+            ThreadPoolBulkheadConfig backendBulkHeadConfig = ThreadPoolBulkheadConfig.custom()
+                    .coreThreadPoolSize(1)
+                    .maxThreadPoolSize(1)
+                    .build();
+
+            return ThreadPoolBulkheadRegistry.custom()
+                    .withThreadPoolBulkheadConfig(ThreadPoolBulkheadConfig.ofDefaults())
+                    .addThreadPoolBulkheadConfig(BACKEND, backendBulkHeadConfig)
+                    .build();
+        }
+    }
+
+    @Autowired
+    BulkheadDummyService testDummyService;
+
+    @Autowired
+    @Qualifier("threadPoolBulkheadRegistry")
+    ThreadPoolBulkheadRegistry registry;
+
+    @Before
+    public void setUp() {
+        // ensure no bulkheads are initialized
+        assertThat(registry.getAllBulkheads()).isEmpty();
+    }
+
+    @After
+    public void tearDown() {
+        registry.getAllBulkheads().stream().map(ThreadPoolBulkhead::getName).forEach(registry::remove);
+    }
+
+    @Test
+    public void testSpelWithoutMappingConfigurationInAspect() throws Exception {
+        assertThat(testDummyService.spelSyncThreadPoolNoCfg("foo").toCompletableFuture().get(5, TimeUnit.SECONDS)).isEqualTo("foo");
+        assertThat(registry.getAllBulkheads()).hasSize(1).first()
+                .matches(bulkhead -> bulkhead.getName().equals("foo"))
+                .matches(bulkhead -> bulkhead.getBulkheadConfig() == registry.getDefaultConfig());
+    }
+
+    @Test
+    public void testSpelWithMappingConfigurationInAspect() throws Exception {
+        // The bulkhead is configured to allow 0 concurrent calls, so the call should be rejected
+        assertThat(testDummyService.spelSyncThreadPoolWithCfg("foo").toCompletableFuture().get(5, TimeUnit.SECONDS)).isEqualTo("foo");
+        assertThat(registry.getAllBulkheads()).hasSize(1).first()
+                .matches(bulkhead -> bulkhead.getName().equals("foo"))
+                .matches(bulkhead -> bulkhead.getBulkheadConfig() == registry.getConfiguration(BACKEND).orElse(null));
+    }
+}

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/circuitbreaker/configure/CircuitBreakerInitializationInAspectTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/circuitbreaker/configure/CircuitBreakerInitializationInAspectTest.java
@@ -82,6 +82,6 @@ public class CircuitBreakerInitializationInAspectTest {
         assertThat(testDummyService.spelSyncWithCfg("foo")).isEqualTo("recovered");
         assertThat(registry.getAllCircuitBreakers()).hasSize(1).first()
                 .matches(circuitBreaker -> circuitBreaker.getName().equals("foo"))
-                .matches(circuitBreaker -> circuitBreaker.getCircuitBreakerConfig() != registry.getDefaultConfig());
+                .matches(circuitBreaker -> circuitBreaker.getCircuitBreakerConfig() == registry.getConfiguration(BACKEND).orElse(null));
     }
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/circuitbreaker/configure/CircuitBreakerInitializationInAspectTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/circuitbreaker/configure/CircuitBreakerInitializationInAspectTest.java
@@ -4,6 +4,7 @@ import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.spring6.TestDummyService;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -54,10 +55,33 @@ public class CircuitBreakerInitializationInAspectTest {
         assertThat(registry.getAllCircuitBreakers()).isEmpty();
     }
 
+    @After
+    public void tearDown() {
+        registry.getAllCircuitBreakers().stream().map(CircuitBreaker::getName).forEach(registry::remove);
+    }
+
     @Test
     public void testCorrectConfigIsUsedInAspect() {
 
         // The circuit breaker is configured to start in the OPEN state, so the call should be rejected
         assertThat(testDummyService.syncSuccess()).isEqualTo("recovered");
+    }
+
+    @Test
+    public void testSpelWithoutConfigurationInAspect() {
+        // default circuit breaker is configured to start in CLOSE state
+        assertThat(testDummyService.spelSyncNoCfg("foo")).isEqualTo("foo");
+        assertThat(registry.getAllCircuitBreakers()).hasSize(1).first()
+                .matches(circuitBreaker -> circuitBreaker.getName().equals("foo"))
+                .matches(circuitBreaker -> circuitBreaker.getCircuitBreakerConfig() == registry.getDefaultConfig());
+    }
+
+    @Test
+    public void testSpelWithConfigurationInAspect() {
+        // backend circuit breaker is configured to start in the OPEN state, so the call should be rejected
+        assertThat(testDummyService.spelSyncWithCfg("foo")).isEqualTo("recovered");
+        assertThat(registry.getAllCircuitBreakers()).hasSize(1).first()
+                .matches(circuitBreaker -> circuitBreaker.getName().equals("foo"))
+                .matches(circuitBreaker -> circuitBreaker.getCircuitBreakerConfig() != registry.getDefaultConfig());
     }
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/ratelimiter/configure/RateLimiterInitializationInAspectTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/ratelimiter/configure/RateLimiterInitializationInAspectTest.java
@@ -60,7 +60,7 @@ public class RateLimiterInitializationInAspectTest {
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         registry.getAllRateLimiters().stream().map(RateLimiter::getName).forEach(registry::remove);
     }
 
@@ -87,6 +87,6 @@ public class RateLimiterInitializationInAspectTest {
         assertThat(testDummyService.spelSyncWithCfg("foo")).isEqualTo("recovered");
         assertThat(registry.getAllRateLimiters()).hasSize(1)
                 .allMatch(limiter -> limiter.getName().equals("foo"))
-                .allMatch(limiter -> limiter.getRateLimiterConfig() != registry.getDefaultConfig());
+                .allMatch(limiter -> limiter.getRateLimiterConfig() == registry.getConfiguration(BACKEND).orElse(null));
     }
 }


### PR DESCRIPTION
When using SpEL for resilience4j components, default configuration is taken.
Say that i have:
`@RateLimiter(name="#param")
int foo(String param) { /* do something */ }
`
Calling it with `foo("bar")` will look for `bar` configuration whereas `foo("baz")` will look for `baz`configuration
which are very unlikely to exist, therefore the default ratelimiter configuration will be used.

My proposal is to add a new param in the resilience4j annotations to ensure that a predefined configuration is used.
`@RateLimiter(name="#param", configurationKey="foo")` to use `foo` rate limiter configuration if exists.

See code attached to this PR.

Let me know if that suits you before i move forwards.
Thx for your help.
