### PR TITLE
Issue #2395: Add Resilience4j @HttpExchange decorator support for Spring 6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ junit-bom = { module = "org.junit:junit-bom", version = "6.0.3" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine" }
+wiremock = { module = "org.wiremock:wiremock", version = "3.13.1" }
 
 # resilience4j-cache
 jcache = { module = "javax.cache:cache-api", version = "1.1.0" }
@@ -54,7 +55,6 @@ mock-clock = { module = "com.statemachinesystems:mock-clock", version = "1.0" }
 
 # resilience4j-feign
 feign-core = { module = "io.github.openfeign:feign-core", version = "12.0" }
-feign-wiremock = { module = "org.wiremock:wiremock", version = "3.13.1" }
 
 # resilience4j-kotlin
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version = "1.9.25" }
@@ -107,6 +107,7 @@ rxjava3 = { module = "io.reactivex.rxjava3:rxjava", version = "3.0.0" }
 aspectj-rt = { module = "org.aspectj:aspectjrt", version = "1.9.2" }
 spring6-context = { module = "org.springframework:spring-context", version.ref = "spring6" }
 spring6-core = { module = "org.springframework:spring-core", version.ref = "spring6" }
+spring6-web = { module = "org.springframework:spring-web", version.ref = "spring6" }
 
 # resilience4j-spring-boot3
 spring-boot3-actuator = { module = "org.springframework.boot:spring-boot-starter-actuator", version.ref = "spring-boot3" }

--- a/resilience4j-feign/build.gradle
+++ b/resilience4j-feign/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     compileOnly(libs.feign.core)
 
     testImplementation(libs.feign.core)
-    testImplementation(libs.feign.wiremock)
+    testImplementation(libs.wiremock)
 }
 ext.moduleName = "io.github.resilience4j.feign"

--- a/resilience4j-spring-boot3/build.gradle
+++ b/resilience4j-spring-boot3/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation(project(":resilience4j-rxjava2"))
     testImplementation(project(":resilience4j-rxjava3"))
     testImplementation(project(":resilience4j-test"))
-    testImplementation(libs.feign.wiremock)
+    testImplementation(libs.wiremock)
     testImplementation(libs.metrics.core)
     testImplementation(libs.micrometer.registry.prometheus)
     testImplementation(libs.reactor.core)

--- a/resilience4j-spring-boot4/build.gradle
+++ b/resilience4j-spring-boot4/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     testImplementation(project(":resilience4j-rxjava2"))
     testImplementation(project(":resilience4j-rxjava3"))
     testImplementation(project(":resilience4j-test"))
-    testImplementation(libs.feign.wiremock)
+    testImplementation(libs.wiremock)
     testImplementation(libs.metrics.core)
     testImplementation(libs.micrometer.registry.prometheus)
     testImplementation(libs.reactor.core)

--- a/resilience4j-spring6/build.gradle
+++ b/resilience4j-spring6/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     compileOnly(libs.rxjava3)
     compileOnly(libs.spring6.context)
     compileOnly(libs.spring6.core)
+    compileOnly(libs.spring6.web)
 
     testRuntimeOnly(libs.junit.vintage.engine)
 
@@ -30,5 +31,6 @@ dependencies {
     testImplementation(libs.spring.boot3.test)
     testImplementation(libs.spring.boot3.web)
     testImplementation(libs.spring6.context)
+    testImplementation(libs.wiremock)
 }
 ext.moduleName = "io.github.resilience4j.spring6"

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/httpservice/DecoratorInvocationHandler.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/httpservice/DecoratorInvocationHandler.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2026 Bobae Kim
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.spring6.httpservice;
+
+import io.github.resilience4j.core.functions.CheckedFunction;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * An instance of {@link InvocationHandler} that uses {@link HttpServiceDecorator}s to enhance the
+ * invocations of methods.
+ */
+class DecoratorInvocationHandler implements InvocationHandler {
+
+    private final HttpServiceTarget<?> target;
+    private final Object delegate;
+    private final Map<Method, CheckedFunction<Object[], Object>> decoratedDispatch;
+
+    public DecoratorInvocationHandler(HttpServiceTarget<?> target,
+                                      Object delegate,
+                                      HttpServiceDecorator invocationDecorator) {
+        this.target = Objects.requireNonNull(target, "target must not be null");
+        this.delegate = Objects.requireNonNull(delegate, "delegate must not be null");
+        Objects.requireNonNull(invocationDecorator, "invocationDecorator must not be null");
+        this.decoratedDispatch = decorateMethodHandlers(target, delegate, invocationDecorator);
+    }
+
+    /**
+     * Applies the specified {@link HttpServiceDecorator} to all methods and returns the result as
+     * a map of {@link CheckedFunction}s. Invoking a {@link CheckedFunction} will therefore invoke
+     * the decorator which, in turn, may invoke the corresponding method on the delegate.
+     *
+     * @param target              the target HTTP Service metadata.
+     * @param delegate            the Spring-created proxy to delegate calls to.
+     * @param invocationDecorator the {@link HttpServiceDecorator} with which to decorate methods.
+     * @return a new map where the methods are decorated with the {@link HttpServiceDecorator}.
+     */
+    private Map<Method, CheckedFunction<Object[], Object>> decorateMethodHandlers(
+            HttpServiceTarget<?> target,
+            Object delegate,
+            HttpServiceDecorator invocationDecorator) {
+
+        final Map<Method, CheckedFunction<Object[], Object>> map = new HashMap<>();
+
+        for (Method method : target.type().getMethods()) {
+            if (isObjectMethod(method) || method.isSynthetic()) {
+                continue;
+            }
+
+            CheckedFunction<Object[], Object> invocation = args -> {
+                try {
+                    return method.invoke(delegate, args);
+                } catch (InvocationTargetException e) {
+                    throw e.getCause();
+                }
+            };
+
+            CheckedFunction<Object[], Object> decorated =
+                    invocationDecorator.decorate(invocation, method, target);
+            map.put(method, decorated);
+        }
+        return map;
+    }
+
+    private boolean isObjectMethod(Method method) {
+        return method.getDeclaringClass() == Object.class;
+    }
+
+    @Override
+    public Object invoke(final Object proxy, final Method method, final Object[] args)
+            throws Throwable {
+        switch (method.getName()) {
+            case "equals":
+                return equals(args.length > 0 ? args[0] : null);
+
+            case "hashCode":
+                return hashCode();
+
+            case "toString":
+                return toString();
+
+            default:
+                break;
+        }
+
+        if (method.isDefault()) {
+            return InvocationHandler.invokeDefault(proxy, method, args);
+        }
+
+        CheckedFunction<Object[], Object> decorated = decoratedDispatch.get(method);
+        if (decorated != null) {
+            return decorated.apply(args);
+        }
+
+        try {
+            return method.invoke(delegate, args);
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
+        }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        Object compareTo = obj;
+        if (compareTo == null) {
+            return false;
+        }
+        if (Proxy.isProxyClass(compareTo.getClass())) {
+            compareTo = Proxy.getInvocationHandler(compareTo);
+        }
+        if (compareTo instanceof DecoratorInvocationHandler other) {
+            return target.equals(other.target);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return target.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return target.toString();
+    }
+}

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/httpservice/DefaultFallbackHandler.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/httpservice/DefaultFallbackHandler.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Bobae Kim
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.spring6.httpservice;
+
+import io.github.resilience4j.core.functions.CheckedFunction;
+
+import java.lang.reflect.Method;
+import java.util.function.Predicate;
+
+/**
+ * A {@link FallbackHandler} simply wrapping a fallback instance of type {@param T}.
+ *
+ * @param <T> the type of the fallback
+ */
+class DefaultFallbackHandler<T> implements FallbackHandler<T> {
+
+    private final T fallback;
+
+    DefaultFallbackHandler(T fallback) {
+        this.fallback = fallback;
+    }
+
+    @Override
+    public CheckedFunction<Object[], Object> decorate(
+            CheckedFunction<Object[], Object> invocationCall,
+            Method method,
+            Predicate<Exception> filter) {
+        Method fallbackMethod = validateAndGetFallbackMethod(fallback, method);
+        return args -> {
+            try {
+                return invocationCall.apply(args);
+            } catch (Exception exception) {
+                if (filter.test(exception)) {
+                    return fallbackMethod.invoke(fallback, args);
+                }
+                throw exception;
+            }
+        };
+    }
+}

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/httpservice/DefaultFallbackHandler.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/httpservice/DefaultFallbackHandler.java
@@ -17,6 +17,7 @@ package io.github.resilience4j.spring6.httpservice;
 
 import io.github.resilience4j.core.functions.CheckedFunction;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.function.Predicate;
 
@@ -44,7 +45,11 @@ class DefaultFallbackHandler<T> implements FallbackHandler<T> {
                 return invocationCall.apply(args);
             } catch (Exception exception) {
                 if (filter.test(exception)) {
-                    return fallbackMethod.invoke(fallback, args);
+                    try {
+                        return fallbackMethod.invoke(fallback, args);
+                    } catch (InvocationTargetException e) {
+                        throw e.getCause();
+                    }
                 }
                 throw exception;
             }

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/httpservice/FallbackDecorator.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/httpservice/FallbackDecorator.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Bobae Kim
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.spring6.httpservice;
+
+import io.github.resilience4j.core.functions.CheckedFunction;
+
+import java.lang.reflect.Method;
+import java.util.function.Predicate;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Decorator that calls a fallback in the case that an exception is thrown.
+ */
+class FallbackDecorator<T> implements HttpServiceDecorator {
+
+    private final FallbackHandler<T> fallback;
+    private final Predicate<Exception> filter;
+
+    /**
+     * Creates a fallback that will be called for every {@link Exception}.
+     */
+    FallbackDecorator(FallbackHandler<T> fallback) {
+        this(fallback, ex -> true);
+    }
+
+    /**
+     * Creates a fallback that will only be called for the specified {@link Exception}.
+     */
+    FallbackDecorator(FallbackHandler<T> fallback, Class<? extends Exception> filter) {
+        this(fallback, filter::isInstance);
+        requireNonNull(filter, "Filter cannot be null!");
+    }
+
+    /**
+     * Creates a fallback that will only be called if the specified {@link Predicate} returns
+     * <code>true</code>.
+     */
+    FallbackDecorator(FallbackHandler<T> fallback, Predicate<Exception> filter) {
+        this.fallback = requireNonNull(fallback, "Fallback cannot be null!");
+        this.filter = requireNonNull(filter, "Filter cannot be null!");
+    }
+
+    /**
+     * Calls the fallback if the invocationCall throws an {@link Exception}.
+     *
+     * @throws IllegalArgumentException if the fallback object does not have a corresponding
+     *                                  fallback method.
+     */
+    @Override
+    public CheckedFunction<Object[], Object> decorate(
+            CheckedFunction<Object[], Object> invocationCall,
+            Method method,
+            HttpServiceTarget<?> target) {
+        return fallback.decorate(invocationCall, method, filter);
+    }
+}

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/httpservice/FallbackDecorator.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/httpservice/FallbackDecorator.java
@@ -41,8 +41,7 @@ class FallbackDecorator<T> implements HttpServiceDecorator {
      * Creates a fallback that will only be called for the specified {@link Exception}.
      */
     FallbackDecorator(FallbackHandler<T> fallback, Class<? extends Exception> filter) {
-        this(fallback, filter::isInstance);
-        requireNonNull(filter, "Filter cannot be null!");
+        this(fallback, requireNonNull(filter, "Filter cannot be null!")::isInstance);
     }
 
     /**

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/httpservice/FallbackFactory.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/httpservice/FallbackFactory.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Bobae Kim
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.spring6.httpservice;
+
+import io.github.resilience4j.core.functions.CheckedFunction;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * A {@link FallbackHandler} wrapping a fallback of type {@param T} whose instance will consume the
+ * exception thrown on error. A new instance of the fallback will be created for every thrown
+ * exception.
+ *
+ * @param <T> the type of the fallback
+ */
+class FallbackFactory<T> implements FallbackHandler<T> {
+
+    private final Function<Exception, T> fallbackSupplier;
+
+    FallbackFactory(Function<Exception, T> fallbackSupplier) {
+        this.fallbackSupplier = fallbackSupplier;
+    }
+
+    @Override
+    public CheckedFunction<Object[], Object> decorate(
+            CheckedFunction<Object[], Object> invocationCall,
+            Method method,
+            Predicate<Exception> filter) {
+        return args -> {
+            try {
+                return invocationCall.apply(args);
+            } catch (Exception exception) {
+                if (filter.test(exception)) {
+                    T fallbackInstance = fallbackSupplier.apply(exception);
+                    Method fallbackMethod = validateAndGetFallbackMethod(fallbackInstance, method);
+                    try {
+                        return fallbackMethod.invoke(fallbackInstance, args);
+                    } catch (InvocationTargetException e) {
+                        // Rethrow the exception thrown in the fallback wrapped by InvocationTargetException
+                        throw e.getCause();
+                    }
+                }
+                throw exception;
+            }
+        };
+    }
+}

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/httpservice/FallbackHandler.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/httpservice/FallbackHandler.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Bobae Kim
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.spring6.httpservice;
+
+import io.github.resilience4j.core.functions.CheckedFunction;
+
+import java.lang.reflect.Method;
+import java.util.function.Predicate;
+
+/**
+ * Handles a fallback of type {@param T}.
+ *
+ * @param <T> the type of the fallback
+ */
+interface FallbackHandler<T> {
+
+    CheckedFunction<Object[], Object> decorate(CheckedFunction<Object[], Object> invocationCall,
+                                               Method method, Predicate<Exception> filter);
+
+    default Method validateAndGetFallbackMethod(T fallback, Method method) {
+        validateFallback(fallback, method);
+        return getFallbackMethod(fallback, method);
+    }
+
+    default void validateFallback(T fallback, Method method) {
+        if (fallback.getClass().isAssignableFrom(method.getDeclaringClass())) {
+            throw new IllegalArgumentException("Cannot use the fallback ["
+                    + fallback.getClass() + "] for ["
+                    + method.getDeclaringClass() + "]!");
+        }
+    }
+
+    default Method getFallbackMethod(T fallbackInstance, Method method) {
+        Method fallbackMethod;
+        try {
+            fallbackMethod = fallbackInstance.getClass()
+                    .getMethod(method.getName(), method.getParameterTypes());
+        } catch (NoSuchMethodException | SecurityException e) {
+            throw new IllegalArgumentException("Cannot use the fallback ["
+                    + fallbackInstance.getClass() + "] for ["
+                    + method.getDeclaringClass() + "]", e);
+        }
+        return fallbackMethod;
+    }
+}

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/httpservice/FallbackHandler.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/httpservice/FallbackHandler.java
@@ -53,6 +53,7 @@ interface FallbackHandler<T> {
                     + fallbackInstance.getClass() + "] for ["
                     + method.getDeclaringClass() + "]", e);
         }
+        fallbackMethod.setAccessible(true);
         return fallbackMethod;
     }
 }

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/httpservice/HttpServiceDecorator.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/httpservice/HttpServiceDecorator.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Bobae Kim
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.spring6.httpservice;
+
+import io.github.resilience4j.core.functions.CheckedFunction;
+
+import java.lang.reflect.Method;
+
+/**
+ * Used to decorate methods defined by HTTP Service clients. Decorators can be stacked, allowing
+ * multiple Decorators to be combined. See {@link HttpServiceDecorators}.
+ */
+@FunctionalInterface
+public interface HttpServiceDecorator {
+
+    /**
+     * Decorates the invocation of a method defined by an HTTP Service client.
+     *
+     * @param invocationCall represents the call to the method. This should be decorated by the
+     *                       implementing class.
+     * @param method         the method of the HTTP Service that is invoked.
+     * @param target         metadata about the target HTTP Service.
+     * @return the decorated invocationCall
+     */
+    CheckedFunction<Object[], Object> decorate(CheckedFunction<Object[], Object> invocationCall,
+                                               Method method,
+                                               HttpServiceTarget<?> target);
+
+}

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/httpservice/HttpServiceDecorators.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/httpservice/HttpServiceDecorators.java
@@ -44,7 +44,7 @@ import java.util.function.UnaryOperator;
  *             .withRateLimiter(rateLimiter)
  *             .build();
  *     MyService myService = Resilience4jHttpService.builder(decorators)
