### PR TITLE
Prepare test infrastructure for JUnit 6 migration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,8 +66,14 @@ configure(project.coreProjects) {
     tasks.withType(Test).all {
         if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
             jvmArgs += [
-                    "-XX:+AllowRedefinitionToAddDeleteMethods", "--add-opens=java.base/java.lang=ALL-UNNAMED", "--add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED", "--add-opens=java.base/java.time=ALL-UNNAMED", "--add-opens=java.base/java.io=ALL-UNNAMED"
+                    "--add-opens=java.base/java.lang=ALL-UNNAMED",
+                    "--add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED",
+                    "--add-opens=java.base/java.time=ALL-UNNAMED",
+                    "--add-opens=java.base/java.io=ALL-UNNAMED",
             ]
+        }
+        if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_21)) {
+            jvmArgs += ["-XX:+EnableDynamicAgentLoading"]
         }
     }
 
@@ -77,9 +83,9 @@ configure(project.coreProjects) {
         // JSR-305 only used for non-required meta-annotations
         compileOnly(libs.jsr305)
 
-        testImplementation(libs.vavr)
+        testImplementation(platform(libs.junit.bom))
+        testRuntimeOnly(libs.junit.platform.launcher)
         testImplementation(libs.bundles.testing)
-        testImplementation(libs.jaxws.ri)
     }
 
     tasks.withType(JavaCompile) {
@@ -96,6 +102,7 @@ configure(project.coreProjects) {
             maxFailures = 20
             failOnPassedAfterRetry = true
         }
+        useJUnitPlatform()
     }
 
     jacocoTestReport {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ spring-cloud5 = "5.0.0"
 asciidoctor = { id = "org.asciidoctor.jvm.convert", version = "2.4.0" }
 bnd-builder = { id = "biz.aQute.bnd.builder", version = "7.1.0" }
 jmh = { id = "me.champeau.jmh", version = "0.6.8" }
-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "1.9.25" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.1.21" }
 nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }
 sonarqube = { id = "org.sonarqube", version = "3.5.0.2730" }
 test-retry = { id = "org.gradle.test-retry", version = "1.5.10" }
@@ -28,11 +28,16 @@ jsr305 = { module = "com.google.code.findbugs:jsr305", version = "3.0.2" }
 
 # Common test dependencies
 assertj-core = { module = "org.assertj:assertj-core", version = "3.18.1" }
-awaitility = { module = "com.jayway.awaitility:awaitility", version = "1.7.0" }
-jaxws-ri = { module = "com.sun.xml.ws:jaxws-ri", version = "2.3.2" }
-junit = { module = "junit:junit", version = "4.12" }
+awaitility = { module = "org.awaitility:awaitility", version = "4.3.0" }
+awaitility-old = { module = "com.jayway.awaitility:awaitility", version = "1.7.0" }
+junit = { module = "junit:junit", version = "4.13.2" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version = "1.2.3" }
 mockito-core = { module = "org.mockito:mockito-core", version = "5.16.1" }
+mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version = "5.16.1" }
+junit-bom = { module = "org.junit:junit-bom", version = "6.0.3" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine" }
 
 # resilience4j-cache
 jcache = { module = "javax.cache:cache-api", version = "1.1.0" }
@@ -52,7 +57,7 @@ feign-core = { module = "io.github.openfeign:feign-core", version = "12.0" }
 feign-wiremock = { module = "com.github.tomakehurst:wiremock-jre8", version = "2.26.0" }
 
 # resilience4j-kotlin
-kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8" }
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version = "1.9.25" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.6.4" }
 
 # resilience4j-metrics (Dropwizard)
@@ -138,4 +143,4 @@ spring7-core = { module = "org.springframework:spring-core", version.ref = "spri
 vavr = { module = "io.vavr:vavr", version = "0.10.2" }
 
 [bundles]
-testing = ["junit", "assertj-core", "logback-classic", "mockito-core", "awaitility"]
+testing = ["assertj-core", "logback-classic", "mockito-core", "mockito-junit-jupiter", "awaitility", "junit-jupiter"]

--- a/resilience4j-all/build.gradle
+++ b/resilience4j-all/build.gradle
@@ -7,6 +7,11 @@ dependencies {
     api(project(":resilience4j-retry"))
     api(project(":resilience4j-timelimiter"))
 
+    testRuntimeOnly(libs.junit.vintage.engine)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.awaitility.old)
+    testImplementation(libs.vavr)
     testImplementation(project(":resilience4j-test"))
 }
 ext.moduleName = "io.github.resilience4j.all"

--- a/resilience4j-bulkhead/build.gradle
+++ b/resilience4j-bulkhead/build.gradle
@@ -1,6 +1,11 @@
 dependencies {
     api(project(":resilience4j-core"))
 
+    testRuntimeOnly(libs.junit.vintage.engine)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.awaitility.old)
+    testImplementation(libs.vavr)
     testImplementation(project(":resilience4j-test"))
 }
 ext.moduleName = "io.github.resilience4j.bulkhead"

