### PR TITLE
Added bulkhead name to BulkheadFullException

### DIFF
--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/BulkheadFullException.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/BulkheadFullException.java
@@ -22,9 +22,12 @@ package io.github.resilience4j.bulkhead;
  * A {@link BulkheadFullException} signals that the bulkhead is full.
  */
 public class BulkheadFullException extends RuntimeException {
+    private final String bulkheadName;
 
-    private BulkheadFullException(String message, boolean writableStackTrace) {
+    private BulkheadFullException(String bulkheadName, String message, boolean writableStackTrace) {
         super(message, null, false, writableStackTrace);
+
+        this.bulkheadName = bulkheadName;
     }
 
     /**
@@ -36,17 +39,19 @@ public class BulkheadFullException extends RuntimeException {
         boolean writableStackTraceEnabled = bulkhead.getBulkheadConfig()
             .isWritableStackTraceEnabled();
 
+        String bulkheadName = bulkhead.getName();
+
         String message;
         if (Thread.currentThread().isInterrupted()) {
             message = String
                 .format("Bulkhead '%s' is full and thread was interrupted during permission wait",
-                    bulkhead.getName());
+                    bulkheadName);
         } else {
             message = String.format("Bulkhead '%s' is full and does not permit further calls",
-                bulkhead.getName());
+                bulkheadName);
         }
 
-        return new BulkheadFullException(message, writableStackTraceEnabled);
+        return new BulkheadFullException(bulkheadName, message, writableStackTraceEnabled);
     }
 
     /**
@@ -58,9 +63,15 @@ public class BulkheadFullException extends RuntimeException {
         boolean writableStackTraceEnabled = bulkhead.getBulkheadConfig()
             .isWritableStackTraceEnabled();
 
-        String message = String
-            .format("Bulkhead '%s' is full and does not permit further calls", bulkhead.getName());
+        String bulkheadName = bulkhead.getName();
 
-        return new BulkheadFullException(message, writableStackTraceEnabled);
+        String message = String
+            .format("Bulkhead '%s' is full and does not permit further calls", bulkheadName);
+
+        return new BulkheadFullException(bulkheadName, message, writableStackTraceEnabled);
+    }
+
+    public String getBulkheadName() {
+        return bulkheadName;
     }
 }

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/BulkheadTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/BulkheadTest.java
@@ -356,7 +356,11 @@ public class BulkheadTest {
         Try<Void> result = Try.run(() -> checkedRunnable.run());
 
         assertThat(result.isFailure()).isTrue();
-        assertThat(result.failed().get()).isInstanceOf(BulkheadFullException.class);
+
+        final Throwable throwable = result.failed().get();
+
+        assertThat(throwable).isInstanceOf(BulkheadFullException.class);
+        assertThat(((BulkheadFullException) throwable).getBulkheadName()).isEqualTo(bulkhead.getName());
         // end::bulkheadFullException[]
     }
 

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadTest.java
@@ -92,7 +92,10 @@ public class ThreadPoolBulkheadTest {
         second.join(100);
         third.join(100);
 
-        assertThat(exception.get()).isInstanceOf(BulkheadFullException.class);
+        final Exception caughtException = exception.get();
+
+        assertThat(caughtException).isInstanceOf(BulkheadFullException.class);
+        assertThat(((BulkheadFullException) caughtException).getBulkheadName()).isEqualTo(bulkhead.getName());
     }
 
     @Test
@@ -133,7 +136,10 @@ public class ThreadPoolBulkheadTest {
         second.join(100);
         third.join(100);
 
-        assertThat(exception.get()).isInstanceOf(BulkheadFullException.class);
+        final Exception caughtException = exception.get();
+
+        assertThat(caughtException).isInstanceOf(BulkheadFullException.class);
+        assertThat(((BulkheadFullException) caughtException).getBulkheadName()).isEqualTo(bulkhead.getName());
     }
 
     @Test
@@ -174,7 +180,10 @@ public class ThreadPoolBulkheadTest {
         second.join(100);
         third.join(100);
 
-        assertThat(exception.get()).isInstanceOf(BulkheadFullException.class);
+        final Exception caughtException = exception.get();
+
+        assertThat(caughtException).isInstanceOf(BulkheadFullException.class);
+        assertThat(((BulkheadFullException) caughtException).getBulkheadName()).isEqualTo(bulkhead.getName());
     }
 
 
@@ -224,7 +233,9 @@ public class ThreadPoolBulkheadTest {
         bulkhead.executeRunnable(CheckedRunnable.of(latch::await).unchecked());
 
         assertThatThrownBy(() -> bulkhead.executeCallable(helloWorldService::returnHelloWorld))
-            .isInstanceOf(BulkheadFullException.class);
+            .isInstanceOf(BulkheadFullException.class)
+            .hasFieldOrPropertyWithValue("bulkheadName", bulkhead.getName());
+
         assertThat(bulkhead.getMetrics().getQueueDepth()).isZero();
         assertThat(bulkhead.getMetrics().getRemainingQueueCapacity()).isZero();
         assertThat(bulkhead.getMetrics().getQueueCapacity()).isZero();
@@ -233,5 +244,4 @@ public class ThreadPoolBulkheadTest {
 
         latch.countDown();
     }
-
 }


### PR DESCRIPTION
## Motivation

When using Resilience4J in common with Spring Boot, it's often useful to have the actual bulkhead name in the BulkheadFullException, e.g. when tracking application-metrics in a ControllerAdvice that catches the BulkheadFullException. 

```Kotlin
    @ExceptionHandler(BulkheadFullException::class)
    fun handleBulkheadFullException(e: BulkheadFullException) =
        ResponseEntity(
            "Too many concurrent requests. Please try again later.",
            HttpStatus.SERVICE_UNAVAILABLE
        ).also {
            logger.warn("Caught BulkheadFullException: {}", e.message, e)
            bulkheadRejectedCounter(e.getBulkheadName()).increase()
        }
```