- *             .restClient(restClient)
+ *             .factory(factory)
  *             .build(MyService.class);
  * }
  * </pre>

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/httpservice/HttpServiceDecorators.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/httpservice/HttpServiceDecorators.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2026 Bobae Kim
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.spring6.httpservice;
+
+import io.github.resilience4j.bulkhead.Bulkhead;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.core.functions.CheckedFunction;
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.timelimiter.TimeLimiter;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+
+/**
+ * Builder to help build stacked decorators. <br>
+ *
+ * <pre>
+ * {
+ *     &#64;code
+ *     CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("backendName");
+ *     RateLimiter rateLimiter = RateLimiter.ofDefaults("backendName");
+ *     HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+ *             .withCircuitBreaker(circuitBreaker)
+ *             .withRateLimiter(rateLimiter)
+ *             .build();
+ *     MyService myService = Resilience4jHttpService.builder(decorators)
+ *             .restClient(restClient)
+ *             .build(MyService.class);
+ * }
+ * </pre>
+ * <p>
+ * The order in which decorators are applied correspond to the order in which they are declared. For
+ * example, calling {@link HttpServiceDecorators.Builder#withFallback(Object)} before {@link
+ * HttpServiceDecorators.Builder#withCircuitBreaker(CircuitBreaker)} would mean that the fallback is
+ * called when the HTTP request fails, but would no longer be reachable if the CircuitBreaker were
+ * open. However, reversing the order would mean that the fallback is called both when the HTTP
+ * request fails and when the CircuitBreaker is open. <br> So be wary of this when designing your
+ * "resilience" strategy.
+ */
+public class HttpServiceDecorators implements HttpServiceDecorator {
+
+    private final List<HttpServiceDecorator> decorators;
+
+    private HttpServiceDecorators(List<HttpServiceDecorator> decorators) {
+        this.decorators = decorators;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public CheckedFunction<Object[], Object> decorate(CheckedFunction<Object[], Object> fn,
+                                                      Method method, HttpServiceTarget<?> target) {
+        CheckedFunction<Object[], Object> decoratedFn = fn;
+        for (final HttpServiceDecorator decorator : decorators) {
+            decoratedFn = decorator.decorate(decoratedFn, method, target);
+        }
+        return decoratedFn;
+    }
+
+    public static final class Builder {
+
+        private final List<HttpServiceDecorator> decorators = new ArrayList<>();
+
+        /**
+         * Adds a {@link Retry} to the decorator chain.
+         *
+         * @param retry a fully configured {@link Retry}.
+         * @return the builder
+         */
+        public Builder withRetry(Retry retry) {
+            addDecorator(fn -> Retry.decorateCheckedFunction(retry, fn));
+            return this;
+        }
+
+        /**
+         * Adds a {@link CircuitBreaker} to the decorator chain.
+         *
+         * @param circuitBreaker a fully configured {@link CircuitBreaker}.
+         * @return the builder
+         */
+        public Builder withCircuitBreaker(CircuitBreaker circuitBreaker) {
+            addDecorator(fn -> CircuitBreaker.decorateCheckedFunction(circuitBreaker, fn));
+            return this;
+        }
+
+        /**
+         * Adds a {@link RateLimiter} to the decorator chain.
+         *
+         * @param rateLimiter a fully configured {@link RateLimiter}.
+         * @return the builder
+         */
+        public Builder withRateLimiter(RateLimiter rateLimiter) {
+            addDecorator(fn -> RateLimiter.decorateCheckedFunction(rateLimiter, fn));
+            return this;
+        }
+
+        /**
+         * Adds a {@link Bulkhead} to the decorator chain.
+         *
+         * @param bulkhead a fully configured {@link Bulkhead}.
+         * @return the builder
+         */
+        public Builder withBulkhead(Bulkhead bulkhead) {
+            addDecorator(fn -> Bulkhead.decorateCheckedFunction(bulkhead, fn));
+            return this;
+        }
+
+        /**
+         * Adds a {@link TimeLimiter} to the decorator chain. Only methods returning a
+         * {@link CompletionStage} are supported; applying this builder to an interface
+         * whose non-default methods return a synchronous type will fail when the proxy
+         * is built.
+         *
+         * @param timeLimiter a fully configured {@link TimeLimiter}.
+         * @param scheduler   the scheduler used to fire the timeout.
+         * @return the builder
+         */
+        public Builder withTimeLimiter(TimeLimiter timeLimiter, ScheduledExecutorService scheduler) {
+            decorators.add(new TimeLimiterDecorator(timeLimiter, scheduler));
+            return this;
+        }
+
+        /**
+         * Adds a fallback to the decorator chain. Multiple fallbacks can be applied with the next
+         * fallback being called when the previous one fails.
+         *
+         * @param fallback must match the HTTP Service, i.e. the interface specified when
+         *                 calling {@link Resilience4jHttpService.Builder#build(Class)}.
+         * @return the builder
+         */
+        public Builder withFallback(Object fallback) {
+            decorators.add(new FallbackDecorator<>(new DefaultFallbackHandler<>(fallback)));
+            return this;
+        }
+
+        /**
+         * Adds a fallback factory to the decorator chain. A factory can consume the exception
+         * thrown on error. Multiple fallbacks can be applied with the next fallback being called
+         * when the previous one fails.
+         *
+         * @param fallbackFactory must return an instance matching the HTTP Service.
+         * @return the builder
+         */
+        public Builder withFallbackFactory(Function<Exception, ?> fallbackFactory) {
+            decorators.add(new FallbackDecorator<>(new FallbackFactory<>(fallbackFactory)));
+            return this;
+        }
+
+        /**
+         * Adds a fallback to the decorator chain. Multiple fallbacks can be applied with the next
+         * fallback being called when the previous one fails.
+         *
+         * @param fallback must match the HTTP Service.
+         * @param filter   only {@link Exception}s matching the specified {@link Exception} will
+         *                 trigger the fallback.
+         * @return the builder
+         */
+        public Builder withFallback(Object fallback, Class<? extends Exception> filter) {
+            decorators.add(new FallbackDecorator<>(new DefaultFallbackHandler<>(fallback), filter));
+            return this;
+        }
+
+        /**
+         * Adds a fallback factory to the decorator chain. A factory can consume the exception
+         * thrown on error. Multiple fallbacks can be applied with the next fallback being called
+         * when the previous one fails.
+         *
+         * @param fallbackFactory must return an instance matching the HTTP Service.
+         * @param filter          only {@link Exception}s matching the specified {@link Exception}
+         *                        will trigger the fallback.
+         * @return the builder
+         */
+        public Builder withFallbackFactory(Function<Exception, ?> fallbackFactory,
+                                           Class<? extends Exception> filter) {
+            decorators.add(new FallbackDecorator<>(new FallbackFactory<>(fallbackFactory), filter));
+            return this;
+        }
+
+        /**
+         * Adds a fallback to the decorator chain. Multiple fallbacks can be applied with the next
+         * fallback being called when the previous one fails.
+         *
+         * @param fallback must match the HTTP Service.
+         * @param filter   the filter must return <code>true</code> for the fallback to be called.
+         * @return the builder
+         */
+        public Builder withFallback(Object fallback, Predicate<Exception> filter) {
+            decorators.add(new FallbackDecorator<>(new DefaultFallbackHandler<>(fallback), filter));
+            return this;
+        }
+
+        /**
+         * Adds a fallback factory to the decorator chain. A factory can consume the exception
+         * thrown on error. Multiple fallbacks can be applied with the next fallback being called
+         * when the previous one fails.
+         *
+         * @param fallbackFactory must return an instance matching the HTTP Service.
+         * @param filter          the filter must return <code>true</code> for the fallback to be
+         *                        called.
+         * @return the builder
+         */
+        public Builder withFallbackFactory(Function<Exception, ?> fallbackFactory,
+                                           Predicate<Exception> filter) {
+            decorators.add(new FallbackDecorator<>(new FallbackFactory<>(fallbackFactory), filter));
+            return this;
+        }
+
+        private void addDecorator(UnaryOperator<CheckedFunction<Object[], Object>> decorator) {
+            decorators.add((fn, m, t) -> {
+                // prevent default methods from being decorated
+                // as they do not participate in actual web requests
+                if (m.isDefault()) {
+                    return fn;
+                } else {
+                    return decorator.apply(fn);
+                }
+            });
+        }
+
+        /**
+         * Builds the decorator chain. This can then be used to setup an instance of {@link
+         * Resilience4jHttpService}.
+         *
+         * @return the decorators.
+         */
+        public HttpServiceDecorators build() {
+            return new HttpServiceDecorators(new ArrayList<>(decorators));
+        }
+    }
+
+    /**
+     * Internal decorator for TimeLimiter. Only methods returning a {@link CompletionStage}
+     * are supported; for any other non-default method the decorator rejects the build.
+     */
+    private record TimeLimiterDecorator(TimeLimiter timeLimiter,
+                                        ScheduledExecutorService scheduler) implements HttpServiceDecorator {
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public CheckedFunction<Object[], Object> decorate(
+                CheckedFunction<Object[], Object> invocationCall,
+                Method method,
+                HttpServiceTarget<?> target) {
+
+            if (method.isDefault()) {
+                return invocationCall;
+            }
+
+            Class<?> returnType = method.getReturnType();
+            if (!CompletionStage.class.isAssignableFrom(returnType)) {
+                throw new IllegalArgumentException(
+                        "TimeLimiter only supports CompletionStage return types, "
+                                + "but method '" + method.getName() + "' returns "
+                                + returnType.getName() + ".");
+            }
+
+            return args -> {
+                CompletionStage<Object> stage =
+                        (CompletionStage<Object>) invocationCall.apply(args);
+                return timeLimiter.executeCompletionStage(scheduler, () -> stage);
+            };
+        }
+    }
+}

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/httpservice/HttpServiceTarget.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/httpservice/HttpServiceTarget.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 Bobae Kim
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.spring6.httpservice;
+
+import java.util.Objects;
+
+/**
+ * Holds metadata about the HTTP Service target being proxied.
+ *
+ * @param <T> the type of the HTTP Service
+ */
+public final class HttpServiceTarget<T> {
+
+    private final Class<T> type;
+    private final String name;
+
+    private HttpServiceTarget(Class<T> type, String name) {
+        this.type = Objects.requireNonNull(type, "type must not be null");
+        this.name = Objects.requireNonNull(name, "name must not be null");
+    }
+
+    /**
+     * Creates a new target with the interface type and uses the simple class name as the name.
+     *
+     * @param type the HTTP Service class
+     * @param <T>  the type of the interface
+     * @return a new HttpServiceTarget
+     */
+    public static <T> HttpServiceTarget<T> of(Class<T> type) {
+        return new HttpServiceTarget<>(type, type.getSimpleName());
+    }
+
+    /**
+     * Creates a new target with the interface type and a custom name.
+     *
+     * @param type the HTTP Service class
+     * @param name the name for this target (used in metrics/logging)
+     * @param <T>  the type of the interface
+     * @return a new HttpServiceTarget
+     */
+    public static <T> HttpServiceTarget<T> of(Class<T> type, String name) {
+        return new HttpServiceTarget<>(type, name);
+    }
+
+    /**
+     * @return the HTTP Service class
+     */
+    public Class<T> type() {
+        return type;
+    }
+
+    /**
+     * @return the name of this target
+     */
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof HttpServiceTarget<?> that)) return false;
+        return type.equals(that.type) && name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, name);
+    }
+
+    @Override
+    public String toString() {
+        return "HttpServiceTarget{type=" + type.getName() + ", name='" + name + "'}";
+    }
+}

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/httpservice/Resilience4jHttpService.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/httpservice/Resilience4jHttpService.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2026 Bobae Kim
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.spring6.httpservice;
+
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.Objects;
+
+/**
+ * Main class for combining Spring HTTP Service clients with Resilience4j.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * RestClient restClient = RestClient.builder()
+ *     .baseUrl("http://localhost:8080")
+ *     .build();
+ *
+ * HttpServiceProxyFactory factory = HttpServiceProxyFactory
+ *     .builderFor(RestClientAdapter.create(restClient))
+ *     .build();
+ *
+ * HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+ *     .withCircuitBreaker(circuitBreaker)
+ *     .withRetry(retry)
+ *     .withFallback(fallbackInstance)
+ *     .build();
+ *
+ * MyService service = Resilience4jHttpService.builder(decorators)
+ *     .factory(factory)
+ *     .build(MyService.class);
+ * }</pre>
+ *
+ * @see HttpServiceDecorators
+ * @see HttpServiceDecorator
+ */
+public final class Resilience4jHttpService {
+
+    private Resilience4jHttpService() {
+    }
+
+    /**
+     * Creates a new builder with the specified decorator.
+     *
+     * @param decorator the decorator to apply to HTTP Service method invocations
+     * @return a new Builder instance
+     */
+    public static Builder builder(HttpServiceDecorator decorator) {
+        return new Builder(decorator);
+    }
+
+    /**
+     * Builder for creating resilient HTTP Service client proxies.
+     */
+    public static final class Builder {
+
+        private final HttpServiceDecorator decorator;
+        private HttpServiceProxyFactory factory;
+
+        Builder(HttpServiceDecorator decorator) {
+            this.decorator = Objects.requireNonNull(decorator, "decorator must not be null");
+        }
+
+        /**
+         * Configure with a HttpServiceProxyFactory.
+         *
+         * @param factory the factory to use for creating HTTP Service clients
+         * @return this builder
+         */
+        public Builder factory(HttpServiceProxyFactory factory) {
+            this.factory = Objects.requireNonNull(factory, "factory must not be null");
+            return this;
+        }
+
+        /**
+         * Build a resilient HTTP Service client proxy.
+         *
+         * @param serviceType the HTTP Service class
+         * @param <T>         the type of the service interface
+         * @return a decorated proxy implementing the service interface
+         */
+        public <T> T build(Class<T> serviceType) {
+            return build(serviceType, serviceType.getSimpleName());
+        }
+
+        /**
+         * Build a resilient HTTP Service client proxy with a custom name.
+         *
+         * @param serviceType the HTTP Service class
+         * @param name        the name for this client (used in metrics/logging)
+         * @param <T>         the type of the service interface
+         * @return a decorated proxy implementing the service interface
+         */
+        @SuppressWarnings("unchecked")
+        public <T> T build(Class<T> serviceType, String name) {
+            Objects.requireNonNull(serviceType, "serviceType must not be null");
+            Objects.requireNonNull(name, "name must not be null");
+
+            if (!serviceType.isInterface()) {
+                throw new IllegalArgumentException("serviceType must be an interface");
+            }
+
+            InvocationHandler invocationHandler = new DecoratorInvocationHandler(
+                    HttpServiceTarget.of(serviceType, name),
+                    factory.createClient(serviceType),
+                    decorator
+            );
+
+            return (T) Proxy.newProxyInstance(
+                    serviceType.getClassLoader(),
+                    new Class<?>[]{serviceType},
+                    invocationHandler
+            );
+        }
+    }
+}

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/httpservice/Resilience4jHttpService.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/httpservice/Resilience4jHttpService.java
@@ -109,6 +109,7 @@ public final class Resilience4jHttpService {
         public <T> T build(Class<T> serviceType, String name) {
             Objects.requireNonNull(serviceType, "serviceType must not be null");
             Objects.requireNonNull(name, "name must not be null");
+            Objects.requireNonNull(factory, "factory must not be null");
 
             if (!serviceType.isInterface()) {
                 throw new IllegalArgumentException("serviceType must be an interface");

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/httpservice/package-info.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/httpservice/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2026 Bobae Kim
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NonNullApi
+@NonNullFields
+package io.github.resilience4j.spring6.httpservice;
+
+import io.github.resilience4j.core.lang.NonNullApi;
+import io.github.resilience4j.core.lang.NonNullFields;

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/DecoratorInvocationHandlerTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/DecoratorInvocationHandlerTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2026 Bobae Kim
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.spring6.httpservice;
+
+import io.github.resilience4j.spring6.httpservice.test.TestHttpService;
+import io.github.resilience4j.spring6.httpservice.test.TestHttpServiceDecorator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+class DecoratorInvocationHandlerTest {
+
+    private DecoratorInvocationHandler testSubject;
+    private TestHttpService delegate;
+    private Method greetingMethod;
+    private TestHttpServiceDecorator decorator;
+    private HttpServiceTarget<TestHttpService> target;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        target = HttpServiceTarget.of(TestHttpService.class, "TestHttpService");
+        delegate = mock(TestHttpService.class);
+        when(delegate.greeting()).thenReturn("Hello from delegate");
+
+        greetingMethod = TestHttpService.class.getMethod("greeting");
+        decorator = new TestHttpServiceDecorator();
+
+        testSubject = new DecoratorInvocationHandler(target, delegate, decorator);
+    }
+
+    @Test
+    void testInvoke() throws Throwable {
+        Object result = testSubject.invoke(delegate, greetingMethod, new Object[0]);
+
+        verify(delegate, times(1)).greeting();
+        assertThat(decorator.isCalled())
+                .describedAs("HttpServiceDecorator is called")
+                .isTrue();
+        assertThat(result)
+                .describedAs("Return of invocation")
+                .isEqualTo("Hello from delegate");
+    }
+
+    @Test
+    void testDecorator() throws Throwable {
+        decorator.setAlternativeFunction(fnArgs -> "AlternativeFunction");
+        testSubject = new DecoratorInvocationHandler(target, delegate, decorator);
+
+        Object result = testSubject.invoke(delegate, greetingMethod, new Object[0]);
+
+        verify(delegate, times(0)).greeting();
+        assertThat(decorator.isCalled())
+                .describedAs("HttpServiceDecorator is called")
+                .isTrue();
+        assertThat(result)
+                .describedAs("Return of invocation")
+                .isEqualTo("AlternativeFunction");
+    }
+
+    @Test
+    void testInvokeToString() throws Throwable {
+        Method toStringMethod = Object.class.getMethod("toString");
+
+        Object result = testSubject.invoke(delegate, toStringMethod, new Object[0]);
+
+        verify(delegate, times(0)).greeting();
+        assertThat(result)
+                .describedAs("Return of invocation")
+                .isEqualTo(target.toString());
+    }
+
+    @Test
+    void testInvokeEquals() throws Throwable {
+        Method equalsMethod = Object.class.getMethod("equals", Object.class);
+
+        // Create a proxy to test equals with
+        Object proxy = Proxy.newProxyInstance(
+                TestHttpService.class.getClassLoader(),
+                new Class<?>[]{TestHttpService.class},
+                testSubject
+        );
+
+        Boolean result = (Boolean) testSubject.invoke(proxy, equalsMethod, new Object[]{proxy});
+
+        verify(delegate, times(0)).greeting();
+        assertThat(result)
+                .describedAs("Return of invocation")
+                .isTrue();
+    }
+
+    @Test
+    void testInvokeEqualsWithNull() throws Throwable {
+        Method equalsMethod = Object.class.getMethod("equals", Object.class);
+
+        Boolean result = (Boolean) testSubject.invoke(delegate, equalsMethod, new Object[]{null});
+
+        assertThat(result)
+                .describedAs("Return of invocation")
+                .isFalse();
+    }
+
+    @Test
+    void testInvokeEqualsWithDifferentHandler() throws Throwable {
+        Method equalsMethod = Object.class.getMethod("equals", Object.class);
+
+        HttpServiceTarget<TestHttpService> otherTarget = HttpServiceTarget.of(TestHttpService.class, "OtherService");
+        DecoratorInvocationHandler otherHandler = new DecoratorInvocationHandler(otherTarget, delegate, decorator);
+
+        Object proxy = Proxy.newProxyInstance(
+                TestHttpService.class.getClassLoader(),
+                new Class<?>[]{TestHttpService.class},
+                testSubject
+        );
+
+        Object otherProxy = Proxy.newProxyInstance(
+                TestHttpService.class.getClassLoader(),
+                new Class<?>[]{TestHttpService.class},
+                otherHandler
+        );
+
+        Boolean result = (Boolean) testSubject.invoke(proxy, equalsMethod, new Object[]{otherProxy});
+
+        assertThat(result)
+                .describedAs("Return of invocation - different targets should not be equal")
+                .isFalse();
+    }
+
+    @Test
+    void testInvokeHashcode() throws Throwable {
+        Method hashCodeMethod = Object.class.getMethod("hashCode");
+
+        Integer result = (Integer) testSubject.invoke(delegate, hashCodeMethod, new Object[0]);
+
+        verify(delegate, times(0)).greeting();
+        assertThat(result)
+                .describedAs("Return of invocation")
+                .isEqualTo(target.hashCode());
+    }
+
+    @Test
+    void testInvokeWithParameters() throws Throwable {
+        Method greetingWithNameMethod = TestHttpService.class.getMethod("greetingWithName", String.class);
+        when(delegate.greetingWithName("John")).thenReturn("Hello John");
+
+        Object result = testSubject.invoke(delegate, greetingWithNameMethod, new Object[]{"John"});
+
+        verify(delegate, times(1)).greetingWithName("John");
+        assertThat(decorator.isCalled()).isTrue();
+        assertThat(result).isEqualTo("Hello John");
+    }
+
+    @Test
+    void testDecoratorThrowsException() {
+        decorator.setAlternativeFunction(fnArgs -> {
+            throw new RuntimeException("Decorator exception");
+        });
+        testSubject = new DecoratorInvocationHandler(target, delegate, decorator);
+
+        RuntimeException e = assertThrows(RuntimeException.class,
+                () -> testSubject.invoke(delegate, greetingMethod, new Object[0]));
+        assertThat(e.getMessage()).isEqualTo("Decorator exception");
+        verify(delegate, times(0)).greeting();
+        assertThat(decorator.isCalled()).isTrue();
+    }
+
+    @Test
+    void testDelegateThrowsException() {
+        when(delegate.greeting()).thenThrow(new RuntimeException("Delegate exception"));
+
+        RuntimeException e = assertThrows(RuntimeException.class,
+                () -> testSubject.invoke(delegate, greetingMethod, new Object[0]));
+        assertThat(e.getMessage()).isEqualTo("Delegate exception");
+        verify(delegate, times(1)).greeting();
+        assertThat(decorator.isCalled()).isTrue();
+    }
+}

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/HttpServiceDecoratorsTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/HttpServiceDecoratorsTest.java
@@ -23,8 +23,11 @@ import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
+import io.github.resilience4j.ratelimiter.RequestNotPermitted;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
+import io.github.resilience4j.timelimiter.TimeLimiter;
+import io.github.resilience4j.timelimiter.TimeLimiterConfig;
 import io.github.resilience4j.spring6.httpservice.test.TestHttpService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -250,8 +253,13 @@ class HttpServiceDecoratorsTest {
         assertThat(service.greeting()).isNotNull();
         assertThat(service.greeting()).isNotNull();
 
-        // Third call should be rate limited (might throw exception or timeout)
-        // Note: This test might be flaky depending on timing
+        // Third call should be rate limited and throw RequestNotPermitted
+        assertThatThrownBy(() -> service.greeting())
+                .isInstanceOf(RequestNotPermitted.class);
+
+        // Verify metrics
+        RateLimiter.Metrics metrics = rateLimiter.getMetrics();
+        assertThat(metrics.getAvailablePermissions()).isEqualTo(0);
     }
 
     @Test
@@ -319,7 +327,7 @@ class HttpServiceDecoratorsTest {
         assertThatThrownBy(() ->
                 Resilience4jHttpService.builder(decorators)
                         .build(TestHttpService.class))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("factory must be configured");
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("factory must not be null");
     }
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/HttpServiceDecoratorsTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/HttpServiceDecoratorsTest.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright 2026 Bobae Kim
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.spring6.httpservice;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import io.github.resilience4j.ratelimiter.RateLimiterConfig;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryConfig;
+import io.github.resilience4j.spring6.httpservice.test.TestHttpService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.support.RestClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+import java.time.Duration;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@WireMockTest
+class HttpServiceDecoratorsTest {
+
+    private HttpServiceProxyFactory factory;
+
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
+        RestClient restClient = RestClient.builder()
+                .baseUrl(wmRuntimeInfo.getHttpBaseUrl())
+                .build();
+        factory = HttpServiceProxyFactory
+                .builderFor(RestClientAdapter.create(restClient))
+                .build();
+    }
+
+    @Test
+    void shouldBuildDecoratorsWithCircuitBreaker() {
+        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("test");
+
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withCircuitBreaker(circuitBreaker)
+                .build();
+
+        assertThat(decorators).isNotNull();
+    }
+
+    @Test
+    void shouldBuildDecoratorsWithMultipleComponents() {
+        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("test");
+        RateLimiter rateLimiter = RateLimiter.ofDefaults("test");
+        Retry retry = Retry.ofDefaults("test");
+
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withRetry(retry)
+                .withCircuitBreaker(circuitBreaker)
+                .withRateLimiter(rateLimiter)
+                .build();
+
+        assertThat(decorators).isNotNull();
+    }
+
+    @Test
+    void shouldCallServiceSuccessfully() {
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("Hello World")));
+
+        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("test");
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withCircuitBreaker(circuitBreaker)
+                .build();
+
+        TestHttpService service = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class);
+
+        String result = service.greeting();
+
+        assertThat(result).isEqualTo("Hello World");
+        assertThat(circuitBreaker.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldOpenCircuitBreakerOnFailures() {
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .willReturn(aResponse().withStatus(500)));
+
+        CircuitBreaker circuitBreaker = CircuitBreaker.of("test",
+                CircuitBreakerConfig.custom()
+                        .slidingWindowSize(5)
+                        .minimumNumberOfCalls(5)
+                        .failureRateThreshold(50)
+                        .waitDurationInOpenState(Duration.ofSeconds(30))
+                        .build());
+
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withCircuitBreaker(circuitBreaker)
+                .build();
+
+        TestHttpService service = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class);
+
+        // Call until circuit opens
+        for (int i = 0; i < 5; i++) {
+            try {
+                service.greeting();
+            } catch (Exception e) {
+                // Expected failures
+            }
+        }
+
+        // Circuit should be open now
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.OPEN);
+
+        // Further calls should throw CallNotPermittedException
+        assertThatThrownBy(service::greeting)
+                .isInstanceOf(CallNotPermittedException.class);
+    }
+
+    @Test
+    void shouldUseFallbackOnFailure() {
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .willReturn(aResponse().withStatus(500)));
+
+        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("test");
+
+        TestHttpService fallback = new TestHttpService() {
+            @Override
+            public String greeting() {
+                return "Fallback greeting";
+            }
+
+            @Override
+            public String greetingWithName(String name) {
+                return "Fallback: " + name;
+            }
+
+            @Override
+            public String echo(String message) {
+                return "Fallback echo: " + message;
+            }
+        };
+
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withCircuitBreaker(circuitBreaker)
+                .withFallback(fallback)
+                .build();
+
+        TestHttpService service = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class);
+
+        String result = service.greeting();
+
+        assertThat(result).isEqualTo("Fallback greeting");
+    }
+
+    @Test
+    void shouldRetryOnFailure() {
+        // First two calls fail, third succeeds using scenario
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .inScenario("retry")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(aResponse().withStatus(500))
+                .willSetStateTo("second"));
+
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .inScenario("retry")
+                .whenScenarioStateIs("second")
+                .willReturn(aResponse().withStatus(500))
+                .willSetStateTo("third"));
+
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .inScenario("retry")
+                .whenScenarioStateIs("third")
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("Success after retries")));
+
+        Retry retry = Retry.of("test",
+                RetryConfig.custom()
+                        .maxAttempts(3)
+                        .waitDuration(Duration.ofMillis(100))
+                        .build());
+
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withRetry(retry)
+                .build();
+
+        TestHttpService service = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class);
+
+        String result = service.greeting();
+
+        assertThat(result).isEqualTo("Success after retries");
+        assertThat(retry.getMetrics().getNumberOfSuccessfulCallsWithRetryAttempt()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldApplyRateLimiter() {
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("Response")));
+
+        RateLimiter rateLimiter = RateLimiter.of("test",
+                RateLimiterConfig.custom()
+                        .limitRefreshPeriod(Duration.ofSeconds(1))
+                        .limitForPeriod(2)
+                        .timeoutDuration(Duration.ofMillis(100))
+                        .build());
+
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withRateLimiter(rateLimiter)
+                .build();
+
+        TestHttpService service = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class);
+
+        // First two calls should succeed
+        assertThat(service.greeting()).isNotNull();
+        assertThat(service.greeting()).isNotNull();
+
+        // Third call should be rate limited (might throw exception or timeout)
+        // Note: This test might be flaky depending on timing
+    }
+
+    @Test
+    void shouldRejectTimeLimiterOnSynchronousMethod() {
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        TimeLimiter timeLimiter = TimeLimiter.of("test",
+                TimeLimiterConfig.custom()
+                        .timeoutDuration(Duration.ofMillis(500))
+                        .build());
+
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withTimeLimiter(timeLimiter, scheduler)
+                .build();
+
+        assertThatThrownBy(() -> Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("CompletionStage");
+
+        scheduler.shutdown();
+    }
+
+    @Test
+    void shouldBuildWithCustomName() {
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("Hello")));
+
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withCircuitBreaker(CircuitBreaker.ofDefaults("test"))
+                .build();
+
+        TestHttpService service = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class, "customServiceName");
+
+        String result = service.greeting();
+
+        assertThat(result).isEqualTo("Hello");
+    }
+
+    @Test
+    void shouldThrowExceptionForNonInterface() {
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withCircuitBreaker(CircuitBreaker.ofDefaults("test"))
+                .build();
+
+        assertThatThrownBy(() ->
+                Resilience4jHttpService.builder(decorators)
+                        .factory(factory)
+                        .build(String.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("serviceType must be an interface");
+    }
+
+    @Test
+    void shouldThrowExceptionWhenNoClientConfigured() {
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withCircuitBreaker(CircuitBreaker.ofDefaults("test"))
+                .build();
+
+        assertThatThrownBy(() ->
+                Resilience4jHttpService.builder(decorators)
+                        .build(TestHttpService.class))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("factory must be configured");
+    }
+}

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/Resilience4jHttpServiceBulkheadTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/Resilience4jHttpServiceBulkheadTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2026 Bobae Kim
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.spring6.httpservice;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.github.resilience4j.bulkhead.Bulkhead;
+import io.github.resilience4j.bulkhead.BulkheadConfig;
+import io.github.resilience4j.bulkhead.BulkheadFullException;
+import io.github.resilience4j.spring6.httpservice.test.TestHttpService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.support.RestClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests the integration of the {@link Resilience4jHttpService} with {@link Bulkhead}
+ */
+@WireMockTest
+class Resilience4jHttpServiceBulkheadTest {
+
+    private HttpServiceProxyFactory factory;
+    private TestHttpService testService;
+    private Bulkhead bulkhead;
+
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
+        RestClient restClient = RestClient.builder()
+                .baseUrl(wmRuntimeInfo.getHttpBaseUrl())
+                .build();
+        factory = HttpServiceProxyFactory
+                .builderFor(RestClientAdapter.create(restClient))
+                .build();
+
+        bulkhead = spy(Bulkhead.of("bulkheadTest", BulkheadConfig.ofDefaults()));
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withBulkhead(bulkhead)
+                .build();
+        testService = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class);
+    }
+
+    @Test
+    void testSuccessfulCall() {
+        givenResponse(200);
+
+        testService.greeting();
+
+        verify(1, getRequestedFor(urlPathEqualTo("/api/greeting")));
+        verify(bulkhead).acquirePermission();
+    }
+
+    @Test
+    void testSuccessfulCallWithDefaultMethod() {
+        givenResponse(200);
+
+        testService.defaultGreeting();
+
+        verify(1, getRequestedFor(urlPathEqualTo("/api/greeting")));
+        verify(bulkhead).acquirePermission();
+    }
+
+    @Test
+    void testBulkheadFull() {
+        givenResponse(200);
+
+        when(bulkhead.tryAcquirePermission()).thenReturn(false);
+
+        assertThatThrownBy(() -> testService.greeting())
+                .isInstanceOf(BulkheadFullException.class);
+
+        verify(0, getRequestedFor(urlPathEqualTo("/api/greeting")));
+    }
+
+    @Test
+    void testFailedCall() {
+        givenResponse(500);
+
+        assertThatThrownBy(() -> testService.greeting())
+                .isInstanceOf(HttpServerErrorException.class);
+
+        verify(bulkhead).acquirePermission();
+    }
+
+    @Test
+    void testBulkheadReleasesPermissionAfterSuccess() {
+        givenResponse(200);
+
+        Bulkhead realBulkhead = Bulkhead.of("test", BulkheadConfig.custom()
+                .maxConcurrentCalls(1)
+                .build());
+
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withBulkhead(realBulkhead)
+                .build();
+        TestHttpService service = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class);
+
+        service.greeting();
+
+        Bulkhead.Metrics metrics = realBulkhead.getMetrics();
+        assertThat(metrics.getAvailableConcurrentCalls()).isEqualTo(1);
+    }
+
+    @Test
+    void testBulkheadReleasesPermissionAfterFailure() {
+        givenResponse(500);
+
+        Bulkhead realBulkhead = Bulkhead.of("test", BulkheadConfig.custom()
+                .maxConcurrentCalls(1)
+                .build());
+
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withBulkhead(realBulkhead)
+                .build();
+        TestHttpService service = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class);
+
+        try {
+            service.greeting();
+        } catch (Exception ignored) {
+            // ignore
+        }
+
+        Bulkhead.Metrics metrics = realBulkhead.getMetrics();
+        assertThat(metrics.getAvailableConcurrentCalls()).isEqualTo(1);
+    }
+
+    @Test
+    void testBulkheadConcurrentCalls() throws InterruptedException {
+        Bulkhead realBulkhead = Bulkhead.of("test", BulkheadConfig.custom()
+                .maxConcurrentCalls(2)
+                .maxWaitDuration(Duration.ofMillis(100))
+                .build());
+
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withBulkhead(realBulkhead)
+                .build();
+        TestHttpService service = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class);
+
+        // Stub slow response
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("Response")
+                        .withFixedDelay(500)));
+
+        try (ExecutorService executor = Executors.newFixedThreadPool(3)) {
+            CountDownLatch latch = new CountDownLatch(3);
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger rejectedCount = new AtomicInteger(0);
+
+            for (int i = 0; i < 3; i++) {
+                executor.submit(() -> {
+                    try {
+                        service.greeting();
+                        successCount.incrementAndGet();
+                    } catch (BulkheadFullException e) {
+                        rejectedCount.incrementAndGet();
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            boolean completed = latch.await(5, TimeUnit.SECONDS);
+            assertThat(completed).isTrue();
+
+            // At least one call should be rejected due to bulkhead limit
+            assertThat(rejectedCount.get()).isGreaterThanOrEqualTo(1);
+        }
+    }
+
+    private void givenResponse(int responseCode) {
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .willReturn(aResponse()
+                        .withStatus(responseCode)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("hello world")));
+    }
+}

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/Resilience4jHttpServiceBulkheadTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/Resilience4jHttpServiceBulkheadTest.java
@@ -36,11 +36,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.verify;
 
 /**
  * Tests the integration of the {@link Resilience4jHttpService} with {@link Bulkhead}

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/Resilience4jHttpServiceCircuitBreakerTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/Resilience4jHttpServiceCircuitBreakerTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2026 Bobae Kim
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.spring6.httpservice;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.spring6.httpservice.test.TestHttpService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.support.RestClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+import java.time.Duration;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests the integration of the {@link Resilience4jHttpService} with {@link CircuitBreaker}
+ */
+@WireMockTest
+class Resilience4jHttpServiceCircuitBreakerTest {
+
+    private static final CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
+            .slidingWindowSize(3)
+            .waitDurationInOpenState(Duration.ofMillis(1000))
+            .build();
+
+    private CircuitBreaker circuitBreaker;
+    private TestHttpService testService;
+
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
+        RestClient restClient = RestClient.builder()
+                .baseUrl(wmRuntimeInfo.getHttpBaseUrl())
+                .build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory
+                .builderFor(RestClientAdapter.create(restClient))
+                .build();
+
+        circuitBreaker = CircuitBreaker.of("test", circuitBreakerConfig);
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withCircuitBreaker(circuitBreaker)
+                .build();
+        testService = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class);
+    }
+
+    @Test
+    void testSuccessfulCall() {
+        givenResponse(200);
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+
+        testService.greeting();
+
+        verify(1, getRequestedFor(urlPathEqualTo("/api/greeting")));
+        assertThat(metrics.getNumberOfSuccessfulCalls())
+                .describedAs("Successful Calls")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void testSuccessfulCallWithDefaultMethod() {
+        givenResponse(200);
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+
+        testService.defaultGreeting();
+
+        verify(1, getRequestedFor(urlPathEqualTo("/api/greeting")));
+        assertThat(metrics.getNumberOfSuccessfulCalls())
+                .describedAs("Successful Calls")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void testFailedCall() {
+        givenResponse(500);
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+
+        assertThatThrownBy(() -> testService.greeting())
+                .isInstanceOf(Exception.class);
+
+        assertThat(metrics.getNumberOfFailedCalls())
+                .describedAs("Failed Calls")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void testCircuitBreakerOpen() {
+        givenResponse(500);
+        int threshold = circuitBreaker.getCircuitBreakerConfig().getSlidingWindowSize() + 1;
+
+        for (int i = 0; i < threshold - 1; i++) {
+            try {
+                testService.greeting();
+            } catch (Exception ex) {
+                // ignore
+            }
+        }
+
+        // Circuit should be open now
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.OPEN);
+
+        // Further calls should throw CallNotPermittedException
+        assertThatThrownBy(() -> testService.greeting())
+                .isInstanceOf(CallNotPermittedException.class);
+
+        assertThat(circuitBreaker.tryAcquirePermission())
+                .describedAs("CircuitBreaker Closed")
+                .isFalse();
+    }
+
+    @Test
+    void testCircuitBreakerClosed() {
+        givenResponse(500);
+        int threshold = circuitBreaker.getCircuitBreakerConfig().getSlidingWindowSize() - 1;
+
+        for (int i = 0; i < threshold; i++) {
+            try {
+                testService.greeting();
+            } catch (Exception ex) {
+                // ignore
+            }
+        }
+
+        assertThat(circuitBreaker.tryAcquirePermission())
+                .describedAs("CircuitBreaker Closed")
+                .isTrue();
+    }
+
+    @Test
+    void testCircuitBreakerRecordsMetricsCorrectly() {
+        CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
+
+        // Use scenario to return different responses sequentially
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .inScenario("metrics")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("success"))
+                .willSetStateTo("second"));
+
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .inScenario("metrics")
+                .whenScenarioStateIs("second")
+                .willReturn(aResponse().withStatus(500))
+                .willSetStateTo("third"));
+
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .inScenario("metrics")
+                .whenScenarioStateIs("third")
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("success")));
+
+        testService.greeting();
+        try {
+            testService.greeting();
+        } catch (Exception ignored) {
+            // ignored
+        }
+        testService.greeting();
+
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(2);
+        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
+    }
+
+    private void givenResponse(int responseCode) {
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .willReturn(aResponse()
+                        .withStatus(responseCode)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("hello world")));
+    }
+}

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/Resilience4jHttpServiceFallbackFactoryLambdaTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/Resilience4jHttpServiceFallbackFactoryLambdaTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Bobae Kim
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.spring6.httpservice;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.github.resilience4j.spring6.httpservice.test.LambdaFallbackCreator;
+import io.github.resilience4j.spring6.httpservice.test.TestGreetingService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.support.RestClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests the integration of the {@link Resilience4jHttpService} with lambda expressions
+ * used as a fallback factory.
+ * <p>
+ * This test verifies that lambda fallbacks created in a different class
+ * do not cause IllegalAccessException (GitHub issue #560).
+ */
+@WireMockTest
+class Resilience4jHttpServiceFallbackFactoryLambdaTest {
+
+    private HttpServiceProxyFactory factory;
+    private TestGreetingService testService;
+
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
+        RestClient restClient = RestClient.builder()
+                .baseUrl(wmRuntimeInfo.getHttpBaseUrl())
+                .build();
+        factory = HttpServiceProxyFactory
+                .builderFor(RestClientAdapter.create(restClient))
+                .build();
+
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withFallbackFactory(e -> LambdaFallbackCreator.createLambdaFallback())
+                .build();
+
+        testService = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestGreetingService.class);
+    }
+
+    @Test
+    void testFallbackFactory() {
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .willReturn(aResponse()
+                        .withStatus(400)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("Hello, world!")));
+
+        String result = testService.greeting();
+
+        assertThat(result).describedAs("Result").isEqualTo("fallback");
+        verify(1, getRequestedFor(urlPathEqualTo("/api/greeting")));
+    }
+
+}

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/Resilience4jHttpServiceFallbackFactoryTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/Resilience4jHttpServiceFallbackFactoryTest.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2026 Bobae Kim
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.spring6.httpservice;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.github.resilience4j.spring6.httpservice.test.TestHttpService;
+import io.github.resilience4j.spring6.httpservice.test.TestHttpServiceFallbackThrowingException;
+import io.github.resilience4j.spring6.httpservice.test.TestHttpServiceFallbackWithException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.support.RestClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+import java.util.function.Function;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests on fallback factories.
+ */
+@WireMockTest
+class Resilience4jHttpServiceFallbackFactoryTest {
+
+    private HttpServiceProxyFactory factory;
+
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
+        RestClient restClient = RestClient.builder()
+                .baseUrl(wmRuntimeInfo.getHttpBaseUrl())
+                .build();
+        factory = HttpServiceProxyFactory
+                .builderFor(RestClientAdapter.create(restClient))
+                .build();
+    }
+
+    private TestHttpService buildTestService(Function<Exception, ?> fallbackSupplier) {
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withFallbackFactory(fallbackSupplier)
+                .build();
+        return Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class);
+    }
+
+    @Test
+    void should_successfully_get_a_response() {
+        givenResponse(200);
+        TestHttpService testService = buildTestService(e -> mock(TestHttpService.class));
+
+        String result = testService.greeting();
+
+        assertThat(result).isEqualTo("Hello, world!");
+        verify(1, getRequestedFor(urlPathEqualTo("/api/greeting")));
+    }
+
+    @Test
+    void should_lazily_fail_on_invalid_fallback() {
+        givenResponse(500);
+        TestHttpService testService = buildTestService(e -> "my fallback");
+
+        Throwable throwable = catchThrowable(testService::greeting);
+
+        assertThat(throwable).isNotNull()
+                .hasMessageContaining(
+                        "Cannot use the fallback [class java.lang.String] for [interface io.github.resilience4j.spring6.httpservice.test.TestHttpService]");
+    }
+
+    @Test
+    void should_go_to_fallback_and_consume_exception() {
+        givenResponse(500);
+        TestHttpService testService = buildTestService(TestHttpServiceFallbackWithException::new);
+
+        String result = testService.greeting();
+
+        assertThat(result)
+                .startsWith("Message from exception:");
+        verify(1, getRequestedFor(urlPathEqualTo("/api/greeting")));
+    }
+
+    @Test
+    void should_go_to_fallback_and_rethrow_an_exception_thrown_in_fallback() {
+        givenResponse(500);
+        TestHttpService testService = buildTestService(e -> new TestHttpServiceFallbackThrowingException());
+
+        Throwable result = catchThrowable(testService::greeting);
+
+        assertThat(result).isNotNull()
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Exception in greeting fallback");
+        verify(1, getRequestedFor(urlPathEqualTo("/api/greeting")));
+    }
+
+    @Test
+    void should_go_to_fallback_and_consume_exception_with_exception_filter() {
+        givenResponse(500);
+        TestHttpService uselessFallback = spy(TestHttpService.class);
+        when(uselessFallback.greeting()).thenReturn("I should not be called");
+
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withFallbackFactory(TestHttpServiceFallbackWithException::new, HttpServerErrorException.class)
+                .withFallbackFactory(e -> uselessFallback)
+                .build();
+        TestHttpService testService = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class);
+
+        String result = testService.greeting();
+
+        assertThat(result)
+                .startsWith("Message from exception:");
+        verify(uselessFallback, times(0)).greeting();
+        verify(1, getRequestedFor(urlPathEqualTo("/api/greeting")));
+    }
+
+    @Test
+    void should_go_to_second_fallback_and_consume_exception_with_exception_filter() {
+        givenResponse(500);
+        TestHttpService uselessFallback = spy(TestHttpService.class);
+        when(uselessFallback.greeting()).thenReturn("I should not be called");
+
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withFallbackFactory(e -> uselessFallback, MyException.class)
+                .withFallbackFactory(TestHttpServiceFallbackWithException::new)
+                .build();
+        TestHttpService testService = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class);
+
+        String result = testService.greeting();
+
+        assertThat(result)
+                .startsWith("Message from exception:");
+        verify(uselessFallback, times(0)).greeting();
+        verify(1, getRequestedFor(urlPathEqualTo("/api/greeting")));
+    }
+
+    @Test
+    void should_go_to_fallback_and_consume_exception_with_predicate() {
+        givenResponse(500);
+        TestHttpService uselessFallback = spy(TestHttpService.class);
+        when(uselessFallback.greeting()).thenReturn("I should not be called");
+
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withFallbackFactory(TestHttpServiceFallbackWithException::new,
+                        HttpServerErrorException.class::isInstance)
+                .withFallbackFactory(e -> uselessFallback)
+                .build();
+        TestHttpService testService = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class);
+
+        String result = testService.greeting();
+
+        assertThat(result)
+                .startsWith("Message from exception:");
+        verify(uselessFallback, times(0)).greeting();
+        verify(1, getRequestedFor(urlPathEqualTo("/api/greeting")));
+    }
+
+    @Test
+    void should_go_to_second_fallback_and_consume_exception_with_predicate() {
+        givenResponse(500);
+        TestHttpService uselessFallback = spy(TestHttpService.class);
+        when(uselessFallback.greeting()).thenReturn("I should not be called");
+
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withFallbackFactory(e -> uselessFallback, MyException.class::isInstance)
+                .withFallbackFactory(TestHttpServiceFallbackWithException::new)
+                .build();
+        TestHttpService testService = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class);
+
+        String result = testService.greeting();
+
+        assertThat(result)
+                .startsWith("Message from exception:");
+        verify(uselessFallback, times(0)).greeting();
+        verify(1, getRequestedFor(urlPathEqualTo("/api/greeting")));
+    }
+
+    @Test
+    void should_pass_exception_to_factory() {
+        givenResponse(500);
+
+        TestHttpService testService = buildTestService(e -> {
+            assertThat(e).isInstanceOf(HttpServerErrorException.class);
+            return new TestHttpServiceFallbackWithException(e);
+        });
+
+        String result = testService.greeting();
+
+        assertThat(result).startsWith("Message from exception:");
+    }
+
+    private void givenResponse(int responseCode) {
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .willReturn(aResponse()
+                        .withStatus(responseCode)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("Hello, world!")));
+    }
+
+    private static class MyException extends Exception {
+    }
+}

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/Resilience4jHttpServiceFallbackFactoryTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/Resilience4jHttpServiceFallbackFactoryTest.java
@@ -30,11 +30,9 @@ import org.springframework.web.service.invoker.HttpServiceProxyFactory;
 import java.util.function.Function;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.verify;
 
 /**
  * Unit tests on fallback factories.

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/Resilience4jHttpServiceFallbackLambdaTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/Resilience4jHttpServiceFallbackLambdaTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Bobae Kim
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.spring6.httpservice;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.github.resilience4j.spring6.httpservice.test.LambdaFallbackCreator;
+import io.github.resilience4j.spring6.httpservice.test.TestGreetingService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.support.RestClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@WireMockTest
+class Resilience4jHttpServiceFallbackLambdaTest {
+
+    private HttpServiceProxyFactory factory;
+    private TestGreetingService testService;
+
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
+        RestClient restClient = RestClient.builder()
+                .baseUrl(wmRuntimeInfo.getHttpBaseUrl())
+                .build();
+        factory = HttpServiceProxyFactory
+                .builderFor(RestClientAdapter.create(restClient))
+                .build();
+
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withFallback(LambdaFallbackCreator.createLambdaFallback())
+                .build();
+
+        testService = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestGreetingService.class);
+    }
+
+    @Test
+    void testFallback() {
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .willReturn(aResponse()
+                        .withStatus(400)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("Hello, world!")));
+
+        String result = testService.greeting();
+
+        assertThat(result).describedAs("Result").isEqualTo("fallback");
+        verify(1, getRequestedFor(urlPathEqualTo("/api/greeting")));
+    }
+
+}

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/Resilience4jHttpServiceFallbackTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/Resilience4jHttpServiceFallbackTest.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2026 Bobae Kim
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.spring6.httpservice;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.spring6.httpservice.test.TestHttpService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.support.RestClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests the integration of the {@link Resilience4jHttpService} with fallback.
+ */
+@WireMockTest
+class Resilience4jHttpServiceFallbackTest {
+
+    private HttpServiceProxyFactory factory;
+    private TestHttpService testService;
+    private TestHttpService testServiceFallback;
+
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
+        RestClient restClient = RestClient.builder()
+                .baseUrl(wmRuntimeInfo.getHttpBaseUrl())
+                .build();
+        factory = HttpServiceProxyFactory
+                .builderFor(RestClientAdapter.create(restClient))
+                .build();
+
+        testServiceFallback = mock(TestHttpService.class);
+        when(testServiceFallback.greeting()).thenReturn("fallback");
+
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withFallback(testServiceFallback)
+                .build();
+
+        testService = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class);
+    }
+
+    @Test
+    void testSuccessful() {
+        givenResponse(200);
+
+        String result = testService.greeting();
+
+        assertThat(result).describedAs("Result").isEqualTo("Hello, world!");
+        verify(testServiceFallback, times(0)).greeting();
+        verify(1, getRequestedFor(urlPathEqualTo("/api/greeting")));
+    }
+
+    @Test
+    void testInvalidFallback() {
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withFallback("not a fallback")
+                .build();
+
+        assertThatThrownBy(() ->
+                Resilience4jHttpService.builder(decorators)
+                        .factory(factory)
+                        .build(TestHttpService.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cannot use the fallback");
+    }
+
+    @Test
+    void testFallback() {
+        givenResponse(500);
+
+        String result = testService.greeting();
+
+        assertThat(result).describedAs("Result")
+                .isNotEqualTo("Hello, world!")
+                .isEqualTo("fallback");
+        verify(testServiceFallback, times(1)).greeting();
+        verify(1, getRequestedFor(urlPathEqualTo("/api/greeting")));
+    }
+
+    @Test
+    void testFallbackExceptionFilter() {
+        TestHttpService testServiceExceptionFallback = mock(TestHttpService.class);
+        when(testServiceExceptionFallback.greeting()).thenReturn("exception fallback");
+
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withFallback(testServiceExceptionFallback, HttpServerErrorException.class)
+                .withFallback(testServiceFallback)
+                .build();
+
+        testService = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class);
+        givenResponse(500);
+
+        String result = testService.greeting();
+
+        assertThat(result).describedAs("Result")
+                .isNotEqualTo("Hello, world!")
+                .isEqualTo("exception fallback");
+        verify(testServiceFallback, times(0)).greeting();
+        verify(testServiceExceptionFallback, times(1)).greeting();
+        verify(1, getRequestedFor(urlPathEqualTo("/api/greeting")));
+    }
+
+    @Test
+    void testFallbackExceptionFilterNotCalled() {
+        TestHttpService testServiceExceptionFallback = mock(TestHttpService.class);
+        when(testServiceExceptionFallback.greeting()).thenReturn("exception fallback");
+
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withFallback(testServiceExceptionFallback, CallNotPermittedException.class)
+                .withFallback(testServiceFallback)
+                .build();
+
+        testService = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class);
+        givenResponse(500);
+
+        String result = testService.greeting();
+
+        assertThat(result).describedAs("Result")
+                .isNotEqualTo("Hello, world!")
+                .isEqualTo("fallback");
+        verify(testServiceFallback, times(1)).greeting();
+        verify(testServiceExceptionFallback, times(0)).greeting();
+        verify(1, getRequestedFor(urlPathEqualTo("/api/greeting")));
+    }
+
+    @Test
+    void testFallbackFilter() {
+        TestHttpService testServiceFilterFallback = mock(TestHttpService.class);
+        when(testServiceFilterFallback.greeting()).thenReturn("filter fallback");
+
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withFallback(testServiceFilterFallback, ex -> true)
+                .withFallback(testServiceFallback)
+                .build();
+
+        testService = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class);
+        givenResponse(500);
+
+        String result = testService.greeting();
+
+        assertThat(result).describedAs("Result")
+                .isNotEqualTo("Hello, world!")
+                .isEqualTo("filter fallback");
+        verify(testServiceFallback, times(0)).greeting();
+        verify(testServiceFilterFallback, times(1)).greeting();
+        verify(1, getRequestedFor(urlPathEqualTo("/api/greeting")));
+    }
+
+    @Test
+    void testFallbackFilterNotCalled() {
+        TestHttpService testServiceFilterFallback = mock(TestHttpService.class);
+        when(testServiceFilterFallback.greeting()).thenReturn("filter fallback");
+
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withFallback(testServiceFilterFallback, ex -> false)
+                .withFallback(testServiceFallback)
+                .build();
+
+        testService = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class);
+        givenResponse(500);
+
+        String result = testService.greeting();
+
+        assertThat(result).describedAs("Result")
+                .isNotEqualTo("Hello, world!")
+                .isEqualTo("fallback");
+        verify(testServiceFallback, times(1)).greeting();
+        verify(testServiceFilterFallback, times(0)).greeting();
+        verify(1, getRequestedFor(urlPathEqualTo("/api/greeting")));
+    }
+
+    @Test
+    void testRevertFallback() {
+        // First call fails, second succeeds
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .inScenario("revert")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(aResponse()
+                        .withStatus(500)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("Hello, world!"))
+                .willSetStateTo("second"));
+
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .inScenario("revert")
+                .whenScenarioStateIs("second")
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("Hello, world!")));
+
+        testService.greeting();
+        String result = testService.greeting();
+
+        assertThat(result).describedAs("Result").isEqualTo("Hello, world!");
+        verify(testServiceFallback, times(1)).greeting();
+        verify(2, getRequestedFor(urlPathEqualTo("/api/greeting")));
+    }
+
+    @Test
+    void testFallbackWithCircuitBreaker() {
+        CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("test");
+
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withCircuitBreaker(circuitBreaker)
+                .withFallback(testServiceFallback)
+                .build();
+
+        testService = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class);
+
+        givenResponse(500);
+
+        String result = testService.greeting();
+
+        assertThat(result).isEqualTo("fallback");
+        assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls()).isEqualTo(1);
+    }
+
+    @Test
+    void testFallbackWithParameters() {
+        when(testServiceFallback.greetingWithName(anyString())).thenReturn("fallback greeting");
+
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withFallback(testServiceFallback)
+                .build();
+
+        testService = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class);
+
+        stubFor(get(urlPathMatching("/api/greeting/.*"))
+                .willReturn(aResponse()
+                        .withStatus(500)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("Hello, world!")));
+
+        String result = testService.greetingWithName("John");
+
+        assertThat(result).isEqualTo("fallback greeting");
+        verify(testServiceFallback).greetingWithName("John");
+    }
+
+    private void givenResponse(int responseCode) {
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .willReturn(aResponse()
+                        .withStatus(responseCode)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("Hello, world!")));
+    }
+}

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/Resilience4jHttpServiceFallbackTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/Resilience4jHttpServiceFallbackTest.java
@@ -29,11 +29,9 @@ import org.springframework.web.client.support.RestClientAdapter;
 import org.springframework.web.service.invoker.HttpServiceProxyFactory;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.verify;
 
 /**
  * Tests the integration of the {@link Resilience4jHttpService} with fallback.

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/Resilience4jHttpServiceFallbackTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/Resilience4jHttpServiceFallbackTest.java
@@ -21,6 +21,7 @@ import com.github.tomakehurst.wiremock.stubbing.Scenario;
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.spring6.httpservice.test.TestHttpService;
+import io.github.resilience4j.spring6.httpservice.test.TestHttpServiceFallbackThrowingException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.client.HttpServerErrorException;
@@ -273,6 +274,22 @@ class Resilience4jHttpServiceFallbackTest {
 
         assertThat(result).isEqualTo("fallback greeting");
         verify(testServiceFallback).greetingWithName("John");
+    }
+
+    @Test
+    void testFallbackMethodThrowingException() {
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withFallback(new TestHttpServiceFallbackThrowingException())
+                .build();
+
+        TestHttpService service = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class);
+        givenResponse(500);
+
+        assertThatThrownBy(service::greeting)
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Exception in greeting fallback");
     }
 
     private void givenResponse(int responseCode) {

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/Resilience4jHttpServiceRateLimiterTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/Resilience4jHttpServiceRateLimiterTest.java
@@ -31,12 +31,10 @@ import org.springframework.web.service.invoker.HttpServiceProxyFactory;
 import java.time.Duration;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.verify;
 
 /**
  * Tests the integration of the {@link Resilience4jHttpService} with {@link RateLimiter}

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/Resilience4jHttpServiceRateLimiterTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/Resilience4jHttpServiceRateLimiterTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2026 Bobae Kim
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.spring6.httpservice;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import io.github.resilience4j.ratelimiter.RateLimiterConfig;
+import io.github.resilience4j.ratelimiter.RequestNotPermitted;
+import io.github.resilience4j.spring6.httpservice.test.TestHttpService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.support.RestClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+import java.time.Duration;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests the integration of the {@link Resilience4jHttpService} with {@link RateLimiter}
+ */
+@WireMockTest
+class Resilience4jHttpServiceRateLimiterTest {
+
+    private HttpServiceProxyFactory factory;
+    private TestHttpService testService;
+    private RateLimiter rateLimiter;
+
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
+        RestClient restClient = RestClient.builder()
+                .baseUrl(wmRuntimeInfo.getHttpBaseUrl())
+                .build();
+        factory = HttpServiceProxyFactory
+                .builderFor(RestClientAdapter.create(restClient))
+                .build();
+
+        rateLimiter = mock(RateLimiter.class);
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withRateLimiter(rateLimiter)
+                .build();
+        testService = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class);
+    }
+
+    @Test
+    void testSuccessfulCall() {
+        givenResponse(200);
+        when(rateLimiter.acquirePermission(1)).thenReturn(true);
+
+        testService.greeting();
+
+        verify(1, getRequestedFor(urlPathEqualTo("/api/greeting")));
+        verify(rateLimiter).acquirePermission(anyInt());
+    }
+
+    @Test
+    void testSuccessfulCallWithDefaultMethod() {
+        givenResponse(200);
+        when(rateLimiter.acquirePermission(1)).thenReturn(true);
+
+        testService.defaultGreeting();
+
+        verify(1, getRequestedFor(urlPathEqualTo("/api/greeting")));
+        verify(rateLimiter).acquirePermission(anyInt());
+    }
+
+    @Test
+    void testRateLimiterLimiting() {
+        givenResponse(200);
+        when(rateLimiter.acquirePermission(1)).thenReturn(false);
+        when(rateLimiter.getRateLimiterConfig()).thenReturn(RateLimiterConfig.ofDefaults());
+
+        assertThatThrownBy(() -> testService.greeting())
+                .isInstanceOf(RequestNotPermitted.class);
+
+        verify(0, getRequestedFor(urlPathEqualTo("/api/greeting")));
+    }
+
+    @Test
+    void testFailedHttpCall() {
+        givenResponse(500);
+        when(rateLimiter.acquirePermission(1)).thenReturn(true);
+
+        assertThatThrownBy(() -> testService.greeting())
+                .isInstanceOf(HttpServerErrorException.class);
+    }
+
+    @Test
+    void testRateLimiterWithRealConfig(WireMockRuntimeInfo wmRuntimeInfo) {
+        RestClient restClient = RestClient.builder()
+                .baseUrl(wmRuntimeInfo.getHttpBaseUrl())
+                .build();
+        HttpServiceProxyFactory newFactory = HttpServiceProxyFactory
+                .builderFor(RestClientAdapter.create(restClient))
+                .build();
+
+        RateLimiter realRateLimiter = RateLimiter.of("test",
+                RateLimiterConfig.custom()
+                        .limitRefreshPeriod(Duration.ofSeconds(1))
+                        .limitForPeriod(2)
+                        .timeoutDuration(Duration.ofMillis(100))
+                        .build());
+
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withRateLimiter(realRateLimiter)
+                .build();
+
+        TestHttpService service = Resilience4jHttpService.builder(decorators)
+                .factory(newFactory)
+                .build(TestHttpService.class);
+
+        // Stub responses
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("Response")));
+
+        // First two calls should succeed
+        assertThat(service.greeting()).isNotNull();
+        assertThat(service.greeting()).isNotNull();
+
+        // Third call should be rate limited
+        assertThatThrownBy(service::greeting)
+                .isInstanceOf(RequestNotPermitted.class);
+    }
+
+    @Test
+    void testRateLimiterMetrics(WireMockRuntimeInfo wmRuntimeInfo) {
+        RestClient restClient = RestClient.builder()
+                .baseUrl(wmRuntimeInfo.getHttpBaseUrl())
+                .build();
+        HttpServiceProxyFactory newFactory = HttpServiceProxyFactory
+                .builderFor(RestClientAdapter.create(restClient))
+                .build();
+
+        RateLimiter realRateLimiter = RateLimiter.of("test",
+                RateLimiterConfig.custom()
+                        .limitRefreshPeriod(Duration.ofSeconds(10))
+                        .limitForPeriod(5)
+                        .timeoutDuration(Duration.ofMillis(100))
+                        .build());
+
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withRateLimiter(realRateLimiter)
+                .build();
+
+        TestHttpService service = Resilience4jHttpService.builder(decorators)
+                .factory(newFactory)
+                .build(TestHttpService.class);
+
+        // Stub responses
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("Response")));
+
+        service.greeting();
+        service.greeting();
+        service.greeting();
+
+        RateLimiter.Metrics metrics = realRateLimiter.getMetrics();
+        assertThat(metrics.getAvailablePermissions()).isEqualTo(2);
+        assertThat(metrics.getNumberOfWaitingThreads()).isEqualTo(0);
+    }
+
+    private void givenResponse(int responseCode) {
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .willReturn(aResponse()
+                        .withStatus(responseCode)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("hello world")));
+    }
+}

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/Resilience4jHttpServiceRetryTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/Resilience4jHttpServiceRetryTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2026 Bobae Kim
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.spring6.httpservice;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryConfig;
+import io.github.resilience4j.spring6.httpservice.test.TestHttpService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.support.RestClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+import java.time.Duration;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests the integration of the {@link Resilience4jHttpService} with {@link Retry}
+ */
+@WireMockTest
+class Resilience4jHttpServiceRetryTest {
+
+    private HttpServiceProxyFactory factory;
+    private TestHttpService testService;
+    private Retry retry;
+
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
+        RestClient restClient = RestClient.builder()
+                .baseUrl(wmRuntimeInfo.getHttpBaseUrl())
+                .build();
+        factory = HttpServiceProxyFactory
+                .builderFor(RestClientAdapter.create(restClient))
+                .build();
+
+        retry = Retry.ofDefaults("test");
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withRetry(retry)
+                .build();
+        testService = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class);
+    }
+
+    @Test
+    void testSuccessfulCall() {
+        givenResponse(200);
+
+        String result = testService.greeting();
+
+        assertThat(result).isEqualTo("hello world");
+        verify(1, getRequestedFor(urlPathEqualTo("/api/greeting")));
+    }
+
+    @Test
+    void testSuccessfulCallWithDefaultMethod() {
+        givenResponse(200);
+
+        String result = testService.defaultGreeting();
+
+        assertThat(result).isEqualTo("hello world");
+        verify(1, getRequestedFor(urlPathEqualTo("/api/greeting")));
+    }
+
+    @Test
+    void testFailedHttpCall() {
+        givenResponse(500);
+
+        assertThatThrownBy(() -> testService.greeting())
+                .isInstanceOf(HttpServerErrorException.class);
+    }
+
+    @Test
+    void testFailedHttpCallWithRetry() {
+        givenResponse(500);
+
+        retry = Retry.of("test", RetryConfig.custom()
+                .retryExceptions(HttpServerErrorException.class)
+                .maxAttempts(3)
+                .waitDuration(Duration.ofMillis(50))
+                .build());
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withRetry(retry)
+                .build();
+        testService = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class);
+
+        assertThatThrownBy(() -> testService.greeting())
+                .isInstanceOf(HttpServerErrorException.class);
+
+        verify(3, getRequestedFor(urlPathEqualTo("/api/greeting")));
+    }
+
+    @Test
+    void testSuccessAfterRetry() {
+        retry = Retry.of("test", RetryConfig.custom()
+                .retryExceptions(HttpServerErrorException.class)
+                .maxAttempts(3)
+                .waitDuration(Duration.ofMillis(50))
+                .build());
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withRetry(retry)
+                .build();
+        testService = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class);
+
+        // First two calls fail, third succeeds using scenario
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .inScenario("retry")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(aResponse().withStatus(500))
+                .willSetStateTo("second"));
+
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .inScenario("retry")
+                .whenScenarioStateIs("second")
+                .willReturn(aResponse().withStatus(500))
+                .willSetStateTo("third"));
+
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .inScenario("retry")
+                .whenScenarioStateIs("third")
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("success after retry")));
+
+        String result = testService.greeting();
+
+        assertThat(result).isEqualTo("success after retry");
+        verify(3, getRequestedFor(urlPathEqualTo("/api/greeting")));
+        assertThat(retry.getMetrics().getNumberOfSuccessfulCallsWithRetryAttempt()).isEqualTo(1);
+    }
+
+    @Test
+    void testRetryOnResult() {
+        retry = Retry.of("test", RetryConfig.<String>custom()
+                .retryOnResult(s -> s.equalsIgnoreCase("retry me"))
+                .maxAttempts(3)
+                .waitDuration(Duration.ofMillis(50))
+                .build());
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withRetry(retry)
+                .build();
+        testService = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class);
+
+        // First two return "retry me", third returns success
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .inScenario("retryOnResult")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("retry me"))
+                .willSetStateTo("second"));
+
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .inScenario("retryOnResult")
+                .whenScenarioStateIs("second")
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("retry me"))
+                .willSetStateTo("third"));
+
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .inScenario("retryOnResult")
+                .whenScenarioStateIs("third")
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("success")));
+
+        String result = testService.greeting();
+
+        assertThat(result).isEqualTo("success");
+        verify(3, getRequestedFor(urlPathEqualTo("/api/greeting")));
+    }
+
+    @Test
+    void testRetryMetrics() {
+        retry = Retry.of("test", RetryConfig.custom()
+                .retryExceptions(HttpServerErrorException.class)
+                .maxAttempts(2)
+                .waitDuration(Duration.ofMillis(50))
+                .build());
+        HttpServiceDecorators decorators = HttpServiceDecorators.builder()
+                .withRetry(retry)
+                .build();
+        testService = Resilience4jHttpService.builder(decorators)
+                .factory(factory)
+                .build(TestHttpService.class);
+
+        // First call fails, second succeeds
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .inScenario("metrics")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(aResponse().withStatus(500))
+                .willSetStateTo("second"));
+
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .inScenario("metrics")
+                .whenScenarioStateIs("second")
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("success")));
+
+        testService.greeting();
+
+        Retry.Metrics metrics = retry.getMetrics();
+        assertThat(metrics.getNumberOfSuccessfulCallsWithRetryAttempt()).isEqualTo(1);
+        assertThat(metrics.getNumberOfSuccessfulCallsWithoutRetryAttempt()).isZero();
+    }
+
+    private void givenResponse(int responseCode) {
+        stubFor(get(urlPathEqualTo("/api/greeting"))
+                .willReturn(aResponse()
+                        .withStatus(responseCode)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("hello world")));
+    }
+}

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/test/LambdaFallbackCreator.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/test/LambdaFallbackCreator.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Bobae Kim
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.spring6.httpservice.test;
+
+/**
+ * Creates lambda-based fallback instances.
+ */
+public class LambdaFallbackCreator {
+
+    /**
+     * Creates a lambda-based fallback for TestGreetingService.
+     * Uses a functional interface to enable lambda expression.
+     *
+     * @return a lambda-based fallback instance
+     */
+    public static TestGreetingService createLambdaFallback() {
+        return () -> "fallback";
+    }
+}

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/test/TestGreetingService.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/test/TestGreetingService.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Bobae Kim
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.spring6.httpservice.test;
+
+import org.springframework.web.service.annotation.GetExchange;
+import org.springframework.web.service.annotation.HttpExchange;
+
+/**
+ * A simple functional interface for testing lambda-based fallbacks.
+ */
+@FunctionalInterface
+@HttpExchange("/api")
+public interface TestGreetingService {
+    @GetExchange("/greeting")
+    String greeting();
+}

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/test/TestHttpService.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/test/TestHttpService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Bobae Kim
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.spring6.httpservice.test;
+
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.service.annotation.GetExchange;
+import org.springframework.web.service.annotation.HttpExchange;
+import org.springframework.web.service.annotation.PostExchange;
+
+/**
+ * Test HTTP Service for unit tests.
+ */
+@HttpExchange("/api")
+public interface TestHttpService {
+
+    @GetExchange("/greeting")
+    String greeting();
+
+    @GetExchange("/greeting/{name}")
+    String greetingWithName(@PathVariable String name);
+
+    @PostExchange("/echo")
+    String echo(String message);
+
+    /**
+     * Default method that calls greeting().
+     * Should not be decorated.
+     */
+    default String defaultGreeting() {
+        return greeting();
+    }
+}

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/test/TestHttpServiceDecorator.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/test/TestHttpServiceDecorator.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Bobae Kim
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.spring6.httpservice.test;
+
+import io.github.resilience4j.core.functions.CheckedFunction;
+import io.github.resilience4j.spring6.httpservice.HttpServiceDecorator;
+import io.github.resilience4j.spring6.httpservice.HttpServiceTarget;
+
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+/**
+ * Test decorator for unit tests that tracks whether it has been called
+ * and optionally provides an alternative function.
+ */
+public class TestHttpServiceDecorator implements HttpServiceDecorator {
+
+    private boolean called = false;
+    private CheckedFunction<Object[], Object> alternativeFunction;
+
+    @Override
+    public CheckedFunction<Object[], Object> decorate(CheckedFunction<Object[], Object> fn,
+                                                      Method method,
+                                                      HttpServiceTarget<?> target) {
+        return args -> {
+            called = true;
+            return Objects.requireNonNullElse(alternativeFunction, fn).apply(args);
+        };
+    }
+
+    public boolean isCalled() {
+        return called;
+    }
+
+    public void setAlternativeFunction(CheckedFunction<Object[], Object> alternativeFunction) {
+        this.alternativeFunction = alternativeFunction;
+    }
+}

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/test/TestHttpServiceFallbackThrowingException.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/test/TestHttpServiceFallbackThrowingException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Bobae Kim
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.spring6.httpservice.test;
+
+/**
+ * A fallback throwing an exception.
+ */
+public class TestHttpServiceFallbackThrowingException implements TestHttpService {
+
+    @Override
+    public String greeting() {
+        throw new RuntimeException("Exception in greeting fallback");
+    }
+
+    @Override
+    public String greetingWithName(String name) {
+        throw new RuntimeException("Exception in greetingWithName fallback");
+    }
+
+    @Override
+    public String echo(String message) {
+        throw new RuntimeException("Exception in echo fallback");
+    }
+}

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/test/TestHttpServiceFallbackWithException.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/httpservice/test/TestHttpServiceFallbackWithException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Bobae Kim
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.spring6.httpservice.test;
+
+/**
+ * A fallback consuming the thrown exception.
+ */
+public class TestHttpServiceFallbackWithException implements TestHttpService {
+
+    private final Exception cause;
+
+    public TestHttpServiceFallbackWithException(Exception cause) {
+        this.cause = cause;
+    }
+
+    @Override
+    public String greeting() {
+        return "Message from exception: " + cause.getMessage();
+    }
+
+    @Override
+    public String greetingWithName(String name) {
+        return "Fallback with exception for: " + name + ", cause: " + cause.getMessage();
+    }
+
+    @Override
+    public String echo(String message) {
+        return "Echo fallback with exception: " + message + ", cause: " + cause.getMessage();
+    }
+}


