### PR TITLE
Fix #2327: Correct @see tag usage in CircuitBreakerConfig Javadoc

### DIFF
--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfig.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfig.java
@@ -879,17 +879,18 @@ public class CircuitBreakerConfig implements Serializable {
          * failure rate. Any exception matching or inheriting from one of the list should count as a
          * failure, unless ignored via {@link #ignoreExceptions(Class[])} or {@link
          * #ignoreException(Predicate)}.
-         *
-         * @param errorClasses the error classes that are recorded
-         * @return the CircuitBreakerConfig.Builder
-         * @see #ignoreExceptions(Class[]) ). Ignoring an exception has priority over recording an
-         * exception.
+         * <p>
+         * Ignoring an exception has priority over recording an exception.
          * <p>
          * Example: recordExceptions(Throwable.class) and ignoreExceptions(RuntimeException.class)
          * would capture all Errors and checked Exceptions, and ignore RuntimeExceptions.
          * <p>
          * For a more sophisticated exception management use the
-         * @see #recordException(Predicate) method
+         * {@link #recordException(Predicate)} method
+         *
+         * @param errorClasses the error classes that are recorded
+         * @return the CircuitBreakerConfig.Builder
+         * @see #ignoreExceptions(Class[])
          */
         @SuppressWarnings("unchecked")
         @SafeVarargs


### PR DESCRIPTION
## Description
Fixes #2327

Corrects improper `@see` tag usage in `CircuitBreakerConfig.java` to fix Javadoc rendering in IDEs.

## Changes
- Moved `@see` tags to correct position (after `@param` and `@return`)
- Removed descriptive text from `@see` tags (moved to method description)
- Affected methods: `recordExceptions()` and `ignoreExceptions()`

**Before:**
```java
* @return the CircuitBreakerConfig.Builder
* @see #ignoreExceptions(Class[]) ). Ignoring an exception has priority...
```

**After:**
```java
* @param errorClasses the error classes that are recorded
* @return the CircuitBreakerConfig.Builder
* @see #ignoreExceptions(Class[])
```
<img width="664" height="482" alt="issue_2327" src="https://github.com/user-attachments/assets/dfb45d7f-ea5c-4839-8f7b-33dac9da52a1" />

## Testing
- [x] `./gradlew javadoc` - builds successfully
- [x] Verified rendering in IntelliJ IDEA