### PR TITLE
Issue #2405: Support composed resilience annotations in Spring6

### DIFF
--- a/resilience4j-annotations/src/main/java/io/github/resilience4j/bulkhead/annotation/Bulkhead.java
+++ b/resilience4j-annotations/src/main/java/io/github/resilience4j/bulkhead/annotation/Bulkhead.java
@@ -8,7 +8,7 @@ import java.lang.annotation.*;
  * {@code name} and {@code fallbackMethod} can be resolved using Spring Expression Language (SpEL).
  */
 @Retention(value = RetentionPolicy.RUNTIME)
-@Target(value = {ElementType.METHOD, ElementType.TYPE})
+@Target(value = {ElementType.METHOD, ElementType.TYPE, ElementType.ANNOTATION_TYPE})
 @Documented
 public @interface Bulkhead {
 

--- a/resilience4j-annotations/src/main/java/io/github/resilience4j/circuitbreaker/annotation/CircuitBreaker.java
+++ b/resilience4j-annotations/src/main/java/io/github/resilience4j/circuitbreaker/annotation/CircuitBreaker.java
@@ -25,7 +25,7 @@ import java.lang.annotation.*;
  * {@code name} and {@code fallbackMethod} can be resolved using Spring Expression Language (SpEL).
  */
 @Retention(value = RetentionPolicy.RUNTIME)
-@Target(value = {ElementType.METHOD, ElementType.TYPE})
+@Target(value = {ElementType.METHOD, ElementType.TYPE, ElementType.ANNOTATION_TYPE})
 @Documented
 public @interface CircuitBreaker {
 

--- a/resilience4j-annotations/src/main/java/io/github/resilience4j/ratelimiter/annotation/RateLimiter.java
+++ b/resilience4j-annotations/src/main/java/io/github/resilience4j/ratelimiter/annotation/RateLimiter.java
@@ -25,7 +25,7 @@ import java.lang.annotation.*;
  * {@code name} and {@code fallbackMethod} can be resolved using Spring Expression Language (SpEL).
  */
 @Retention(value = RetentionPolicy.RUNTIME)
-@Target(value = {ElementType.METHOD, ElementType.TYPE})
+@Target(value = {ElementType.METHOD, ElementType.TYPE, ElementType.ANNOTATION_TYPE})
 @Documented
 public @interface RateLimiter {
 

--- a/resilience4j-annotations/src/main/java/io/github/resilience4j/retry/annotation/Retry.java
+++ b/resilience4j-annotations/src/main/java/io/github/resilience4j/retry/annotation/Retry.java
@@ -24,7 +24,7 @@ import java.lang.annotation.*;
  * {@code name} and {@code fallbackMethod} can be resolved using Spring Expression Language (SpEL).
  */
 @Retention(value = RetentionPolicy.RUNTIME)
-@Target(value = {ElementType.METHOD, ElementType.TYPE})
+@Target(value = {ElementType.METHOD, ElementType.TYPE, ElementType.ANNOTATION_TYPE})
 @Documented
 public @interface Retry {
 

--- a/resilience4j-annotations/src/main/java/io/github/resilience4j/timelimiter/annotation/TimeLimiter.java
+++ b/resilience4j-annotations/src/main/java/io/github/resilience4j/timelimiter/annotation/TimeLimiter.java
@@ -25,7 +25,7 @@ import java.lang.annotation.*;
  * {@code name} and {@code fallbackMethod} can be resolved using Spring Expression Language (SpEL).
  */
 @Retention(value = RetentionPolicy.RUNTIME)
-@Target(value = {ElementType.METHOD, ElementType.TYPE})
+@Target(value = {ElementType.METHOD, ElementType.TYPE, ElementType.ANNOTATION_TYPE})
 @Documented
 public @interface TimeLimiter {
 

--- a/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/circuitbreaker/CircuitBreakerAutoConfigurationTest.java
+++ b/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/circuitbreaker/CircuitBreakerAutoConfigurationTest.java
@@ -23,6 +23,7 @@ import io.github.resilience4j.springboot3.circuitbreaker.autoconfigure.CircuitBr
 import io.github.resilience4j.spring6.circuitbreaker.configure.CircuitBreakerAspect;
 import io.github.resilience4j.common.circuitbreaker.monitoring.endpoint.CircuitBreakerEventDTO;
 import io.github.resilience4j.common.circuitbreaker.monitoring.endpoint.CircuitBreakerEventsEndpointResponse;
+import io.github.resilience4j.springboot3.service.test.ComposedCircuitBreakerDummyService;
 import io.github.resilience4j.springboot3.service.test.DummyService;
 import io.github.resilience4j.springboot3.service.test.TestApplication;
 import org.apache.http.HttpStatus;
@@ -62,6 +63,8 @@ public class CircuitBreakerAutoConfigurationTest {
     CircuitBreakerAspect circuitBreakerAspect;
     @Autowired
     DummyService dummyService;
+    @Autowired
+    ComposedCircuitBreakerDummyService composedCircuitBreakerDummyService;
     @Autowired
     private TestRestTemplate restTemplate;
 
@@ -118,6 +121,21 @@ public class CircuitBreakerAutoConfigurationTest {
         CircuitBreaker backendC = circuitBreakerRegistry.circuitBreaker("backendC");
 
         verifyCircuitBreakerAutoConfiguration(dynamicCircuitBreaker, sharedA, sharedB, backendB, backendC);
+    }
+
+    @Test
+    public void testComposedCircuitBreakerAnnotationAutoConfiguration() throws IOException {
+        int eventsBefore = getCircuitBreakerEvents(ComposedCircuitBreakerDummyService.BACKEND).size();
+
+        try {
+            composedCircuitBreakerDummyService.doSomething(true);
+        } catch (IOException ex) {
+            // Expected failure, recorded by CircuitBreaker.
+        }
+        composedCircuitBreakerDummyService.doSomething(false);
+
+        assertThat(getCircuitBreakerEvents(ComposedCircuitBreakerDummyService.BACKEND))
+            .hasSize(eventsBefore + 2);
     }
 
     private void verifyCircuitBreakerAutoConfiguration(CircuitBreaker dynamicCircuitBreaker, CircuitBreaker sharedA, CircuitBreaker sharedB, CircuitBreaker backendB, CircuitBreaker backendC) {

--- a/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/service/test/ComposedCircuitBreakerDummyService.java
+++ b/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/service/test/ComposedCircuitBreakerDummyService.java
@@ -1,0 +1,33 @@
+package io.github.resilience4j.springboot3.service.test;
+
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Component
+public class ComposedCircuitBreakerDummyService {
+
+    public static final String BACKEND = "backendComposed";
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @CircuitBreaker(name = BACKEND)
+    public @interface ComposedCircuitBreaker {
+
+        @AliasFor(annotation = CircuitBreaker.class, attribute = "name")
+        String name() default BACKEND;
+    }
+
+    @ComposedCircuitBreaker
+    public void doSomething(boolean throwBackendTrouble) throws IOException {
+        if (throwBackendTrouble) {
+            throw new IOException("Test Message");
+        }
+    }
+}

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/CircuitBreakerAutoConfigurationTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/CircuitBreakerAutoConfigurationTest.java
@@ -23,6 +23,7 @@ import io.github.resilience4j.springboot.circuitbreaker.autoconfigure.CircuitBre
 import io.github.resilience4j.spring6.circuitbreaker.configure.CircuitBreakerAspect;
 import io.github.resilience4j.common.circuitbreaker.monitoring.endpoint.CircuitBreakerEventDTO;
 import io.github.resilience4j.common.circuitbreaker.monitoring.endpoint.CircuitBreakerEventsEndpointResponse;
+import io.github.resilience4j.springboot.service.test.ComposedCircuitBreakerDummyService;
 import io.github.resilience4j.springboot.service.test.DummyService;
 import io.github.resilience4j.springboot.service.test.TestApplication;
 import org.apache.http.HttpStatus;
@@ -64,6 +65,8 @@ public class CircuitBreakerAutoConfigurationTest {
     CircuitBreakerAspect circuitBreakerAspect;
     @Autowired
     DummyService dummyService;
+    @Autowired
+    ComposedCircuitBreakerDummyService composedCircuitBreakerDummyService;
     @Autowired
     private TestRestTemplate restTemplate;
 
@@ -120,6 +123,21 @@ public class CircuitBreakerAutoConfigurationTest {
         CircuitBreaker backendC = circuitBreakerRegistry.circuitBreaker("backendC");
 
         verifyCircuitBreakerAutoConfiguration(dynamicCircuitBreaker, sharedA, sharedB, backendB, backendC);
+    }
+
+    @Test
+    public void testComposedCircuitBreakerAnnotationAutoConfiguration() throws IOException {
+        int eventsBefore = getCircuitBreakerEvents(ComposedCircuitBreakerDummyService.BACKEND).size();
+
+        try {
+            composedCircuitBreakerDummyService.doSomething(true);
+        } catch (IOException ex) {
+            // Expected failure, recorded by CircuitBreaker.
+        }
+        composedCircuitBreakerDummyService.doSomething(false);
+
+        assertThat(getCircuitBreakerEvents(ComposedCircuitBreakerDummyService.BACKEND))
+            .hasSize(eventsBefore + 2);
     }
 
     private void verifyCircuitBreakerAutoConfiguration(CircuitBreaker dynamicCircuitBreaker, CircuitBreaker sharedA, CircuitBreaker sharedB, CircuitBreaker backendB, CircuitBreaker backendC) {

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/service/test/ComposedCircuitBreakerDummyService.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/service/test/ComposedCircuitBreakerDummyService.java
@@ -1,0 +1,33 @@
+package io.github.resilience4j.springboot.service.test;
+
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Component
+public class ComposedCircuitBreakerDummyService {
+
+    public static final String BACKEND = "backendComposed";
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @CircuitBreaker(name = BACKEND)
+    public @interface ComposedCircuitBreaker {
+
+        @AliasFor(annotation = CircuitBreaker.class, attribute = "name")
+        String name() default BACKEND;
+    }
+
+    @ComposedCircuitBreaker
+    public void doSomething(boolean throwBackendTrouble) throws IOException {
+        if (throwBackendTrouble) {
+            throw new IOException("Test Message");
+        }
+    }
+}

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/bulkhead/configure/BulkheadAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/bulkhead/configure/BulkheadAspect.java
@@ -105,7 +105,9 @@ public class BulkheadAspect implements Ordered {
     public void matchMetaAnnotatedMethod() {
     }
 
-    @Pointcut("within(@(@io.github.resilience4j.bulkhead.annotation.Bulkhead *) *)")
+    @Pointcut("within(@(@io.github.resilience4j.bulkhead.annotation.Bulkhead *) *)" +
+        " && !execution(@io.github.resilience4j.bulkhead.annotation.Bulkhead * *(..))" +
+        " && !execution(@(@io.github.resilience4j.bulkhead.annotation.Bulkhead *) * *(..))")
     public void matchMetaAnnotatedClass() {
     }
 
@@ -134,14 +136,8 @@ public class BulkheadAspect implements Ordered {
         }
     }
 
-    @Around("matchMetaAnnotatedMethod()")
+    @Around("matchMetaAnnotatedMethod() || matchMetaAnnotatedClass()")
     public Object bulkheadMetaAnnotationAroundAdvice(ProceedingJoinPoint proceedingJoinPoint)
-        throws Throwable {
-        return bulkheadAroundAdvice(proceedingJoinPoint, null);
-    }
-
-    @Around("matchMetaAnnotatedClass()")
-    public Object bulkheadMetaAnnotationClassAroundAdvice(ProceedingJoinPoint proceedingJoinPoint)
         throws Throwable {
         return bulkheadAroundAdvice(proceedingJoinPoint, null);
     }

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/bulkhead/configure/BulkheadAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/bulkhead/configure/BulkheadAspect.java
@@ -31,7 +31,9 @@ import org.aspectj.lang.annotation.Pointcut;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.Ordered;
 
 import io.github.resilience4j.bulkhead.BulkheadConfig;
@@ -99,6 +101,14 @@ public class BulkheadAspect implements Ordered {
     public void matchAnnotatedClassOrMethod(Bulkhead Bulkhead) {
     }
 
+    @Pointcut("execution(@(@io.github.resilience4j.bulkhead.annotation.Bulkhead *) * *(..))")
+    public void matchMetaAnnotatedMethod() {
+    }
+
+    @Pointcut("within(@(@io.github.resilience4j.bulkhead.annotation.Bulkhead *) *)")
+    public void matchMetaAnnotatedClass() {
+    }
+
     @Around(value = "matchAnnotatedClassOrMethod(bulkheadAnnotation)", argNames = "proceedingJoinPoint, bulkheadAnnotation")
     public Object bulkheadAroundAdvice(ProceedingJoinPoint proceedingJoinPoint,
         @Nullable Bulkhead bulkheadAnnotation) throws Throwable {
@@ -122,6 +132,18 @@ public class BulkheadAspect implements Ordered {
             final CheckedSupplier<Object> bulkheadExecution = () -> proceed(proceedingJoinPoint, methodName, bulkhead, returnType);
             return fallbackExecutor.execute(proceedingJoinPoint, method, bulkheadAnnotation.fallbackMethod(), bulkheadExecution);
         }
+    }
+
+    @Around("matchMetaAnnotatedMethod()")
+    public Object bulkheadMetaAnnotationAroundAdvice(ProceedingJoinPoint proceedingJoinPoint)
+        throws Throwable {
+        return bulkheadAroundAdvice(proceedingJoinPoint, null);
+    }
+
+    @Around("matchMetaAnnotatedClass()")
+    public Object bulkheadMetaAnnotationClassAroundAdvice(ProceedingJoinPoint proceedingJoinPoint)
+        throws Throwable {
+        return bulkheadAroundAdvice(proceedingJoinPoint, null);
     }
 
     /**
@@ -187,6 +209,20 @@ public class BulkheadAspect implements Ordered {
      */
     @Nullable
     private Bulkhead getBulkheadAnnotation(ProceedingJoinPoint proceedingJoinPoint) {
+        Method method = ((MethodSignature) proceedingJoinPoint.getSignature()).getMethod();
+        Class<?> targetClass = proceedingJoinPoint.getTarget() != null ? proceedingJoinPoint.getTarget().getClass() : method.getDeclaringClass();
+        Method targetMethod = AopUtils.getMostSpecificMethod(method, targetClass);
+
+        Bulkhead annotation = AnnotatedElementUtils.findMergedAnnotation(targetMethod, Bulkhead.class);
+        if (annotation != null) {
+            return annotation;
+        }
+
+        annotation = AnnotatedElementUtils.findMergedAnnotation(targetClass, Bulkhead.class);
+        if (annotation != null) {
+            return annotation;
+        }
+
         if (logger.isDebugEnabled()) {
             logger.debug("bulkhead parameter is null");
         }

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/bulkhead/configure/BulkheadAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/bulkhead/configure/BulkheadAspect.java
@@ -101,7 +101,8 @@ public class BulkheadAspect implements Ordered {
     public void matchAnnotatedClassOrMethod(Bulkhead Bulkhead) {
     }
 
-    @Pointcut("execution(@(@io.github.resilience4j.bulkhead.annotation.Bulkhead *) * *(..))")
+    @Pointcut("execution(@(@io.github.resilience4j.bulkhead.annotation.Bulkhead *) * *(..))" +
+        " && !execution(@io.github.resilience4j.bulkhead.annotation.Bulkhead * *(..))")
     public void matchMetaAnnotatedMethod() {
     }
 

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/bulkhead/configure/BulkheadAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/bulkhead/configure/BulkheadAspect.java
@@ -31,9 +31,7 @@ import org.aspectj.lang.annotation.Pointcut;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.Ordered;
 
 import io.github.resilience4j.bulkhead.BulkheadConfig;
@@ -101,7 +99,12 @@ public class BulkheadAspect implements Ordered {
     public void matchAnnotatedClassOrMethod(Bulkhead Bulkhead) {
     }
 
+    /**
+     * Matches one-level composed annotations.
+     * AspectJ {@code @(@Ann *)} does not match transitive meta-annotation hierarchies.
+     */
     @Pointcut("execution(@(@io.github.resilience4j.bulkhead.annotation.Bulkhead *) * *(..))" +
+        " && !within(@io.github.resilience4j.bulkhead.annotation.Bulkhead *)" +
         " && !execution(@io.github.resilience4j.bulkhead.annotation.Bulkhead * *(..))")
     public void matchMetaAnnotatedMethod() {
     }
@@ -117,8 +120,9 @@ public class BulkheadAspect implements Ordered {
         @Nullable Bulkhead bulkheadAnnotation) throws Throwable {
         Method method = ((MethodSignature) proceedingJoinPoint.getSignature()).getMethod();
         String methodName = method.getDeclaringClass().getName() + "#" + method.getName();
-        if (bulkheadAnnotation == null) {
-            bulkheadAnnotation = getBulkheadAnnotation(proceedingJoinPoint);
+        Bulkhead resolvedAnnotation = getBulkheadAnnotation(proceedingJoinPoint);
+        if (resolvedAnnotation != null) {
+            bulkheadAnnotation = resolvedAnnotation;
         }
         if (bulkheadAnnotation == null) { //because annotations wasn't found
             return proceedingJoinPoint.proceed();
@@ -206,32 +210,8 @@ public class BulkheadAspect implements Ordered {
      */
     @Nullable
     private Bulkhead getBulkheadAnnotation(ProceedingJoinPoint proceedingJoinPoint) {
-        Method method = ((MethodSignature) proceedingJoinPoint.getSignature()).getMethod();
-        Class<?> targetClass = proceedingJoinPoint.getTarget() != null ? proceedingJoinPoint.getTarget().getClass() : method.getDeclaringClass();
-        Method targetMethod = AopUtils.getMostSpecificMethod(method, targetClass);
-
-        Bulkhead annotation = AnnotatedElementUtils.findMergedAnnotation(targetMethod, Bulkhead.class);
-        if (annotation != null) {
-            return annotation;
-        }
-
-        annotation = AnnotatedElementUtils.findMergedAnnotation(targetClass, Bulkhead.class);
-        if (annotation != null) {
-            return annotation;
-        }
-
-        if (logger.isDebugEnabled()) {
-            logger.debug("bulkhead parameter is null");
-        }
-        if (proceedingJoinPoint.getTarget() instanceof Proxy) {
-            logger
-                .debug("The bulkhead annotation is kept on a interface which is acting as a proxy");
-            return AnnotationExtractor
-                .extractAnnotationFromProxy(proceedingJoinPoint.getTarget(), Bulkhead.class);
-        } else {
-            return AnnotationExtractor
-                .extract(proceedingJoinPoint.getTarget().getClass(), Bulkhead.class);
-        }
+        return AnnotationExtractor.extractAnnotationFromJoinPoint(proceedingJoinPoint,
+            Bulkhead.class);
     }
 
     /**

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/circuitbreaker/configure/CircuitBreakerAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/circuitbreaker/configure/CircuitBreakerAspect.java
@@ -31,12 +31,9 @@ import org.aspectj.lang.reflect.MethodSignature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.Ordered;
-import org.springframework.aop.support.AopUtils;
 
 import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
 import java.util.List;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
@@ -93,7 +90,12 @@ public class CircuitBreakerAspect implements Ordered {
     public void matchAnnotatedClassOrMethod(CircuitBreaker circuitBreaker) {
     }
 
+    /**
+     * Matches one-level composed annotations.
+     * AspectJ {@code @(@Ann *)} does not match transitive meta-annotation hierarchies.
+     */
     @Pointcut("execution(@(@io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker *) * *(..))" +
+        " && !within(@io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker *)" +
         " && !execution(@io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker * *(..))")
     public void matchMetaAnnotatedMethod() {
     }
@@ -109,8 +111,9 @@ public class CircuitBreakerAspect implements Ordered {
         @Nullable CircuitBreaker circuitBreakerAnnotation) throws Throwable {
         Method method = ((MethodSignature) proceedingJoinPoint.getSignature()).getMethod();
         String methodName = method.getDeclaringClass().getName() + "#" + method.getName();
-        if (circuitBreakerAnnotation == null) {
-            circuitBreakerAnnotation = getCircuitBreakerAnnotation(proceedingJoinPoint);
+        CircuitBreaker resolvedAnnotation = getCircuitBreakerAnnotation(proceedingJoinPoint);
+        if (resolvedAnnotation != null) {
+            circuitBreakerAnnotation = resolvedAnnotation;
         }
         if (circuitBreakerAnnotation == null) { //because annotations wasn't found
             return proceedingJoinPoint.proceed();
@@ -164,32 +167,8 @@ public class CircuitBreakerAspect implements Ordered {
 
     @Nullable
     private CircuitBreaker getCircuitBreakerAnnotation(ProceedingJoinPoint proceedingJoinPoint) {
-        Method method = ((MethodSignature) proceedingJoinPoint.getSignature()).getMethod();
-        Class<?> targetClass = proceedingJoinPoint.getTarget() != null ? proceedingJoinPoint.getTarget().getClass() : method.getDeclaringClass();
-        Method targetMethod = AopUtils.getMostSpecificMethod(method, targetClass);
-
-        CircuitBreaker annotation = AnnotatedElementUtils.findMergedAnnotation(targetMethod, CircuitBreaker.class);
-        if (annotation != null) {
-            return annotation;
-        }
-
-        annotation = AnnotatedElementUtils.findMergedAnnotation(targetClass, CircuitBreaker.class);
-        if (annotation != null) {
-            return annotation;
-        }
-
-        if (logger.isDebugEnabled()) {
-            logger.debug("circuitBreaker parameter is null");
-        }
-        if (proceedingJoinPoint.getTarget() instanceof Proxy) {
-            logger.debug(
-                "The circuit breaker annotation is kept on a interface which is acting as a proxy");
-            return AnnotationExtractor
-                .extractAnnotationFromProxy(proceedingJoinPoint.getTarget(), CircuitBreaker.class);
-        } else {
-            return AnnotationExtractor
-                .extract(proceedingJoinPoint.getTarget().getClass(), CircuitBreaker.class);
-        }
+        return AnnotationExtractor.extractAnnotationFromJoinPoint(proceedingJoinPoint,
+            CircuitBreaker.class);
     }
 
     /**

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/circuitbreaker/configure/CircuitBreakerAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/circuitbreaker/configure/CircuitBreakerAspect.java
@@ -31,7 +31,9 @@ import org.aspectj.lang.reflect.MethodSignature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.Ordered;
+import org.springframework.aop.support.AopUtils;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
@@ -91,6 +93,14 @@ public class CircuitBreakerAspect implements Ordered {
     public void matchAnnotatedClassOrMethod(CircuitBreaker circuitBreaker) {
     }
 
+    @Pointcut("execution(@(@io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker *) * *(..))")
+    public void matchMetaAnnotatedMethod() {
+    }
+
+    @Pointcut("within(@(@io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker *) *)")
+    public void matchMetaAnnotatedClass() {
+    }
+
     @Around(value = "matchAnnotatedClassOrMethod(circuitBreakerAnnotation)", argNames = "proceedingJoinPoint, circuitBreakerAnnotation")
     public Object circuitBreakerAroundAdvice(ProceedingJoinPoint proceedingJoinPoint,
         @Nullable CircuitBreaker circuitBreakerAnnotation) throws Throwable {
@@ -108,6 +118,18 @@ public class CircuitBreakerAspect implements Ordered {
         Class<?> returnType = method.getReturnType();
         final CheckedSupplier<Object> circuitBreakerExecution = () -> proceed(proceedingJoinPoint, methodName, circuitBreaker, returnType);
         return fallbackExecutor.execute(proceedingJoinPoint, method, circuitBreakerAnnotation.fallbackMethod(), circuitBreakerExecution);
+    }
+
+    @Around("matchMetaAnnotatedMethod()")
+    public Object circuitBreakerMetaAnnotationAroundAdvice(ProceedingJoinPoint proceedingJoinPoint)
+        throws Throwable {
+        return circuitBreakerAroundAdvice(proceedingJoinPoint, null);
+    }
+
+    @Around("matchMetaAnnotatedClass()")
+    public Object circuitBreakerMetaAnnotationClassAroundAdvice(ProceedingJoinPoint proceedingJoinPoint)
+        throws Throwable {
+        return circuitBreakerAroundAdvice(proceedingJoinPoint, null);
     }
 
     private Object proceed(ProceedingJoinPoint proceedingJoinPoint, String methodName,
@@ -145,6 +167,20 @@ public class CircuitBreakerAspect implements Ordered {
 
     @Nullable
     private CircuitBreaker getCircuitBreakerAnnotation(ProceedingJoinPoint proceedingJoinPoint) {
+        Method method = ((MethodSignature) proceedingJoinPoint.getSignature()).getMethod();
+        Class<?> targetClass = proceedingJoinPoint.getTarget() != null ? proceedingJoinPoint.getTarget().getClass() : method.getDeclaringClass();
+        Method targetMethod = AopUtils.getMostSpecificMethod(method, targetClass);
+
+        CircuitBreaker annotation = AnnotatedElementUtils.findMergedAnnotation(targetMethod, CircuitBreaker.class);
+        if (annotation != null) {
+            return annotation;
+        }
+
+        annotation = AnnotatedElementUtils.findMergedAnnotation(targetClass, CircuitBreaker.class);
+        if (annotation != null) {
+            return annotation;
+        }
+
         if (logger.isDebugEnabled()) {
             logger.debug("circuitBreaker parameter is null");
         }

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/circuitbreaker/configure/CircuitBreakerAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/circuitbreaker/configure/CircuitBreakerAspect.java
@@ -97,7 +97,9 @@ public class CircuitBreakerAspect implements Ordered {
     public void matchMetaAnnotatedMethod() {
     }
 
-    @Pointcut("within(@(@io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker *) *)")
+    @Pointcut("within(@(@io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker *) *)" +
+        " && !execution(@io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker * *(..))" +
+        " && !execution(@(@io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker *) * *(..))")
     public void matchMetaAnnotatedClass() {
     }
 
@@ -120,14 +122,8 @@ public class CircuitBreakerAspect implements Ordered {
         return fallbackExecutor.execute(proceedingJoinPoint, method, circuitBreakerAnnotation.fallbackMethod(), circuitBreakerExecution);
     }
 
-    @Around("matchMetaAnnotatedMethod()")
+    @Around("matchMetaAnnotatedMethod() || matchMetaAnnotatedClass()")
     public Object circuitBreakerMetaAnnotationAroundAdvice(ProceedingJoinPoint proceedingJoinPoint)
-        throws Throwable {
-        return circuitBreakerAroundAdvice(proceedingJoinPoint, null);
-    }
-
-    @Around("matchMetaAnnotatedClass()")
-    public Object circuitBreakerMetaAnnotationClassAroundAdvice(ProceedingJoinPoint proceedingJoinPoint)
         throws Throwable {
         return circuitBreakerAroundAdvice(proceedingJoinPoint, null);
     }

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/circuitbreaker/configure/CircuitBreakerAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/circuitbreaker/configure/CircuitBreakerAspect.java
@@ -93,7 +93,8 @@ public class CircuitBreakerAspect implements Ordered {
     public void matchAnnotatedClassOrMethod(CircuitBreaker circuitBreaker) {
     }
 
-    @Pointcut("execution(@(@io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker *) * *(..))")
+    @Pointcut("execution(@(@io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker *) * *(..))" +
+        " && !execution(@io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker * *(..))")
     public void matchMetaAnnotatedMethod() {
     }
 

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/ratelimiter/configure/RateLimiterAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/ratelimiter/configure/RateLimiterAspect.java
@@ -30,7 +30,9 @@ import org.aspectj.lang.annotation.Pointcut;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.Ordered;
 
 import java.lang.reflect.Method;
@@ -97,6 +99,14 @@ public class RateLimiterAspect implements Ordered {
         // Method used as pointcut
     }
 
+    @Pointcut("execution(@(@io.github.resilience4j.ratelimiter.annotation.RateLimiter *) * *(..))")
+    public void matchMetaAnnotatedMethod() {
+    }
+
+    @Pointcut("within(@(@io.github.resilience4j.ratelimiter.annotation.RateLimiter *) *)")
+    public void matchMetaAnnotatedClass() {
+    }
+
     @Around(value = "matchAnnotatedClassOrMethod(rateLimiterAnnotation)", argNames = "proceedingJoinPoint, rateLimiterAnnotation")
     public Object rateLimiterAroundAdvice(ProceedingJoinPoint proceedingJoinPoint,
         @Nullable RateLimiter rateLimiterAnnotation) throws Throwable {
@@ -114,6 +124,18 @@ public class RateLimiterAspect implements Ordered {
         Class<?> returnType = method.getReturnType();
         final CheckedSupplier<Object> rateLimiterExecution = () -> proceed(proceedingJoinPoint, methodName, returnType, rateLimiter);
         return fallbackExecutor.execute(proceedingJoinPoint, method, rateLimiterAnnotation.fallbackMethod(), rateLimiterExecution);
+    }
+
+    @Around("matchMetaAnnotatedMethod()")
+    public Object rateLimiterMetaAnnotationAroundAdvice(ProceedingJoinPoint proceedingJoinPoint)
+        throws Throwable {
+        return rateLimiterAroundAdvice(proceedingJoinPoint, null);
+    }
+
+    @Around("matchMetaAnnotatedClass()")
+    public Object rateLimiterMetaAnnotationClassAroundAdvice(ProceedingJoinPoint proceedingJoinPoint)
+        throws Throwable {
+        return rateLimiterAroundAdvice(proceedingJoinPoint, null);
     }
 
     private Object proceed(ProceedingJoinPoint proceedingJoinPoint, String methodName,
@@ -154,6 +176,20 @@ public class RateLimiterAspect implements Ordered {
 
     @Nullable
     private RateLimiter getRateLimiterAnnotation(ProceedingJoinPoint proceedingJoinPoint) {
+        Method method = ((MethodSignature) proceedingJoinPoint.getSignature()).getMethod();
+        Class<?> targetClass = proceedingJoinPoint.getTarget() != null ? proceedingJoinPoint.getTarget().getClass() : method.getDeclaringClass();
+        Method targetMethod = AopUtils.getMostSpecificMethod(method, targetClass);
+
+        RateLimiter annotation = AnnotatedElementUtils.findMergedAnnotation(targetMethod, RateLimiter.class);
+        if (annotation != null) {
+            return annotation;
+        }
+
+        annotation = AnnotatedElementUtils.findMergedAnnotation(targetClass, RateLimiter.class);
+        if (annotation != null) {
+            return annotation;
+        }
+
         if (proceedingJoinPoint.getTarget() instanceof Proxy) {
             logger.debug(
                 "The rate limiter annotation is kept on a interface which is acting as a proxy");

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/ratelimiter/configure/RateLimiterAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/ratelimiter/configure/RateLimiterAspect.java
@@ -103,7 +103,9 @@ public class RateLimiterAspect implements Ordered {
     public void matchMetaAnnotatedMethod() {
     }
 
-    @Pointcut("within(@(@io.github.resilience4j.ratelimiter.annotation.RateLimiter *) *)")
+    @Pointcut("within(@(@io.github.resilience4j.ratelimiter.annotation.RateLimiter *) *)" +
+        " && !execution(@io.github.resilience4j.ratelimiter.annotation.RateLimiter * *(..))" +
+        " && !execution(@(@io.github.resilience4j.ratelimiter.annotation.RateLimiter *) * *(..))")
     public void matchMetaAnnotatedClass() {
     }
 
@@ -126,14 +128,8 @@ public class RateLimiterAspect implements Ordered {
         return fallbackExecutor.execute(proceedingJoinPoint, method, rateLimiterAnnotation.fallbackMethod(), rateLimiterExecution);
     }
 
-    @Around("matchMetaAnnotatedMethod()")
+    @Around("matchMetaAnnotatedMethod() || matchMetaAnnotatedClass()")
     public Object rateLimiterMetaAnnotationAroundAdvice(ProceedingJoinPoint proceedingJoinPoint)
-        throws Throwable {
-        return rateLimiterAroundAdvice(proceedingJoinPoint, null);
-    }
-
-    @Around("matchMetaAnnotatedClass()")
-    public Object rateLimiterMetaAnnotationClassAroundAdvice(ProceedingJoinPoint proceedingJoinPoint)
         throws Throwable {
         return rateLimiterAroundAdvice(proceedingJoinPoint, null);
     }

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/ratelimiter/configure/RateLimiterAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/ratelimiter/configure/RateLimiterAspect.java
@@ -30,13 +30,10 @@ import org.aspectj.lang.annotation.Pointcut;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.Ordered;
 
 import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
 import java.util.List;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
@@ -99,7 +96,12 @@ public class RateLimiterAspect implements Ordered {
         // Method used as pointcut
     }
 
+    /**
+     * Matches one-level composed annotations.
+     * AspectJ {@code @(@Ann *)} does not match transitive meta-annotation hierarchies.
+     */
     @Pointcut("execution(@(@io.github.resilience4j.ratelimiter.annotation.RateLimiter *) * *(..))" +
+        " && !within(@io.github.resilience4j.ratelimiter.annotation.RateLimiter *)" +
         " && !execution(@io.github.resilience4j.ratelimiter.annotation.RateLimiter * *(..))")
     public void matchMetaAnnotatedMethod() {
     }
@@ -115,8 +117,9 @@ public class RateLimiterAspect implements Ordered {
         @Nullable RateLimiter rateLimiterAnnotation) throws Throwable {
         Method method = ((MethodSignature) proceedingJoinPoint.getSignature()).getMethod();
         String methodName = method.getDeclaringClass().getName() + "#" + method.getName();
-        if (rateLimiterAnnotation == null) {
-            rateLimiterAnnotation = getRateLimiterAnnotation(proceedingJoinPoint);
+        RateLimiter resolvedAnnotation = getRateLimiterAnnotation(proceedingJoinPoint);
+        if (resolvedAnnotation != null) {
+            rateLimiterAnnotation = resolvedAnnotation;
         }
         if (rateLimiterAnnotation == null) { //because annotations wasn't found
             return proceedingJoinPoint.proceed();
@@ -173,29 +176,8 @@ public class RateLimiterAspect implements Ordered {
 
     @Nullable
     private RateLimiter getRateLimiterAnnotation(ProceedingJoinPoint proceedingJoinPoint) {
-        Method method = ((MethodSignature) proceedingJoinPoint.getSignature()).getMethod();
-        Class<?> targetClass = proceedingJoinPoint.getTarget() != null ? proceedingJoinPoint.getTarget().getClass() : method.getDeclaringClass();
-        Method targetMethod = AopUtils.getMostSpecificMethod(method, targetClass);
-
-        RateLimiter annotation = AnnotatedElementUtils.findMergedAnnotation(targetMethod, RateLimiter.class);
-        if (annotation != null) {
-            return annotation;
-        }
-
-        annotation = AnnotatedElementUtils.findMergedAnnotation(targetClass, RateLimiter.class);
-        if (annotation != null) {
-            return annotation;
-        }
-
-        if (proceedingJoinPoint.getTarget() instanceof Proxy) {
-            logger.debug(
-                "The rate limiter annotation is kept on a interface which is acting as a proxy");
-            return AnnotationExtractor
-                .extractAnnotationFromProxy(proceedingJoinPoint.getTarget(), RateLimiter.class);
-        } else {
-            return AnnotationExtractor
-                .extract(proceedingJoinPoint.getTarget().getClass(), RateLimiter.class);
-        }
+        return AnnotationExtractor.extractAnnotationFromJoinPoint(proceedingJoinPoint,
+            RateLimiter.class);
     }
 
     private Object handleJoinPoint(ProceedingJoinPoint proceedingJoinPoint,

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/ratelimiter/configure/RateLimiterAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/ratelimiter/configure/RateLimiterAspect.java
@@ -99,7 +99,8 @@ public class RateLimiterAspect implements Ordered {
         // Method used as pointcut
     }
 
-    @Pointcut("execution(@(@io.github.resilience4j.ratelimiter.annotation.RateLimiter *) * *(..))")
+    @Pointcut("execution(@(@io.github.resilience4j.ratelimiter.annotation.RateLimiter *) * *(..))" +
+        " && !execution(@io.github.resilience4j.ratelimiter.annotation.RateLimiter * *(..))")
     public void matchMetaAnnotatedMethod() {
     }
 

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/retry/configure/RetryAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/retry/configure/RetryAspect.java
@@ -31,13 +31,10 @@ import org.aspectj.lang.annotation.Pointcut;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.Ordered;
 
 import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
 import java.util.List;
 import java.util.concurrent.*;
 
@@ -102,7 +99,12 @@ public class RetryAspect implements Ordered, AutoCloseable {
     public void matchAnnotatedClassOrMethod(Retry retry) {
     }
 
+    /**
+     * Matches one-level composed annotations.
+     * AspectJ {@code @(@Ann *)} does not match transitive meta-annotation hierarchies.
+     */
     @Pointcut("execution(@(@io.github.resilience4j.retry.annotation.Retry *) * *(..))" +
+        " && !within(@io.github.resilience4j.retry.annotation.Retry *)" +
         " && !execution(@io.github.resilience4j.retry.annotation.Retry * *(..))")
     public void matchMetaAnnotatedMethod() {
     }
@@ -118,8 +120,9 @@ public class RetryAspect implements Ordered, AutoCloseable {
         @Nullable Retry retryAnnotation) throws Throwable {
         Method method = ((MethodSignature) proceedingJoinPoint.getSignature()).getMethod();
         String methodName = method.getDeclaringClass().getName() + "#" + method.getName();
-        if (retryAnnotation == null) {
-            retryAnnotation = getRetryAnnotation(proceedingJoinPoint);
+        Retry resolvedAnnotation = getRetryAnnotation(proceedingJoinPoint);
+        if (resolvedAnnotation != null) {
+            retryAnnotation = resolvedAnnotation;
         }
         if (retryAnnotation == null) { //because annotations wasn't found
             return proceedingJoinPoint.proceed();
@@ -177,28 +180,8 @@ public class RetryAspect implements Ordered, AutoCloseable {
      */
     @Nullable
     private Retry getRetryAnnotation(ProceedingJoinPoint proceedingJoinPoint) {
-        Method method = ((MethodSignature) proceedingJoinPoint.getSignature()).getMethod();
-        Class<?> targetClass = proceedingJoinPoint.getTarget() != null ? proceedingJoinPoint.getTarget().getClass() : method.getDeclaringClass();
-        Method targetMethod = AopUtils.getMostSpecificMethod(method, targetClass);
-
-        Retry annotation = AnnotatedElementUtils.findMergedAnnotation(targetMethod, Retry.class);
-        if (annotation != null) {
-            return annotation;
-        }
-
-        annotation = AnnotatedElementUtils.findMergedAnnotation(targetClass, Retry.class);
-        if (annotation != null) {
-            return annotation;
-        }
-
-        if (proceedingJoinPoint.getTarget() instanceof Proxy) {
-            logger.debug("The retry annotation is kept on a interface which is acting as a proxy");
-            return AnnotationExtractor
-                .extractAnnotationFromProxy(proceedingJoinPoint.getTarget(), Retry.class);
-        } else {
-            return AnnotationExtractor
-                .extract(proceedingJoinPoint.getTarget().getClass(), Retry.class);
-        }
+        return AnnotationExtractor.extractAnnotationFromJoinPoint(proceedingJoinPoint,
+            Retry.class);
     }
 
     /**

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/retry/configure/RetryAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/retry/configure/RetryAspect.java
@@ -106,7 +106,9 @@ public class RetryAspect implements Ordered, AutoCloseable {
     public void matchMetaAnnotatedMethod() {
     }
 
-    @Pointcut("within(@(@io.github.resilience4j.retry.annotation.Retry *) *)")
+    @Pointcut("within(@(@io.github.resilience4j.retry.annotation.Retry *) *)" +
+        " && !execution(@io.github.resilience4j.retry.annotation.Retry * *(..))" +
+        " && !execution(@(@io.github.resilience4j.retry.annotation.Retry *) * *(..))")
     public void matchMetaAnnotatedClass() {
     }
 
@@ -129,14 +131,8 @@ public class RetryAspect implements Ordered, AutoCloseable {
         return fallbackExecutor.execute(proceedingJoinPoint, method, retryAnnotation.fallbackMethod(), retryExecution);
     }
 
-    @Around("matchMetaAnnotatedMethod()")
+    @Around("matchMetaAnnotatedMethod() || matchMetaAnnotatedClass()")
     public Object retryMetaAnnotationAroundAdvice(ProceedingJoinPoint proceedingJoinPoint)
-        throws Throwable {
-        return retryAroundAdvice(proceedingJoinPoint, null);
-    }
-
-    @Around("matchMetaAnnotatedClass()")
-    public Object retryMetaAnnotationClassAroundAdvice(ProceedingJoinPoint proceedingJoinPoint)
         throws Throwable {
         return retryAroundAdvice(proceedingJoinPoint, null);
     }

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/retry/configure/RetryAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/retry/configure/RetryAspect.java
@@ -31,7 +31,9 @@ import org.aspectj.lang.annotation.Pointcut;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.Ordered;
 
 import java.lang.reflect.Method;
@@ -100,6 +102,14 @@ public class RetryAspect implements Ordered, AutoCloseable {
     public void matchAnnotatedClassOrMethod(Retry retry) {
     }
 
+    @Pointcut("execution(@(@io.github.resilience4j.retry.annotation.Retry *) * *(..))")
+    public void matchMetaAnnotatedMethod() {
+    }
+
+    @Pointcut("within(@(@io.github.resilience4j.retry.annotation.Retry *) *)")
+    public void matchMetaAnnotatedClass() {
+    }
+
     @Around(value = "matchAnnotatedClassOrMethod(retryAnnotation)", argNames = "proceedingJoinPoint, retryAnnotation")
     public Object retryAroundAdvice(ProceedingJoinPoint proceedingJoinPoint,
         @Nullable Retry retryAnnotation) throws Throwable {
@@ -117,6 +127,18 @@ public class RetryAspect implements Ordered, AutoCloseable {
         Class<?> returnType = method.getReturnType();
         final CheckedSupplier<Object> retryExecution = () -> proceed(proceedingJoinPoint, methodName, retry, returnType);
         return fallbackExecutor.execute(proceedingJoinPoint, method, retryAnnotation.fallbackMethod(), retryExecution);
+    }
+
+    @Around("matchMetaAnnotatedMethod()")
+    public Object retryMetaAnnotationAroundAdvice(ProceedingJoinPoint proceedingJoinPoint)
+        throws Throwable {
+        return retryAroundAdvice(proceedingJoinPoint, null);
+    }
+
+    @Around("matchMetaAnnotatedClass()")
+    public Object retryMetaAnnotationClassAroundAdvice(ProceedingJoinPoint proceedingJoinPoint)
+        throws Throwable {
+        return retryAroundAdvice(proceedingJoinPoint, null);
     }
 
     private Object proceed(ProceedingJoinPoint proceedingJoinPoint, String methodName,
@@ -158,6 +180,20 @@ public class RetryAspect implements Ordered, AutoCloseable {
      */
     @Nullable
     private Retry getRetryAnnotation(ProceedingJoinPoint proceedingJoinPoint) {
+        Method method = ((MethodSignature) proceedingJoinPoint.getSignature()).getMethod();
+        Class<?> targetClass = proceedingJoinPoint.getTarget() != null ? proceedingJoinPoint.getTarget().getClass() : method.getDeclaringClass();
+        Method targetMethod = AopUtils.getMostSpecificMethod(method, targetClass);
+
+        Retry annotation = AnnotatedElementUtils.findMergedAnnotation(targetMethod, Retry.class);
+        if (annotation != null) {
+            return annotation;
+        }
+
+        annotation = AnnotatedElementUtils.findMergedAnnotation(targetClass, Retry.class);
+        if (annotation != null) {
+            return annotation;
+        }
+
         if (proceedingJoinPoint.getTarget() instanceof Proxy) {
             logger.debug("The retry annotation is kept on a interface which is acting as a proxy");
             return AnnotationExtractor

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/retry/configure/RetryAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/retry/configure/RetryAspect.java
@@ -102,7 +102,8 @@ public class RetryAspect implements Ordered, AutoCloseable {
     public void matchAnnotatedClassOrMethod(Retry retry) {
     }
 
-    @Pointcut("execution(@(@io.github.resilience4j.retry.annotation.Retry *) * *(..))")
+    @Pointcut("execution(@(@io.github.resilience4j.retry.annotation.Retry *) * *(..))" +
+        " && !execution(@io.github.resilience4j.retry.annotation.Retry * *(..))")
     public void matchMetaAnnotatedMethod() {
     }
 

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterAspect.java
@@ -74,7 +74,8 @@ public class TimeLimiterAspect implements Ordered, AutoCloseable {
         // a marker method
     }
 
-    @Pointcut("execution(@(@io.github.resilience4j.timelimiter.annotation.TimeLimiter *) * *(..))")
+    @Pointcut("execution(@(@io.github.resilience4j.timelimiter.annotation.TimeLimiter *) * *(..))" +
+        " && !execution(@io.github.resilience4j.timelimiter.annotation.TimeLimiter * *(..))")
     public void matchMetaAnnotatedMethod() {
     }
 

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterAspect.java
@@ -32,12 +32,9 @@ import org.aspectj.lang.annotation.Pointcut;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.aop.support.AopUtils;
-import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.Ordered;
 
 import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
 import java.util.List;
 import java.util.concurrent.*;
 
@@ -74,7 +71,12 @@ public class TimeLimiterAspect implements Ordered, AutoCloseable {
         // a marker method
     }
 
+    /**
+     * Matches one-level composed annotations.
+     * AspectJ {@code @(@Ann *)} does not match transitive meta-annotation hierarchies.
+     */
     @Pointcut("execution(@(@io.github.resilience4j.timelimiter.annotation.TimeLimiter *) * *(..))" +
+        " && !within(@io.github.resilience4j.timelimiter.annotation.TimeLimiter *)" +
         " && !execution(@io.github.resilience4j.timelimiter.annotation.TimeLimiter * *(..))")
     public void matchMetaAnnotatedMethod() {
     }
@@ -90,8 +92,9 @@ public class TimeLimiterAspect implements Ordered, AutoCloseable {
         @Nullable TimeLimiter timeLimiterAnnotation) throws Throwable {
         Method method = ((MethodSignature) proceedingJoinPoint.getSignature()).getMethod();
         String methodName = method.getDeclaringClass().getName() + "#" + method.getName();
-        if (timeLimiterAnnotation == null) {
-            timeLimiterAnnotation = getTimeLimiterAnnotation(proceedingJoinPoint);
+        TimeLimiter resolvedAnnotation = getTimeLimiterAnnotation(proceedingJoinPoint);
+        if (resolvedAnnotation != null) {
+            timeLimiterAnnotation = resolvedAnnotation;
         }
         if(timeLimiterAnnotation == null) {
             return proceedingJoinPoint.proceed();
@@ -146,26 +149,8 @@ public class TimeLimiterAspect implements Ordered, AutoCloseable {
 
     @Nullable
     private TimeLimiter getTimeLimiterAnnotation(ProceedingJoinPoint proceedingJoinPoint) {
-        Method method = ((MethodSignature) proceedingJoinPoint.getSignature()).getMethod();
-        Class<?> targetClass = proceedingJoinPoint.getTarget() != null ? proceedingJoinPoint.getTarget().getClass() : method.getDeclaringClass();
-        Method targetMethod = AopUtils.getMostSpecificMethod(method, targetClass);
-
-        TimeLimiter annotation = AnnotatedElementUtils.findMergedAnnotation(targetMethod, TimeLimiter.class);
-        if (annotation != null) {
-            return annotation;
-        }
-
-        annotation = AnnotatedElementUtils.findMergedAnnotation(targetClass, TimeLimiter.class);
-        if (annotation != null) {
-            return annotation;
-        }
-
-        if (proceedingJoinPoint.getTarget() instanceof Proxy) {
-            logger.debug("The TimeLimiter annotation is kept on a interface which is acting as a proxy");
-            return AnnotationExtractor.extractAnnotationFromProxy(proceedingJoinPoint.getTarget(), TimeLimiter.class);
-        } else {
-            return AnnotationExtractor.extract(proceedingJoinPoint.getTarget().getClass(), TimeLimiter.class);
-        }
+        return AnnotationExtractor.extractAnnotationFromJoinPoint(proceedingJoinPoint,
+            TimeLimiter.class);
     }
 
     private Object handleJoinPointCompletableFuture(

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterAspect.java
@@ -32,6 +32,8 @@ import org.aspectj.lang.annotation.Pointcut;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.Ordered;
 
 import java.lang.reflect.Method;
@@ -72,6 +74,14 @@ public class TimeLimiterAspect implements Ordered, AutoCloseable {
         // a marker method
     }
 
+    @Pointcut("execution(@(@io.github.resilience4j.timelimiter.annotation.TimeLimiter *) * *(..))")
+    public void matchMetaAnnotatedMethod() {
+    }
+
+    @Pointcut("within(@(@io.github.resilience4j.timelimiter.annotation.TimeLimiter *) *)")
+    public void matchMetaAnnotatedClass() {
+    }
+
     @Around(value = "matchAnnotatedClassOrMethod(timeLimiterAnnotation)", argNames = "proceedingJoinPoint, timeLimiterAnnotation")
     public Object timeLimiterAroundAdvice(ProceedingJoinPoint proceedingJoinPoint,
         @Nullable TimeLimiter timeLimiterAnnotation) throws Throwable {
@@ -89,6 +99,18 @@ public class TimeLimiterAspect implements Ordered, AutoCloseable {
         Class<?> returnType = method.getReturnType();
         final CheckedSupplier<Object> timeLimiterExecution = () -> proceed(proceedingJoinPoint, methodName, timeLimiter, returnType);
         return fallbackExecutor.execute(proceedingJoinPoint, method, timeLimiterAnnotation.fallbackMethod(), timeLimiterExecution);
+    }
+
+    @Around("matchMetaAnnotatedMethod()")
+    public Object timeLimiterMetaAnnotationAroundAdvice(ProceedingJoinPoint proceedingJoinPoint)
+        throws Throwable {
+        return timeLimiterAroundAdvice(proceedingJoinPoint, null);
+    }
+
+    @Around("matchMetaAnnotatedClass()")
+    public Object timeLimiterMetaAnnotationClassAroundAdvice(ProceedingJoinPoint proceedingJoinPoint)
+        throws Throwable {
+        return timeLimiterAroundAdvice(proceedingJoinPoint, null);
     }
 
     private Object proceed(ProceedingJoinPoint proceedingJoinPoint, String methodName,
@@ -126,7 +148,21 @@ public class TimeLimiterAspect implements Ordered, AutoCloseable {
     }
 
     @Nullable
-    private static TimeLimiter getTimeLimiterAnnotation(ProceedingJoinPoint proceedingJoinPoint) {
+    private TimeLimiter getTimeLimiterAnnotation(ProceedingJoinPoint proceedingJoinPoint) {
+        Method method = ((MethodSignature) proceedingJoinPoint.getSignature()).getMethod();
+        Class<?> targetClass = proceedingJoinPoint.getTarget() != null ? proceedingJoinPoint.getTarget().getClass() : method.getDeclaringClass();
+        Method targetMethod = AopUtils.getMostSpecificMethod(method, targetClass);
+
+        TimeLimiter annotation = AnnotatedElementUtils.findMergedAnnotation(targetMethod, TimeLimiter.class);
+        if (annotation != null) {
+            return annotation;
+        }
+
+        annotation = AnnotatedElementUtils.findMergedAnnotation(targetClass, TimeLimiter.class);
+        if (annotation != null) {
+            return annotation;
+        }
+
         if (proceedingJoinPoint.getTarget() instanceof Proxy) {
             logger.debug("The TimeLimiter annotation is kept on a interface which is acting as a proxy");
             return AnnotationExtractor.extractAnnotationFromProxy(proceedingJoinPoint.getTarget(), TimeLimiter.class);

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterAspect.java
@@ -78,7 +78,9 @@ public class TimeLimiterAspect implements Ordered, AutoCloseable {
     public void matchMetaAnnotatedMethod() {
     }
 
-    @Pointcut("within(@(@io.github.resilience4j.timelimiter.annotation.TimeLimiter *) *)")
+    @Pointcut("within(@(@io.github.resilience4j.timelimiter.annotation.TimeLimiter *) *)" +
+        " && !execution(@io.github.resilience4j.timelimiter.annotation.TimeLimiter * *(..))" +
+        " && !execution(@(@io.github.resilience4j.timelimiter.annotation.TimeLimiter *) * *(..))")
     public void matchMetaAnnotatedClass() {
     }
 
@@ -101,14 +103,8 @@ public class TimeLimiterAspect implements Ordered, AutoCloseable {
         return fallbackExecutor.execute(proceedingJoinPoint, method, timeLimiterAnnotation.fallbackMethod(), timeLimiterExecution);
     }
 
-    @Around("matchMetaAnnotatedMethod()")
+    @Around("matchMetaAnnotatedMethod() || matchMetaAnnotatedClass()")
     public Object timeLimiterMetaAnnotationAroundAdvice(ProceedingJoinPoint proceedingJoinPoint)
-        throws Throwable {
-        return timeLimiterAroundAdvice(proceedingJoinPoint, null);
-    }
-
-    @Around("matchMetaAnnotatedClass()")
-    public Object timeLimiterMetaAnnotationClassAroundAdvice(ProceedingJoinPoint proceedingJoinPoint)
         throws Throwable {
         return timeLimiterAroundAdvice(proceedingJoinPoint, null);
     }

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/utils/AnnotationExtractor.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/utils/AnnotationExtractor.java
@@ -1,17 +1,62 @@
 package io.github.resilience4j.spring6.utils;
 
 import io.github.resilience4j.core.lang.Nullable;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.core.annotation.AnnotatedElementUtils;
 
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.lang.annotation.Annotation;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class AnnotationExtractor {
 
     private static final Logger logger = LoggerFactory.getLogger(AnnotationExtractor.class);
+    private static final Map<AnnotationCacheKey, Optional<? extends Annotation>> MERGED_ANNOTATION_CACHE = new ConcurrentHashMap<>();
 
     private AnnotationExtractor() {
+    }
+
+    /**
+     * Extract annotation from join point method/class and fallback to proxy/interface lookup.
+     *
+     * @param proceedingJoinPoint proceedingJoinPoint
+     * @param annotationClass annotation class
+     * @param <T> The annotation type.
+     * @return annotation
+     */
+    @Nullable
+    public static <T extends Annotation> T extractAnnotationFromJoinPoint(
+        ProceedingJoinPoint proceedingJoinPoint, Class<T> annotationClass) {
+        Method method = ((MethodSignature) proceedingJoinPoint.getSignature()).getMethod();
+        Class<?> targetClass = proceedingJoinPoint.getTarget() != null
+            ? proceedingJoinPoint.getTarget().getClass()
+            : method.getDeclaringClass();
+        Method targetMethod = AopUtils.getMostSpecificMethod(method, targetClass);
+
+        T annotation = findMergedAnnotation(targetMethod, annotationClass);
+        if (annotation != null) {
+            return annotation;
+        }
+
+        annotation = findMergedAnnotation(targetClass, annotationClass);
+        if (annotation != null) {
+            return annotation;
+        }
+
+        if (proceedingJoinPoint.getTarget() instanceof Proxy) {
+            return extractAnnotationFromProxy(proceedingJoinPoint.getTarget(), annotationClass);
+        } else {
+            return extract(targetClass, annotationClass);
+        }
     }
 
     /**
@@ -70,5 +115,20 @@ public class AnnotationExtractor {
             }
         }
         return null;
+    }
+
+    @Nullable
+    private static <T extends Annotation> T findMergedAnnotation(AnnotatedElement annotatedElement,
+        Class<T> annotationClass) {
+        AnnotationCacheKey cacheKey = new AnnotationCacheKey(annotatedElement, annotationClass);
+        @SuppressWarnings("unchecked")
+        Optional<T> cached = (Optional<T>) MERGED_ANNOTATION_CACHE.computeIfAbsent(cacheKey,
+            ignored -> Optional.ofNullable(
+                AnnotatedElementUtils.findMergedAnnotation(annotatedElement, annotationClass)));
+        return cached.orElse(null);
+    }
+
+    private record AnnotationCacheKey(AnnotatedElement annotatedElement,
+                                      Class<? extends Annotation> annotationClass) {
     }
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/BulkheadDummyService.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/BulkheadDummyService.java
@@ -2,15 +2,34 @@ package io.github.resilience4j.spring6;
 
 import io.github.resilience4j.bulkhead.annotation.Bulkhead;
 import io.reactivex.*;
+import org.springframework.core.annotation.AliasFor;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 @Component
 public class BulkheadDummyService implements TestDummyService {
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @Bulkhead(name = BACKEND, fallbackMethod = "recovery")
+    public @interface ComposedBulkhead {
+        @AliasFor(annotation = Bulkhead.class, attribute = "name")
+        String name() default BACKEND;
+
+        @AliasFor(annotation = Bulkhead.class, attribute = "fallbackMethod")
+        String fallbackMethod() default "recovery";
+
+        @AliasFor(annotation = Bulkhead.class, attribute = "type")
+        Bulkhead.Type type() default Bulkhead.Type.SEMAPHORE;
+    }
 
     @Override
     @Bulkhead(name = BACKEND, fallbackMethod = "recovery")
@@ -141,5 +160,15 @@ public class BulkheadDummyService implements TestDummyService {
     @Bulkhead(name = "#root.args[0]", configuration = BACKEND, fallbackMethod = "#{'recovery'}", type = Bulkhead.Type.THREADPOOL)
     public CompletionStage<String> spelSyncThreadPoolWithCfg(String backend) {
         return CompletableFuture.completedFuture(backend);
+    }
+
+    @ComposedBulkhead
+    public String composedSync() {
+        return syncError();
+    }
+
+    @ComposedBulkhead(name = "#root.args[0]", fallbackMethod = "#{'recovery'}")
+    public String composedSpelSync(String backend) {
+        return syncError();
     }
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/CircuitBreakerDummyService.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/CircuitBreakerDummyService.java
@@ -15,6 +15,7 @@ import java.util.concurrent.CompletionStage;
 
 @Component
 public class CircuitBreakerDummyService implements TestDummyService {
+    public static final String DIRECT_AND_COMPOSED_BACKEND = "backendDirectAndComposed";
 
     @Target(ElementType.METHOD)
     @Retention(RetentionPolicy.RUNTIME)
@@ -142,6 +143,12 @@ public class CircuitBreakerDummyService implements TestDummyService {
 
     @ComposedCircuitBreaker(name = "#root.args[0]", fallbackMethod = "#{'recovery'}")
     public String composedSpelSync(String backend) {
+        return syncError();
+    }
+
+    @CircuitBreaker(name = DIRECT_AND_COMPOSED_BACKEND, fallbackMethod = "recovery")
+    @ComposedCircuitBreaker(name = DIRECT_AND_COMPOSED_BACKEND, fallbackMethod = "recovery")
+    public String directAndComposedSync() {
         return syncError();
     }
 

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/CircuitBreakerDummyService.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/CircuitBreakerDummyService.java
@@ -2,14 +2,30 @@ package io.github.resilience4j.spring6;
 
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.reactivex.*;
+import org.springframework.core.annotation.AliasFor;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.concurrent.CompletionStage;
 
 @Component
 public class CircuitBreakerDummyService implements TestDummyService {
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @CircuitBreaker(name = BACKEND, fallbackMethod = "recovery")
+    public @interface ComposedCircuitBreaker {
+        @AliasFor(annotation = CircuitBreaker.class, attribute = "name")
+        String name() default BACKEND;
+
+        @AliasFor(annotation = CircuitBreaker.class, attribute = "fallbackMethod")
+        String fallbackMethod() default "recovery";
+    }
 
     @Override
     @CircuitBreaker(name = BACKEND, fallbackMethod = "recovery")
@@ -116,6 +132,16 @@ public class CircuitBreakerDummyService implements TestDummyService {
     @Override
     @CircuitBreaker(name = "#root.args[0]", fallbackMethod = "#{'recovery'}")
     public String spelSync(String backend) {
+        return syncError();
+    }
+
+    @ComposedCircuitBreaker
+    public String composedSync() {
+        return syncError();
+    }
+
+    @ComposedCircuitBreaker(name = "#root.args[0]", fallbackMethod = "#{'recovery'}")
+    public String composedSpelSync(String backend) {
         return syncError();
     }
 

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/ComposedClassLevelCircuitBreakerService.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/ComposedClassLevelCircuitBreakerService.java
@@ -1,0 +1,36 @@
+package io.github.resilience4j.spring6;
+
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Component
+@ComposedClassLevelCircuitBreakerService.ComposedCircuitBreakerClassLevel
+public class ComposedClassLevelCircuitBreakerService {
+
+    private static final String BACKEND = TestDummyService.BACKEND;
+
+    @Target(ElementType.TYPE)
+    @Retention(RetentionPolicy.RUNTIME)
+    @CircuitBreaker(name = BACKEND, fallbackMethod = "recovery")
+    public @interface ComposedCircuitBreakerClassLevel {
+        @AliasFor(annotation = CircuitBreaker.class, attribute = "name")
+        String name() default BACKEND;
+
+        @AliasFor(annotation = CircuitBreaker.class, attribute = "fallbackMethod")
+        String fallbackMethod() default "recovery";
+    }
+
+    public String sync() {
+        throw new RuntimeException("Test");
+    }
+
+    public String recovery(RuntimeException throwable) {
+        return "recovered";
+    }
+}

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/RateLimiterDummyService.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/RateLimiterDummyService.java
@@ -2,14 +2,30 @@ package io.github.resilience4j.spring6;
 
 import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import io.reactivex.*;
+import org.springframework.core.annotation.AliasFor;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.concurrent.CompletionStage;
 
 @Component
 public class RateLimiterDummyService implements TestDummyService {
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @RateLimiter(name = BACKEND, fallbackMethod = "recovery")
+    public @interface ComposedRateLimiter {
+        @AliasFor(annotation = RateLimiter.class, attribute = "name")
+        String name() default BACKEND;
+
+        @AliasFor(annotation = RateLimiter.class, attribute = "fallbackMethod")
+        String fallbackMethod() default "recovery";
+    }
 
     @Override
     @RateLimiter(name = BACKEND, fallbackMethod = "recovery")
@@ -129,5 +145,15 @@ public class RateLimiterDummyService implements TestDummyService {
     @RateLimiter(name = "#root.args[0]", configuration = BACKEND, fallbackMethod = "recovery")
     public String spelSyncWithCfg(String backend) {
         return backend;
+    }
+
+    @ComposedRateLimiter
+    public String composedSync() {
+        return syncError();
+    }
+
+    @ComposedRateLimiter(name = "#root.args[0]", fallbackMethod = "#{'recovery'}")
+    public String composedSpelSync(String backend) {
+        return syncError();
     }
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/RetryDummyService.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/RetryDummyService.java
@@ -2,10 +2,15 @@ package io.github.resilience4j.spring6;
 
 import io.github.resilience4j.retry.annotation.Retry;
 import io.reactivex.*;
+import org.springframework.core.annotation.AliasFor;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -13,6 +18,17 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class RetryDummyService implements TestDummyService {
 
     private final AtomicInteger attemptCounter = new AtomicInteger(0);
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @Retry(name = BACKEND, fallbackMethod = "recovery")
+    public @interface ComposedRetry {
+        @AliasFor(annotation = Retry.class, attribute = "name")
+        String name() default BACKEND;
+
+        @AliasFor(annotation = Retry.class, attribute = "fallbackMethod")
+        String fallbackMethod() default "recovery";
+    }
 
     @Override
     @Retry(name = BACKEND, fallbackMethod = "recovery")
@@ -136,5 +152,15 @@ public class RetryDummyService implements TestDummyService {
     @Retry(name = "#root.args[0]", configuration = BACKEND, fallbackMethod = "#{'recovery'}")
     public String spelSyncWithCfg(String backend) {
         return backend;
+    }
+
+    @ComposedRetry
+    public String composedSync() {
+        return syncError();
+    }
+
+    @ComposedRetry(name = "#root.args[0]", fallbackMethod = "#{'recovery'}")
+    public String composedSpelSync(String backend) {
+        return syncError();
     }
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/TimeLimiterDummyService.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/TimeLimiterDummyService.java
@@ -2,15 +2,31 @@ package io.github.resilience4j.spring6;
 
 import io.github.resilience4j.timelimiter.annotation.TimeLimiter;
 import io.reactivex.*;
+import org.springframework.core.annotation.AliasFor;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 @Component
 public class TimeLimiterDummyService implements TestDummyService {
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @TimeLimiter(name = BACKEND, fallbackMethod = "completionStageRecovery")
+    public @interface ComposedTimeLimiter {
+        @AliasFor(annotation = TimeLimiter.class, attribute = "name")
+        String name() default BACKEND;
+
+        @AliasFor(annotation = TimeLimiter.class, attribute = "fallbackMethod")
+        String fallbackMethod() default "completionStageRecovery";
+    }
 
     @Override
     public String sync() {
@@ -136,5 +152,15 @@ public class TimeLimiterDummyService implements TestDummyService {
     @TimeLimiter(name = "#root.args[0]", configuration = BACKEND, fallbackMethod = "${missing.property:monoRecovery}")
     public Mono<String> spelMonoWithCfg(String backend) {
         return monoError(backend);
+    }
+
+    @ComposedTimeLimiter
+    public CompletionStage<String> composedAsync() {
+        return asyncError();
+    }
+
+    @ComposedTimeLimiter(name = "#root.args[0]", fallbackMethod = "#{'completionStageRecovery'}")
+    public CompletionStage<String> composedSpelAsync(String backend) {
+        return asyncError();
     }
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/bulkhead/configure/BulkheadRecoveryTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/bulkhead/configure/BulkheadRecoveryTest.java
@@ -16,6 +16,7 @@
 package io.github.resilience4j.spring6.bulkhead.configure;
 
 import io.github.resilience4j.spring6.TestApplication;
+import io.github.resilience4j.spring6.BulkheadDummyService;
 import io.github.resilience4j.spring6.TestDummyService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,9 +37,22 @@ public class BulkheadRecoveryTest {
     @Qualifier("bulkheadDummyService")
     TestDummyService testDummyService;
 
+    @Autowired
+    BulkheadDummyService bulkheadDummyService;
+
     @Test
     public void testRecovery() {
         assertThat(testDummyService.sync()).isEqualTo("recovered");
+    }
+
+    @Test
+    public void testComposedAnnotationRecovery() {
+        assertThat(bulkheadDummyService.composedSync()).isEqualTo("recovered");
+    }
+
+    @Test
+    public void testComposedAnnotationSpelRecovery() {
+        assertThat(bulkheadDummyService.composedSpelSync("backendB")).isEqualTo("recovered");
     }
 
     @Test

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/circuitbreaker/configure/CircuitBreakerRecoveryTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/circuitbreaker/configure/CircuitBreakerRecoveryTest.java
@@ -16,6 +16,8 @@
 package io.github.resilience4j.spring6.circuitbreaker.configure;
 
 import io.github.resilience4j.spring6.TestApplication;
+import io.github.resilience4j.spring6.ComposedClassLevelCircuitBreakerService;
+import io.github.resilience4j.spring6.CircuitBreakerDummyService;
 import io.github.resilience4j.spring6.TestDummyService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,9 +38,30 @@ public class CircuitBreakerRecoveryTest {
     @Qualifier("circuitBreakerDummyService")
     TestDummyService testDummyService;
 
+    @Autowired
+    CircuitBreakerDummyService circuitBreakerDummyService;
+
+    @Autowired
+    ComposedClassLevelCircuitBreakerService composedClassLevelCircuitBreakerService;
+
     @Test
     public void testRecovery() {
         assertThat(testDummyService.sync()).isEqualTo("recovered");
+    }
+
+    @Test
+    public void testComposedAnnotationRecovery() {
+        assertThat(circuitBreakerDummyService.composedSync()).isEqualTo("recovered");
+    }
+
+    @Test
+    public void testComposedAnnotationSpelRecovery() {
+        assertThat(circuitBreakerDummyService.composedSpelSync("backendB")).isEqualTo("recovered");
+    }
+
+    @Test
+    public void testComposedClassLevelAnnotationRecovery() {
+        assertThat(composedClassLevelCircuitBreakerService.sync()).isEqualTo("recovered");
     }
 
     @Test

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/circuitbreaker/configure/CircuitBreakerRecoveryTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/circuitbreaker/configure/CircuitBreakerRecoveryTest.java
@@ -15,6 +15,8 @@
  */
 package io.github.resilience4j.spring6.circuitbreaker.configure;
 
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.spring6.TestApplication;
 import io.github.resilience4j.spring6.ComposedClassLevelCircuitBreakerService;
 import io.github.resilience4j.spring6.CircuitBreakerDummyService;
@@ -42,6 +44,9 @@ public class CircuitBreakerRecoveryTest {
     CircuitBreakerDummyService circuitBreakerDummyService;
 
     @Autowired
+    CircuitBreakerRegistry circuitBreakerRegistry;
+
+    @Autowired
     ComposedClassLevelCircuitBreakerService composedClassLevelCircuitBreakerService;
 
     @Test
@@ -62,6 +67,15 @@ public class CircuitBreakerRecoveryTest {
     @Test
     public void testComposedClassLevelAnnotationRecovery() {
         assertThat(composedClassLevelCircuitBreakerService.sync()).isEqualTo("recovered");
+    }
+
+    @Test
+    public void testDirectAndComposedAnnotationRecoveryWithoutDuplicateAdvice() {
+        assertThat(circuitBreakerDummyService.directAndComposedSync()).isEqualTo("recovered");
+        CircuitBreaker circuitBreaker = circuitBreakerRegistry
+            .circuitBreaker(CircuitBreakerDummyService.DIRECT_AND_COMPOSED_BACKEND);
+        assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls()).isEqualTo(1);
+        assertThat(circuitBreaker.getMetrics().getNumberOfSuccessfulCalls()).isZero();
     }
 
     @Test

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/ratelimiter/configure/RateLimiterRecoveryTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/ratelimiter/configure/RateLimiterRecoveryTest.java
@@ -16,6 +16,7 @@
 package io.github.resilience4j.spring6.ratelimiter.configure;
 
 import io.github.resilience4j.spring6.TestApplication;
+import io.github.resilience4j.spring6.RateLimiterDummyService;
 import io.github.resilience4j.spring6.TestDummyService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,9 +37,22 @@ public class RateLimiterRecoveryTest {
     @Qualifier("rateLimiterDummyService")
     TestDummyService testDummyService;
 
+    @Autowired
+    RateLimiterDummyService rateLimiterDummyService;
+
     @Test
     public void testRecovery() {
         assertThat(testDummyService.sync()).isEqualTo("recovered");
+    }
+
+    @Test
+    public void testComposedAnnotationRecovery() {
+        assertThat(rateLimiterDummyService.composedSync()).isEqualTo("recovered");
+    }
+
+    @Test
+    public void testComposedAnnotationSpelRecovery() {
+        assertThat(rateLimiterDummyService.composedSpelSync("backendB")).isEqualTo("recovered");
     }
 
     @Test

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/retry/configure/RetryRecoveryTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/retry/configure/RetryRecoveryTest.java
@@ -16,6 +16,7 @@
 package io.github.resilience4j.spring6.retry.configure;
 
 import io.github.resilience4j.spring6.TestApplication;
+import io.github.resilience4j.spring6.RetryDummyService;
 import io.github.resilience4j.spring6.TestDummyService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,9 +37,22 @@ public class RetryRecoveryTest {
     @Qualifier("retryDummyService")
     TestDummyService testDummyService;
 
+    @Autowired
+    RetryDummyService retryDummyService;
+
     @Test
     public void testRecovery() {
         assertThat(testDummyService.sync()).isEqualTo("recovered");
+    }
+
+    @Test
+    public void testComposedAnnotationRecovery() {
+        assertThat(retryDummyService.composedSync()).isEqualTo("recovered");
+    }
+
+    @Test
+    public void testComposedAnnotationSpelRecovery() {
+        assertThat(retryDummyService.composedSpelSync("backendB")).isEqualTo("recovered");
     }
 
     @Test

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterRecoveryTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterRecoveryTest.java
@@ -1,6 +1,7 @@
 package io.github.resilience4j.spring6.timelimiter.configure;
 
 import io.github.resilience4j.spring6.TestApplication;
+import io.github.resilience4j.spring6.TimeLimiterDummyService;
 import io.github.resilience4j.spring6.TestDummyService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -20,9 +21,24 @@ public class TimeLimiterRecoveryTest {
     @Qualifier("timeLimiterDummyService")
     TestDummyService testDummyService;
 
+    @Autowired
+    TimeLimiterDummyService timeLimiterDummyService;
+
     @Test
     public void testAsyncRecovery() throws Exception {
         String result = testDummyService.async().toCompletableFuture().get(5, TimeUnit.SECONDS);
+        assertThat(result).isEqualTo("recovered");
+    }
+
+    @Test
+    public void testComposedAnnotationRecovery() throws Exception {
+        String result = timeLimiterDummyService.composedAsync().toCompletableFuture().get(5, TimeUnit.SECONDS);
+        assertThat(result).isEqualTo("recovered");
+    }
+
+    @Test
+    public void testComposedAnnotationSpelRecovery() throws Exception {
+        String result = timeLimiterDummyService.composedSpelAsync("backendB").toCompletableFuture().get(5, TimeUnit.SECONDS);
         assertThat(result).isEqualTo("recovered");
     }
 


### PR DESCRIPTION
## Summary
- Add `ElementType.ANNOTATION_TYPE` to `@CircuitBreaker`, `@Bulkhead`, `@RateLimiter`, `@Retry`, and `@TimeLimiter` so they can be used as composed annotations.
- Add Spring6 aspect pointcuts for composed/meta-annotations on methods and classes.
- Resolve resilience annotations via `AnnotatedElementUtils.findMergedAnnotation(...)` to honor `@AliasFor` values from composed annotations.
- Add recovery tests for all five aspects with composed annotations.
- Add a class-level composed annotation recovery test for `@CircuitBreaker`.

## Why this approach
- Keeps existing direct annotation behavior (`@within` / `@annotation`) unchanged.
- Adds dedicated pointcuts for composed/meta-annotation cases to minimize behavior changes.
- Uses merged annotation resolution only for annotation extraction, which supports alias chains.

## Verification
- `./gradlew :resilience4j-spring6:test`

Closes #2405
