### PR TITLE
resilience4j-cache: JUnit 4 → JUnit 6 migration

### DIFF
--- a/resilience4j-cache/build.gradle
+++ b/resilience4j-cache/build.gradle
@@ -2,9 +2,6 @@ dependencies {
     api(project(":resilience4j-core"))
     api(libs.jcache)
 
-    testRuntimeOnly(libs.junit.vintage.engine)
-
-    testImplementation(libs.junit)
     testImplementation(project(":resilience4j-rxjava2"))
     testImplementation(libs.rxjava2)
 }

--- a/resilience4j-cache/src/test/java/io/github/resilience4j/cache/CacheEventPublisherTest.java
+++ b/resilience4j-cache/src/test/java/io/github/resilience4j/cache/CacheEventPublisherTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2016 Robert Winkler
+ *  Copyright 2026 Robert Winkler
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@
 package io.github.resilience4j.cache;
 
 import io.github.resilience4j.core.functions.CheckedFunction;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
@@ -36,20 +36,20 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 
-public class CacheEventPublisherTest {
+class CacheEventPublisherTest {
 
     private javax.cache.Cache<String, String> cache;
     private Logger logger;
 
     @SuppressWarnings("unchecked")
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         cache = mock(javax.cache.Cache.class);
         logger = mock(Logger.class);
     }
 
     @Test
-    public void shouldReturnTheSameConsumer() {
+    void shouldReturnTheSameConsumer() {
         Cache<String, String> cacheContext = Cache.of(cache);
         Cache.EventPublisher eventPublisher = cacheContext.getEventPublisher();
         Cache.EventPublisher eventPublisher2 = cacheContext.getEventPublisher();
@@ -58,7 +58,7 @@ public class CacheEventPublisherTest {
     }
 
     @Test
-    public void shouldConsumeOnCacheHitEvent() throws Throwable {
+    void shouldConsumeOnCacheHitEvent() throws Throwable {
         given(cache.get("testKey")).willReturn("Hello world");
         Cache<String, String> cacheContext = Cache.of(cache);
         cacheContext.getEventPublisher().onCacheHit(
@@ -73,7 +73,7 @@ public class CacheEventPublisherTest {
     }
 
     @Test
-    public void shouldConsumeOnCacheMissEvent() throws Throwable {
+    void shouldConsumeOnCacheMissEvent() throws Throwable {
         given(cache.get("testKey")).willReturn(null);
         given(cache.invoke(eq("testKey"), any())).willAnswer(new CacheInvokeAnswer());
         Cache<String, String> cacheContext = Cache.of(cache);
@@ -89,7 +89,7 @@ public class CacheEventPublisherTest {
     }
 
     @Test
-    public void shouldConsumeOnGetErrorEvent() throws Throwable {
+    void shouldConsumeOnGetErrorEvent() throws Throwable {
         given(cache.get("testKey")).willThrow(new RuntimeException("BLA"));
         given(cache.invoke(eq("testKey"), any())).willAnswer(new CacheInvokeAnswer());
         Cache<String, String> cacheContext = Cache.of(cache);
@@ -105,7 +105,7 @@ public class CacheEventPublisherTest {
     }
 
     @Test
-    public void shouldConsumeOnGetAndInvokeErrorEvent() throws Throwable {
+    void shouldConsumeOnGetAndInvokeErrorEvent() throws Throwable {
         given(cache.get("testKey")).willThrow(new RuntimeException("BLA"));
         given(cache.invoke(eq("testKey"), any())).willThrow(new RuntimeException("ALSO BLA"));
         Cache<String, String> cacheContext = Cache.of(cache);

--- a/resilience4j-cache/src/test/java/io/github/resilience4j/cache/CacheRegistryStoreTest.java
+++ b/resilience4j-cache/src/test/java/io/github/resilience4j/cache/CacheRegistryStoreTest.java
@@ -1,11 +1,27 @@
+/*
+ *
+ * Copyright 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *
+ */
 package io.github.resilience4j.cache;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.cache.Cache;
 import javax.cache.processor.EntryProcessor;
@@ -13,15 +29,19 @@ import javax.cache.processor.EntryProcessorException;
 import javax.cache.processor.MutableEntry;
 import java.util.function.Function;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
+@ExtendWith(MockitoExtension.class)
 @SuppressWarnings("unchecked")
-@RunWith(MockitoJUnitRunner.class)
-public class CacheRegistryStoreTest {
+class CacheRegistryStoreTest {
 
     private static final String CACHE_KEY = "testKey";
 
@@ -39,17 +59,17 @@ public class CacheRegistryStoreTest {
 
     private CacheRegistryStore<Integer> classUnderTest;
 
-    @Before
-    public void setupTest() {
-        doReturn(CACHE_KEY).when(mutableEntryMock).getKey();
-        doAnswer(invocation -> entryProcessorMock.process(mutableEntryMock, entryProcessorArgMock))
+    @BeforeEach
+    void setupTest() {
+        lenient().doReturn(CACHE_KEY).when(mutableEntryMock).getKey();
+        lenient().doAnswer(invocation -> entryProcessorMock.process(mutableEntryMock, entryProcessorArgMock))
             .when(cacheStoreMock).invoke(eq(CACHE_KEY), any(EntryProcessor.class), any());
 
         classUnderTest = new CacheRegistryStore<>(cacheStoreMock);
     }
 
     @Test
-    public void computeIfAbsent_cacheHit_mappingFunctionNotInvoked() {
+    void computeIfAbsent_cacheHit_mappingFunctionNotInvoked() {
         doReturn(1).when(mutableEntryMock).getValue();
         Function<String, Integer> mappingFunctionMock = Mockito.mock(Function.class);
         entryProcessorMock = new CacheRegistryStore.AtomicComputeProcessor<>();
@@ -62,7 +82,7 @@ public class CacheRegistryStoreTest {
     }
 
     @Test
-    public void computeIfAbsent_cacheMiss_mappingFunctionInvoked() {
+    void computeIfAbsent_cacheMiss_mappingFunctionInvoked() {
         Function<String, Integer> mappingFunction = k -> 7;
         doReturn(null).when(mutableEntryMock).getValue();
         entryProcessorMock = new CacheRegistryStore.AtomicComputeProcessor<>();
@@ -70,12 +90,12 @@ public class CacheRegistryStoreTest {
 
         Integer cacheResult = classUnderTest.computeIfAbsent(CACHE_KEY, mappingFunction);
 
-        verify(mutableEntryMock, times(1)).setValue(7);
-        assertEquals(Integer.valueOf(7), cacheResult);
+        verify(mutableEntryMock).setValue(7);
+        assertThat(cacheResult).isEqualTo(Integer.valueOf(7));
     }
 
     @Test
-    public void computeIfAbsent_cacheMiss_mappingFunctionReturnsNull_returnOldValue() {
+    void computeIfAbsent_cacheMiss_mappingFunctionReturnsNull_returnOldValue() {
         Function<String, Integer> mappingFunction = k -> null;
         doReturn(null).when(mutableEntryMock).getValue();
         entryProcessorMock = new CacheRegistryStore.AtomicComputeProcessor<>();
@@ -84,11 +104,11 @@ public class CacheRegistryStoreTest {
         Integer cacheResult = classUnderTest.computeIfAbsent(CACHE_KEY, mappingFunction);
 
         verify(mutableEntryMock, never()).setValue(any());
-        assertNull(cacheResult);
+        assertThat(cacheResult).isNull();
     }
 
     @Test
-    public void computeIfAbsent_cacheThrowsException_throwsUnwrappedEntryProcessorException() {
+    void computeIfAbsent_cacheThrowsException_throwsUnwrappedEntryProcessorException() {
         Function<String, Integer> mappingFunction = s -> {
             throw new EntryProcessorException(new IllegalArgumentException());
         };
@@ -96,16 +116,13 @@ public class CacheRegistryStoreTest {
         entryProcessorMock = new CacheRegistryStore.AtomicComputeProcessor<>();
         entryProcessorArgMock = mappingFunction;
 
-        try {
-            classUnderTest.computeIfAbsent(CACHE_KEY, mappingFunction);
-            fail("Test should've thrown EntryProcessorException");
-        } catch (RuntimeException e) {
-            assertTrue(e.getCause() instanceof IllegalArgumentException);
-        }
+        assertThatThrownBy(() -> classUnderTest.computeIfAbsent(CACHE_KEY, mappingFunction))
+            .isInstanceOf(RuntimeException.class)
+            .hasCauseInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void putIfAbsent_cacheHit_noCacheUpdate() {
+    void putIfAbsent_cacheHit_noCacheUpdate() {
         Function<String, Integer> mappingFunctionMock = Mockito.mock(Function.class);
         doReturn(36).when(mutableEntryMock).getValue();
         entryProcessorMock = new CacheRegistryStore.AtomicComputeProcessor<>();
@@ -114,11 +131,11 @@ public class CacheRegistryStoreTest {
         Integer cacheResult = classUnderTest.putIfAbsent(CACHE_KEY, 36);
 
         verify(mutableEntryMock, never()).setValue(any());
-        assertEquals(Integer.valueOf(36), cacheResult);
+        assertThat(cacheResult).isEqualTo(Integer.valueOf(36));
     }
 
     @Test
-    public void putIfAbsent_cacheMiss_updatesCache() {
+    void putIfAbsent_cacheMiss_updatesCache() {
         Function<String, Integer> mappingFunction = k -> 17;
         doReturn(null).when(mutableEntryMock).getValue();
         entryProcessorMock = new CacheRegistryStore.AtomicComputeProcessor<>();
@@ -126,12 +143,12 @@ public class CacheRegistryStoreTest {
 
         Integer cacheResult = classUnderTest.putIfAbsent(CACHE_KEY, 17);
 
-        verify(mutableEntryMock, times(1)).setValue(17);
-        assertEquals(Integer.valueOf(17), cacheResult);
+        verify(mutableEntryMock).setValue(17);
+        assertThat(cacheResult).isEqualTo(Integer.valueOf(17));
     }
 
     @Test
-    public void putIfAbsent_cacheThrowsException_throwsUnwrappedEntryProcessorException() {
+    void putIfAbsent_cacheThrowsException_throwsUnwrappedEntryProcessorException() {
         Function<String, Integer> mappingFunction = s -> {
             throw new EntryProcessorException(new IllegalStateException());
         };
@@ -139,11 +156,8 @@ public class CacheRegistryStoreTest {
         entryProcessorMock = new CacheRegistryStore.AtomicComputeProcessor<>();
         entryProcessorArgMock = mappingFunction;
 
-        try {
-            classUnderTest.putIfAbsent(CACHE_KEY, 54);
-            fail("Test should've thrown EntryProcessorException");
-        } catch (RuntimeException e) {
-            assertTrue(e.getCause() instanceof IllegalStateException);
-        }
+        assertThatThrownBy(() -> classUnderTest.putIfAbsent(CACHE_KEY, 54))
+            .isInstanceOf(RuntimeException.class)
+            .hasCauseInstanceOf(IllegalStateException.class);
     }
 }

--- a/resilience4j-cache/src/test/java/io/github/resilience4j/cache/CacheTest.java
+++ b/resilience4j-cache/src/test/java/io/github/resilience4j/cache/CacheTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2016 Robert Winkler
+ *  Copyright 2026 Robert Winkler
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -21,8 +21,8 @@ package io.github.resilience4j.cache;
 import io.github.resilience4j.cache.event.CacheEvent;
 import io.github.resilience4j.core.functions.CheckedFunction;
 import io.reactivex.subscribers.TestSubscriber;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -32,21 +32,24 @@ import java.util.function.Function;
 
 import static io.github.resilience4j.adapter.RxJava2Adapter.toFlowable;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 
-public class CacheTest {
+class CacheTest {
 
     private javax.cache.Cache<String, String> cache;
 
     @SuppressWarnings("unchecked")
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         cache = mock(javax.cache.Cache.class);
     }
 
     @Test
-    public void shouldReturnValueFromDecoratedCheckedSupplier() throws Throwable {
+    void shouldReturnValueFromDecoratedCheckedSupplier() throws Throwable {
         given(cache.get("testKey")).willReturn(null);
         given(cache.invoke(eq("testKey"), any())).willAnswer(new CacheInvokeAnswer());
         Cache<String, String> cacheContext = Cache.of(cache);
@@ -61,14 +64,14 @@ public class CacheTest {
 
         assertThat(value).isEqualTo("Hello world");
         assertThat(cacheContext.getMetrics().getNumberOfCacheHits()).isZero();
-        assertThat(cacheContext.getMetrics().getNumberOfCacheMisses()).isEqualTo(1);
+        assertThat(cacheContext.getMetrics().getNumberOfCacheMisses()).isOne();
         testSubscriber
             .assertValueCount(1)
             .assertValues(CacheEvent.Type.CACHE_MISS);
     }
 
     @Test
-    public void shouldReturnValueFromDecoratedSupplier() {
+    void shouldReturnValueFromDecoratedSupplier() {
         given(cache.get("testKey")).willReturn(null);
         given(cache.invoke(eq("testKey"), any())).willAnswer(new CacheInvokeAnswer());
         Cache<String, String> cacheContext = Cache.of(cache);
@@ -83,14 +86,14 @@ public class CacheTest {
 
         assertThat(value).isEqualTo("Hello world");
         assertThat(cacheContext.getMetrics().getNumberOfCacheHits()).isZero();
-        assertThat(cacheContext.getMetrics().getNumberOfCacheMisses()).isEqualTo(1);
+        assertThat(cacheContext.getMetrics().getNumberOfCacheMisses()).isOne();
         testSubscriber
             .assertValueCount(1)
             .assertValues(CacheEvent.Type.CACHE_MISS);
     }
 
     @Test
-    public void shouldReturnValueFromDecoratedCallable() throws Throwable {
+    void shouldReturnValueFromDecoratedCallable() throws Throwable {
         given(cache.get("testKey")).willReturn(null);
         given(cache.invoke(eq("testKey"), any())).willAnswer(new CacheInvokeAnswer());
         Cache<String, String> cacheContext = Cache.of(cache);
@@ -105,14 +108,14 @@ public class CacheTest {
 
         assertThat(value).isEqualTo("Hello world");
         assertThat(cacheContext.getMetrics().getNumberOfCacheHits()).isZero();
-        assertThat(cacheContext.getMetrics().getNumberOfCacheMisses()).isEqualTo(1);
+        assertThat(cacheContext.getMetrics().getNumberOfCacheMisses()).isOne();
         testSubscriber
             .assertValueCount(1)
             .assertValues(CacheEvent.Type.CACHE_MISS);
     }
 
     @Test
-    public void shouldReturnValueOfSupplier() throws Throwable {
+    void shouldReturnValueOfSupplier() throws Throwable {
         given(cache.get("testKey")).willReturn(null);
         willThrow(new RuntimeException("Cache is not available")).given(cache)
             .invoke(eq("testKey"), any());
@@ -128,14 +131,14 @@ public class CacheTest {
 
         assertThat(value).isEqualTo("Hello world");
         assertThat(cacheContext.getMetrics().getNumberOfCacheHits()).isZero();
-        assertThat(cacheContext.getMetrics().getNumberOfCacheMisses()).isEqualTo(1);
+        assertThat(cacheContext.getMetrics().getNumberOfCacheMisses()).isOne();
         testSubscriber
             .assertValueCount(2)
             .assertValues(CacheEvent.Type.CACHE_MISS, CacheEvent.Type.ERROR);
     }
 
     @Test
-    public void shouldReturnCachedValue() throws Throwable {
+    void shouldReturnCachedValue() throws Throwable {
         given(cache.get("testKey")).willReturn("Hello from cache");
         Cache<String, String> cacheContext = Cache.of(cache);
         TestSubscriber<CacheEvent.Type> testSubscriber =
@@ -148,7 +151,7 @@ public class CacheTest {
         String value = cachedFunction.apply("testKey");
 
         assertThat(value).isEqualTo("Hello from cache");
-        assertThat(cacheContext.getMetrics().getNumberOfCacheHits()).isEqualTo(1);
+        assertThat(cacheContext.getMetrics().getNumberOfCacheHits()).isOne();
         assertThat(cacheContext.getMetrics().getNumberOfCacheMisses()).isZero();
         testSubscriber
             .assertValueCount(1)
@@ -156,7 +159,7 @@ public class CacheTest {
     }
 
     @Test
-    public void shouldReturnValueFromDecoratedCallableBecauseOfException() throws Throwable {
+    void shouldReturnValueFromDecoratedCallableBecauseOfException() throws Throwable {
         given(cache.get("testKey")).willThrow(new RuntimeException("Cache is not available"));
         given(cache.invoke(eq("testKey"), any())).willThrow(new RuntimeException("Cache is not available"));
         Cache<String, String> cacheContext = Cache.of(cache);

--- a/resilience4j-cache/src/test/java/io/github/resilience4j/cache/event/CacheEventTest.java
+++ b/resilience4j-cache/src/test/java/io/github/resilience4j/cache/event/CacheEventTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2016 Robert Winkler
+ *  Copyright 2026 Robert Winkler
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -18,17 +18,17 @@
  */
 package io.github.resilience4j.cache.event;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
 import static io.github.resilience4j.cache.event.CacheEvent.Type;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CacheEventTest {
+class CacheEventTest {
 
     @Test
-    public void testCacheOnErrorEvent() {
+    void cacheOnErrorEvent() {
         CacheOnErrorEvent cacheOnErrorEvent = new CacheOnErrorEvent("test",
             new IOException());
         assertThat(cacheOnErrorEvent.getCacheName()).isEqualTo("test");
@@ -39,7 +39,7 @@ public class CacheEventTest {
     }
 
     @Test
-    public void testCacheOnHitEvent() {
+    void cacheOnHitEvent() {
         CacheOnHitEvent<String> cacheOnHitEvent = new CacheOnHitEvent<>("test",
             "testKey");
         assertThat(cacheOnHitEvent.getCacheName()).isEqualTo("test");
@@ -50,7 +50,7 @@ public class CacheEventTest {
     }
 
     @Test
-    public void testCacheOnMissEvent() {
+    void cacheOnMissEvent() {
         CacheOnMissEvent<String> cacheOnMissEvent = new CacheOnMissEvent<>("test",
             "testKey");
         assertThat(cacheOnMissEvent.getCacheName()).isEqualTo("test");

--- a/resilience4j-cache/src/test/java/io/github/resilience4j/cache/internal/ComputeIfAbsentTest.java
+++ b/resilience4j-cache/src/test/java/io/github/resilience4j/cache/internal/ComputeIfAbsentTest.java
@@ -1,30 +1,49 @@
+/*
+ *
+ * Copyright 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *
+ */
 package io.github.resilience4j.cache.internal;
 
 import io.github.resilience4j.cache.internal.CacheImpl.ComputeIfAbsent;
 import io.github.resilience4j.core.functions.CheckedSupplier;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.cache.processor.MutableEntry;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
-public class ComputeIfAbsentTest {
+class ComputeIfAbsentTest {
 
     private MutableEntry<String, String> mockEntry;
 
     @SuppressWarnings("unchecked")
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         mockEntry = mock(MutableEntry.class);
     }
 
     @SuppressWarnings("unchecked")
     @Test
-    public void shouldReturnCachedValueIfCached() {
+    void shouldReturnCachedValueIfCached() {
         given(mockEntry.exists()).willReturn(true);
         given(mockEntry.getValue()).willReturn("Cached Value");
         CheckedSupplier<String> mockedSupplier = mock(CheckedSupplier.class);
@@ -36,7 +55,7 @@ public class ComputeIfAbsentTest {
     }
 
     @Test
-    public void shouldReturnSuppliedValueIfNotCached() throws Throwable {
+    void shouldReturnSuppliedValueIfNotCached() throws Throwable {
         given(mockEntry.exists()).willReturn(false);
         CheckedSupplier<String> supplier = spy(new SpyableSupplier("Supplied Value"));
 
@@ -48,7 +67,7 @@ public class ComputeIfAbsentTest {
     }
 
     @Test
-    public void shouldRethrowSupplierException() {
+    void shouldRethrowSupplierException() {
         given(mockEntry.exists()).willReturn(false);
         CheckedSupplier<String> supplier = () -> {
             throw new RuntimeException("Boom!");


### PR DESCRIPTION
## Changes

* Migrated JUnit 4.13 annotations to Junit Jupiter equivalents
* Applied OpenRewrite recipes
    * [JUnit 6 best practices](https://docs.openrewrite.org/recipes/java/testing/junit/junit6bestpractices)
    * [Mockito best practices](https://docs.openrewrite.org/recipes/java/testing/mockito/mockitobestpractices)
    * [Migrate JUnit asserts to AssertJ](https://docs.openrewrite.org/recipes/java/testing/assertj/junittoassertj)
    * [AssertJ best practices](https://docs.openrewrite.org/recipes/java/testing/assertj/assertj-best-practices)
* Removed `public` modifiers
* Expanded star imports to explicit imports
* Converted `try/catch/fail` blocks to `assertThatThrownBy`
* Updated Copyright to 2026

## Coverage

| Metric      | Before | After |
|-------------|--------|-------|
| Instruction | 90.5%  | 90.5% |
| Line        | 92.3%  | 92.3% |
| Branch      | 90.0%  | 90.0% |

## Test runtime

| Metric | Before | After |
|--------|--------|-------|
| Tests  | 24     | 24    |
| Time   | 10.8s  | 10.1s |
