### PR TITLE
Issue #2362: Fixed consumeResultBeforeRetryAttempt not being called on last attempt

### DIFF
--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/retry/RetryTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/retry/RetryTest.kt
@@ -175,6 +175,6 @@ class RetryTest {
 
         Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(3)
         Assertions.assertThat(result).isEqualTo(helloWorldServiceReturnValue)
-        Assertions.assertThat(consumerInvocations.get()).isEqualTo(2)
+        Assertions.assertThat(consumerInvocations.get()).isEqualTo(3)
     }
 }

--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/internal/RetryImpl.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/internal/RetryImpl.java
@@ -187,13 +187,15 @@ public class RetryImpl<T> implements Retry {
             if (null != resultPredicate && resultPredicate.test(result)) {
                 totalAttemptsCounter.increment();
                 int currentNumOfAttempts = numOfAttempts.incrementAndGet();
-                if (currentNumOfAttempts >= maxAttempts) {
-                    return false;
-                }
 
                 if (consumeResultBeforeRetryAttempt != null) {
                     consumeResultBeforeRetryAttempt.accept(currentNumOfAttempts, result);
                 }
+
+                if (currentNumOfAttempts >= maxAttempts) {
+                    return false;
+                }
+
                 waitIntervalAfterRuntimeException(currentNumOfAttempts, Either.right(result));
                 return true;
             }
@@ -378,13 +380,15 @@ public class RetryImpl<T> implements Retry {
             if (null != resultPredicate && resultPredicate.test(result)) {
                 totalAttemptsCounter.increment();
                 int currentNumOfAttempts = numOfAttempts.incrementAndGet();
-                if (currentNumOfAttempts >= maxAttempts) {
-                    return -1;
-                }
 
                 if(consumeResultBeforeRetryAttempt != null){
                     consumeResultBeforeRetryAttempt.accept(currentNumOfAttempts, result);
                 }
+
+                if (currentNumOfAttempts >= maxAttempts) {
+                    return -1;
+                }
+
                 Long interval = intervalBiFunction.apply(currentNumOfAttempts, Either.right(result));
                 publishRetryEvent(() -> new RetryOnRetryEvent(getName(), currentNumOfAttempts, null, interval));
                 return interval;

--- a/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/SupplierRetryTest.java
+++ b/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/SupplierRetryTest.java
@@ -522,7 +522,7 @@ public class SupplierRetryTest {
 
         then(helloWorldService).should(times(3)).returnHelloWorld();
         assertThat(result).isEqualTo(helloWorldServiceReturnValue);
-        assertThat(consumerInvocations.get()).isEqualTo(2);
+        assertThat(consumerInvocations.get()).isEqualTo(3);
     }
 
     @Test
@@ -555,7 +555,7 @@ public class SupplierRetryTest {
         then(helloWorldServiceAsync).should(times(3)).returnHelloWorld();
         assertThat(resultTry.isSuccess()).isTrue();
         assertThat(resultTry.get()).isEqualTo(helloWorldServiceReturnValue);
-        assertThat(consumerInvocations.get()).isEqualTo(2);
+        assertThat(consumerInvocations.get()).isEqualTo(3);
     }
 
 }


### PR DESCRIPTION
## Problem

The `consumeResultBeforeRetryAttempt` callback was designed to enable resource cleanup for intermediate retry results - for example, closing HTTP response streams before attempting another request. However, when all retry attempts are exhausted, the callback silently skips the final failed attempt.

This creates a critical gap: resources from the last attempt are never cleaned up, potentially causing leaks. For a configuration with `maxAttempts=3`, users expect their cleanup callback to execute 3 times (once per attempt), but it only executes 2 times.

This violates the principle of least surprise:
- The method name suggests it runs for every retry attempt
- The original feature request (#1253) required cleanup for all intermediate results
- Users cannot predict that the final attempt behaves differently

**Example Impact**:
```java
// User configures cleanup for HTTP responses
RetryConfig.<HttpResponse>custom()
    .maxAttempts(3)
    .retryOnResult(response -> response.statusCode() >= 500)
    .consumeResultBeforeRetryAttempt((attempt, response) -> {
        response.close();  // Expected: 3 calls, Actual: 2 calls
    })
    .build();
// Result: Third response never closed → connection leak
```

## Solution

The fix ensures the callback is invoked consistently for every result that triggers the retry predicate, regardless of whether additional retries remain. This reestablishes the contract implied by the method name: process each failed attempt before deciding whether to retry.

Both synchronous (`ContextImpl`) and asynchronous (`AsyncContextImpl`) retry contexts exhibited the same issue and have been corrected to provide consistent behavior across all retry execution modes.

## Impact

**Behavioral Change**: The callback will now be invoked N times for N attempts (previously N-1 times).

**User Benefits**:
- Complete resource cleanup - no more leaks from the final attempt
- Predictable behavior aligned with method naming and documentation
- Consistent callback invocation across all retry attempts

**Compatibility**: While technically a behavior change, this corrects a clear deviation from documented behavior. Most use cases (logging, cleanup, monitoring) will benefit from the fix. Users who implemented workarounds for the bug can remove them.

Fixes #2362