--- a/resilience4j-cache/build.gradle
+++ b/resilience4j-cache/build.gradle
@@ -2,6 +2,9 @@ dependencies {
     api(project(":resilience4j-core"))
     api(libs.jcache)
 
+    testRuntimeOnly(libs.junit.vintage.engine)
+
+    testImplementation(libs.junit)
     testImplementation(project(":resilience4j-rxjava2"))
     testImplementation(libs.rxjava2)
 }

--- a/resilience4j-circuitbreaker/build.gradle
+++ b/resilience4j-circuitbreaker/build.gradle
@@ -1,8 +1,12 @@
 dependencies {
     api(project(":resilience4j-core"))
 
+    testRuntimeOnly(libs.junit.vintage.engine)
+
+    testImplementation(libs.junit)
     testImplementation(project(":resilience4j-test"))
     testImplementation(libs.junit.params)
     testImplementation(libs.mock.clock)
+    testImplementation(libs.vavr)
 }
 ext.moduleName = "io.github.resilience4j.circuitbreaker"

--- a/resilience4j-circularbuffer/build.gradle
+++ b/resilience4j-circularbuffer/build.gradle
@@ -1,1 +1,7 @@
 ext.moduleName = "io.github.resilience4j.circularbuffer"
+
+dependencies {
+    testRuntimeOnly(libs.junit.vintage.engine)
+
+    testImplementation(libs.junit)
+}

--- a/resilience4j-commons-configuration/build.gradle
+++ b/resilience4j-commons-configuration/build.gradle
@@ -4,5 +4,9 @@ dependencies {
 
     runtimeOnly(libs.apache.commons.beanutils)
     runtimeOnly(libs.jackson.dataformat.yaml)
+
+    testRuntimeOnly(libs.junit.vintage.engine)
+
+    testImplementation(libs.junit)
 }
 ext.moduleName = "io.github.resilience4j.commons.configuration"

--- a/resilience4j-consumer/build.gradle
+++ b/resilience4j-consumer/build.gradle
@@ -2,6 +2,9 @@ dependencies {
     implementation(project(":resilience4j-circularbuffer"))
     implementation(project(":resilience4j-core"))
 
+    testRuntimeOnly(libs.junit.vintage.engine)
+
+    testImplementation(libs.junit)
     testImplementation(project(":resilience4j-circuitbreaker"))
 }
 ext.moduleName = "io.github.resilience4j.consumer"

--- a/resilience4j-core/build.gradle
+++ b/resilience4j-core/build.gradle
@@ -1,8 +1,12 @@
 ext.moduleName = "io.github.resilience4j.core"
 
 dependencies {
+    testRuntimeOnly(libs.junit.vintage.engine)
+
+    testImplementation(libs.junit)
     testImplementation(libs.junit.params)
-    testImplementation(libs.lincheck)
+    testImplementation(libs.awaitility.old)
+    testImplementation(libs.vavr)
     testImplementation(libs.mock.clock)
 }
 

--- a/resilience4j-feign/build.gradle
+++ b/resilience4j-feign/build.gradle
@@ -6,6 +6,9 @@ dependencies {
 
     compileOnly(libs.feign.core)
 
+    testRuntimeOnly(libs.junit.vintage.engine)
+
+    testImplementation(libs.junit)
     testImplementation(libs.feign.core)
     testImplementation(libs.feign.wiremock)
 }

--- a/resilience4j-framework-common/build.gradle
+++ b/resilience4j-framework-common/build.gradle
@@ -6,6 +6,9 @@ dependencies {
     api(project(":resilience4j-retry"))
     api(project(":resilience4j-timelimiter"))
 
+    testRuntimeOnly(libs.junit.vintage.engine)
+
+    testImplementation(libs.junit)
     testImplementation(project(":resilience4j-test"))
 }
 

--- a/resilience4j-hedge/build.gradle
+++ b/resilience4j-hedge/build.gradle
@@ -1,6 +1,9 @@
 dependencies {
     api(project(":resilience4j-core"))
 
+    testRuntimeOnly(libs.junit.vintage.engine)
+
+    testImplementation(libs.junit)
     testImplementation(project(":resilience4j-test"))
 }
 ext.moduleName = "io.github.resilience4j.hedge"

