### PR TITLE
Added decorateFunction and executeFunction to TimeLimiter

### DIFF
--- a/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/timelimiter/TimeLimiter.kt
+++ b/resilience4j-kotlin/src/main/kotlin/io/github/resilience4j/kotlin/timelimiter/TimeLimiter.kt
@@ -22,6 +22,7 @@ import io.github.resilience4j.kotlin.isCancellation
 import io.github.resilience4j.timelimiter.TimeLimiter
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeout
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeoutException
 import kotlin.coroutines.coroutineContext
 
@@ -76,4 +77,31 @@ suspend fun <T> TimeLimiter.executeSuspendFunction(block: suspend () -> T): T =
  */
 fun <T> TimeLimiter.decorateSuspendFunction(block: suspend () -> T): suspend () -> T = {
     executeSuspendFunction(block)
+}
+
+/**
+ * Decorates and executes the given function [block].
+ *
+ * The function is wrapped in a [CompletableFuture] and the timeout is applied using the
+ * TimeLimiter's configured timeout duration.
+ *
+ * @throws TimeoutException if the function execution exceeds the configured timeout
+ * @throws Exception if the function throws an exception
+ */
+@Throws(Exception::class)
+fun <T> TimeLimiter.executeFunction(block: () -> T): T {
+    return this.executeFutureSupplier { CompletableFuture.supplyAsync(block) }
+}
+
+/**
+ * Decorates the given function [block] and returns it.
+ *
+ * The returned function wraps the original in a [CompletableFuture] and applies the
+ * TimeLimiter's configured timeout.
+ *
+ * @throws TimeoutException if the function execution exceeds the configured timeout
+ * @throws Exception if the function throws an exception
+ */
+fun <T> TimeLimiter.decorateFunction(block: () -> T): () -> T = {
+    executeFunction(block)
 }

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/timelimiter/TimeLimiterFunctionTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/timelimiter/TimeLimiterFunctionTest.kt
@@ -1,0 +1,135 @@
+/*
+ *
+ *  Copyright 2019: Brad Newman
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.kotlin.timelimiter
+
+import io.github.resilience4j.kotlin.HelloWorldService
+import io.github.resilience4j.timelimiter.TimeLimiter
+import io.github.resilience4j.timelimiter.event.TimeLimiterOnErrorEvent
+import io.github.resilience4j.timelimiter.event.TimeLimiterOnSuccessEvent
+import io.github.resilience4j.timelimiter.event.TimeLimiterOnTimeoutEvent
+import org.assertj.core.api.Assertions
+import org.junit.Test
+import java.time.Duration
+import java.util.concurrent.TimeoutException
+
+class TimeLimiterFunctionTest {
+
+    @Test
+    fun `should execute successful function`() {
+        val timelimiter = TimeLimiter.ofDefaults()
+        val helloWorldService = HelloWorldService()
+        val successfulEvents = mutableListOf<TimeLimiterOnSuccessEvent>()
+        timelimiter.eventPublisher.onSuccess(successfulEvents::add)
+
+        // When
+        val result = timelimiter.executeFunction {
+            helloWorldService.returnHelloWorld()
+        }
+
+        // Then
+        Assertions.assertThat(result).isEqualTo("Hello world")
+        Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(1)
+        Assertions.assertThat(successfulEvents).hasSize(1)
+    }
+
+    @Test
+    fun `should execute unsuccessful function`() {
+        val timelimiter = TimeLimiter.ofDefaults()
+        val helloWorldService = HelloWorldService()
+        val errorEvents = mutableListOf<TimeLimiterOnErrorEvent>()
+        timelimiter.eventPublisher.onError(errorEvents::add)
+
+        // When
+        try {
+            timelimiter.executeFunction {
+                helloWorldService.throwException()
+            }
+            Assertions.failBecauseExceptionWasNotThrown<Nothing>(IllegalStateException::class.java)
+        } catch (e: IllegalStateException) {
+            // nothing - proceed
+        }
+
+        // Then
+        Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(1)
+        Assertions.assertThat(errorEvents).hasSize(1)
+    }
+
+    @Test
+    fun `should timeout operation that takes too long`() {
+        val timelimiter = TimeLimiter.of(TimeLimiterConfig { timeoutDuration(Duration.ofMillis(10)) })
+        val timeoutEvents = mutableListOf<TimeLimiterOnTimeoutEvent>()
+        timelimiter.eventPublisher.onTimeout(timeoutEvents::add)
+
+        // When
+        try {
+            timelimiter.executeFunction {
+                Thread.sleep(1000)
+                "Hello world"
+            }
+            Assertions.failBecauseExceptionWasNotThrown<Nothing>(TimeoutException::class.java)
+        } catch (e: TimeoutException) {
+            // nothing - proceed
+        }
+
+        // Then
+        Assertions.assertThat(timeoutEvents).hasSize(1)
+    }
+
+    @Test
+    fun `should decorate successful function`() {
+        val timelimiter = TimeLimiter.ofDefaults()
+        val helloWorldService = HelloWorldService()
+        val successfulEvents = mutableListOf<TimeLimiterOnSuccessEvent>()
+        timelimiter.eventPublisher.onSuccess(successfulEvents::add)
+
+        // When
+        val function = timelimiter.decorateFunction {
+            helloWorldService.returnHelloWorld()
+        }
+
+        // Then
+        Assertions.assertThat(function()).isEqualTo("Hello world")
+        Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(1)
+        Assertions.assertThat(successfulEvents).hasSize(1)
+    }
+
+    @Test
+    fun `should decorate unsuccessful function`() {
+        val timelimiter = TimeLimiter.ofDefaults()
+        val helloWorldService = HelloWorldService()
+        val errorEvents = mutableListOf<TimeLimiterOnErrorEvent>()
+        timelimiter.eventPublisher.onError(errorEvents::add)
+
+        // When
+        val function = timelimiter.decorateFunction {
+            helloWorldService.throwException()
+        }
+
+        try {
+            function()
+            Assertions.failBecauseExceptionWasNotThrown<Nothing>(IllegalStateException::class.java)
+        } catch (e: IllegalStateException) {
+            // nothing - proceed
+        }
+
+        // Then
+        Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(1)
+        Assertions.assertThat(errorEvents).hasSize(1)
+    }
+}


### PR DESCRIPTION
## Summary
- Added `decorateFunction` and `executeFunction` extension functions to TimeLimiter.kt
- Added corresponding test class `TimeLimiterFunctionTest.kt` with 5 test cases
- Closes #2307

## Changes
Added synchronous function decorators to `TimeLimiter.kt` for consistency with other modules (Retry, CircuitBreaker, RateLimiter, Bulkhead). The functions wrap synchronous blocks in `CompletableFuture` and apply the TimeLimiter's timeout mechanism.

### New Extension Functions
- `executeFunction(block: () -> T): T` - Decorates and executes the given function with timeout
- `decorateFunction(block: () -> T): () -> T` - Returns a decorated function that applies timeout

### Test Coverage
- `should execute successful function`
- `should execute unsuccessful function`
- `should timeout operation that takes too long`
- `should decorate successful function`
- `should decorate unsuccessful function`

## Test plan
- [x] Run `./gradlew :resilience4j-kotlin:test --tests "io.github.resilience4j.kotlin.timelimiter.TimeLimiterFunctionTest"`
- [x] All 5 tests pass

The Kotlin module already provides suspend variants
(e.g., executeSuspendFunction).

This PR adds equivalent support for regular functions
to keep the API consistent and easier to use from Kotlin.
