### PR TITLE
Set JDK target back to 17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,8 +90,8 @@ configure(project.coreProjects) {
     }
 
     tasks.withType(JavaCompile) {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
         options.deprecation = true
         options.encoding = 'UTF-8'
         options.compilerArgs += ["-Xlint:unchecked", "-parameters"]

--- a/resilience4j-kotlin/build.gradle
+++ b/resilience4j-kotlin/build.gradle
@@ -28,13 +28,13 @@ dependencies {
 
 compileKotlin {
     compilerOptions {
-        it.jvmTarget.set(JvmTarget.JVM_21)
+        it.jvmTarget.set(JvmTarget.JVM_17)
     }
 }
 
 compileTestKotlin {
     compilerOptions {
-        it.jvmTarget.set(JvmTarget.JVM_21)
+        it.jvmTarget.set(JvmTarget.JVM_17)
     }
 }
 


### PR DESCRIPTION
As discussed in PR https://github.com/resilience4j/resilience4j/pull/2335#issuecomment-4016433260 and in slack thread, this sets JDK target back to 17 so that `2.4.0` can be released with various fixes and features (including Spring Boot 4 support #2371 / #2351).
JDK requirement will be set back to 21 in a PR that adds full support for virtual threads (https://github.com/resilience4j/resilience4j/pull/2335), releasing that in the next major version `3.0.0`. 