--- a/resilience4j-kotlin/build.gradle
+++ b/resilience4j-kotlin/build.gradle
@@ -15,6 +15,9 @@ dependencies {
     compileOnly(project(":resilience4j-retry"))
     compileOnly(project(":resilience4j-timelimiter"))
 
+    testRuntimeOnly(libs.junit.vintage.engine)
+
+    testImplementation(libs.junit)
     testImplementation(project(":resilience4j-bulkhead"))
     testImplementation(project(":resilience4j-circuitbreaker"))
     testImplementation(project(":resilience4j-micrometer"))

--- a/resilience4j-metrics/build.gradle
+++ b/resilience4j-metrics/build.gradle
@@ -6,6 +6,11 @@ dependencies {
     compileOnly(project(":resilience4j-timelimiter"))
     compileOnly(libs.metrics.core)
 
+    testRuntimeOnly(libs.junit.vintage.engine)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.awaitility.old)
+    testImplementation(libs.vavr)
     testImplementation(project(":resilience4j-bulkhead"))
     testImplementation(project(":resilience4j-circuitbreaker"))
     testImplementation(project(":resilience4j-ratelimiter"))

--- a/resilience4j-micrometer/build.gradle
+++ b/resilience4j-micrometer/build.gradle
@@ -8,6 +8,11 @@ dependencies {
     implementation(project(":resilience4j-retry"))
     implementation(project(":resilience4j-timelimiter"))
 
+    testRuntimeOnly(libs.junit.vintage.engine)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.awaitility.old)
+    testImplementation(libs.vavr)
     testImplementation(project(":resilience4j-test"))
     testImplementation(libs.micrometer.observation.test)
 }

--- a/resilience4j-micronaut-annotation/build.gradle
+++ b/resilience4j-micronaut-annotation/build.gradle
@@ -10,8 +10,4 @@ dependencies {
     testAnnotationProcessor(platform(libs.micronaut.platform))
 }
 
-test {
-    useJUnitPlatform()
-}
-
 ext.moduleName = "io.github.resilience4j.micronautannotation"

--- a/resilience4j-micronaut/build.gradle
+++ b/resilience4j-micronaut/build.gradle
@@ -55,8 +55,4 @@ dependencies {
     testImplementation(libs.objenesis)
 }
 
-test {
-    useJUnitPlatform()
-}
-
 ext.moduleName = "io.github.resilience4j.micronaut"

--- a/resilience4j-ratelimiter/build.gradle
+++ b/resilience4j-ratelimiter/build.gradle
@@ -1,4 +1,10 @@
 dependencies {
     api(project(":resilience4j-core"))
+
+    testRuntimeOnly(libs.junit.vintage.engine)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.awaitility.old)
+    testImplementation(libs.vavr)
 }
 ext.moduleName = "io.github.resilience4j.ratelimiter"

--- a/resilience4j-reactor/build.gradle
+++ b/resilience4j-reactor/build.gradle
@@ -8,6 +8,9 @@ dependencies {
     implementation(project(":resilience4j-retry"))
     implementation(project(":resilience4j-timelimiter"))
 
+    testRuntimeOnly(libs.junit.vintage.engine)
+
+    testImplementation(libs.junit)
     testImplementation(project(":resilience4j-micrometer").sourceSets.test.output)
     testImplementation(project(":resilience4j-test"))
     testImplementation(libs.blockhound)

--- a/resilience4j-retry/build.gradle
+++ b/resilience4j-retry/build.gradle
@@ -1,7 +1,12 @@
 dependencies {
     api(project(":resilience4j-core"))
 
+    testRuntimeOnly(libs.junit.vintage.engine)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.vavr)
     testImplementation(project(":resilience4j-test"))
     testImplementation(libs.rxjava2)
+
 }
 ext.moduleName = "io.github.resilience4j.retry"