### PR DESCRIPTION
  ## Summary

#2395 

This PR adds Resilience4j decorator support for Spring 6's `@HttpExchange` HTTP Service Client (introduced in Spring 6.0).

The implementation follows the same patterns as the existing Resilience4j Feign integration, providing a familiar API for users already using Resilience4j with Feign.


## Changes

### New Features

- **Resilience4jHttpService**: Main entry point for creating resilient HTTP Service client proxies (similar to `Resilience4jFeign`)
- **HttpServiceDecorators**: Builder for composing multiple resilience decorators in a specified order (similar to `FeignDecorators`)
- **HttpServiceDecorator**: Functional interface for decorating HTTP Service method invocations
- **HttpServiceTarget**: Metadata holder for the HTTP Service target being proxied
- **FallbackFactory**: Creates fallback instances that can consume the thrown exception
- **FallbackHandler / DefaultFallbackHandler**: Handles fallback method invocation
- **FallbackDecorator**: Decorator that applies fallback logic with optional exception filtering
- **DecoratorInvocationHandler**: `InvocationHandler` that applies decorators to proxy method calls

### Supported Patterns

- CircuitBreaker
- RateLimiter
- Retry
- Bulkhead
- TimeLimiter
- Fallback (with filter support and FallbackFactory)

### Dependencies

