### PR TITLE
Remove unrelated flaky Clock test from CircuitBreakerEventTest

### DIFF
--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/event/CircuitBreakerEventTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/event/CircuitBreakerEventTest.java
@@ -21,15 +21,10 @@ package io.github.resilience4j.circuitbreaker.event;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.time.Clock;
 import java.time.Duration;
-import java.time.Instant;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 
 import static io.github.resilience4j.circuitbreaker.CircuitBreaker.StateTransition;
 import static io.github.resilience4j.circuitbreaker.event.CircuitBreakerEvent.Type;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CircuitBreakerEventTest {
@@ -106,21 +101,4 @@ public class CircuitBreakerEventTest {
             .contains("CircuitBreaker 'test' recorded a call which was not permitted.");
     }
 
-    @Test
-    public void name() throws InterruptedException {
-        final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
-        final ZonedDateTime now = ZonedDateTime.now();
-        System.out.println(now.format(formatter));
-
-        final Clock clock = Clock.systemDefaultZone();
-        final Instant instant0 = clock.instant();
-        assertThat(clock.millis()).isEqualTo(instant0.toEpochMilli());
-        SECONDS.sleep(1);
-
-        final Instant instant1 = clock.instant();
-        assertThat(instant1.toEpochMilli() - instant0.toEpochMilli()).isGreaterThanOrEqualTo(1000L);
-
-        final ZonedDateTime dateTime = ZonedDateTime.ofInstant(instant1, clock.getZone());
-        assertThat(dateTime.format(formatter)).isNotEqualTo(now.format(formatter));
-    }
 }


### PR DESCRIPTION
## Summary

Remove unrelated flaky `name()` test from `CircuitBreakerEventTest`.

This test was a leftover scratch test that only verified `java.time.Clock` behavior — it has no relation to resilience4j or CircuitBreaker events. It caused intermittent CI failures due to a race condition between `clock.instant()` and `clock.millis()` calls, where the millisecond could change between the two invocations.

## Changes

- Removed `CircuitBreakerEventTest.name()` test method
- Removed unused imports (`Clock`, `Instant`, `ZonedDateTime`, `DateTimeFormatter`, `SECONDS`)

## CI Failure Evidence

<!-- Paste your failed CI run link(s) below -->
- https://github.com/resilience4j/resilience4j/actions/runs/22765463261

## Test Plan

- [x] Verified remaining `CircuitBreakerEventTest` tests still pass
- [x] No other code references the removed test
