### PR TITLE
Issue #536: Added best practices documentation for instance management

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -132,7 +132,7 @@ Creating separate instances for each backend service is critical for:
 
 1. *Proper metrics collection* - Each instance tracks its own metrics, allowing you to monitor the health of individual services
 2. *Isolation of failures* - If Service A fails, it won't affect the resilience patterns protecting Service B
-3. *Independent configuration* - Different backends may require different timeout settings, retry policies, or circuit breaker thresholds
+3. *Independent configuration* - Different backends may require different circuit breaker thresholds, concurrency limits, rate limits, or retry policies
 
 ==== Instance-Aware vs. Non-Instance-Aware Patterns
 
@@ -248,13 +248,13 @@ public class ServiceOrchestrator {
             .decorate()
             .get();
 
-        // Call notification service (if payment fails, notification circuit is unaffected)
-        Supplier<Void> notificationCall = () -> notificationService.send(request);
-        Decorators.ofSupplier(notificationCall)
+        // Call notification service (demonstrates circuit isolation: the notification circuit breaker remains independent of the payment circuit breaker, even if payment opens its circuit in other calls)
+        Runnable notificationCall = () -> notificationService.send(request);
+        Decorators.ofRunnable(notificationCall)
             .withCircuitBreaker(notificationCB)
             .withRetry(notificationRetry)
             .decorate()
-            .get();
+            .run();
 
         return new Order(payment, inventory);
     }


### PR DESCRIPTION
 ## Summary
  This PR addresses #536 by adding a comprehensive "Best Practices" section to the README.adoc.

  ## What Changed
  - Added new "Best Practices" section after the "Overview" section
  - Documented when to share vs. not share resilience4j instances
  - Clearly distinguished between instance-aware patterns (CircuitBreaker, Bulkhead, RateLimiter) and non-instance-aware patterns (Retry, TimeLimiter)
  - Included code examples showing correct vs. incorrect usage
  - Added a complete example with multiple services
  - Provided guidance on using Registries for instance management
  - Added summary table for quick reference

  ## Why This Helps
  New users were confused about when to create separate instances vs. sharing them across services. This documentation:
  - Clarifies that instance-aware patterns (CircuitBreaker, Bulkhead, RateLimiter) MUST NOT be shared
  - Explains that even shareable patterns benefit from unique instances for better metrics
  - Provides practical examples to illustrate the concepts
  - Emphasizes the importance of unique instances for proper metrics collection (as mentioned by @RobWin)

  Closes #536