- Added Spring Web dependencies for HTTP Service support
- Added WireMock 3.x for testing

## Usage Example

```java
// 1. Create RestClient
RestClient restClient = RestClient.builder()
    .baseUrl("http://localhost:8080")
    .build();

// 2. Create HttpServiceProxyFactory
HttpServiceProxyFactory factory = HttpServiceProxyFactory
    .builderFor(RestClientAdapter.create(restClient))
    .build();

// 3. Create decorators (similar to FeignDecorators)
HttpServiceDecorators decorators = HttpServiceDecorators.builder()
    .withCircuitBreaker(circuitBreaker)
    .withRetry(retry)
    .withFallback(new MyServiceFallback())
    .build();

// 4. Build resilient HTTP Service client (similar to Resilience4jFeign.builder())
MyService service = Resilience4jHttpService.builder(decorators)
    .factory(factory)
    .build(MyService.class);
```

---


## Note on Package Naming

The package is named `httpservice` to align with Spring's official terminology:
- Spring refers to this feature as **"HTTP service"** or **"HTTP service client"** — "the ability to define an HTTP service through a Java interface with `@HttpExchange`-annotated methods"
- `@HttpExchange` is simply an annotation used to mark methods within an HTTP service interface
- Related Spring components also use this naming: `HttpServiceProxyFactory`, `HttpServiceProxyRegistry`

If there's a more appropriate name, suggestions are welcome.