### PR TITLE
Fix SpEL template evaluation and support external bean fallback

### DIFF
--- a/resilience4j-annotations/src/main/java/io/github/resilience4j/bulkhead/annotation/Bulkhead.java
+++ b/resilience4j-annotations/src/main/java/io/github/resilience4j/bulkhead/annotation/Bulkhead.java
@@ -30,6 +30,8 @@ public @interface Bulkhead {
 
     /**
      * fallbackMethod method name.
+     * It can be a SpEL expression. Use {@code "beanName::methodName"} to reference
+     * a fallback method on an external Spring bean.
      *
      * @return fallbackMethod method name.
      */

--- a/resilience4j-annotations/src/main/java/io/github/resilience4j/circuitbreaker/annotation/CircuitBreaker.java
+++ b/resilience4j-annotations/src/main/java/io/github/resilience4j/circuitbreaker/annotation/CircuitBreaker.java
@@ -51,6 +51,8 @@ public @interface CircuitBreaker {
 
     /**
      * fallbackMethod method name.
+     * It can be a SpEL expression. Use {@code "beanName::methodName"} to reference
+     * a fallback method on an external Spring bean.
      *
      * @return fallbackMethod method name.
      */

--- a/resilience4j-annotations/src/main/java/io/github/resilience4j/micrometer/annotation/Timer.java
+++ b/resilience4j-annotations/src/main/java/io/github/resilience4j/micrometer/annotation/Timer.java
@@ -47,6 +47,8 @@ public @interface Timer {
 
     /**
      * fallbackMethod method name.
+     * It can be a SpEL expression. Use {@code "beanName::methodName"} to reference
+     * a fallback method on an external Spring bean.
      *
      * @return fallbackMethod method name.
      */

--- a/resilience4j-annotations/src/main/java/io/github/resilience4j/ratelimiter/annotation/RateLimiter.java
+++ b/resilience4j-annotations/src/main/java/io/github/resilience4j/ratelimiter/annotation/RateLimiter.java
@@ -47,6 +47,8 @@ public @interface RateLimiter {
 
     /**
      * fallbackMethod method name.
+     * It can be a SpEL expression. Use {@code "beanName::methodName"} to reference
+     * a fallback method on an external Spring bean.
      *
      * @return fallbackMethod method name.
      */

--- a/resilience4j-annotations/src/main/java/io/github/resilience4j/retry/annotation/Retry.java
+++ b/resilience4j-annotations/src/main/java/io/github/resilience4j/retry/annotation/Retry.java
@@ -46,6 +46,8 @@ public @interface Retry {
 
     /**
      * fallbackMethod method name.
+     * It can be a SpEL expression. Use {@code "beanName::methodName"} to reference
+     * a fallback method on an external Spring bean.
      *
      * @return fallbackMethod method name.
      */

--- a/resilience4j-annotations/src/main/java/io/github/resilience4j/timelimiter/annotation/TimeLimiter.java
+++ b/resilience4j-annotations/src/main/java/io/github/resilience4j/timelimiter/annotation/TimeLimiter.java
@@ -47,6 +47,8 @@ public @interface TimeLimiter {
 
     /**
      * fallbackMethod method name.
+     * It can be a SpEL expression. Use {@code "beanName::methodName"} to reference
+     * a fallback method on an external Spring bean.
      *
      * @return fallbackMethod method name.
      */

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/fallback/FallbackExecutor.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/fallback/FallbackExecutor.java
@@ -5,32 +5,79 @@ import io.github.resilience4j.spelresolver.SpelResolver;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.aop.framework.AopProxyUtils;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.util.StringUtils;
 
 import java.lang.reflect.Method;
 
-public class FallbackExecutor {
+public class FallbackExecutor implements BeanFactoryAware {
 
     private static final Logger logger = LoggerFactory.getLogger(FallbackExecutor.class);
+    private static final String BEAN_METHOD_SEPARATOR = "::";
 
     private final SpelResolver spelResolver;
     private final FallbackDecorators fallbackDecorators;
+    private BeanFactory beanFactory;
 
     public FallbackExecutor(SpelResolver spelResolver, FallbackDecorators fallbackDecorators) {
         this.spelResolver = spelResolver;
         this.fallbackDecorators = fallbackDecorators;
     }
 
+    @Override
+    public void setBeanFactory(BeanFactory beanFactory) {
+        this.beanFactory = beanFactory;
+    }
+
     public Object execute(ProceedingJoinPoint proceedingJoinPoint, Method method, String fallbackMethodValue, CheckedSupplier<Object> primaryFunction) throws Throwable {
         String fallbackMethodName = spelResolver.resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue);
 
         FallbackMethod fallbackMethod = null;
+        String beanName = null;
         if (StringUtils.hasLength(fallbackMethodName)) {
             try {
+                Object original;
+                Object proxy;
+                int separatorIdx = fallbackMethodName.indexOf(BEAN_METHOD_SEPARATOR);
+                if (separatorIdx == 0) {
+                    throw new NoSuchMethodException(
+                        "Invalid fallbackMethod format: bean name is empty in '" + fallbackMethodValue + "'");
+                }
+                if (separatorIdx > 0 && beanFactory == null) {
+                    throw new NoSuchMethodException(
+                        "beanName::methodName syntax requires BeanFactory but it was not injected. "
+                            + "Ensure FallbackExecutor is a Spring-managed bean.");
+                }
+                if (separatorIdx > 0) {
+                    int nextSeparatorIdx = fallbackMethodName.indexOf(
+                        BEAN_METHOD_SEPARATOR, separatorIdx + BEAN_METHOD_SEPARATOR.length());
+                    if (nextSeparatorIdx != -1) {
+                        throw new NoSuchMethodException(
+                            "Invalid fallbackMethod format: expected 'beanName::methodName' but got '" + fallbackMethodValue + "'");
+                    }
+                    beanName = fallbackMethodName.substring(0, separatorIdx);
+                    fallbackMethodName = fallbackMethodName.substring(separatorIdx + BEAN_METHOD_SEPARATOR.length());
+                    if (!StringUtils.hasLength(fallbackMethodName)) {
+                        throw new NoSuchMethodException(
+                            "Invalid fallbackMethod format: expected 'beanName::methodName' but got '" + fallbackMethodValue + "'");
+                    }
+                    Object fallbackBean = beanFactory.getBean(beanName);
+                    proxy = fallbackBean;
+                    Object singletonTarget = AopProxyUtils.getSingletonTarget(fallbackBean);
+                    original = (singletonTarget != null) ? singletonTarget : fallbackBean;
+                } else {
+                    original = proceedingJoinPoint.getTarget();
+                    proxy = proceedingJoinPoint.getThis();
+                }
                 fallbackMethod = FallbackMethod
-                    .create(fallbackMethodName, method, proceedingJoinPoint.getArgs(), proceedingJoinPoint.getTarget(), proceedingJoinPoint.getThis());
+                    .create(fallbackMethodName, method, proceedingJoinPoint.getArgs(), original, proxy);
             } catch (NoSuchMethodException ex) {
                 logger.warn("No fallback method match found", ex);
+            } catch (BeansException ex) {
+                logger.warn("Failed to resolve fallback bean '{}'", beanName, ex);
             }
         }
         if (fallbackMethod == null) {

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/fallback/FallbackExecutor.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/fallback/FallbackExecutor.java
@@ -6,9 +6,10 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.aop.framework.AopProxyUtils;
-import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.BeanNotOfRequiredTypeException;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.util.StringUtils;
 
 import java.lang.reflect.Method;
@@ -20,11 +21,17 @@ public class FallbackExecutor implements BeanFactoryAware {
 
     private final SpelResolver spelResolver;
     private final FallbackDecorators fallbackDecorators;
+    // TODO: cache FallbackMethod by (beanName, methodName, originalMethod) for hot paths
     private BeanFactory beanFactory;
 
     public FallbackExecutor(SpelResolver spelResolver, FallbackDecorators fallbackDecorators) {
         this.spelResolver = spelResolver;
         this.fallbackDecorators = fallbackDecorators;
+    }
+
+    public FallbackExecutor(SpelResolver spelResolver, FallbackDecorators fallbackDecorators, BeanFactory beanFactory) {
+        this(spelResolver, fallbackDecorators);
+        this.beanFactory = beanFactory;
     }
 
     @Override
@@ -46,12 +53,12 @@ public class FallbackExecutor implements BeanFactoryAware {
                     throw new NoSuchMethodException(
                         "Invalid fallbackMethod format: bean name is empty in '" + fallbackMethodValue + "'");
                 }
-                if (separatorIdx > 0 && beanFactory == null) {
-                    throw new NoSuchMethodException(
-                        "beanName::methodName syntax requires BeanFactory but it was not injected. "
-                            + "Ensure FallbackExecutor is a Spring-managed bean.");
-                }
                 if (separatorIdx > 0) {
+                    if (beanFactory == null) {
+                        throw new NoSuchMethodException(
+                            "beanName::methodName syntax requires BeanFactory but it was not injected. "
+                                + "Ensure FallbackExecutor is a Spring-managed bean.");
+                    }
                     int nextSeparatorIdx = fallbackMethodName.indexOf(
                         BEAN_METHOD_SEPARATOR, separatorIdx + BEAN_METHOD_SEPARATOR.length());
                     if (nextSeparatorIdx != -1) {
@@ -76,7 +83,7 @@ public class FallbackExecutor implements BeanFactoryAware {
                     .create(fallbackMethodName, method, proceedingJoinPoint.getArgs(), original, proxy);
             } catch (NoSuchMethodException ex) {
                 logger.warn("No fallback method match found", ex);
-            } catch (BeansException ex) {
+            } catch (NoSuchBeanDefinitionException | BeanNotOfRequiredTypeException ex) {
                 logger.warn("Failed to resolve fallback bean '{}'", beanName, ex);
             }
         }

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/spelresolver/DefaultSpelResolver.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/spelresolver/DefaultSpelResolver.java
@@ -47,7 +47,7 @@ public class DefaultSpelResolver implements EmbeddedValueResolverAware, SpelReso
 
     @Override
     public String resolve(Method method, Object[] arguments, String spelExpression) {
-        if (!StringUtils.hasText(spelExpression)) {
+        if (StringUtils.isEmpty(spelExpression)) {
             return spelExpression;
         }
 

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/spelresolver/DefaultSpelResolver.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/spelresolver/DefaultSpelResolver.java
@@ -20,6 +20,7 @@ import org.springframework.context.EmbeddedValueResolverAware;
 import org.springframework.context.expression.BeanFactoryResolver;
 import org.springframework.context.expression.MethodBasedEvaluationContext;
 import org.springframework.core.ParameterNameDiscoverer;
+import org.springframework.expression.common.TemplateParserContext;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.util.StringUtils;
 import org.springframework.util.StringValueResolver;
@@ -27,9 +28,11 @@ import org.springframework.util.StringValueResolver;
 import java.lang.reflect.Method;
 
 public class DefaultSpelResolver implements EmbeddedValueResolverAware, SpelResolver {
-    private static final String PLACEHOLDER_SPEL_REGEX = "^[$#]\\{.+}$";
+    private static final String PLACEHOLDER_SPEL_REGEX = "^\\$\\{.+}$";
+    private static final String SPEL_TEMPLATE_REGEX = "^#\\{.+}$";
     private static final String METHOD_SPEL_REGEX = "^#.+$";
     private static final String BEAN_SPEL_REGEX = "^@.+";
+    private static final TemplateParserContext TEMPLATE_PARSER_CONTEXT = new TemplateParserContext();
 
     private final SpelExpressionParser expressionParser;
     private final ParameterNameDiscoverer parameterNameDiscoverer;
@@ -44,12 +47,19 @@ public class DefaultSpelResolver implements EmbeddedValueResolverAware, SpelReso
 
     @Override
     public String resolve(Method method, Object[] arguments, String spelExpression) {
-        if (StringUtils.isEmpty(spelExpression)) {
+        if (!StringUtils.hasText(spelExpression)) {
             return spelExpression;
         }
 
         if (spelExpression.matches(PLACEHOLDER_SPEL_REGEX) && stringValueResolver != null) {
             return stringValueResolver.resolveStringValue(spelExpression);
+        }
+
+        if (spelExpression.matches(SPEL_TEMPLATE_REGEX)) {
+            SpelRootObject rootObject = new SpelRootObject(method, arguments);
+            MethodBasedEvaluationContext evaluationContext = new MethodBasedEvaluationContext(rootObject, method, arguments, parameterNameDiscoverer);
+            evaluationContext.setBeanResolver(new BeanFactoryResolver(this.beanFactory));
+            return expressionParser.parseExpression(spelExpression, TEMPLATE_PARSER_CONTEXT).getValue(evaluationContext, String.class);
         }
 
         if (spelExpression.matches(METHOD_SPEL_REGEX)) {

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/spelresolver/DefaultSpelResolver.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/spelresolver/DefaultSpelResolver.java
@@ -29,7 +29,7 @@ import java.lang.reflect.Method;
 
 public class DefaultSpelResolver implements EmbeddedValueResolverAware, SpelResolver {
     private static final String PLACEHOLDER_SPEL_REGEX = "^\\$\\{.+}$";
-    private static final String SPEL_TEMPLATE_REGEX = "^#\\{.+}$";
+    private static final String SPEL_TEMPLATE_REGEX = ".*#\\{.+}.*";
     private static final String METHOD_SPEL_REGEX = "^#.+$";
     private static final String BEAN_SPEL_REGEX = "^@.+";
     private static final TemplateParserContext TEMPLATE_PARSER_CONTEXT = new TemplateParserContext();

--- a/resilience4j-spring/src/test/java/io/github/resilience4j/fallback/FallbackExecutorTest.java
+++ b/resilience4j-spring/src/test/java/io/github/resilience4j/fallback/FallbackExecutorTest.java
@@ -4,6 +4,8 @@ import io.github.resilience4j.core.functions.CheckedSupplier;
 import io.github.resilience4j.spelresolver.SpelResolver;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.junit.Test;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 
 import java.lang.reflect.Method;
 
@@ -16,9 +18,15 @@ public class FallbackExecutorTest {
     private final SpelResolver spelResolver = mock(SpelResolver.class);
     private final FallbackDecorators fallbackDecorators = mock(FallbackDecorators.class);
     private final ProceedingJoinPoint proceedingJoinPoint = mock(ProceedingJoinPoint.class);
+    private final BeanFactory beanFactory = mock(BeanFactory.class);
 
-    private final FallbackExecutor fallbackExecutor = new FallbackExecutor(spelResolver, fallbackDecorators);
+    private final FallbackExecutor fallbackExecutor = createFallbackExecutor();
 
+    private FallbackExecutor createFallbackExecutor() {
+        FallbackExecutor executor = new FallbackExecutor(spelResolver, fallbackDecorators);
+        executor.setBeanFactory(beanFactory);
+        return executor;
+    }
 
     @Test
     public void testPrimaryMethodExecutionWithFallback() throws Throwable {
@@ -103,5 +111,152 @@ public class FallbackExecutorTest {
 
     public String getNameValidFallback(String parameter, Throwable throwable) {
         return "recovered-from-valid-fallback";
+    }
+
+    @Test
+    public void testPrimaryMethodExecutionWithFallbackBean() throws Throwable {
+        ExternalFallbackBean fallbackBean = new ExternalFallbackBean();
+        Method method = this.getClass().getMethod("getName", String.class);
+        final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
+        final String fallbackMethodValue = "myFallbackBean::getNameValidFallback";
+
+        when(proceedingJoinPoint.getArgs()).thenReturn(new Object[]{});
+        when(spelResolver.resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue)).thenReturn(fallbackMethodValue);
+        when(beanFactory.getBean("myFallbackBean")).thenReturn(fallbackBean);
+        when(fallbackDecorators.decorate(any(), eq(primaryFunction))).thenReturn(primaryFunction);
+
+        final Object result = fallbackExecutor.execute(proceedingJoinPoint, method, fallbackMethodValue, primaryFunction);
+        assertThat(result).isEqualTo("Name");
+
+        verify(spelResolver, times(1)).resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue);
+        verify(beanFactory, times(1)).getBean("myFallbackBean");
+        verify(fallbackDecorators, times(1)).decorate(any(), eq(primaryFunction));
+    }
+
+    @Test
+    public void testPrimaryMethodExecutionWithFallbackBeanNotFound() throws Throwable {
+        Method method = this.getClass().getMethod("getName", String.class);
+        final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
+        final String fallbackMethodValue = "myFallbackBean::nonExistentMethod";
+
+        when(proceedingJoinPoint.getArgs()).thenReturn(new Object[]{});
+        when(spelResolver.resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue)).thenReturn(fallbackMethodValue);
+        when(beanFactory.getBean("myFallbackBean")).thenReturn(new ExternalFallbackBean());
+
+        final Object result = fallbackExecutor.execute(proceedingJoinPoint, method, fallbackMethodValue, primaryFunction);
+        assertThat(result).isEqualTo("Name");
+
+        verify(spelResolver, times(1)).resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue);
+        verify(beanFactory, times(1)).getBean("myFallbackBean");
+        verify(fallbackDecorators, never()).decorate(any(), any());
+    }
+
+    @Test
+    public void testPrimaryMethodExecutionWithEmptyFallbackBeanMethod() throws Throwable {
+        Method method = this.getClass().getMethod("getName", String.class);
+        final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
+        final String fallbackMethodValue = "myFallbackBean::";
+
+        when(proceedingJoinPoint.getArgs()).thenReturn(new Object[]{});
+        when(spelResolver.resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue)).thenReturn(fallbackMethodValue);
+
+        final Object result = fallbackExecutor.execute(proceedingJoinPoint, method, fallbackMethodValue, primaryFunction);
+        assertThat(result).isEqualTo("Name");
+
+        verify(spelResolver, times(1)).resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue);
+        verify(beanFactory, never()).getBean(anyString());
+        verify(fallbackDecorators, never()).decorate(any(), any());
+    }
+
+    @Test
+    public void testPrimaryMethodExecutionWithNonExistentFallbackBean() throws Throwable {
+        Method method = this.getClass().getMethod("getName", String.class);
+        final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
+        final String fallbackMethodValue = "nonExistentBean::recover";
+
+        when(proceedingJoinPoint.getArgs()).thenReturn(new Object[]{});
+        when(spelResolver.resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue)).thenReturn(fallbackMethodValue);
+        when(beanFactory.getBean("nonExistentBean")).thenThrow(new NoSuchBeanDefinitionException("nonExistentBean"));
+
+        final Object result = fallbackExecutor.execute(proceedingJoinPoint, method, fallbackMethodValue, primaryFunction);
+        assertThat(result).isEqualTo("Name");
+
+        verify(beanFactory, times(1)).getBean("nonExistentBean");
+        verify(fallbackDecorators, never()).decorate(any(), any());
+    }
+
+    @Test
+    public void testPrimaryMethodExecutionWithEmptyBeanName() throws Throwable {
+        Method method = this.getClass().getMethod("getName", String.class);
+        final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
+        final String fallbackMethodValue = "::recover";
+
+        when(proceedingJoinPoint.getArgs()).thenReturn(new Object[]{});
+        when(spelResolver.resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue)).thenReturn(fallbackMethodValue);
+
+        final Object result = fallbackExecutor.execute(proceedingJoinPoint, method, fallbackMethodValue, primaryFunction);
+        assertThat(result).isEqualTo("Name");
+
+        verify(beanFactory, never()).getBean(anyString());
+        verify(fallbackDecorators, never()).decorate(any(), any());
+    }
+
+    @Test
+    public void testPrimaryMethodExecutionWithSpelResolvedFallbackBean() throws Throwable {
+        ExternalFallbackBean fallbackBean = new ExternalFallbackBean();
+        Method method = this.getClass().getMethod("getName", String.class);
+        final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
+        final String fallbackMethodValue = "#{myFallbackBean + '::getNameValidFallback'}";
+        final String resolvedValue = "myFallbackBean::getNameValidFallback";
+
+        when(proceedingJoinPoint.getArgs()).thenReturn(new Object[]{});
+        when(spelResolver.resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue)).thenReturn(resolvedValue);
+        when(beanFactory.getBean("myFallbackBean")).thenReturn(fallbackBean);
+        when(fallbackDecorators.decorate(any(), eq(primaryFunction))).thenReturn(primaryFunction);
+
+        final Object result = fallbackExecutor.execute(proceedingJoinPoint, method, fallbackMethodValue, primaryFunction);
+        assertThat(result).isEqualTo("Name");
+
+        verify(beanFactory, times(1)).getBean("myFallbackBean");
+        verify(fallbackDecorators, times(1)).decorate(any(), eq(primaryFunction));
+    }
+
+    @Test
+    public void testPrimaryMethodExecutionWithMultipleSeparators() throws Throwable {
+        Method method = this.getClass().getMethod("getName", String.class);
+        final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
+        final String fallbackMethodValue = "bean::method::extra";
+
+        when(proceedingJoinPoint.getArgs()).thenReturn(new Object[]{});
+        when(spelResolver.resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue)).thenReturn(fallbackMethodValue);
+
+        final Object result = fallbackExecutor.execute(proceedingJoinPoint, method, fallbackMethodValue, primaryFunction);
+        assertThat(result).isEqualTo("Name");
+
+        verify(beanFactory, never()).getBean(anyString());
+        verify(fallbackDecorators, never()).decorate(any(), any());
+    }
+
+    @Test
+    public void testPrimaryMethodExecutionWithBeanFactoryNullAndSeparator() throws Throwable {
+        FallbackExecutor executorWithoutBeanFactory = new FallbackExecutor(spelResolver, fallbackDecorators);
+        Method method = this.getClass().getMethod("getName", String.class);
+        final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
+        final String fallbackMethodValue = "myBean::recover";
+
+        when(proceedingJoinPoint.getArgs()).thenReturn(new Object[]{});
+        when(spelResolver.resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue)).thenReturn(fallbackMethodValue);
+
+        final Object result = executorWithoutBeanFactory.execute(proceedingJoinPoint, method, fallbackMethodValue, primaryFunction);
+        assertThat(result).isEqualTo("Name");
+
+        verify(beanFactory, never()).getBean(anyString());
+        verify(fallbackDecorators, never()).decorate(any(), any());
+    }
+
+    public static class ExternalFallbackBean {
+        public String getNameValidFallback(String parameter, Throwable throwable) {
+            return "recovered-from-external-bean";
+        }
     }
 }

--- a/resilience4j-spring/src/test/java/io/github/resilience4j/fallback/FallbackExecutorTest.java
+++ b/resilience4j-spring/src/test/java/io/github/resilience4j/fallback/FallbackExecutorTest.java
@@ -4,6 +4,8 @@ import io.github.resilience4j.core.functions.CheckedSupplier;
 import io.github.resilience4j.spelresolver.SpelResolver;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 
@@ -119,22 +121,26 @@ public class FallbackExecutorTest {
         Method method = this.getClass().getMethod("getName", String.class);
         final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
         final String fallbackMethodValue = "myFallbackBean::getNameValidFallback";
+        final Object[] args = new Object[]{"Name"};
 
-        when(proceedingJoinPoint.getArgs()).thenReturn(new Object[]{});
-        when(spelResolver.resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue)).thenReturn(fallbackMethodValue);
+        when(proceedingJoinPoint.getArgs()).thenReturn(args);
+        when(spelResolver.resolve(method, args, fallbackMethodValue)).thenReturn(fallbackMethodValue);
         when(beanFactory.getBean("myFallbackBean")).thenReturn(fallbackBean);
         when(fallbackDecorators.decorate(any(), eq(primaryFunction))).thenReturn(primaryFunction);
 
-        final Object result = fallbackExecutor.execute(proceedingJoinPoint, method, fallbackMethodValue, primaryFunction);
-        assertThat(result).isEqualTo("Name");
+        fallbackExecutor.execute(proceedingJoinPoint, method, fallbackMethodValue, primaryFunction);
 
-        verify(spelResolver, times(1)).resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue);
+        verify(spelResolver, times(1)).resolve(method, args, fallbackMethodValue);
         verify(beanFactory, times(1)).getBean("myFallbackBean");
-        verify(fallbackDecorators, times(1)).decorate(any(), eq(primaryFunction));
+
+        ArgumentCaptor<FallbackMethod> captor = ArgumentCaptor.forClass(FallbackMethod.class);
+        verify(fallbackDecorators, times(1)).decorate(captor.capture(), eq(primaryFunction));
+        Object fallbackResult = captor.getValue().fallback(new RuntimeException("boom"));
+        assertThat(fallbackResult).isEqualTo("recovered-from-external-bean");
     }
 
     @Test
-    public void testPrimaryMethodExecutionWithFallbackBeanNotFound() throws Throwable {
+    public void testPrimaryMethodExecutionWithFallbackMethodNotFound() throws Throwable {
         Method method = this.getClass().getMethod("getName", String.class);
         final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
         final String fallbackMethodValue = "myFallbackBean::nonExistentMethod";
@@ -149,6 +155,34 @@ public class FallbackExecutorTest {
         verify(spelResolver, times(1)).resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue);
         verify(beanFactory, times(1)).getBean("myFallbackBean");
         verify(fallbackDecorators, never()).decorate(any(), any());
+    }
+
+    @Test
+    public void testPrimaryMethodExecutionWithAopProxiedFallbackBean() throws Throwable {
+        // CGLIB-proxied bean must be unwrapped via AopProxyUtils.getSingletonTarget
+        // so method discovery walks the real class instead of the synthetic subclass.
+        ExternalFallbackBean target = new ExternalFallbackBean();
+        ProxyFactory proxyFactory = new ProxyFactory(target);
+        proxyFactory.setProxyTargetClass(true);
+        Object proxiedFallbackBean = proxyFactory.getProxy();
+        assertThat(proxiedFallbackBean).isNotSameAs(target);
+
+        Method method = this.getClass().getMethod("getName", String.class);
+        final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
+        final String fallbackMethodValue = "myFallbackBean::getNameValidFallback";
+        final Object[] args = new Object[]{"Name"};
+
+        when(proceedingJoinPoint.getArgs()).thenReturn(args);
+        when(spelResolver.resolve(method, args, fallbackMethodValue)).thenReturn(fallbackMethodValue);
+        when(beanFactory.getBean("myFallbackBean")).thenReturn(proxiedFallbackBean);
+        when(fallbackDecorators.decorate(any(), eq(primaryFunction))).thenReturn(primaryFunction);
+
+        fallbackExecutor.execute(proceedingJoinPoint, method, fallbackMethodValue, primaryFunction);
+
+        ArgumentCaptor<FallbackMethod> captor = ArgumentCaptor.forClass(FallbackMethod.class);
+        verify(fallbackDecorators, times(1)).decorate(captor.capture(), eq(primaryFunction));
+        Object fallbackResult = captor.getValue().fallback(new RuntimeException("boom"));
+        assertThat(fallbackResult).isEqualTo("recovered-from-external-bean");
     }
 
     @Test
@@ -235,6 +269,26 @@ public class FallbackExecutorTest {
 
         verify(beanFactory, never()).getBean(anyString());
         verify(fallbackDecorators, never()).decorate(any(), any());
+    }
+
+    @Test
+    public void testCtorWithBeanFactoryArgResolvesExternalFallback() throws Throwable {
+        ExternalFallbackBean fallbackBean = new ExternalFallbackBean();
+        FallbackExecutor executor = new FallbackExecutor(spelResolver, fallbackDecorators, beanFactory);
+        Method method = this.getClass().getMethod("getName", String.class);
+        final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
+        final String fallbackMethodValue = "myFallbackBean::getNameValidFallback";
+        final Object[] args = new Object[]{"Name"};
+
+        when(proceedingJoinPoint.getArgs()).thenReturn(args);
+        when(spelResolver.resolve(method, args, fallbackMethodValue)).thenReturn(fallbackMethodValue);
+        when(beanFactory.getBean("myFallbackBean")).thenReturn(fallbackBean);
+        when(fallbackDecorators.decorate(any(), eq(primaryFunction))).thenReturn(primaryFunction);
+
+        executor.execute(proceedingJoinPoint, method, fallbackMethodValue, primaryFunction);
+
+        verify(beanFactory, times(1)).getBean("myFallbackBean");
+        verify(fallbackDecorators, times(1)).decorate(any(), eq(primaryFunction));
     }
 
     @Test

--- a/resilience4j-spring/src/test/java/io/github/resilience4j/spelresolver/DefaultSpelResolverTest.java
+++ b/resilience4j-spring/src/test/java/io/github/resilience4j/spelresolver/DefaultSpelResolverTest.java
@@ -245,6 +245,41 @@ public class DefaultSpelResolverTest {
         assertThat(result).isEqualTo("$");
     }
 
+    /**
+     * #{'one.' + #root.args[0]} - SpEL template with method args context
+     */
+    @Test
+    public void spelTemplateWithArgsTest() throws Exception {
+        String testExpression = "#{'one.' + #root.args[0]}";
+        String firstArgument = "two";
+
+        DefaultSpelResolverTest target = new DefaultSpelResolverTest();
+        Method testMethod = target.getClass().getMethod("testMethod", String.class);
+
+        String result = sut.resolve(testMethod, new Object[]{firstArgument}, testExpression);
+
+        assertThat(result).isEqualTo("one.two");
+    }
+
+    /**
+     * #{'prefix.' + @dummySpelBean.getBulkheadName(#parameter)} - SpEL template with bean reference
+     */
+    @Test
+    public void spelTemplateWithBeanReferenceTest() throws Exception {
+        String testExpression = "#{'prefix.' + @dummySpelBean.getBulkheadName(#parameter)}";
+        String testMethodArg = "argg";
+        String bulkheadName = "sgt. bulko";
+        DefaultSpelResolverTest target = new DefaultSpelResolverTest();
+        Method testMethod = target.getClass().getMethod("testMethod", String.class);
+
+        given(dummySpelBean.getBulkheadName(testMethodArg)).willReturn(bulkheadName);
+
+        String result = sut.resolve(testMethod, new Object[]{testMethodArg}, testExpression);
+
+        then(dummySpelBean).should(times(1)).getBulkheadName(testMethodArg);
+        assertThat(result).isEqualTo("prefix.sgt. bulko");
+    }
+
     public String testMethod(String parameter) {
         return "test";
     }

--- a/resilience4j-spring/src/test/java/io/github/resilience4j/spelresolver/DefaultSpelResolverTest.java
+++ b/resilience4j-spring/src/test/java/io/github/resilience4j/spelresolver/DefaultSpelResolverTest.java
@@ -280,7 +280,42 @@ public class DefaultSpelResolverTest {
         assertThat(result).isEqualTo("prefix.sgt. bulko");
     }
 
+    /**
+     * prefix-#{#root.args[0]}-suffix - SpEL template with literal text and embedded expression
+     */
+    @Test
+    public void spelTemplateWithMixedLiteralAndExpressionTest() throws Exception {
+        String testExpression = "prefix-#{#root.args[0]}-suffix";
+        String firstArgument = "value";
+
+        DefaultSpelResolverTest target = new DefaultSpelResolverTest();
+        Method testMethod = target.getClass().getMethod("testMethod", String.class);
+
+        String result = sut.resolve(testMethod, new Object[]{firstArgument}, testExpression);
+
+        assertThat(result).isEqualTo("prefix-value-suffix");
+    }
+
+    /**
+     * #{#root.args[0]}-#{#root.args[1]} - SpEL template with multiple embedded expressions
+     */
+    @Test
+    public void spelTemplateWithMultipleEmbeddedExpressionsTest() throws Exception {
+        String testExpression = "#{#root.args[0]}-#{#root.args[1]}";
+
+        DefaultSpelResolverTest target = new DefaultSpelResolverTest();
+        Method testMethod = target.getClass().getMethod("testMethodTwoArgs", String.class, String.class);
+
+        String result = sut.resolve(testMethod, new Object[]{"foo", "bar"}, testExpression);
+
+        assertThat(result).isEqualTo("foo-bar");
+    }
+
     public String testMethod(String parameter) {
+        return "test";
+    }
+
+    public String testMethodTwoArgs(String first, String second) {
         return "test";
     }
 }

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/fallback/FallbackExecutor.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/fallback/FallbackExecutor.java
@@ -6,9 +6,10 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.aop.framework.AopProxyUtils;
-import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.BeanNotOfRequiredTypeException;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.util.StringUtils;
 
 import java.lang.reflect.Method;
@@ -20,11 +21,17 @@ public class FallbackExecutor implements BeanFactoryAware {
 
     private final SpelResolver spelResolver;
     private final FallbackDecorators fallbackDecorators;
+    // TODO: cache FallbackMethod by (beanName, methodName, originalMethod) for hot paths
     private BeanFactory beanFactory;
 
     public FallbackExecutor(SpelResolver spelResolver, FallbackDecorators fallbackDecorators) {
         this.spelResolver = spelResolver;
         this.fallbackDecorators = fallbackDecorators;
+    }
+
+    public FallbackExecutor(SpelResolver spelResolver, FallbackDecorators fallbackDecorators, BeanFactory beanFactory) {
+        this(spelResolver, fallbackDecorators);
+        this.beanFactory = beanFactory;
     }
 
     @Override
@@ -46,12 +53,12 @@ public class FallbackExecutor implements BeanFactoryAware {
                     throw new NoSuchMethodException(
                         "Invalid fallbackMethod format: bean name is empty in '" + fallbackMethodValue + "'");
                 }
-                if (separatorIdx > 0 && beanFactory == null) {
-                    throw new NoSuchMethodException(
-                        "beanName::methodName syntax requires BeanFactory but it was not injected. "
-                            + "Ensure FallbackExecutor is a Spring-managed bean.");
-                }
                 if (separatorIdx > 0) {
+                    if (beanFactory == null) {
+                        throw new NoSuchMethodException(
+                            "beanName::methodName syntax requires BeanFactory but it was not injected. "
+                                + "Ensure FallbackExecutor is a Spring-managed bean.");
+                    }
                     int nextSeparatorIdx = fallbackMethodName.indexOf(
                         BEAN_METHOD_SEPARATOR, separatorIdx + BEAN_METHOD_SEPARATOR.length());
                     if (nextSeparatorIdx != -1) {
@@ -76,7 +83,7 @@ public class FallbackExecutor implements BeanFactoryAware {
                     .create(fallbackMethodName, method, proceedingJoinPoint.getArgs(), original, proxy);
             } catch (NoSuchMethodException ex) {
                 logger.warn("No fallback method match found", ex);
-            } catch (BeansException ex) {
+            } catch (NoSuchBeanDefinitionException | BeanNotOfRequiredTypeException ex) {
                 logger.warn("Failed to resolve fallback bean '{}'", beanName, ex);
             }
         }

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/fallback/FallbackExecutor.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/fallback/FallbackExecutor.java
@@ -5,32 +5,79 @@ import io.github.resilience4j.spring6.spelresolver.SpelResolver;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.aop.framework.AopProxyUtils;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.util.StringUtils;
 
 import java.lang.reflect.Method;
 
-public class FallbackExecutor {
+public class FallbackExecutor implements BeanFactoryAware {
 
     private static final Logger logger = LoggerFactory.getLogger(FallbackExecutor.class);
+    private static final String BEAN_METHOD_SEPARATOR = "::";
 
     private final SpelResolver spelResolver;
     private final FallbackDecorators fallbackDecorators;
+    private BeanFactory beanFactory;
 
     public FallbackExecutor(SpelResolver spelResolver, FallbackDecorators fallbackDecorators) {
         this.spelResolver = spelResolver;
         this.fallbackDecorators = fallbackDecorators;
     }
 
+    @Override
+    public void setBeanFactory(BeanFactory beanFactory) {
+        this.beanFactory = beanFactory;
+    }
+
     public Object execute(ProceedingJoinPoint proceedingJoinPoint, Method method, String fallbackMethodValue, CheckedSupplier<Object> primaryFunction) throws Throwable {
         String fallbackMethodName = spelResolver.resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue);
 
         FallbackMethod fallbackMethod = null;
+        String beanName = null;
         if (StringUtils.hasLength(fallbackMethodName)) {
             try {
+                Object original;
+                Object proxy;
+                int separatorIdx = fallbackMethodName.indexOf(BEAN_METHOD_SEPARATOR);
+                if (separatorIdx == 0) {
+                    throw new NoSuchMethodException(
+                        "Invalid fallbackMethod format: bean name is empty in '" + fallbackMethodValue + "'");
+                }
+                if (separatorIdx > 0 && beanFactory == null) {
+                    throw new NoSuchMethodException(
+                        "beanName::methodName syntax requires BeanFactory but it was not injected. "
+                            + "Ensure FallbackExecutor is a Spring-managed bean.");
+                }
+                if (separatorIdx > 0) {
+                    int nextSeparatorIdx = fallbackMethodName.indexOf(
+                        BEAN_METHOD_SEPARATOR, separatorIdx + BEAN_METHOD_SEPARATOR.length());
+                    if (nextSeparatorIdx != -1) {
+                        throw new NoSuchMethodException(
+                            "Invalid fallbackMethod format: expected 'beanName::methodName' but got '" + fallbackMethodValue + "'");
+                    }
+                    beanName = fallbackMethodName.substring(0, separatorIdx);
+                    fallbackMethodName = fallbackMethodName.substring(separatorIdx + BEAN_METHOD_SEPARATOR.length());
+                    if (!StringUtils.hasLength(fallbackMethodName)) {
+                        throw new NoSuchMethodException(
+                            "Invalid fallbackMethod format: expected 'beanName::methodName' but got '" + fallbackMethodValue + "'");
+                    }
+                    Object fallbackBean = beanFactory.getBean(beanName);
+                    proxy = fallbackBean;
+                    Object singletonTarget = AopProxyUtils.getSingletonTarget(fallbackBean);
+                    original = (singletonTarget != null) ? singletonTarget : fallbackBean;
+                } else {
+                    original = proceedingJoinPoint.getTarget();
+                    proxy = proceedingJoinPoint.getThis();
+                }
                 fallbackMethod = FallbackMethod
-                    .create(fallbackMethodName, method, proceedingJoinPoint.getArgs(), proceedingJoinPoint.getTarget(), proceedingJoinPoint.getThis());
+                    .create(fallbackMethodName, method, proceedingJoinPoint.getArgs(), original, proxy);
             } catch (NoSuchMethodException ex) {
                 logger.warn("No fallback method match found", ex);
+            } catch (BeansException ex) {
+                logger.warn("Failed to resolve fallback bean '{}'", beanName, ex);
             }
         }
         if (fallbackMethod == null) {

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/spelresolver/DefaultSpelResolver.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/spelresolver/DefaultSpelResolver.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
 
 public class DefaultSpelResolver implements EmbeddedValueResolverAware, SpelResolver {
     private static final Pattern PLACEHOLDER_SPEL_REGEX = Pattern.compile("^\\$\\{.+}$");
-    private static final Pattern SPEL_TEMPLATE_REGEX = Pattern.compile("^#\\{.+}$");
+    private static final Pattern SPEL_TEMPLATE_REGEX = Pattern.compile(".*#\\{.+}.*");
     private static final Pattern METHOD_SPEL_REGEX = Pattern.compile("^#.+$");
     private static final Pattern BEAN_SPEL_REGEX = Pattern.compile("^@.+");
     private static final TemplateParserContext TEMPLATE_PARSER_CONTEXT = new TemplateParserContext();

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/spelresolver/DefaultSpelResolver.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/spelresolver/DefaultSpelResolver.java
@@ -20,6 +20,7 @@ import org.springframework.context.EmbeddedValueResolverAware;
 import org.springframework.context.expression.BeanFactoryResolver;
 import org.springframework.context.expression.MethodBasedEvaluationContext;
 import org.springframework.core.ParameterNameDiscoverer;
+import org.springframework.expression.common.TemplateParserContext;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.util.StringUtils;
 import org.springframework.util.StringValueResolver;
@@ -28,9 +29,11 @@ import java.lang.reflect.Method;
 import java.util.regex.Pattern;
 
 public class DefaultSpelResolver implements EmbeddedValueResolverAware, SpelResolver {
-    private static final Pattern PLACEHOLDER_SPEL_REGEX = Pattern.compile("^[$#]\\{.+}$");
+    private static final Pattern PLACEHOLDER_SPEL_REGEX = Pattern.compile("^\\$\\{.+}$");
+    private static final Pattern SPEL_TEMPLATE_REGEX = Pattern.compile("^#\\{.+}$");
     private static final Pattern METHOD_SPEL_REGEX = Pattern.compile("^#.+$");
     private static final Pattern BEAN_SPEL_REGEX = Pattern.compile("^@.+");
+    private static final TemplateParserContext TEMPLATE_PARSER_CONTEXT = new TemplateParserContext();
 
     private final SpelExpressionParser expressionParser;
     private final ParameterNameDiscoverer parameterNameDiscoverer;
@@ -51,6 +54,13 @@ public class DefaultSpelResolver implements EmbeddedValueResolverAware, SpelReso
 
         if (PLACEHOLDER_SPEL_REGEX.matcher(spelExpression).matches() && stringValueResolver != null) {
             return stringValueResolver.resolveStringValue(spelExpression);
+        }
+
+        if (SPEL_TEMPLATE_REGEX.matcher(spelExpression).matches()) {
+            SpelRootObject rootObject = new SpelRootObject(method, arguments);
+            MethodBasedEvaluationContext evaluationContext = new MethodBasedEvaluationContext(rootObject, method, arguments, parameterNameDiscoverer);
+            evaluationContext.setBeanResolver(new BeanFactoryResolver(this.beanFactory));
+            return expressionParser.parseExpression(spelExpression, TEMPLATE_PARSER_CONTEXT).getValue(evaluationContext, String.class);
         }
 
         if (METHOD_SPEL_REGEX.matcher(spelExpression).matches()) {

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/fallback/FallbackExecutorTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/fallback/FallbackExecutorTest.java
@@ -6,6 +6,8 @@ import io.github.resilience4j.spring6.fallback.FallbackExecutor;
 import io.github.resilience4j.spring6.spelresolver.SpelResolver;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.junit.Test;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 
 import java.lang.reflect.Method;
 
@@ -18,9 +20,15 @@ public class FallbackExecutorTest {
     private final SpelResolver spelResolver = mock(SpelResolver.class);
     private final FallbackDecorators fallbackDecorators = mock(FallbackDecorators.class);
     private final ProceedingJoinPoint proceedingJoinPoint = mock(ProceedingJoinPoint.class);
+    private final BeanFactory beanFactory = mock(BeanFactory.class);
 
-    private final FallbackExecutor fallbackExecutor = new FallbackExecutor(spelResolver, fallbackDecorators);
+    private final FallbackExecutor fallbackExecutor = createFallbackExecutor();
 
+    private FallbackExecutor createFallbackExecutor() {
+        FallbackExecutor executor = new FallbackExecutor(spelResolver, fallbackDecorators);
+        executor.setBeanFactory(beanFactory);
+        return executor;
+    }
 
     @Test
     public void testPrimaryMethodExecutionWithFallback() throws Throwable {
@@ -105,5 +113,152 @@ public class FallbackExecutorTest {
 
     public String getNameValidFallback(String parameter, Throwable throwable) {
         return "recovered-from-valid-fallback";
+    }
+
+    @Test
+    public void testPrimaryMethodExecutionWithFallbackBean() throws Throwable {
+        ExternalFallbackBean fallbackBean = new ExternalFallbackBean();
+        Method method = this.getClass().getMethod("getName", String.class);
+        final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
+        final String fallbackMethodValue = "myFallbackBean::getNameValidFallback";
+
+        when(proceedingJoinPoint.getArgs()).thenReturn(new Object[]{});
+        when(spelResolver.resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue)).thenReturn(fallbackMethodValue);
+        when(beanFactory.getBean("myFallbackBean")).thenReturn(fallbackBean);
+        when(fallbackDecorators.decorate(any(), eq(primaryFunction))).thenReturn(primaryFunction);
+
+        final Object result = fallbackExecutor.execute(proceedingJoinPoint, method, fallbackMethodValue, primaryFunction);
+        assertThat(result).isEqualTo("Name");
+
+        verify(spelResolver, times(1)).resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue);
+        verify(beanFactory, times(1)).getBean("myFallbackBean");
+        verify(fallbackDecorators, times(1)).decorate(any(), eq(primaryFunction));
+    }
+
+    @Test
+    public void testPrimaryMethodExecutionWithFallbackBeanNotFound() throws Throwable {
+        Method method = this.getClass().getMethod("getName", String.class);
+        final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
+        final String fallbackMethodValue = "myFallbackBean::nonExistentMethod";
+
+        when(proceedingJoinPoint.getArgs()).thenReturn(new Object[]{});
+        when(spelResolver.resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue)).thenReturn(fallbackMethodValue);
+        when(beanFactory.getBean("myFallbackBean")).thenReturn(new ExternalFallbackBean());
+
+        final Object result = fallbackExecutor.execute(proceedingJoinPoint, method, fallbackMethodValue, primaryFunction);
+        assertThat(result).isEqualTo("Name");
+
+        verify(spelResolver, times(1)).resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue);
+        verify(beanFactory, times(1)).getBean("myFallbackBean");
+        verify(fallbackDecorators, never()).decorate(any(), any());
+    }
+
+    @Test
+    public void testPrimaryMethodExecutionWithEmptyFallbackBeanMethod() throws Throwable {
+        Method method = this.getClass().getMethod("getName", String.class);
+        final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
+        final String fallbackMethodValue = "myFallbackBean::";
+
+        when(proceedingJoinPoint.getArgs()).thenReturn(new Object[]{});
+        when(spelResolver.resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue)).thenReturn(fallbackMethodValue);
+
+        final Object result = fallbackExecutor.execute(proceedingJoinPoint, method, fallbackMethodValue, primaryFunction);
+        assertThat(result).isEqualTo("Name");
+
+        verify(spelResolver, times(1)).resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue);
+        verify(beanFactory, never()).getBean(anyString());
+        verify(fallbackDecorators, never()).decorate(any(), any());
+    }
+
+    @Test
+    public void testPrimaryMethodExecutionWithNonExistentFallbackBean() throws Throwable {
+        Method method = this.getClass().getMethod("getName", String.class);
+        final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
+        final String fallbackMethodValue = "nonExistentBean::recover";
+
+        when(proceedingJoinPoint.getArgs()).thenReturn(new Object[]{});
+        when(spelResolver.resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue)).thenReturn(fallbackMethodValue);
+        when(beanFactory.getBean("nonExistentBean")).thenThrow(new NoSuchBeanDefinitionException("nonExistentBean"));
+
+        final Object result = fallbackExecutor.execute(proceedingJoinPoint, method, fallbackMethodValue, primaryFunction);
+        assertThat(result).isEqualTo("Name");
+
+        verify(beanFactory, times(1)).getBean("nonExistentBean");
+        verify(fallbackDecorators, never()).decorate(any(), any());
+    }
+
+    @Test
+    public void testPrimaryMethodExecutionWithEmptyBeanName() throws Throwable {
+        Method method = this.getClass().getMethod("getName", String.class);
+        final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
+        final String fallbackMethodValue = "::recover";
+
+        when(proceedingJoinPoint.getArgs()).thenReturn(new Object[]{});
+        when(spelResolver.resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue)).thenReturn(fallbackMethodValue);
+
+        final Object result = fallbackExecutor.execute(proceedingJoinPoint, method, fallbackMethodValue, primaryFunction);
+        assertThat(result).isEqualTo("Name");
+
+        verify(beanFactory, never()).getBean(anyString());
+        verify(fallbackDecorators, never()).decorate(any(), any());
+    }
+
+    @Test
+    public void testPrimaryMethodExecutionWithSpelResolvedFallbackBean() throws Throwable {
+        ExternalFallbackBean fallbackBean = new ExternalFallbackBean();
+        Method method = this.getClass().getMethod("getName", String.class);
+        final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
+        final String fallbackMethodValue = "#{myFallbackBean + '::getNameValidFallback'}";
+        final String resolvedValue = "myFallbackBean::getNameValidFallback";
+
+        when(proceedingJoinPoint.getArgs()).thenReturn(new Object[]{});
+        when(spelResolver.resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue)).thenReturn(resolvedValue);
+        when(beanFactory.getBean("myFallbackBean")).thenReturn(fallbackBean);
+        when(fallbackDecorators.decorate(any(), eq(primaryFunction))).thenReturn(primaryFunction);
+
+        final Object result = fallbackExecutor.execute(proceedingJoinPoint, method, fallbackMethodValue, primaryFunction);
+        assertThat(result).isEqualTo("Name");
+
+        verify(beanFactory, times(1)).getBean("myFallbackBean");
+        verify(fallbackDecorators, times(1)).decorate(any(), eq(primaryFunction));
+    }
+
+    @Test
+    public void testPrimaryMethodExecutionWithMultipleSeparators() throws Throwable {
+        Method method = this.getClass().getMethod("getName", String.class);
+        final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
+        final String fallbackMethodValue = "bean::method::extra";
+
+        when(proceedingJoinPoint.getArgs()).thenReturn(new Object[]{});
+        when(spelResolver.resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue)).thenReturn(fallbackMethodValue);
+
+        final Object result = fallbackExecutor.execute(proceedingJoinPoint, method, fallbackMethodValue, primaryFunction);
+        assertThat(result).isEqualTo("Name");
+
+        verify(beanFactory, never()).getBean(anyString());
+        verify(fallbackDecorators, never()).decorate(any(), any());
+    }
+
+    @Test
+    public void testPrimaryMethodExecutionWithBeanFactoryNullAndSeparator() throws Throwable {
+        FallbackExecutor executorWithoutBeanFactory = new FallbackExecutor(spelResolver, fallbackDecorators);
+        Method method = this.getClass().getMethod("getName", String.class);
+        final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
+        final String fallbackMethodValue = "myBean::recover";
+
+        when(proceedingJoinPoint.getArgs()).thenReturn(new Object[]{});
+        when(spelResolver.resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue)).thenReturn(fallbackMethodValue);
+
+        final Object result = executorWithoutBeanFactory.execute(proceedingJoinPoint, method, fallbackMethodValue, primaryFunction);
+        assertThat(result).isEqualTo("Name");
+
+        verify(beanFactory, never()).getBean(anyString());
+        verify(fallbackDecorators, never()).decorate(any(), any());
+    }
+
+    public static class ExternalFallbackBean {
+        public String getNameValidFallback(String parameter, Throwable throwable) {
+            return "recovered-from-external-bean";
+        }
     }
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/fallback/FallbackExecutorTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/fallback/FallbackExecutorTest.java
@@ -6,6 +6,8 @@ import io.github.resilience4j.spring6.fallback.FallbackExecutor;
 import io.github.resilience4j.spring6.spelresolver.SpelResolver;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 
@@ -121,22 +123,26 @@ public class FallbackExecutorTest {
         Method method = this.getClass().getMethod("getName", String.class);
         final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
         final String fallbackMethodValue = "myFallbackBean::getNameValidFallback";
+        final Object[] args = new Object[]{"Name"};
 
-        when(proceedingJoinPoint.getArgs()).thenReturn(new Object[]{});
-        when(spelResolver.resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue)).thenReturn(fallbackMethodValue);
+        when(proceedingJoinPoint.getArgs()).thenReturn(args);
+        when(spelResolver.resolve(method, args, fallbackMethodValue)).thenReturn(fallbackMethodValue);
         when(beanFactory.getBean("myFallbackBean")).thenReturn(fallbackBean);
         when(fallbackDecorators.decorate(any(), eq(primaryFunction))).thenReturn(primaryFunction);
 
-        final Object result = fallbackExecutor.execute(proceedingJoinPoint, method, fallbackMethodValue, primaryFunction);
-        assertThat(result).isEqualTo("Name");
+        fallbackExecutor.execute(proceedingJoinPoint, method, fallbackMethodValue, primaryFunction);
 
-        verify(spelResolver, times(1)).resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue);
+        verify(spelResolver, times(1)).resolve(method, args, fallbackMethodValue);
         verify(beanFactory, times(1)).getBean("myFallbackBean");
-        verify(fallbackDecorators, times(1)).decorate(any(), eq(primaryFunction));
+
+        ArgumentCaptor<FallbackMethod> captor = ArgumentCaptor.forClass(FallbackMethod.class);
+        verify(fallbackDecorators, times(1)).decorate(captor.capture(), eq(primaryFunction));
+        Object fallbackResult = captor.getValue().fallback(new RuntimeException("boom"));
+        assertThat(fallbackResult).isEqualTo("recovered-from-external-bean");
     }
 
     @Test
-    public void testPrimaryMethodExecutionWithFallbackBeanNotFound() throws Throwable {
+    public void testPrimaryMethodExecutionWithFallbackMethodNotFound() throws Throwable {
         Method method = this.getClass().getMethod("getName", String.class);
         final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
         final String fallbackMethodValue = "myFallbackBean::nonExistentMethod";
@@ -151,6 +157,34 @@ public class FallbackExecutorTest {
         verify(spelResolver, times(1)).resolve(method, proceedingJoinPoint.getArgs(), fallbackMethodValue);
         verify(beanFactory, times(1)).getBean("myFallbackBean");
         verify(fallbackDecorators, never()).decorate(any(), any());
+    }
+
+    @Test
+    public void testPrimaryMethodExecutionWithAopProxiedFallbackBean() throws Throwable {
+        // CGLIB-proxied bean must be unwrapped via AopProxyUtils.getSingletonTarget
+        // so method discovery walks the real class instead of the synthetic subclass.
+        ExternalFallbackBean target = new ExternalFallbackBean();
+        ProxyFactory proxyFactory = new ProxyFactory(target);
+        proxyFactory.setProxyTargetClass(true);
+        Object proxiedFallbackBean = proxyFactory.getProxy();
+        assertThat(proxiedFallbackBean).isNotSameAs(target);
+
+        Method method = this.getClass().getMethod("getName", String.class);
+        final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
+        final String fallbackMethodValue = "myFallbackBean::getNameValidFallback";
+        final Object[] args = new Object[]{"Name"};
+
+        when(proceedingJoinPoint.getArgs()).thenReturn(args);
+        when(spelResolver.resolve(method, args, fallbackMethodValue)).thenReturn(fallbackMethodValue);
+        when(beanFactory.getBean("myFallbackBean")).thenReturn(proxiedFallbackBean);
+        when(fallbackDecorators.decorate(any(), eq(primaryFunction))).thenReturn(primaryFunction);
+
+        fallbackExecutor.execute(proceedingJoinPoint, method, fallbackMethodValue, primaryFunction);
+
+        ArgumentCaptor<FallbackMethod> captor = ArgumentCaptor.forClass(FallbackMethod.class);
+        verify(fallbackDecorators, times(1)).decorate(captor.capture(), eq(primaryFunction));
+        Object fallbackResult = captor.getValue().fallback(new RuntimeException("boom"));
+        assertThat(fallbackResult).isEqualTo("recovered-from-external-bean");
     }
 
     @Test
@@ -237,6 +271,26 @@ public class FallbackExecutorTest {
 
         verify(beanFactory, never()).getBean(anyString());
         verify(fallbackDecorators, never()).decorate(any(), any());
+    }
+
+    @Test
+    public void testCtorWithBeanFactoryArgResolvesExternalFallback() throws Throwable {
+        ExternalFallbackBean fallbackBean = new ExternalFallbackBean();
+        FallbackExecutor executor = new FallbackExecutor(spelResolver, fallbackDecorators, beanFactory);
+        Method method = this.getClass().getMethod("getName", String.class);
+        final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
+        final String fallbackMethodValue = "myFallbackBean::getNameValidFallback";
+        final Object[] args = new Object[]{"Name"};
+
+        when(proceedingJoinPoint.getArgs()).thenReturn(args);
+        when(spelResolver.resolve(method, args, fallbackMethodValue)).thenReturn(fallbackMethodValue);
+        when(beanFactory.getBean("myFallbackBean")).thenReturn(fallbackBean);
+        when(fallbackDecorators.decorate(any(), eq(primaryFunction))).thenReturn(primaryFunction);
+
+        executor.execute(proceedingJoinPoint, method, fallbackMethodValue, primaryFunction);
+
+        verify(beanFactory, times(1)).getBean("myFallbackBean");
+        verify(fallbackDecorators, times(1)).decorate(any(), eq(primaryFunction));
     }
 
     @Test

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/spelresolver/DefaultSpelResolverTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/spelresolver/DefaultSpelResolverTest.java
@@ -245,6 +245,41 @@ public class DefaultSpelResolverTest {
         assertThat(result).isEqualTo("$");
     }
 
+    /**
+     * #{'one.' + #root.args[0]} - SpEL template with method args context
+     */
+    @Test
+    public void spelTemplateWithArgsTest() throws Exception {
+        String testExpression = "#{'one.' + #root.args[0]}";
+        String firstArgument = "two";
+
+        DefaultSpelResolverTest target = new DefaultSpelResolverTest();
+        Method testMethod = target.getClass().getMethod("testMethod", String.class);
+
+        String result = sut.resolve(testMethod, new Object[]{firstArgument}, testExpression);
+
+        assertThat(result).isEqualTo("one.two");
+    }
+
+    /**
+     * #{'prefix.' + @dummySpelBean.getBulkheadName(#parameter)} - SpEL template with bean reference
+     */
+    @Test
+    public void spelTemplateWithBeanReferenceTest() throws Exception {
+        String testExpression = "#{'prefix.' + @dummySpelBean.getBulkheadName(#parameter)}";
+        String testMethodArg = "argg";
+        String bulkheadName = "sgt. bulko";
+        DefaultSpelResolverTest target = new DefaultSpelResolverTest();
+        Method testMethod = target.getClass().getMethod("testMethod", String.class);
+
+        given(dummySpelBean.getBulkheadName(testMethodArg)).willReturn(bulkheadName);
+
+        String result = sut.resolve(testMethod, new Object[]{testMethodArg}, testExpression);
+
+        then(dummySpelBean).should(times(1)).getBulkheadName(testMethodArg);
+        assertThat(result).isEqualTo("prefix.sgt. bulko");
+    }
+
     public String testMethod(String parameter) {
         return "test";
     }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/spelresolver/DefaultSpelResolverTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/spelresolver/DefaultSpelResolverTest.java
@@ -280,7 +280,42 @@ public class DefaultSpelResolverTest {
         assertThat(result).isEqualTo("prefix.sgt. bulko");
     }
 
+    /**
+     * prefix-#{#root.args[0]}-suffix - SpEL template with literal text and embedded expression
+     */
+    @Test
+    public void spelTemplateWithMixedLiteralAndExpressionTest() throws Exception {
+        String testExpression = "prefix-#{#root.args[0]}-suffix";
+        String firstArgument = "value";
+
+        DefaultSpelResolverTest target = new DefaultSpelResolverTest();
+        Method testMethod = target.getClass().getMethod("testMethod", String.class);
+
+        String result = sut.resolve(testMethod, new Object[]{firstArgument}, testExpression);
+
+        assertThat(result).isEqualTo("prefix-value-suffix");
+    }
+
+    /**
+     * #{#root.args[0]}-#{#root.args[1]} - SpEL template with multiple embedded expressions
+     */
+    @Test
+    public void spelTemplateWithMultipleEmbeddedExpressionsTest() throws Exception {
+        String testExpression = "#{#root.args[0]}-#{#root.args[1]}";
+
+        DefaultSpelResolverTest target = new DefaultSpelResolverTest();
+        Method testMethod = target.getClass().getMethod("testMethodTwoArgs", String.class, String.class);
+
+        String result = sut.resolve(testMethod, new Object[]{"foo", "bar"}, testExpression);
+
+        assertThat(result).isEqualTo("foo-bar");
+    }
+
     public String testMethod(String parameter) {
+        return "test";
+    }
+
+    public String testMethodTwoArgs(String first, String second) {
         return "test";
     }
 }


### PR DESCRIPTION
## Summary

- **Fix SpEL `#{...}` template expressions** (#2355): Split the regex that previously treated both `${...}` and `#{...}` the same way. `#{...}` is now evaluated as a SpEL template with full method context (`#root.args`, `#root.methodName`, bean references), so expressions like `#{'one.' + #root.args[0]}` work correctly.
- **Support external bean fallback via `beanName::methodName` syntax** (#1848): When using interface-based declarative HTTP clients (Spring Boot 3+), fallback methods can now reference a method on a separate Spring bean — e.g., `@CircuitBreaker(name = "cb", fallbackMethod = "myFallbackBean::recover")`.
- **Properly unwrap AOP proxies** for external fallback beans using `AopProxyUtils.getSingletonTarget()`, so `FallbackMethod.getTarget()` correctly distinguishes the original target from the proxy.
- **Validate `beanName::methodName` format**: Empty method names (e.g., `"myBean::"`) are rejected with a clear error message instead of silently failing.
- **Document the new syntax** in the `fallbackMethod` Javadoc of all 6 annotations (CircuitBreaker, Retry, Bulkhead, TimeLimiter, RateLimiter, Timer).

Closes #1848
Closes #2355

## Test plan

- [x] Unit tests for `beanName::methodName` happy path (bean found, method exists)
- [x] Unit tests for `beanName::methodName` when method does not exist on the external bean
- [x] Unit tests for empty method name edge case (`"myBean::"`)
- [x] Unit tests for SpEL template expressions with `#root.args` context
- [x] Unit tests for SpEL template expressions with `@bean` references
- [ ] Existing tests remain green (spring6 module has pre-existing Mockito compatibility failures unrelated to this PR)