### PR TITLE
Add missing eventConsumerBufferSize merge for Retry config

### DIFF
--- a/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/utils/ConfigUtils.java
+++ b/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/utils/ConfigUtils.java
@@ -140,6 +140,10 @@ public class ConfigUtils {
             baseProperties.getExponentialMaxWaitDuration() != null) {
             instanceProperties.setExponentialMaxWaitDuration(baseProperties.getExponentialMaxWaitDuration());
         }
+        if (instanceProperties.getEventConsumerBufferSize() == null &&
+            baseProperties.getEventConsumerBufferSize() != null) {
+            instanceProperties.setEventConsumerBufferSize(baseProperties.getEventConsumerBufferSize());
+        }
     }
 
 	/**


### PR DESCRIPTION
Fixes missing inheritance of eventConsumerBufferSize from base Retry configuration, so instances receive default buffer size unless overridden

Fixes #2340.