### PR TITLE
Update publishing to use new Sonatype urls and add release workflow

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -3,16 +3,21 @@
 name: Build
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+  workflow_dispatch:
+
 jobs:
   validation:
     name: "Gradle wrapper validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.0
-      - uses: gradle/wrapper-validation-action@v3.5.0
+      - uses: actions/checkout@v6
+      - uses: gradle/actions/wrapper-validation@v3
+
   build:
     name: "Build and publish"
     runs-on: ubuntu-latest
@@ -21,14 +26,17 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4.2.0
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+
       - name: Set up JDK 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
+          cache: 'gradle'
+
       - name: Cache SonarCloud packages
         uses: actions/cache@v4.2.0
         if: env.SONAR_TOKEN != null && env.SONAR_TOKEN != ''
@@ -38,37 +46,69 @@ jobs:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
+
+      - id: get-snapshot-version
+        name: Generate snapshot version
+        shell: bash
+        run: |
+          # expects git tag to be in format 'v0.1.0' or 'v0.1.0-rc1'
+          version=$(git describe --tag --abbrev=0 | cut -c 2-)
+          regex="^([0-9]+)\.([0-9]+)\.([0-9]+)(-[a-zA-Z0-9]+)?$"
+          if [[ $version =~ $regex ]]; then
+            major="${BASH_REMATCH[1]}"
+            minor="${BASH_REMATCH[2]}"
+            patch="${BASH_REMATCH[3]}"
+            pre_release="${BASH_REMATCH[4]:-}"
+
+            # increment patch version of the latest release to create new snapshot version
+            # when pre-release - continue snapshots of the same version
+            # v0.1.0    -> 0.1.1-SNAPSHOT
+            # v0.1.0-rc -> 0.1.0-SNAPSHOT
+            if [[ -z $pre_release ]]; then
+              patch=$(($patch + 1))
+            fi
+
+            snapshot_version="${major}.${minor}.${patch}"
+
+            if ! [[ $snapshot_version =~ $regex ]]; then
+              echo "SNAPSHOT version $snapshot_version is not a valid SemVer"
+              exit 1
+            fi
+
+            echo "${snapshot_version}-SNAPSHOT"
+            echo "snapshot-version=${snapshot_version}-SNAPSHOT" >> $GITHUB_OUTPUT
+          else
+            echo "Version $version is not a valid SemVer"
+            exit 1
+          fi
+
       - name: Build
-        id: gradle
-        uses: eskatos/gradle-command-action@v3.5.0
-        with:
-          arguments: check
-          wrapper-cache-enabled: true
-          dependencies-cache-enabled: true
-          configuration-cache-enabled: true
+        run: |
+          ./gradlew \
+            -Pversion=${{ steps.get-snapshot-version.outputs.snapshot-version }} \
+            check
+
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action/composite@v2
         if: always()
         with:
           junit_files: '**/test-results/**/*.xml'
+
       - name: Analyze with SonarCloud
         continue-on-error: true
         if: env.SONAR_TOKEN != null && env.SONAR_TOKEN != ''
-        uses: eskatos/gradle-command-action@v3.5.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        with:
-          arguments: sonarqube -Psonar.organization=resilience4j
-          dependencies-cache-enabled: true
-          configuration-cache-enabled: true
+        run: |
+          ./gradlew \
+            -Pversion=${{ steps.get-snapshot-version.outputs.snapshot-version }} \
+            -Psonar.organization=resilience4j \
+            sonarqube
+
       - name: Publish to Sonatype
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-        uses: eskatos/gradle-command-action@v3.5.0
-        env:
-          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USER }}
-          ORG_GRADLE_PROJECT_sonatypePassword : ${{ secrets.SONATYPE_PASSWORD }}
-        with:
-          arguments: publishToSonatype
-          dependencies-cache-enabled: true
-          configuration-cache-enabled: true
+        # only run on master and never on forks
+        if: github.ref == 'refs/heads/master' && github.repository == 'resilience4j/resilience4j'
+        run: |
+          ./gradlew \
+            -Pversion=${{ steps.get-snapshot-version.outputs.snapshot-version }} \
+            -PsonatypeUsername=${{ secrets.SONATYPE_USER }} \
+            -PsonatypePassword=${{ secrets.SONATYPE_PASSWORD }} \
+            publishAllPublicationsToSonatypeRepository closeSonatypeStagingRepository

