### PR TITLE
Add general TaskScheduler injection and basic Spring Boot ThreadPoolTaskSchedulerBuilder support

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,8 @@
 micrometer = "1.16.0"
 reactor = "3.4.24"
 
-spring6 = "6.1.1"
-spring-boot3 = "3.2.0"
+spring6 = "6.2.17"
+spring-boot3 = "3.5.11"
 spring-cloud3 = "3.1.5"
 
 spring7 = "7.0.2"

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/ContextAwareScheduledThreadPoolExecutor.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/ContextAwareScheduledThreadPoolExecutor.java
@@ -29,6 +29,10 @@ import java.util.concurrent.TimeUnit;
 
 import static java.util.stream.Collectors.toList;
 
+/**
+ * @deprecated in favor of <a href="https://docs.micrometer.io/context-propagation/reference/index.html">micrometer context-propagation</a>
+ */
+@Deprecated
 public class ContextAwareScheduledThreadPoolExecutor extends ScheduledThreadPoolExecutor {
 
     private final List<ContextPropagator> contextPropagators;

--- a/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/scheduled/threadpool/configuration/ContextAwareScheduledThreadPoolConfigurationProperties.java
+++ b/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/scheduled/threadpool/configuration/ContextAwareScheduledThreadPoolConfigurationProperties.java
@@ -27,22 +27,14 @@ import java.util.List;
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.toList;
 
-public class ContextAwareScheduledThreadPoolConfigurationProperties {
+/**
+ * @deprecated
+ * @see ContextAwareScheduledThreadPoolExecutor
+ */
+@Deprecated
+public class ContextAwareScheduledThreadPoolConfigurationProperties extends Resilience4JThreadPoolConfigurationProperties {
 
-    private int corePoolSize;
     private Class<? extends ContextPropagator>[] contextPropagators = new Class[0];
-
-    public int getCorePoolSize() {
-        return corePoolSize;
-    }
-
-    public void setCorePoolSize(int corePoolSize) {
-        if (corePoolSize < 1) {
-            throw new IllegalArgumentException(
-                "corePoolSize must be a positive integer value >= 1");
-        }
-        this.corePoolSize = corePoolSize;
-    }
 
     public Class<? extends ContextPropagator>[] getContextPropagators() {
         return contextPropagators;
@@ -60,7 +52,7 @@ public class ContextAwareScheduledThreadPoolConfigurationProperties {
             .collect(toList());
 
         return ContextAwareScheduledThreadPoolExecutor.newScheduledThreadPool()
-            .corePoolSize(this.corePoolSize)
+            .corePoolSize(this.getCorePoolSize())
             .contextPropagators(contextPropagatorsList.toArray(new ContextPropagator[0]))
             .build();
     }

--- a/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/scheduled/threadpool/configuration/Resilience4JThreadPoolConfigurationProperties.java
+++ b/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/scheduled/threadpool/configuration/Resilience4JThreadPoolConfigurationProperties.java
@@ -1,0 +1,17 @@
+package io.github.resilience4j.common.scheduled.threadpool.configuration;
+
+public class Resilience4JThreadPoolConfigurationProperties {
+    protected int corePoolSize;
+
+    public int getCorePoolSize() {
+        return corePoolSize;
+    }
+
+    public void setCorePoolSize(int corePoolSize) {
+        if (corePoolSize < 1) {
+            throw new IllegalArgumentException(
+                "corePoolSize must be a positive integer value >= 1");
+        }
+        this.corePoolSize = corePoolSize;
+    }
+}

--- a/resilience4j-spring-boot3/src/main/java/io/github/resilience4j/springboot3/retry/autoconfigure/AbstractRetryConfigurationOnMissingBean.java
+++ b/resilience4j-spring-boot3/src/main/java/io/github/resilience4j/springboot3/retry/autoconfigure/AbstractRetryConfigurationOnMissingBean.java
@@ -18,7 +18,6 @@ package io.github.resilience4j.springboot3.retry.autoconfigure;
 import io.github.resilience4j.common.CompositeCustomizer;
 import io.github.resilience4j.common.retry.configuration.RetryConfigCustomizer;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
-import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
 import io.github.resilience4j.spring6.fallback.FallbackExecutor;
 import io.github.resilience4j.spring6.utils.RxJava3OnClasspathCondition;
@@ -39,6 +38,7 @@ import org.springframework.context.annotation.*;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 /**
  * {@link Configuration Configuration} for resilience4j-retry.
@@ -99,11 +99,11 @@ public abstract class AbstractRetryConfigurationOnMissingBean {
         @Autowired(required = false) List<RetryAspectExt> retryAspectExtList,
         FallbackExecutor fallbackExecutor,
         SpelResolver spelResolver,
-        @Autowired(required = false) ContextAwareScheduledThreadPoolExecutor contextAwareScheduledThreadPoolExecutor
+        @Autowired(required = false) @Qualifier("resilience4jTaskExecutor") ScheduledThreadPoolExecutor scheduledThreadPoolExecutor
     ) {
         return retryConfiguration
             .retryAspect(retryConfigurationProperties, retryRegistry, retryAspectExtList,
-                fallbackExecutor, spelResolver, contextAwareScheduledThreadPoolExecutor);
+                fallbackExecutor, spelResolver, scheduledThreadPoolExecutor);
     }
 
     @Bean

--- a/resilience4j-spring-boot3/src/main/java/io/github/resilience4j/springboot3/scheduled/threadpool/autoconfigure/ContextAwareScheduledThreadPoolAutoConfiguration.java
+++ b/resilience4j-spring-boot3/src/main/java/io/github/resilience4j/springboot3/scheduled/threadpool/autoconfigure/ContextAwareScheduledThreadPoolAutoConfiguration.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2020 krnsaurabh
+ *  Copyright 2025 krnsaurabh, Artur Havliukovskyi
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -18,19 +18,57 @@
  */
 package io.github.resilience4j.springboot3.scheduled.threadpool.autoconfigure;
 
-import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.task.ThreadPoolTaskSchedulerBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
-@Configuration
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+@AutoConfiguration
 @ConditionalOnProperty(value = "resilience4j.scheduled.executor.core-pool-size")
+@ConditionalOnMissingBean(name = ContextAwareScheduledThreadPoolAutoConfiguration.EXECUTOR_NAME, value = ScheduledThreadPoolExecutor.class)
 @EnableConfigurationProperties({ContextAwareScheduledThreadPoolProperties.class})
 public class ContextAwareScheduledThreadPoolAutoConfiguration {
 
-    @Bean
-    public ContextAwareScheduledThreadPoolExecutor getContextAwareScheduledThreadPool(ContextAwareScheduledThreadPoolProperties contextAwareScheduledThreadPoolProperties) {
+    public static final String EXECUTOR_NAME = "resilience4jTaskExecutor";
+    public static final String SCHEDULER_NAME = "resilience4jThreadPoolTaskScheduler";
+
+    @Bean(name = EXECUTOR_NAME, defaultCandidate = false)
+    @ConditionalOnProperty(value = "resilience4j.scheduled.executor.type", havingValue = "resilience4j", matchIfMissing = true)
+    public ScheduledThreadPoolExecutor getContextAwareScheduledThreadPool(ContextAwareScheduledThreadPoolProperties contextAwareScheduledThreadPoolProperties) {
         return contextAwareScheduledThreadPoolProperties.build();
+    }
+
+    @Configuration
+    @ConditionalOnBean(ThreadPoolTaskSchedulerBuilder.class)
+    @ConditionalOnMissingBean(name = EXECUTOR_NAME, value = ScheduledThreadPoolExecutor.class)
+    @ConditionalOnProperty(value = "resilience4j.scheduled.executor.type", havingValue = "spring")
+    public static class SpringManagedScheduledThreadPoolConfiguration {
+
+        @Bean(name = SCHEDULER_NAME, defaultCandidate = false)
+        @ConditionalOnMissingBean(name = SCHEDULER_NAME)
+        public ThreadPoolTaskScheduler getScheduledThreadPoolExecutor(
+                ContextAwareScheduledThreadPoolProperties poolProperties,
+                ObjectProvider<Resilience4JThreadPoolTaskSchedulerBuilderCustomizer> customizers,
+                ThreadPoolTaskSchedulerBuilder builder) {
+            ThreadPoolTaskSchedulerBuilder actualBuilder = builder.threadNamePrefix("resilience4j-").poolSize(poolProperties.getCorePoolSize());
+            for (Resilience4JThreadPoolTaskSchedulerBuilderCustomizer customizer : customizers) {
+                actualBuilder = customizer.customize(actualBuilder);
+            }
+            return actualBuilder.build();
+        }
+
+        @Bean(name = EXECUTOR_NAME, defaultCandidate = false)
+        public ScheduledThreadPoolExecutor getSpringManagedScheduledThreadPoolExecutor(@Qualifier(SCHEDULER_NAME) ThreadPoolTaskScheduler threadPoolTaskScheduler) {
+            return threadPoolTaskScheduler.getScheduledThreadPoolExecutor();
+        }
     }
 }

--- a/resilience4j-spring-boot3/src/main/java/io/github/resilience4j/springboot3/scheduled/threadpool/autoconfigure/Resilience4JThreadPoolTaskSchedulerBuilderCustomizer.java
+++ b/resilience4j-spring-boot3/src/main/java/io/github/resilience4j/springboot3/scheduled/threadpool/autoconfigure/Resilience4JThreadPoolTaskSchedulerBuilderCustomizer.java
@@ -1,0 +1,8 @@
+package io.github.resilience4j.springboot3.scheduled.threadpool.autoconfigure;
+
+import org.jspecify.annotations.NonNull;
+import org.springframework.boot.task.ThreadPoolTaskSchedulerBuilder;
+
+public interface Resilience4JThreadPoolTaskSchedulerBuilderCustomizer {
+    @NonNull ThreadPoolTaskSchedulerBuilder customize(@NonNull ThreadPoolTaskSchedulerBuilder builder);
+}

--- a/resilience4j-spring-boot3/src/main/java/io/github/resilience4j/springboot3/timelimiter/autoconfigure/AbstractTimeLimiterConfigurationOnMissingBean.java
+++ b/resilience4j-spring-boot3/src/main/java/io/github/resilience4j/springboot3/timelimiter/autoconfigure/AbstractTimeLimiterConfigurationOnMissingBean.java
@@ -40,6 +40,7 @@ import org.springframework.context.annotation.*;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 @Configuration
 @Import({FallbackConfigurationOnMissingBean.class, SpelResolverConfigurationOnMissingBean.class})
@@ -86,10 +87,10 @@ public abstract class AbstractTimeLimiterConfigurationOnMissingBean {
         @Autowired(required = false) List<TimeLimiterAspectExt> timeLimiterAspectExtList,
         FallbackExecutor fallbackExecutor,
         SpelResolver spelResolver,
-        @Autowired(required = false) ContextAwareScheduledThreadPoolExecutor contextAwareScheduledThreadPoolExecutor
+        @Autowired(required = false) @Qualifier("resilience4jTaskExecutor") ScheduledThreadPoolExecutor scheduledThreadPoolExecutor
     ) {
         return timeLimiterConfiguration.timeLimiterAspect(
-            timeLimiterProperties, timeLimiterRegistry, timeLimiterAspectExtList, fallbackExecutor, spelResolver, contextAwareScheduledThreadPoolExecutor);
+            timeLimiterProperties, timeLimiterRegistry, timeLimiterAspectExtList, fallbackExecutor, spelResolver, scheduledThreadPoolExecutor);
     }
 
     @Bean

--- a/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/ContextAwareScheduledThreadPoolAutoConfigurationTest.java
+++ b/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/ContextAwareScheduledThreadPoolAutoConfigurationTest.java
@@ -1,50 +1,93 @@
 package io.github.resilience4j.springboot3;
 
+import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
 import io.github.resilience4j.springboot3.scheduled.threadpool.autoconfigure.ContextAwareScheduledThreadPoolAutoConfiguration;
+import io.github.resilience4j.springboot3.scheduled.threadpool.autoconfigure.Resilience4JThreadPoolTaskSchedulerBuilderCustomizer;
 import org.junit.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.task.ThreadPoolTaskSchedulerBuilder;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class ContextAwareScheduledThreadPoolAutoConfigurationTest {
 
-    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner();
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(ContextAwareScheduledThreadPoolAutoConfiguration.class));
 
     @Test
     public void registersBeanWhenConditionalPropertyIsInKebabCase() {
-        assertBeanHasBeenCreated("resilience4j.scheduled.executor.core-pool-size=1");
+        contextRunner.withPropertyValues("resilience4j.scheduled.executor.core-pool-size=1").run(context ->
+                assertThat(context)
+                        .hasSingleBean(ContextAwareScheduledThreadPoolAutoConfiguration.class)
+                        .getBean(ContextAwareScheduledThreadPoolAutoConfiguration.EXECUTOR_NAME, ScheduledThreadPoolExecutor.class).isInstanceOf(ContextAwareScheduledThreadPoolExecutor.class)
+                        .extracting(ScheduledThreadPoolExecutor::getCorePoolSize).isEqualTo(1)
+        );
     }
 
     @Test
     public void registersBeanWhenConditionalPropertyIsInCamelCase() {
-        assertBeanHasBeenCreated("resilience4j.scheduled.executor.corePoolSize=1");
+        contextRunner.withPropertyValues("resilience4j.scheduled.executor.corePoolSize=1").run(context ->
+                assertThat(context)
+                        .hasSingleBean(ContextAwareScheduledThreadPoolAutoConfiguration.class)
+                        .getBean(ContextAwareScheduledThreadPoolAutoConfiguration.EXECUTOR_NAME, ScheduledThreadPoolExecutor.class).isInstanceOf(ContextAwareScheduledThreadPoolExecutor.class)
+                        .extracting(ScheduledThreadPoolExecutor::getCorePoolSize).isEqualTo(1)
+        );
     }
 
     @Test
-    public void doesNotRegisterBeanWhenConditionalPropertyNotSpecified() {
-        assertBeanWasNotCreated("randomProperty");
+    public void doesNotRegisterBeanWhenBeanAlreadyPresent() {
+        ScheduledThreadPoolExecutor scheduledThreadPoolExecutor = mock(ScheduledThreadPoolExecutor.class);
+        contextRunner.withPropertyValues("resilience4j.scheduled.executor.core-pool-size=1")
+                .withBean(ContextAwareScheduledThreadPoolAutoConfiguration.EXECUTOR_NAME, ScheduledThreadPoolExecutor.class, () -> scheduledThreadPoolExecutor)
+                .run(context -> {
+                            assertThat(context).getBean(ScheduledThreadPoolExecutor.class)
+                                    .isNotInstanceOf(ContextAwareScheduledThreadPoolExecutor.class);
+                            assertThat(context).doesNotHaveBean(ContextAwareScheduledThreadPoolAutoConfiguration.class);
+                        }
+                );
     }
 
-    private void assertBeanHasBeenCreated(String conditionalProperty) {
-        contextRunner(conditionalProperty).run(context ->
-            assertThat(context).hasSingleBean(ContextAwareScheduledThreadPoolAutoConfiguration.class)
-        );
+    @Test
+    public void doesNotRegisterSpringManagedBeanWhenBuilderNotPresent() {
+        contextRunner.withPropertyValues(
+                        "resilience4j.scheduled.executor.core-pool-size=1",
+                        "resilience4j.scheduled.executor.type=spring"
+                )
+                .run(context -> assertThat(context)
+                        .hasSingleBean(ContextAwareScheduledThreadPoolAutoConfiguration.class)
+                        .doesNotHaveBean(ContextAwareScheduledThreadPoolAutoConfiguration.SpringManagedScheduledThreadPoolConfiguration.class)
+                        .doesNotHaveBean(ScheduledThreadPoolExecutor.class)
+                );
     }
 
-    private void assertBeanWasNotCreated(String conditionalProperty) {
-        contextRunner(conditionalProperty).run(context ->
-            assertThat(context).doesNotHaveBean(ContextAwareScheduledThreadPoolAutoConfiguration.class)
-        );
+    @Test
+    public void registersSpringManagedBeanWhenBuilderPresent() {
+        contextRunner.withPropertyValues(
+                        "resilience4j.scheduled.executor.core-pool-size=1",
+                        "resilience4j.scheduled.executor.type=spring"
+                )
+                .withBean(ThreadPoolTaskSchedulerBuilder.class, ThreadPoolTaskSchedulerBuilder::new)
+                .withBean(Resilience4JThreadPoolTaskSchedulerBuilderCustomizer.class, () -> builder -> builder.threadNamePrefix("fooBar"))
+                .run(context -> {
+                            assertThat(context)
+                                    .hasSingleBean(ContextAwareScheduledThreadPoolAutoConfiguration.class)
+                                    .hasSingleBean(ContextAwareScheduledThreadPoolAutoConfiguration.SpringManagedScheduledThreadPoolConfiguration.class);
+                            assertThat(context)
+                                    .getBean(ContextAwareScheduledThreadPoolAutoConfiguration.EXECUTOR_NAME, ScheduledThreadPoolExecutor.class).isNotInstanceOf(ContextAwareScheduledThreadPoolExecutor.class)
+                                    .satisfies(scheduler -> {
+                                        assertThat(scheduler.getCorePoolSize()).isEqualTo(1);
+                                    });
+                            assertThat(context)
+                                    .getBean(ContextAwareScheduledThreadPoolAutoConfiguration.SCHEDULER_NAME, ThreadPoolTaskScheduler.class)
+                                    .satisfies(scheduler -> {
+                                        assertThat(scheduler.getThreadNamePrefix()).isEqualTo("fooBar");
+                                    });
+                        }
+                );
     }
-
-    private ApplicationContextRunner contextRunner(String conditionalProperty) {
-        return contextRunner
-            .withPropertyValues(conditionalProperty)
-            .withConfiguration(AutoConfigurations.of(
-                ContextAwareScheduledThreadPoolAutoConfiguration.class)
-            );
-    }
-
-
 }

--- a/resilience4j-spring-boot4/src/main/java/io/github/resilience4j/springboot/retry/autoconfigure/RetryAutoConfiguration.java
+++ b/resilience4j-spring-boot4/src/main/java/io/github/resilience4j/springboot/retry/autoconfigure/RetryAutoConfiguration.java
@@ -34,6 +34,7 @@ import io.github.resilience4j.retry.RetryRegistry;
 import io.github.resilience4j.retry.event.RetryEvent;
 import io.github.resilience4j.springboot.retry.monitoring.endpoint.RetryEndpoint;
 import io.github.resilience4j.springboot.retry.monitoring.endpoint.RetryEventsEndpoint;
+import io.github.resilience4j.springboot.scheduled.threadpool.autoconfigure.ContextAwareScheduledThreadPoolAutoConfiguration;
 import io.github.resilience4j.springboot.spelresolver.autoconfigure.SpelResolverConfigurationOnMissingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -50,6 +51,7 @@ import org.springframework.context.annotation.Primary;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 
 /**
@@ -123,7 +125,7 @@ public class RetryAutoConfiguration {
         @Autowired(required = false) List<RetryAspectExt> retryAspectExtList,
         FallbackExecutor fallbackExecutor,
         SpelResolver spelResolver,
-        @Autowired(required = false) ContextAwareScheduledThreadPoolExecutor contextAwareScheduledThreadPoolExecutor
+        @Autowired(required = false) @Qualifier(ContextAwareScheduledThreadPoolAutoConfiguration.EXECUTOR_NAME) ScheduledThreadPoolExecutor contextAwareScheduledThreadPoolExecutor
     ) {
         return retryConfiguration
             .retryAspect(retryConfigurationProperties, retryRegistry, retryAspectExtList,

--- a/resilience4j-spring-boot4/src/main/java/io/github/resilience4j/springboot/scheduled/threadpool/autoconfigure/ContextAwareScheduledThreadPoolAutoConfiguration.java
+++ b/resilience4j-spring-boot4/src/main/java/io/github/resilience4j/springboot/scheduled/threadpool/autoconfigure/ContextAwareScheduledThreadPoolAutoConfiguration.java
@@ -18,19 +18,57 @@
  */
 package io.github.resilience4j.springboot.scheduled.threadpool.autoconfigure;
 
-import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.task.ThreadPoolTaskSchedulerBuilder;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 @AutoConfiguration
 @ConditionalOnProperty(value = "resilience4j.scheduled.executor.core-pool-size")
+@ConditionalOnMissingBean(name = ContextAwareScheduledThreadPoolAutoConfiguration.EXECUTOR_NAME, value = ScheduledThreadPoolExecutor.class)
 @EnableConfigurationProperties({ContextAwareScheduledThreadPoolProperties.class})
 public class ContextAwareScheduledThreadPoolAutoConfiguration {
 
-    @Bean
-    public ContextAwareScheduledThreadPoolExecutor getContextAwareScheduledThreadPool(ContextAwareScheduledThreadPoolProperties contextAwareScheduledThreadPoolProperties) {
+    public static final String EXECUTOR_NAME = "resilience4jTaskExecutor";
+    public static final String SCHEDULER_NAME = "resilience4jThreadPoolTaskScheduler";
+
+    @Bean(name = EXECUTOR_NAME, defaultCandidate = false)
+    @ConditionalOnProperty(value = "resilience4j.scheduled.executor.type", havingValue = "resilience4j", matchIfMissing = true)
+    public ScheduledThreadPoolExecutor getContextAwareScheduledThreadPool(ContextAwareScheduledThreadPoolProperties contextAwareScheduledThreadPoolProperties) {
         return contextAwareScheduledThreadPoolProperties.build();
+    }
+
+    @Configuration
+    @ConditionalOnBean(ThreadPoolTaskSchedulerBuilder.class)
+    @ConditionalOnMissingBean(name = EXECUTOR_NAME, value = ScheduledThreadPoolExecutor.class)
+    @ConditionalOnProperty(value = "resilience4j.scheduled.executor.type", havingValue = "spring")
+    public static class SpringManagedScheduledThreadPoolConfiguration {
+
+        @Bean(name = SCHEDULER_NAME, defaultCandidate = false)
+        @ConditionalOnMissingBean(name = SCHEDULER_NAME)
+        public ThreadPoolTaskScheduler getScheduledThreadPoolExecutor(
+                ContextAwareScheduledThreadPoolProperties poolProperties,
+                ObjectProvider<Resilience4JThreadPoolTaskSchedulerBuilderCustomizer> customizers,
+                ThreadPoolTaskSchedulerBuilder builder) {
+            ThreadPoolTaskSchedulerBuilder actualBuilder = builder.threadNamePrefix("resilience4j-").poolSize(poolProperties.getCorePoolSize());
+            for (Resilience4JThreadPoolTaskSchedulerBuilderCustomizer customizer : customizers) {
+                actualBuilder = customizer.customize(actualBuilder);
+            }
+            return actualBuilder.build();
+        }
+
+        @Bean(name = EXECUTOR_NAME, defaultCandidate = false)
+        public ScheduledThreadPoolExecutor getSpringManagedScheduledThreadPoolExecutor(@Qualifier(ContextAwareScheduledThreadPoolAutoConfiguration.SCHEDULER_NAME) ThreadPoolTaskScheduler threadPoolTaskScheduler) {
+            return threadPoolTaskScheduler.getScheduledThreadPoolExecutor();
+        }
     }
 }

--- a/resilience4j-spring-boot4/src/main/java/io/github/resilience4j/springboot/scheduled/threadpool/autoconfigure/Resilience4JThreadPoolTaskSchedulerBuilderCustomizer.java
+++ b/resilience4j-spring-boot4/src/main/java/io/github/resilience4j/springboot/scheduled/threadpool/autoconfigure/Resilience4JThreadPoolTaskSchedulerBuilderCustomizer.java
@@ -1,0 +1,8 @@
+package io.github.resilience4j.springboot.scheduled.threadpool.autoconfigure;
+
+import org.jspecify.annotations.NonNull;
+import org.springframework.boot.task.ThreadPoolTaskSchedulerBuilder;
+
+public interface Resilience4JThreadPoolTaskSchedulerBuilderCustomizer {
+    @NonNull ThreadPoolTaskSchedulerBuilder customize(@NonNull ThreadPoolTaskSchedulerBuilder builder);
+}

--- a/resilience4j-spring-boot4/src/main/java/io/github/resilience4j/springboot/timelimiter/autoconfigure/TimeLimiterAutoConfiguration.java
+++ b/resilience4j-spring-boot4/src/main/java/io/github/resilience4j/springboot/timelimiter/autoconfigure/TimeLimiterAutoConfiguration.java
@@ -20,7 +20,6 @@ import io.github.resilience4j.common.CompositeCustomizer;
 import io.github.resilience4j.common.timelimiter.configuration.TimeLimiterConfigCustomizer;
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
-import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
 import io.github.resilience4j.spring6.fallback.FallbackExecutor;
 import io.github.resilience4j.spring6.spelresolver.SpelResolver;
@@ -30,6 +29,7 @@ import io.github.resilience4j.spring6.utils.ReactorOnClasspathCondition;
 import io.github.resilience4j.spring6.utils.RxJava2OnClasspathCondition;
 import io.github.resilience4j.spring6.utils.RxJava3OnClasspathCondition;
 import io.github.resilience4j.springboot.fallback.autoconfigure.FallbackConfigurationOnMissingBean;
+import io.github.resilience4j.springboot.scheduled.threadpool.autoconfigure.ContextAwareScheduledThreadPoolAutoConfiguration;
 import io.github.resilience4j.springboot.spelresolver.autoconfigure.SpelResolverConfigurationOnMissingBean;
 import io.github.resilience4j.timelimiter.TimeLimiter;
 import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
@@ -51,6 +51,7 @@ import org.springframework.context.annotation.Primary;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 @AutoConfiguration
 @ConditionalOnClass(TimeLimiter.class)
@@ -109,7 +110,7 @@ public class TimeLimiterAutoConfiguration {
         @Autowired(required = false) List<TimeLimiterAspectExt> timeLimiterAspectExtList,
         FallbackExecutor fallbackExecutor,
         SpelResolver spelResolver,
-        @Autowired(required = false) ContextAwareScheduledThreadPoolExecutor contextAwareScheduledThreadPoolExecutor
+        @Autowired(required = false) @Qualifier(ContextAwareScheduledThreadPoolAutoConfiguration.EXECUTOR_NAME) ScheduledThreadPoolExecutor contextAwareScheduledThreadPoolExecutor
     ) {
         return timeLimiterConfiguration.timeLimiterAspect(
             timeLimiterProperties, timeLimiterRegistry, timeLimiterAspectExtList, fallbackExecutor, spelResolver, contextAwareScheduledThreadPoolExecutor);

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/ContextAwareScheduledThreadPoolAutoConfigurationTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/ContextAwareScheduledThreadPoolAutoConfigurationTest.java
@@ -1,50 +1,93 @@
 package io.github.resilience4j.springboot;
 
+import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
 import io.github.resilience4j.springboot.scheduled.threadpool.autoconfigure.ContextAwareScheduledThreadPoolAutoConfiguration;
+import io.github.resilience4j.springboot.scheduled.threadpool.autoconfigure.Resilience4JThreadPoolTaskSchedulerBuilderCustomizer;
 import org.junit.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.task.ThreadPoolTaskSchedulerBuilder;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class ContextAwareScheduledThreadPoolAutoConfigurationTest {
 
-    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner();
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(ContextAwareScheduledThreadPoolAutoConfiguration.class));
 
     @Test
     public void registersBeanWhenConditionalPropertyIsInKebabCase() {
-        assertBeanHasBeenCreated("resilience4j.scheduled.executor.core-pool-size=1");
+        contextRunner.withPropertyValues("resilience4j.scheduled.executor.core-pool-size=1").run(context ->
+                assertThat(context)
+                        .hasSingleBean(ContextAwareScheduledThreadPoolAutoConfiguration.class)
+                        .getBean(ContextAwareScheduledThreadPoolAutoConfiguration.EXECUTOR_NAME, ScheduledThreadPoolExecutor.class).isInstanceOf(ContextAwareScheduledThreadPoolExecutor.class)
+                        .extracting(ScheduledThreadPoolExecutor::getCorePoolSize).isEqualTo(1)
+        );
     }
 
     @Test
     public void registersBeanWhenConditionalPropertyIsInCamelCase() {
-        assertBeanHasBeenCreated("resilience4j.scheduled.executor.corePoolSize=1");
+        contextRunner.withPropertyValues("resilience4j.scheduled.executor.corePoolSize=1").run(context ->
+                assertThat(context)
+                        .hasSingleBean(ContextAwareScheduledThreadPoolAutoConfiguration.class)
+                        .getBean(ContextAwareScheduledThreadPoolAutoConfiguration.EXECUTOR_NAME, ScheduledThreadPoolExecutor.class).isInstanceOf(ContextAwareScheduledThreadPoolExecutor.class)
+                        .extracting(ScheduledThreadPoolExecutor::getCorePoolSize).isEqualTo(1)
+        );
     }
 
     @Test
-    public void doesNotRegisterBeanWhenConditionalPropertyNotSpecified() {
-        assertBeanWasNotCreated("randomProperty");
+    public void doesNotRegisterBeanWhenBeanAlreadyPresent() {
+        ScheduledThreadPoolExecutor scheduledThreadPoolExecutor = mock(ScheduledThreadPoolExecutor.class);
+        contextRunner.withPropertyValues("resilience4j.scheduled.executor.core-pool-size=1")
+                .withBean(ContextAwareScheduledThreadPoolAutoConfiguration.EXECUTOR_NAME, ScheduledThreadPoolExecutor.class, () -> scheduledThreadPoolExecutor)
+                .run(context -> {
+                            assertThat(context).getBean(ScheduledThreadPoolExecutor.class)
+                                    .isNotInstanceOf(ContextAwareScheduledThreadPoolExecutor.class);
+                            assertThat(context).doesNotHaveBean(ContextAwareScheduledThreadPoolAutoConfiguration.class);
+                        }
+                );
     }
 
-    private void assertBeanHasBeenCreated(String conditionalProperty) {
-        contextRunner(conditionalProperty).run(context ->
-            assertThat(context).hasSingleBean(ContextAwareScheduledThreadPoolAutoConfiguration.class)
-        );
+    @Test
+    public void doesNotRegisterSpringManagedBeanWhenBuilderNotPresent() {
+        contextRunner.withPropertyValues(
+                        "resilience4j.scheduled.executor.core-pool-size=1",
+                        "resilience4j.scheduled.executor.type=spring"
+                )
+                .run(context -> assertThat(context)
+                        .hasSingleBean(ContextAwareScheduledThreadPoolAutoConfiguration.class)
+                        .doesNotHaveBean(ContextAwareScheduledThreadPoolAutoConfiguration.SpringManagedScheduledThreadPoolConfiguration.class)
+                        .doesNotHaveBean(ScheduledThreadPoolExecutor.class)
+                );
     }
 
-    private void assertBeanWasNotCreated(String conditionalProperty) {
-        contextRunner(conditionalProperty).run(context ->
-            assertThat(context).doesNotHaveBean(ContextAwareScheduledThreadPoolAutoConfiguration.class)
-        );
+    @Test
+    public void registersSpringManagedBeanWhenBuilderPresent() {
+        contextRunner.withPropertyValues(
+                        "resilience4j.scheduled.executor.core-pool-size=1",
+                        "resilience4j.scheduled.executor.type=spring"
+                )
+                .withBean(ThreadPoolTaskSchedulerBuilder.class, ThreadPoolTaskSchedulerBuilder::new)
+                .withBean(Resilience4JThreadPoolTaskSchedulerBuilderCustomizer.class, () -> builder -> builder.threadNamePrefix("fooBar"))
+                .run(context -> {
+                            assertThat(context)
+                                    .hasSingleBean(ContextAwareScheduledThreadPoolAutoConfiguration.class)
+                                    .hasSingleBean(ContextAwareScheduledThreadPoolAutoConfiguration.SpringManagedScheduledThreadPoolConfiguration.class);
+                            assertThat(context)
+                                    .getBean(ContextAwareScheduledThreadPoolAutoConfiguration.EXECUTOR_NAME, ScheduledThreadPoolExecutor.class).isNotInstanceOf(ContextAwareScheduledThreadPoolExecutor.class)
+                                    .satisfies(scheduler -> {
+                                        assertThat(scheduler.getCorePoolSize()).isEqualTo(1);
+                                    });
+                            assertThat(context)
+                                    .getBean(ContextAwareScheduledThreadPoolAutoConfiguration.SCHEDULER_NAME, ThreadPoolTaskScheduler.class)
+                                    .satisfies(scheduler -> {
+                                        assertThat(scheduler.getThreadNamePrefix()).isEqualTo("fooBar");
+                                    });
+                        }
+                );
     }
-
-    private ApplicationContextRunner contextRunner(String conditionalProperty) {
-        return contextRunner
-            .withPropertyValues(conditionalProperty)
-            .withConfiguration(AutoConfigurations.of(
-                ContextAwareScheduledThreadPoolAutoConfiguration.class)
-            );
-    }
-
-
 }

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/retry/configure/RetryAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/retry/configure/RetryAspect.java
@@ -15,7 +15,6 @@
  */
 package io.github.resilience4j.spring6.retry.configure;
 
-import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
 import io.github.resilience4j.core.functions.CheckedSupplier;
 import io.github.resilience4j.core.lang.Nullable;
 import io.github.resilience4j.spring6.fallback.FallbackExecutor;
@@ -85,14 +84,14 @@ public class RetryAspect implements Ordered, AutoCloseable {
                        @Autowired(required = false) List<RetryAspectExt> retryAspectExtList,
                        FallbackExecutor fallbackExecutor,
                        SpelResolver spelResolver,
-                       @Nullable ContextAwareScheduledThreadPoolExecutor contextAwareScheduledThreadPoolExecutor) {
+                       @Nullable ScheduledExecutorService scheduledExecutorService) {
         this.retryConfigurationProperties = retryConfigurationProperties;
         this.retryRegistry = retryRegistry;
         this.retryAspectExtList = retryAspectExtList;
         this.fallbackExecutor = fallbackExecutor;
         this.spelResolver = spelResolver;
-        this.retryExecutorService = contextAwareScheduledThreadPoolExecutor != null ?
-            contextAwareScheduledThreadPoolExecutor :
+        this.retryExecutorService = scheduledExecutorService != null ?
+                scheduledExecutorService :
             Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
     }
 

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/retry/configure/RetryConfiguration.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/retry/configure/RetryConfiguration.java
@@ -15,14 +15,11 @@
  */
 package io.github.resilience4j.spring6.retry.configure;
 
-import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
-import io.github.resilience4j.bulkhead.event.BulkheadEvent;
 import io.github.resilience4j.common.CompositeCustomizer;
 import io.github.resilience4j.common.retry.configuration.RetryConfigCustomizer;
 import io.github.resilience4j.common.retry.configuration.CommonRetryConfigurationProperties.InstanceProperties;
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
-import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
 import io.github.resilience4j.core.registry.CompositeRegistryEventConsumer;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
 import io.github.resilience4j.spring6.fallback.FallbackExecutor;
@@ -45,6 +42,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.stream.Collectors;
 
 /**
@@ -168,10 +166,10 @@ public class RetryConfiguration {
         @Autowired(required = false) List<RetryAspectExt> retryAspectExtList,
         FallbackExecutor fallbackExecutor,
         SpelResolver spelResolver,
-        @Autowired(required = false) ContextAwareScheduledThreadPoolExecutor contextAwareScheduledThreadPoolExecutor
+        @Autowired(required = false) @Qualifier("resilience4jTaskExecutor") ScheduledThreadPoolExecutor scheduledThreadPoolExecutor
     ) {
         return new RetryAspect(retryConfigurationProperties, retryRegistry, retryAspectExtList,
-            fallbackExecutor, spelResolver, contextAwareScheduledThreadPoolExecutor);
+            fallbackExecutor, spelResolver, scheduledThreadPoolExecutor);
     }
 
     @Bean

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterAspect.java
@@ -16,7 +16,6 @@
 
 package io.github.resilience4j.spring6.timelimiter.configure;
 
-import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
 import io.github.resilience4j.core.functions.CheckedSupplier;
 import io.github.resilience4j.core.lang.Nullable;
 import io.github.resilience4j.spring6.fallback.FallbackExecutor;
@@ -56,14 +55,14 @@ public class TimeLimiterAspect implements Ordered, AutoCloseable {
                              @Nullable List<TimeLimiterAspectExt> timeLimiterAspectExtList,
                              FallbackExecutor fallbackExecutor,
                              SpelResolver spelResolver,
-                             @Nullable ContextAwareScheduledThreadPoolExecutor contextAwareScheduledThreadPoolExecutor) {
+                             @Nullable ScheduledExecutorService scheduledExecutorService) {
         this.timeLimiterRegistry = timeLimiterRegistry;
         this.properties = properties;
         this.timeLimiterAspectExtList = timeLimiterAspectExtList;
         this.fallbackExecutor = fallbackExecutor;
         this.spelResolver = spelResolver;
-        this.timeLimiterExecutorService = contextAwareScheduledThreadPoolExecutor != null ?
-            contextAwareScheduledThreadPoolExecutor :
+        this.timeLimiterExecutorService = scheduledExecutorService != null ?
+                scheduledExecutorService :
             Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
     }
 

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterConfiguration.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterConfiguration.java
@@ -21,7 +21,6 @@ import io.github.resilience4j.common.timelimiter.configuration.TimeLimiterConfig
 import io.github.resilience4j.common.timelimiter.configuration.CommonTimeLimiterConfigurationProperties.InstanceProperties;
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
-import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
 import io.github.resilience4j.core.registry.CompositeRegistryEventConsumer;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
 import io.github.resilience4j.spring6.fallback.FallbackExecutor;
@@ -44,6 +43,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.stream.Collectors;
 
 /**
@@ -90,9 +90,9 @@ public class TimeLimiterConfiguration {
         @Autowired(required = false) List<TimeLimiterAspectExt> timeLimiterAspectExtList,
         FallbackExecutor fallbackExecutor,
         SpelResolver spelResolver,
-        @Autowired(required = false) ContextAwareScheduledThreadPoolExecutor contextAwareScheduledThreadPoolExecutor
+        @Autowired(required = false) @Qualifier("resilience4jTaskExecutor") ScheduledThreadPoolExecutor scheduledThreadPoolExecutor
     ) {
-        return new TimeLimiterAspect(timeLimiterRegistry, timeLimiterConfigurationProperties, timeLimiterAspectExtList, fallbackExecutor, spelResolver, contextAwareScheduledThreadPoolExecutor);
+        return new TimeLimiterAspect(timeLimiterRegistry, timeLimiterConfigurationProperties, timeLimiterAspectExtList, fallbackExecutor, spelResolver, scheduledThreadPoolExecutor);
     }
 
     @Bean


### PR DESCRIPTION
This adds support for injecting a TaskScheduler wherever currently the ContextAware one was used.

`ContextAwareScheduledThreadPoolExecutor` is marked deprecated and, normally, in the next major release, it should be removed (along with related apis), preferring to redirect developers to Micrometer [context-propagation](https://github.com/micrometer-metrics/context-propagation/tree/main).
In addition, Spring libraries are kept up-to-date, but this upgrade can be done on a separate prior PR if so needed.

Wherever the ContextAware executor and related propagators were explicitly referenced (`Hedge` and `BulkHead`) an alternative implementation or constructor was created, with the sometimes internal nested classes pulled out, reusable methods pulled to an abstract class and new factory methods added to provide instances of the new implementations. On the Spring Boot side the property `resilience4j.scheduled.executor.type` (that has to be explicitly set to `spring`) controls the switch between the now-legacy ContextAware and a Spring-managed executor instance.