### PR TITLE
[Kotlin] Prevent resource leaks if user defined predicates throw.

### DIFF
--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/CircuitBreaker.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/CircuitBreaker.kt
@@ -49,7 +49,9 @@ suspend fun <T> CircuitBreaker.executeSuspendFunction(
         onResult(durationInNanos, TimeUnit.NANOSECONDS, result)
         return result
     } catch (exception: Throwable) {
-        if (ignoreThrowablePredicate(exception, coroutineContext)) {
+        val shouldIgnore =
+            try { ignoreThrowablePredicate(exception, coroutineContext) } catch (_: Throwable) { false }
+        if (shouldIgnore) {
             releasePermission()
         } else {
             val durationInNanos = getCurrentTimestamp() - start

--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/CircuitBreaker.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/circuitbreaker/CircuitBreaker.kt
@@ -50,7 +50,7 @@ suspend fun <T> CircuitBreaker.executeSuspendFunction(
         return result
     } catch (exception: Throwable) {
         val shouldIgnore =
-            try { ignoreThrowablePredicate(exception, coroutineContext) } catch (_: Throwable) { false }
+            try { ignoreThrowablePredicate(exception, coroutineContext) } catch (_: Exception) { false }
         if (shouldIgnore) {
             releasePermission()
         } else {


### PR DESCRIPTION
Fixes #2324

I'm second guessing my choice on whether this should catch `Throwable` or `Exception`.
I'm thinking maybe `Exception` may be better as this exceptions _isn't_ rethrown, so an interrupt or out of memory could be accidentally captured and dropped on the floor.

The other option is to call `onError` on _this_ exception and rethrow _it_. I don't think that would be a very good idea, but I'm not a maintainer. Just saying there's edge cases to think about.