### PR TITLE
[GH-2354] Remove kotlin-stdlib from resilience4j-core

### DIFF
--- a/resilience4j-core/build.gradle
+++ b/resilience4j-core/build.gradle
@@ -1,21 +1,9 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
-plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.9.25'
-}
-
 ext.moduleName = 'io.github.resilience4j.core'
 
 dependencies {
     testImplementation(libraries.mock_clock)
     testImplementation(libraries.junitParams)
     testImplementation(libraries.lincheck)
-}
-
-compileTestKotlin {
-    compilerOptions {
-        it.jvmTarget.set(JvmTarget.JVM_21)
-    }
 }
 
 test {


### PR DESCRIPTION
As can be seen from https://mvnrepository.com/artifact/io.github.resilience4j/resilience4j-core/2.3.0 the resilience4j-core currently includes kotlin-stdlib as a compile dependency. This happens automatically when kotlin plugin is applied in a gradle project and if if the intention was only to allow tests to be written it kotlin there are any kotlin sources in the core package.

```
    <dependency>
      <groupId>org.jetbrains.kotlin</groupId>
      <artifactId>kotlin-stdlib</artifactId>
      <version>1.9.25</version>
      <scope>compile</scope>
    </dependency>
```