--- a/resilience4j-rxjava2/build.gradle
+++ b/resilience4j-rxjava2/build.gradle
@@ -8,6 +8,9 @@ dependencies {
     implementation(project(":resilience4j-retry"))
     implementation(project(":resilience4j-timelimiter"))
 
+    testRuntimeOnly(libs.junit.vintage.engine)
+
+    testImplementation(libs.junit)
     testImplementation(project(":resilience4j-micrometer").sourceSets.test.output)
     testImplementation(project(":resilience4j-test"))
     testImplementation(libs.rxjava2)

--- a/resilience4j-rxjava3/build.gradle
+++ b/resilience4j-rxjava3/build.gradle
@@ -8,6 +8,9 @@ dependencies {
     implementation(project(":resilience4j-retry"))
     implementation(project(":resilience4j-timelimiter"))
 
+    testRuntimeOnly(libs.junit.vintage.engine)
+
+    testImplementation(libs.junit)
     testImplementation(project(":resilience4j-micrometer").sourceSets.test.output)
     testImplementation(project(":resilience4j-test"))
     testImplementation(libs.rxjava3)

--- a/resilience4j-spring-boot3/build.gradle
+++ b/resilience4j-spring-boot3/build.gradle
@@ -11,6 +11,11 @@ dependencies {
     compileOnly(libs.spring.boot3.aop)
     compileOnly(libs.spring.boot3.webflux)
 
+    testRuntimeOnly(libs.junit.vintage.engine)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.awaitility.old)
+    testImplementation(libs.vavr)
     testImplementation(project(":resilience4j-micrometer"))
     testImplementation(project(":resilience4j-micrometer").sourceSets.test.output)
     testImplementation(project(":resilience4j-reactor"))

--- a/resilience4j-spring-boot4/build.gradle
+++ b/resilience4j-spring-boot4/build.gradle
@@ -19,6 +19,11 @@ dependencies {
     compileOnly(libs.spring.cloud5.openfeign.core)
     compileOnly(libs.spring.cloud5.starter.openfeign)
 
+    testRuntimeOnly(libs.junit.vintage.engine)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.awaitility.old)
+    testImplementation(libs.vavr)
     testImplementation(project(":resilience4j-micrometer"))
     testImplementation(project(":resilience4j-micrometer").sourceSets.test.output)
     testImplementation(project(":resilience4j-reactor"))

--- a/resilience4j-spring6/build.gradle
+++ b/resilience4j-spring6/build.gradle
@@ -14,6 +14,9 @@ dependencies {
     compileOnly(libs.spring6.context)
     compileOnly(libs.spring6.core)
 
+    testRuntimeOnly(libs.junit.vintage.engine)
+
+    testImplementation(libs.junit)
     testImplementation(project(":resilience4j-metrics"))
     testImplementation(project(":resilience4j-micrometer").sourceSets.test.output)
     testImplementation(project(":resilience4j-reactor"))

--- a/resilience4j-timelimiter/build.gradle
+++ b/resilience4j-timelimiter/build.gradle
@@ -1,4 +1,9 @@
 dependencies {
     api(project(":resilience4j-core"))
+
+    testRuntimeOnly(libs.junit.vintage.engine)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.vavr)
 }
 ext.moduleName = "io.github.resilience4j.timelimiter"

--- a/resilience4j-vavr/build.gradle
+++ b/resilience4j-vavr/build.gradle
@@ -8,6 +8,9 @@ dependencies {
     implementation(project(":resilience4j-ratelimiter"))
     implementation(project(":resilience4j-retry"))
 
+    testRuntimeOnly(libs.junit.vintage.engine)
+
+    testImplementation(libs.junit)
     testImplementation(project(":resilience4j-test"))
     testImplementation(libs.metrics.core)
 }


### PR DESCRIPTION
## Summary

This PR prepares the build infrastructure to run tests via the JUnit Jupiter engine, while keeping all existing JUnit 4 tests running via `junit-vintage-engine`. No test logic was changed — this is a pure infrastructure PR, intended as the foundation for a module-by-module JUnit 6 migration in future PRs.

---

## Changes

### Build infrastructure
- Updated `junit` to `4.13.2` in `gradle/libs.versions.toml`
- Added `awaitility:4.3.0` while keeping `awaitility:1.7.0` for existing tests (to be migrated in separate PRs).
- In each resilience4j module I've added the following dependencies explicitly: 
   ```
   testRuntimeOnly(libs.junit.vintage.engine)  // run JUnit 4 tests via JUnit Vintage engine
   testImplementation(libs.junit)              // add explicit JUnit 4 dependency
   testImplementation(libs.awaitility.old)     // add old version to test modules that use it
   testImplementation(libs.vavr)               // add vavr to test modules that need it
   ```
   the goal is for all four dependencies to be removed together with tests migration in the follow up PRs (except `libs.vavr` in modules that actually need it).

---

## Actual test migration in follow up PRs

The goal is to migrate all test cases to JUnit 6 module by module in follow-up PRs, building on the infrastructure laid out here. Concretely, each PR will migrate one of the modules, where
* all JUnit asserts will be replaced with AssertJ
* all JUnit 4 methods (`@Test`, `@Before`, `@After`, `@Rule`, etc.) replaced with JUnit 6 alternatives
* all `awaitility:1.7.0` usages are replaced with `awaitility:4.3.0` - package change `com.jayway.awaitility` -> `org.awaitility` and other API changes
* unnecessary vavr usages are removed
* other best practices are applied (openrewrite has a couple of recipes for assert, junit and mockito)
* dependencies `junit:4.13`, `junit-vintage-engine`, `awaitility:1.7.0` are removed from `build.gradle`

While doing so, I plan to check test coverage as well as test execution time before and after the change to make sure no degradation is introduced

Main advantages of making a PR per module are that the changesets are smaller, it's easier to resolve conflicts if any, and revert / hold back changed to certain modules if there are large pending PRs (e.g. virtual threads support), where it would make sense to keep them on junit 4.