--- a/.github/workflows/on-release-tag.yml
+++ b/.github/workflows/on-release-tag.yml
@@ -1,0 +1,48 @@
+name: Release
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    # never run on forks
+    if: github.repository == 'resilience4j/resilience4j'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Get version from tag
+        id: get-version
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          regex="^([0-9]+)\.([0-9]+)\.([0-9]+)(-[a-zA-Z0-9]+)?$"
+          if [[ $version =~ $regex ]]; then
+            echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+          else
+            echo "Version $version is not a valid SemVer"
+            exit 1
+          fi
+
+      - name: Build
+        run: |
+          ./gradlew \
+            -Pversion=${{ steps.get-version.outputs.version }} \
+            publishToMavenLocal
+
+      - name: Upload release artifacts to Sonatype
+        run: |
+          ./gradlew \
+            -Pversion=${{ steps.get-version.outputs.version }} \
+            -PsonatypeUsername=${{ secrets.SONATYPE_USER }} \
+            -PsonatypePassword=${{ secrets.SONATYPE_PASSWORD }} \
+            -PgpgKey=${{ secrets.GPG_KEY }} \
+            -PgpgPassphrase=${{ secrets.GPG_PASSPHRASE }} \
+            publishAllPublicationsToSonatypeRepository closeAndReleaseSonatypeStagingRepository

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ apply from: "${rootDir}/libraries.gradle"
 allprojects {
     apply plugin: 'jacoco'
 
-    version = '3.0.0-SNAPSHOT'
+    version = version == 'unspecified' ? '0.1.0-SNAPSHOT' : version
     group = 'io.github.resilience4j'
     description = 'Resilience4j is a lightweight, easy-to-use fault tolerance library designed for Java8 and functional programming'
 

--- a/publishing.gradle
+++ b/publishing.gradle
@@ -66,8 +66,13 @@ tasks.withType(Sign) {
 }
 
 signing {
+    def gpgKey = project.findProperty("gpgKey")
+    def gpgPassphrase = project.findProperty("gpgPassphrase")
+    required = !version.endsWith("SNAPSHOT")
+    useInMemoryPgpKeys(gpgKey, gpgPassphrase)
     sign publishing.publications
 }
+
 publishing {
     publications {
         resilience4j(MavenPublication) {


### PR DESCRIPTION
This PR updates the URLs for Sonatype, which should fix publishing of snapshots and adds a release workflow that's triggered by GitHub release (what we discussed in Slack).

### Snapshot version publishing

The version is now set exclusively on the pipeline and is not hard-coded anymore. While it's easier that it doesn't have to be updated with every release, it's also a small inconvenience that `./gradlew publishToMavenLocal` will always use `0.1.0-SNAPSHOT` (unless you specify a different version explicitly - `-Pversion=3.0.0-SNAPSHOT`). It also means that currently published snapshots will use `2.3.1-SNAPSHOT`, because the latest tag is `v2.3.0`. For me that was never a problem, but if you prefer explicit snapshot versioning in the source code, I can make changes to keep the version in the file, so you can prepare next snapshot explicitly. Let me know 😃 

#### Docs update
On this page https://resilience4j.readme.io/docs/gradle#snapshot it's mentioned that snapshot releases can be downloaded using the following configuration:
```kotlin
repositories {
    maven {
        url = uri("https://oss.sonatype.org/content/repositories/snapshots")
    }
}
```

however the URL for sonatype snapshots has also changed, so it needs to be updated to
```kotlin
repositories {
    maven {
        url = uri("https://central.sonatype.com/repository/maven-snapshots")
    }
}
```

Please update the docs or let me know where I can find it, so I can do that 😃 

### GPG key / passphrase secrets

The pipeline relies on secrets `GPG_KEY` and `GPG_PASSPHRASE` to sign the artifacts while publishing to Sonatype. Please add those secrets to the repository settings. 
Publishing of snapshots doesn't need those secrets at the moment (was like that before my changes), but I can make necessary changes to sign snapshots as well (if you want to verify that it works before creating a new release). 

### Other changes

This PR updates most used actions to the latest version, adds native caching and a manual dispatch trigger to the build workflow (so that it doesn't require a push if you only need to build from master).

It also replaces deprecated actions:
- [gradle/wrapper-validation-action@v3.5.0](https://github.com/gradle/wrapper-validation-action) (archived) with a suggested alternative
- [eskatos/gradle-command-action@v3.5.0](https://github.com/eskatos/gradle-command-action) (now redirects to https://github.com/gradle/gradle-build-action, which is also archived 🙃) with using `./gradlew` directly

### Note for maintainer

You will need to login to a new portal (credentials used for oss.sonatype.org [should just work](https://central.sonatype.org/pages/ossrh-eol/#logging-in-to-central-portal)) and generate new credentials - [link to guide](https://central.sonatype.org/publish/generate-portal-token/) (takes a couple of minutes). 
After new token is generated, you need to update GitHub Actions secrets ( https://github.com/resilience4j/resilience4j/settings/secrets/actions) to use the new **login** (`SONATYPE_USER`) and **token** (`SONATYPE_PASSWORD`).