### PR TITLE
Add back OSGi meta data with bnd builder plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.asciidoctor.jvm.convert' version '2.4.0'
     id "org.gradle.test-retry" version "1.5.10"
     id "io.github.gradle-nexus.publish-plugin"  version "1.1.0"
+    id 'biz.aQute.bnd.builder' version '7.1.0' apply false
     id "me.champeau.jmh" version "0.6.8"
     id 'idea'
     id 'jacoco-report-aggregation'

--- a/publishing.gradle
+++ b/publishing.gradle
@@ -8,6 +8,7 @@ ext {
 
 def projectArtifactId = 'resilience4j'
 def url = "https://resilience4j.readme.io"
+apply plugin: 'biz.aQute.bnd.builder'
 
 normalization {
     runtimeClasspath {
@@ -29,6 +30,18 @@ jar {
                 'Specification-Version': project.version,
                 'Implementation-Title': projectArtifactId,
                 'Implementation-Version': project.version,
+        )
+    }
+    bundle {
+        bnd(
+                '-exportcontents': '!io.github.resilience4j.*.internal,*;-noimport:=true',
+                'Import-Package': '!javax.annotation,!javax.annotation.meta,*',
+                'Bundle-Description': 'A lightweight fault tolerance library',
+                'Bundle-DocURL': 'https://github.com/resilience4j/resilience4j',
+                'Bundle-Name': project.name,
+                'Bundle-SymbolicName': "${project.group}.${project.name}",
+                '-reproducible': "true",
+                '-noextraheaders': "true"
         )
     }
 }


### PR DESCRIPTION
Closes #1932

Re-Introduced the 'biz.aQute.bnd.builder' plugin to enable OSGi bundle generation. Updated publishing.gradle to apply the plugin and configure bundle metadata and export/import package rules for proper OSGi compatibility.

This makes it easier to use resilience4j in an OSGi based applicatino. 

- See https://github.com/bndtools/bnd/tree/master/gradle-plugins#instructing-bnd-on-how-to-build-your-bundle

I took https://github.com/resilience4j/resilience4j/pull/2141 as a base and did some different things:

- Tweaked the Export-Package (used [-exportcontents](https://bnd.bndtools.org/instructions/exportcontents.html) which is better since it does only export packages from the actual bundle and not from the Bundle's classpath) along with `-noimport:true` which avoids that bnd automatically calculates `Import-Package` Referneces for exported packages (preventing OSGi package subsitution which is usually not needed in libraries)
- make bundle more reproducible ([-reproducible](https://bnd.bndtools.org/instructions/reproducible.html), [-noextraheaders](https://bnd.bndtools.org/instructions/noextraheaders.html)) which skips timestamps and other dynamic things which hinder reproducibility

## Preview of all MANIFEST.MF files for review

Generated via [bnd CLI print](https://bnd.bndtools.org/commands/print.html) command: 

```
./gradlew clean build -x test
bnd print -v -m */build/libs/*.jar > allmanifests.txt
```
[allmanifests.txt](https://github.com/user-attachments/files/24148920/allmanifests.txt)

