### PR TITLE
Use correct constant for initializing CircuitBreakerConfig.Builder.waitIntervalFunctionInOpenState

### DIFF
--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfig.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfig.java
@@ -364,7 +364,7 @@ public class CircuitBreakerConfig implements Serializable {
         private Predicate<Object> recordResultPredicate = DEFAULT_RECORD_RESULT_PREDICATE;
 
         private IntervalFunction waitIntervalFunctionInOpenState = IntervalFunction
-            .of(Duration.ofSeconds(DEFAULT_SLOW_CALL_DURATION_THRESHOLD));
+            .of(Duration.ofSeconds(DEFAULT_WAIT_DURATION_IN_OPEN_STATE));
 
         private Function<Either<Object, Throwable>, TransitionCheckResult> transitionOnResult
             = DEFAULT_TRANSITION_ON_RESULT;


### PR DESCRIPTION
Fixes https://github.com/resilience4j/resilience4j/issues/2401