### PR TITLE
resilience4j-all: JUnit 4 → JUnit 6 migration

### DIFF
--- a/resilience4j-all/build.gradle
+++ b/resilience4j-all/build.gradle
@@ -1,3 +1,5 @@
+ext.moduleName = "io.github.resilience4j.all"
+
 dependencies {
     api(project(":resilience4j-bulkhead"))
     api(project(":resilience4j-cache"))
@@ -7,11 +9,5 @@ dependencies {
     api(project(":resilience4j-retry"))
     api(project(":resilience4j-timelimiter"))
 
-    testRuntimeOnly(libs.junit.vintage.engine)
-
-    testImplementation(libs.junit)
-    testImplementation(libs.awaitility.old)
-    testImplementation(libs.vavr)
     testImplementation(project(":resilience4j-test"))
 }
-ext.moduleName = "io.github.resilience4j.all"

--- a/resilience4j-all/src/test/java/io/github/resilience4j/decorators/DecoratorsTest.java
+++ b/resilience4j-all/src/test/java/io/github/resilience4j/decorators/DecoratorsTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2016 Robert Winkler
+ *  Copyright 2026 Robert Winkler
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -21,16 +21,14 @@ package io.github.resilience4j.decorators;
 import io.github.resilience4j.bulkhead.Bulkhead;
 import io.github.resilience4j.bulkhead.BulkheadFullException;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
-import io.github.resilience4j.bulkhead.ThreadPoolBulkheadConfig;
-import io.github.resilience4j.bulkhead.ThreadPoolBulkheadRegistry;
 import io.github.resilience4j.cache.Cache;
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
 import io.github.resilience4j.core.functions.CheckedConsumer;
 import io.github.resilience4j.core.functions.CheckedFunction;
 import io.github.resilience4j.core.functions.CheckedRunnable;
 import io.github.resilience4j.core.functions.CheckedSupplier;
-import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
 import io.github.resilience4j.ratelimiter.RequestNotPermitted;
@@ -38,44 +36,56 @@ import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.test.AsyncHelloWorldService;
 import io.github.resilience4j.test.HelloWorldException;
 import io.github.resilience4j.test.HelloWorldService;
-import io.github.resilience4j.test.TestContextPropagators.TestThreadLocalContextPropagatorWithHolder;
 import io.github.resilience4j.test.TestContextPropagators.TestThreadLocalContextPropagatorWithHolder.TestThreadLocalContextHolder;
+import io.github.resilience4j.test.TestContextPropagators.TestThreadLocalContextPropagatorWithHolder;
 import io.github.resilience4j.timelimiter.TimeLimiter;
 import io.github.resilience4j.timelimiter.TimeLimiterConfig;
-import io.vavr.control.Try;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.MDC;
 
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
-import java.util.concurrent.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-import static com.jayway.awaitility.Awaitility.matches;
-import static com.jayway.awaitility.Awaitility.waitAtMost;
 import static java.util.Arrays.asList;
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.BDDMockito.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 
-public class DecoratorsTest {
+class DecoratorsTest {
 
     private boolean state = false;
     private HelloWorldService helloWorldService;
     private AsyncHelloWorldService asyncHelloWorldService;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         helloWorldService = mock(HelloWorldService.class);
         asyncHelloWorldService = mock(AsyncHelloWorldService.class);
     }
 
     @Test
-    public void shouldThrowTimeoutException() {
+    void shouldThrowTimeoutException() {
         TimeLimiter timeLimiter = TimeLimiter.of("helloBackend", TimeLimiterConfig.custom()
             .timeoutDuration(Duration.ofMillis(100)).build());
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
@@ -94,12 +104,12 @@ public class DecoratorsTest {
             .hasCauseInstanceOf(TimeoutException.class);
 
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfBufferedCalls()).isOne();
+        assertThat(metrics.getNumberOfFailedCalls()).isOne();
     }
 
     @Test
-    public void shouldThrowTimeoutExceptionAndPropagateContext() {
+    void shouldThrowTimeoutExceptionAndPropagateContext() {
         TimeLimiter timeLimiter = TimeLimiter.of("helloBackend", TimeLimiterConfig.custom()
             .timeoutDuration(Duration.ofMillis(100)).build());
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
@@ -133,16 +143,16 @@ public class DecoratorsTest {
             return null;
         });
 
-        waitAtMost(2, TimeUnit.SECONDS).until(matches(() ->
-            assertThat(completableFuture).isCompletedWithValue("ValueShouldCrossThreadBoundary")));
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() ->
+            assertThat(completableFuture).isCompletedWithValue("ValueShouldCrossThreadBoundary"));
 
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfBufferedCalls()).isOne();
+        assertThat(metrics.getNumberOfFailedCalls()).isOne();
     }
 
     @Test
-    public void shouldThrowTimeoutExceptionAndPropagateMDCContext() {
+    void shouldThrowTimeoutExceptionAndPropagateMDCContext() {
         TimeLimiter timeLimiter = TimeLimiter.of("helloBackend", TimeLimiterConfig.custom()
             .timeoutDuration(Duration.ofMillis(100)).build());
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
@@ -170,22 +180,22 @@ public class DecoratorsTest {
         final CompletableFuture<String> completableFuture = completionStage.toCompletableFuture().exceptionally(throwable -> {
             if (throwable != null) {
                 assertThat(Thread.currentThread().getName()).isEqualTo("ContextAwareScheduledThreadPool-1");
-                assertThat(MDC.getCopyOfContextMap()).hasSize(2).containsExactlyEntriesOf(contextMap);
+                assertThat(MDC.getCopyOfContextMap()).containsExactlyEntriesOf(contextMap);
                 return MDC.getCopyOfContextMap().get("key");
             }
             return null;
         });
 
-        waitAtMost(2, TimeUnit.SECONDS).until(matches(() ->
-            assertThat(completableFuture).isCompletedWithValue("ValueShouldPropagateThreadBoundary")));
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() ->
+            assertThat(completableFuture).isCompletedWithValue("ValueShouldPropagateThreadBoundary"));
 
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfBufferedCalls()).isOne();
+        assertThat(metrics.getNumberOfFailedCalls()).isOne();
     }
 
     @Test
-    public void testDecorateSupplier() {
+    void decorateSupplier() {
         given(helloWorldService.returnHelloWorld()).willReturn("Hello world");
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
         Supplier<String> decoratedSupplier = Decorators
@@ -200,13 +210,13 @@ public class DecoratorsTest {
 
         assertThat(result).isEqualTo("Hello world");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfBufferedCalls()).isOne();
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isOne();
         then(helloWorldService).should(times(1)).returnHelloWorld();
     }
 
     @Test
-    public void testDecorateSupplierWithFallbackFromResult() {
+    void decorateSupplierWithFallbackFromResult() {
         given(helloWorldService.returnHelloWorld()).willReturn("Hello world");
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
         Supplier<String> decoratedSupplier = Decorators
@@ -219,13 +229,13 @@ public class DecoratorsTest {
 
         assertThat(result).isEqualTo("Bla");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfBufferedCalls()).isOne();
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isOne();
         then(helloWorldService).should(times(1)).returnHelloWorld();
     }
 
     @Test
-    public void testDecorateCallableWithFallbackFromResult() throws Exception {
+    void decorateCallableWithFallbackFromResult() throws Exception {
         given(helloWorldService.returnHelloWorldWithException()).willReturn("Hello world");
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
         Callable<String> decoratedSupplier = Decorators
@@ -238,13 +248,13 @@ public class DecoratorsTest {
 
         assertThat(result).isEqualTo("Bla");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfBufferedCalls()).isOne();
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isOne();
         then(helloWorldService).should(times(1)).returnHelloWorldWithException();
     }
 
     @Test
-    public void testDecorateFunctionWithFallbackFromResult() throws Exception {
+    void decorateFunctionWithFallbackFromResult() throws Exception {
         given(helloWorldService.returnHelloWorldWithName("Name")).willReturn("Hello world Name");
         Function<String, String> decoratedFunction = Decorators
                 .ofFunction((Function<String, String>) str -> helloWorldService.returnHelloWorldWithName(str))
@@ -257,7 +267,7 @@ public class DecoratorsTest {
     }
 
     @Test
-    public void testDecorateCheckedFunctionWithFallbackFromResult() throws Throwable {
+    void decorateCheckedFunctionWithFallbackFromResult() throws Throwable {
         given(helloWorldService.returnHelloWorldWithName("Name")).willReturn("Hello world Name");
         CheckedFunction<String, String> decoratedFunction = Decorators
                 .ofCheckedFunction((CheckedFunction<String, String>) str -> helloWorldService.returnHelloWorldWithName(str))
@@ -270,7 +280,7 @@ public class DecoratorsTest {
     }
 
     @Test
-    public void testDecorateCheckedSupplierWithFallbackFromResult() throws Throwable {
+    void decorateCheckedSupplierWithFallbackFromResult() throws Throwable {
         given(helloWorldService.returnHelloWorldWithException()).willReturn("Hello world");
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
         CheckedSupplier<String> decoratedSupplier = Decorators
@@ -283,13 +293,13 @@ public class DecoratorsTest {
 
         assertThat(result).isEqualTo("Bla");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfBufferedCalls()).isOne();
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isOne();
         then(helloWorldService).should(times(1)).returnHelloWorldWithException();
     }
 
     @Test
-    public void testDecorateCompletionStageWithFallbackFromResult() throws Throwable {
+    void decorateCompletionStageWithFallbackFromResult() throws Throwable {
         given(helloWorldService.returnHelloWorld()).willReturn("Hello world");
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
 
@@ -305,14 +315,14 @@ public class DecoratorsTest {
 
         assertThat(result).isEqualTo("Bla");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfBufferedCalls()).isOne();
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isOne();
         then(helloWorldService).should(times(1)).returnHelloWorld();
     }
 
     @Test
-    public void testDecorateSupplierWithThreadPoolBulkhead()
-        throws ExecutionException, InterruptedException {
+    void decorateSupplierWithThreadPoolBulkhead()
+        throws Exception {
 
         given(helloWorldService.returnHelloWorld()).willReturn("Hello world");
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
@@ -328,14 +338,14 @@ public class DecoratorsTest {
 
         assertThat(result).isEqualTo("Hello world");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfBufferedCalls()).isOne();
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isOne();
         then(helloWorldService).should(times(1)).returnHelloWorld();
     }
 
     @Test
-    public void testDecorateRunnableWithThreadPoolBulkhead()
-        throws ExecutionException, InterruptedException {
+    void decorateRunnableWithThreadPoolBulkhead()
+        throws Exception {
 
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
 
@@ -348,13 +358,13 @@ public class DecoratorsTest {
         future.get();
 
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfBufferedCalls()).isOne();
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isOne();
         then(helloWorldService).should(times(1)).sayHelloWorld();
     }
 
     @Test
-    public void testDecorateCallable() throws Exception {
+    void decorateCallable() throws Exception {
         given(helloWorldService.returnHelloWorldWithException()).willReturn("Hello world");
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
         Callable<String> decoratedCallable = Decorators
@@ -369,13 +379,13 @@ public class DecoratorsTest {
 
         assertThat(result).isEqualTo("Hello world");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfBufferedCalls()).isOne();
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isOne();
         then(helloWorldService).should(times(1)).returnHelloWorldWithException();
     }
 
     @Test
-    public void testDecorateSupplierWithFallback() {
+    void decorateSupplierWithFallback() {
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
         circuitBreaker.transitionToOpenState();
 
@@ -389,12 +399,12 @@ public class DecoratorsTest {
 
         assertThat(result).isEqualTo("Fallback");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfNotPermittedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfNotPermittedCalls()).isOne();
         then(helloWorldService).should(never()).returnHelloWorld();
     }
 
     @Test
-    public void testDecorateCheckedSupplier() throws IOException {
+    void decorateCheckedSupplier() throws Throwable {
         given(helloWorldService.returnHelloWorldWithException()).willReturn("Hello world");
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
         CheckedSupplier<String> decoratedSupplier = Decorators
@@ -405,17 +415,17 @@ public class DecoratorsTest {
             .withBulkhead(Bulkhead.ofDefaults("testName"))
             .decorate();
 
-        String result = Try.of(() -> decoratedSupplier.get()).get();
+        String result = decoratedSupplier.get();
 
         assertThat(result).isEqualTo("Hello world");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfBufferedCalls()).isOne();
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isOne();
         then(helloWorldService).should(times(1)).returnHelloWorldWithException();
     }
 
     @Test
-    public void testDecorateCheckedSupplierWithFallback() throws Throwable {
+    void decorateCheckedSupplierWithFallback() throws Throwable {
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
         circuitBreaker.transitionToOpenState();
 
@@ -429,12 +439,12 @@ public class DecoratorsTest {
 
         assertThat(result).isEqualTo("Fallback");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfNotPermittedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfNotPermittedCalls()).isOne();
         then(helloWorldService).should(never()).returnHelloWorld();
     }
 
     @Test
-    public void testDecorateCheckedSupplierWithThreadPoolBulkheadSucceeds() throws Exception {
+    void decorateCheckedSupplierWithThreadPoolBulkheadSucceeds() throws Exception {
         String expected = "Hello world";
         given(helloWorldService.returnHelloWorldWithException()).willReturn(expected);
         ThreadPoolBulkhead threadPoolBulkhead = ThreadPoolBulkhead.ofDefaults("helloBackend");
@@ -450,7 +460,7 @@ public class DecoratorsTest {
     }
 
     @Test
-    public void testDecorateCheckedSupplierWithThreadPoolBulkheadWithExceptionThrown() throws Exception {
+    void decorateCheckedSupplierWithThreadPoolBulkheadWithExceptionThrown() throws Exception {
         IOException exception = new IOException("thrown from mock");
         given(helloWorldService.returnHelloWorldWithException()).willThrow(exception);
         ThreadPoolBulkhead threadPoolBulkhead = ThreadPoolBulkhead.ofDefaults("helloBackend");
@@ -460,17 +470,13 @@ public class DecoratorsTest {
                 .withThreadPoolBulkhead(threadPoolBulkhead)
                 .get();
 
-        try {
-            completionStage.toCompletableFuture().get();
-            fail("expected exception");
-        } catch (Exception ex) {
-            assertThat(ex.getCause()).isEqualTo(exception);
-        }
+        assertThatThrownBy(() -> completionStage.toCompletableFuture().get())
+                .hasCause(exception);
     }
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testDecorateCheckedSupplierWithThreadPoolBulkheadFull() throws Exception {
+    void decorateCheckedSupplierWithThreadPoolBulkheadFull() throws Exception {
         given(helloWorldService.returnHelloWorldWithException()).willReturn("Hello world");
         ThreadPoolBulkhead threadPoolBulkheadMock = mock(ThreadPoolBulkhead.class, RETURNS_DEEP_STUBS);
 
@@ -481,16 +487,12 @@ public class DecoratorsTest {
                 .ofCheckedSupplier(() -> helloWorldService.returnHelloWorldWithException())
                 .withThreadPoolBulkhead(threadPoolBulkheadMock)
                 .get();
-        try {
-            completionStage.toCompletableFuture().get();
-            fail("expected BulkheadFullException");
-        } catch (Exception ex) {
-            assertThat(ex.getCause()).isInstanceOf(BulkheadFullException.class);
-        }
+        assertThatThrownBy(() -> completionStage.toCompletableFuture().get())
+                .hasCauseInstanceOf(BulkheadFullException.class);
     }
 
     @Test
-    public void testDecorateCallableWithFallback() throws Throwable {
+    void decorateCallableWithFallback() throws Throwable {
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
         circuitBreaker.transitionToOpenState();
 
@@ -504,16 +506,16 @@ public class DecoratorsTest {
 
         assertThat(result).isEqualTo("Fallback");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfNotPermittedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfNotPermittedCalls()).isOne();
         then(helloWorldService).should(never()).returnHelloWorld();
     }
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testDecorateSupplierWithBulkheadFullExceptionFallback() throws ExecutionException, InterruptedException {
+    void decorateSupplierWithBulkheadFullExceptionFallback() throws Exception {
         ThreadPoolBulkhead bulkhead = ThreadPoolBulkhead.ofDefaults("helloBackend");
         ThreadPoolBulkhead bulkheadMock = spy(bulkhead);
-        
+
         given(bulkheadMock.submit(any(Callable.class))).willThrow(BulkheadFullException.createBulkheadFullException(bulkhead));
 
         CompletionStage<String> completionStage = Decorators
@@ -529,7 +531,7 @@ public class DecoratorsTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testDecorateCallableWithBulkheadFullExceptionFallback() throws ExecutionException, InterruptedException {
+    void decorateCallableWithBulkheadFullExceptionFallback() throws Exception {
         ThreadPoolBulkhead bulkhead = ThreadPoolBulkhead.ofDefaults("helloBackend");
         ThreadPoolBulkhead bulkheadMock = spy(bulkhead);
         given(bulkheadMock.submit(any(Callable.class))).willThrow(BulkheadFullException.createBulkheadFullException(bulkhead));
@@ -547,7 +549,7 @@ public class DecoratorsTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testDecorateRunnableWithBulkheadFullExceptionFallback() throws ExecutionException, InterruptedException {
+    void decorateRunnableWithBulkheadFullExceptionFallback() throws Exception {
         ThreadPoolBulkhead bulkhead = ThreadPoolBulkhead.ofDefaults("helloBackend");
         ThreadPoolBulkhead bulkheadMock = spy(bulkhead);
         given(bulkheadMock.submit(any(Callable.class))).willThrow(BulkheadFullException.createBulkheadFullException(bulkhead));
@@ -568,7 +570,7 @@ public class DecoratorsTest {
 
 
     @Test
-    public void testDecorateCompletionStageWithCallNotPermittedExceptionFallback() throws ExecutionException, InterruptedException {
+    void decorateCompletionStageWithCallNotPermittedExceptionFallback() throws Exception {
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
         circuitBreaker.transitionToOpenState();
         ThreadPoolBulkhead bulkhead = ThreadPoolBulkhead.ofDefaults("helloBackend");
@@ -583,11 +585,11 @@ public class DecoratorsTest {
 
         assertThat(result).isEqualTo("Fallback");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfNotPermittedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfNotPermittedCalls()).isOne();
     }
 
     @Test
-    public void testDecorateCompletionStageWithTimeoutExceptionFallback() throws ExecutionException, InterruptedException {
+    void decorateCompletionStageWithTimeoutExceptionFallback() throws Exception {
         TimeLimiter timeLimiter = TimeLimiter.of("helloBackend", TimeLimiterConfig.custom()
             .timeoutDuration(Duration.ofMillis(100)).build());
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
@@ -607,11 +609,11 @@ public class DecoratorsTest {
 
         assertThat(result).isEqualTo("Fallback");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfFailedCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfFailedCalls()).isOne();
     }
 
     @Test
-    public void testDecorateRunnable() {
+    void decorateRunnable() {
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
         Runnable decoratedRunnable = Decorators
             .ofRunnable(() -> helloWorldService.sayHelloWorld())
@@ -624,14 +626,14 @@ public class DecoratorsTest {
         decoratedRunnable.run();
 
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfBufferedCalls()).isOne();
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isOne();
         then(helloWorldService).should(times(1)).sayHelloWorld();
     }
 
 
     @Test
-    public void testDecorateCheckedRunnable() throws IOException {
+    void decorateCheckedRunnable() throws Throwable {
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
         CheckedRunnable decoratedRunnable = Decorators
             .ofCheckedRunnable(() -> helloWorldService.sayHelloWorldWithException())
@@ -641,16 +643,16 @@ public class DecoratorsTest {
             .withBulkhead(Bulkhead.ofDefaults("testName"))
             .decorate();
 
-        Try.run(() -> decoratedRunnable.run());
+        decoratedRunnable.run();
 
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfBufferedCalls()).isOne();
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isOne();
         then(helloWorldService).should(times(1)).sayHelloWorldWithException();
     }
 
     @Test
-    public void testDecorateCheckedRunnableWithThreadPoolBulkheadSucceeds() throws Exception {
+    void decorateCheckedRunnableWithThreadPoolBulkheadSucceeds() throws Exception {
         willDoNothing().given(helloWorldService).sayHelloWorldWithException();
         ThreadPoolBulkhead threadPoolBulkhead = ThreadPoolBulkhead.ofDefaults("helloBackend");
 
@@ -664,7 +666,7 @@ public class DecoratorsTest {
     }
 
     @Test
-    public void testDecorateCheckedRunnableWithThreadPoolBulkheadWithExceptionThrown() throws Exception {
+    void decorateCheckedRunnableWithThreadPoolBulkheadWithExceptionThrown() throws Exception {
         IOException exception = new IOException("thrown from mock");
         willThrow(exception).given(helloWorldService).sayHelloWorldWithException();
         ThreadPoolBulkhead threadPoolBulkhead = ThreadPoolBulkhead.ofDefaults("helloBackend");
@@ -674,16 +676,12 @@ public class DecoratorsTest {
                 .withThreadPoolBulkhead(threadPoolBulkhead)
                 .get();
 
-        try {
-            completionStage.toCompletableFuture().get();
-            fail("expected exception");
-        } catch (Exception ex) {
-            assertThat(ex.getCause()).isEqualTo(exception);
-        }
+        assertThatThrownBy(() -> completionStage.toCompletableFuture().get())
+                .hasCause(exception);
     }
 
     @Test
-    public void testDecorateCheckedRunnableWithThreadPoolBulkheadFull() throws Exception {
+    void decorateCheckedRunnableWithThreadPoolBulkheadFull() throws Exception {
         ThreadPoolBulkhead threadPoolBulkheadMock = mock(ThreadPoolBulkhead.class, RETURNS_DEEP_STUBS);
 
         willThrow(BulkheadFullException.createBulkheadFullException(threadPoolBulkheadMock)).given(threadPoolBulkheadMock).submit(any(Runnable.class));
@@ -693,16 +691,12 @@ public class DecoratorsTest {
                 .ofCheckedRunnable(() -> helloWorldService.sayHelloWorldWithException())
                 .withThreadPoolBulkhead(threadPoolBulkheadMock)
                 .get();
-        try {
-            completionStage.toCompletableFuture().get();
-            fail("expected BulkheadFullException");
-        } catch (Exception ex) {
-            assertThat(ex.getCause()).isInstanceOf(BulkheadFullException.class);
-        }
+        assertThatThrownBy(() -> completionStage.toCompletableFuture().get())
+                .hasCauseInstanceOf(BulkheadFullException.class);
     }
 
     @Test
-    public void testDecorateCompletionStage() throws ExecutionException, InterruptedException {
+    void decorateCompletionStage() throws Exception {
         given(helloWorldService.returnHelloWorld()).willReturn("Hello world");
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
         Supplier<CompletionStage<String>> completionStageSupplier =
@@ -718,13 +712,13 @@ public class DecoratorsTest {
 
         assertThat(value).isEqualTo("Hello world");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfBufferedCalls()).isOne();
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isOne();
         then(helloWorldService).should(times(1)).returnHelloWorld();
     }
 
     @Test
-    public void testDecorateCompletionStagePropagatesContextWithRetryAsync() {
+    void decorateCompletionStagePropagatesContextWithRetryAsync() {
         given(helloWorldService.returnHelloWorld()).willReturn("Hello world");
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
 
@@ -757,8 +751,8 @@ public class DecoratorsTest {
             return null;
         });
 
-        waitAtMost(2, TimeUnit.SECONDS).until(matches(() ->
-            assertThat(completableFuture).isCompletedWithValue("ValueShouldCrossThreadBoundary")));
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() ->
+            assertThat(completableFuture).isCompletedWithValue("ValueShouldCrossThreadBoundary"));
 
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
         assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(3);
@@ -767,7 +761,7 @@ public class DecoratorsTest {
     }
 
     @Test
-    public void testDecorateCompletionStagePropagatesMDCContextWithRetryAsync() {
+    void decorateCompletionStagePropagatesMDCContextWithRetryAsync() {
         given(helloWorldService.returnHelloWorld()).willReturn("Hello world");
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
 
@@ -794,14 +788,14 @@ public class DecoratorsTest {
         final CompletableFuture<String> completableFuture = completionStage.toCompletableFuture().exceptionally(throwable -> {
             if (throwable != null) {
                 assertThat(Thread.currentThread().getName()).contains("ContextAwareScheduledThreadPool");
-                assertThat(MDC.getCopyOfContextMap()).hasSize(2).containsExactlyEntriesOf(contextMap);
+                assertThat(MDC.getCopyOfContextMap()).containsExactlyEntriesOf(contextMap);
                 return MDC.getCopyOfContextMap().get("key");
             }
             return null;
         });
 
-        waitAtMost(2, TimeUnit.SECONDS).until(matches(() ->
-            assertThat(completableFuture).isCompletedWithValue("ValueShouldCrossThreadBoundary")));
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() ->
+            assertThat(completableFuture).isCompletedWithValue("ValueShouldCrossThreadBoundary"));
 
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
         assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(3);
@@ -810,7 +804,7 @@ public class DecoratorsTest {
     }
 
     @Test
-    public void testExecuteConsumer() {
+    void executeConsumer() {
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
         Decorators.DecorateConsumer<String> decoratedConsumer =
             Decorators.ofConsumer((String input) -> helloWorldService
@@ -822,13 +816,13 @@ public class DecoratorsTest {
         decoratedConsumer.accept("test");
 
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfBufferedCalls()).isOne();
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isOne();
         then(helloWorldService).should(times(1)).sayHelloWorldWithName("test");
     }
 
     @Test
-    public void testDecorateFunction() {
+    void decorateFunction() {
         given(helloWorldService.returnHelloWorldWithName("Name")).willReturn("Hello world Name");
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
         Function<String, String> decoratedFunction = Decorators
@@ -843,12 +837,12 @@ public class DecoratorsTest {
 
         assertThat(result).isEqualTo("Hello world Name");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfBufferedCalls()).isOne();
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isOne();
     }
 
     @Test
-    public void testDecorateFunctionWithFallback() {
+    void decorateFunctionWithFallback() {
         given(helloWorldService.returnHelloWorldWithName("Name")).willThrow(new RuntimeException("BAM!"));
         Function<String, String> decoratedFunction = Decorators
                 .ofFunction(helloWorldService::returnHelloWorldWithName)
@@ -861,7 +855,7 @@ public class DecoratorsTest {
     }
 
     @Test
-    public void testDecorateCheckedFunction() throws IOException {
+    void decorateCheckedFunction() throws Throwable {
         given(helloWorldService.returnHelloWorldWithNameWithException("Name"))
             .willReturn("Hello world Name");
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
@@ -873,16 +867,16 @@ public class DecoratorsTest {
             .withBulkhead(Bulkhead.ofDefaults("testName"))
             .decorate();
 
-        String result = Try.of(() -> decoratedFunction.apply("Name")).get();
+        String result = decoratedFunction.apply("Name");
 
         assertThat(result).isEqualTo("Hello world Name");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfBufferedCalls()).isOne();
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isOne();
     }
 
     @Test
-    public void testDecorateCheckedFunctionWithFallback() throws Throwable {
+    void decorateCheckedFunctionWithFallback() throws Throwable {
         given(helloWorldService.returnHelloWorldWithName("Name")).willThrow(new RuntimeException("BAM!"));
         CheckedFunction<String, String> decoratedFunction = Decorators
                 .ofCheckedFunction(helloWorldService::returnHelloWorldWithName)
@@ -895,7 +889,7 @@ public class DecoratorsTest {
     }
 
     @Test
-    public void testDecorateCheckedConsumer() {
+    void decorateCheckedConsumer() throws Throwable {
         given(helloWorldService.returnHelloWorldWithName("Name"))
             .willReturn("Hello world Name");
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
@@ -907,16 +901,16 @@ public class DecoratorsTest {
             .withBulkhead(Bulkhead.ofDefaults("testName"))
             .decorate();
 
-        Try.run(() -> decoratedConsumer.accept("Name"));
+        decoratedConsumer.accept("Name");
 
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
-        assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
-        assertThat(metrics.getNumberOfSuccessfulCalls()).isEqualTo(1);
+        assertThat(metrics.getNumberOfBufferedCalls()).isOne();
+        assertThat(metrics.getNumberOfSuccessfulCalls()).isOne();
         then(helloWorldService).should(times(1)).returnHelloWorldWithName("Name");
     }
 
     @Test
-    public void testDecoratorBuilderWithRetry() {
+    void decoratorBuilderWithRetry() {
         given(helloWorldService.returnHelloWorld()).willThrow(new RuntimeException("BAM!"));
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
         Supplier<String> decoratedSupplier = Decorators
@@ -926,7 +920,7 @@ public class DecoratorsTest {
             .withBulkhead(Bulkhead.ofDefaults("testName"))
             .decorate();
 
-        Try.of(decoratedSupplier::get);
+        assertThatThrownBy(decoratedSupplier::get).isInstanceOf(RuntimeException.class);
 
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
         assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(3);
@@ -935,7 +929,7 @@ public class DecoratorsTest {
     }
 
     @Test
-    public void testDecoratorBuilderWithRateLimiter() {
+    void decoratorBuilderWithRateLimiter() throws Throwable {
         given(helloWorldService.returnHelloWorld()).willReturn("Hello world");
         RateLimiterConfig config = RateLimiterConfig.custom()
             .timeoutDuration(Duration.ofMillis(100))
@@ -949,12 +943,10 @@ public class DecoratorsTest {
             .decorate();
         alignTime(rateLimiter);
 
-        Try<String> firstTry = Try.of(() -> restrictedSupplier.get());
-        Try<String> secondTry = Try.of(() -> restrictedSupplier.get());
+        String firstResult = restrictedSupplier.get();
+        assertThatThrownBy(restrictedSupplier::get).isInstanceOf(RequestNotPermitted.class);
 
-        assertThat(firstTry.isSuccess()).isTrue();
-        assertThat(secondTry.isFailure()).isTrue();
-        assertThat(secondTry.getCause()).isInstanceOf(RequestNotPermitted.class);
+        assertThat(firstResult).isEqualTo("Hello world");
         then(helloWorldService).should(times(1)).returnHelloWorld();
     }
 
@@ -972,7 +964,7 @@ public class DecoratorsTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testDecorateCheckedSupplierWithCache() {
+    void decorateCheckedSupplierWithCache() throws Throwable {
         javax.cache.Cache<String, String> cache = mock(javax.cache.Cache.class);
         given(cache.containsKey("testKey")).willReturn(true);
         given(cache.get("testKey")).willReturn("Hello from cache");
@@ -981,15 +973,15 @@ public class DecoratorsTest {
             .withCache(Cache.of(cache))
             .decorate();
 
-        Try<String> value = Try.of(() -> cachedFunction.apply("testKey"));
+        String value = cachedFunction.apply("testKey");
 
-        assertThat(value).contains("Hello from cache");
+        assertThat(value).isEqualTo("Hello from cache");
     }
 
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testDecorateSupplierWithCache() {
+    void decorateSupplierWithCache() {
         javax.cache.Cache<String, String> cache = mock(javax.cache.Cache.class);
         given(cache.containsKey("testKey")).willReturn(true);
         given(cache.get("testKey")).willReturn("Hello from cache");


### PR DESCRIPTION
## Changes

* Migrated JUnit 4.13 annotations to Junit Jupiter equivalents
* Applied OpenRewrite recipes
    * [JUnit 6 best practices](https://docs.openrewrite.org/recipes/java/testing/junit/junit6bestpractices)
    * [Mockito best practices](https://docs.openrewrite.org/recipes/java/testing/mockito/mockitobestpractices)
    * [Migrate JUnit asserts to AssertJ](https://docs.openrewrite.org/recipes/java/testing/assertj/junittoassertj)
    * [AssertJ best practices](https://docs.openrewrite.org/recipes/java/testing/assertj/assertj-best-practices)
* Removed `public` modifiers
* Expanded star imports to explicit imports
* Converted `try/catch/fail` blocks to `assertThatThrownBy`
* Updated Copyright to 2026

## Coverage

| Metric      | Before | After |
|-------------|--------|-------|
| Instruction | 67.7%  | 67.7% |
| Line        | 68.0%  | 68.0% |

## Test runtime

| Metric | Before | After |
|--------|--------|-------|
| Tests  | 43     | 43    |
| Time   | 18.0s  | 7.0s  |
