### PR TITLE
feat: add setter for bulkheadAspectOrder property

### DIFF
--- a/resilience4j-spring/src/main/java/io/github/resilience4j/bulkhead/configure/BulkheadConfigurationProperties.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/bulkhead/configure/BulkheadConfigurationProperties.java
@@ -20,12 +20,21 @@ import org.springframework.core.Ordered;
 public class BulkheadConfigurationProperties extends
     io.github.resilience4j.common.bulkhead.configuration.CommonBulkheadConfigurationProperties {
 
+    private int bulkheadAspectOrder = Ordered.LOWEST_PRECEDENCE;
+
     /**
      * As of release 0.16.0 as we set an implicit spring aspect order for bulkhead to cover the
-     * async case of threadPool bulkhead
+     * async case of threadPool bulkhead but user can override it still if he has different use case
      */
     public int getBulkheadAspectOrder() {
-        return Ordered.LOWEST_PRECEDENCE;
+        return bulkheadAspectOrder;
+    }
+
+    /**
+     * @param bulkheadAspectOrder bulkhead aspect order
+     */
+    public void setBulkheadAspectOrder(int bulkheadAspectOrder) {
+        this.bulkheadAspectOrder = bulkheadAspectOrder;
     }
 
 }

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/bulkhead/configure/BulkheadConfigurationProperties.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/bulkhead/configure/BulkheadConfigurationProperties.java
@@ -20,12 +20,21 @@ import org.springframework.core.Ordered;
 public class BulkheadConfigurationProperties extends
     io.github.resilience4j.common.bulkhead.configuration.CommonBulkheadConfigurationProperties {
 
+    private int bulkheadAspectOrder = Ordered.LOWEST_PRECEDENCE - 1;
+
     /**
      * As of release 0.16.0 as we set an implicit spring aspect order for bulkhead to cover the
-     * async case of threadPool bulkhead
+     * async case of threadPool bulkhead but user can override it still if he has different use case
      */
     public int getBulkheadAspectOrder() {
-        return Ordered.LOWEST_PRECEDENCE -1;
+        return bulkheadAspectOrder;
+    }
+
+    /**
+     * @param bulkheadAspectOrder bulkhead aspect order
+     */
+    public void setBulkheadAspectOrder(int bulkheadAspectOrder) {
+        this.bulkheadAspectOrder = bulkheadAspectOrder;
     }
 
 }


### PR DESCRIPTION
Fixes #1657 - Added setter for bulkheadAspectOrder to allow configuration via application.properties. Previously only getter with fixed value existed, making it impossible to configure via properties.