### PR TITLE
resilience4j-commons-configuration: JUnit 4 → JUnit 6 migration

### DIFF
--- a/resilience4j-commons-configuration/build.gradle
+++ b/resilience4j-commons-configuration/build.gradle
@@ -5,8 +5,6 @@ dependencies {
     runtimeOnly(libs.apache.commons.beanutils)
     runtimeOnly(libs.jackson.dataformat.yaml)
 
-    testRuntimeOnly(libs.junit.vintage.engine)
 
-    testImplementation(libs.junit)
 }
 ext.moduleName = "io.github.resilience4j.commons.configuration"

--- a/resilience4j-commons-configuration/src/test/java/io/github/resilience4j/commons/configuration/bulkhead/configure/CommonsConfigurationBulkHeadConfigurationTest.java
+++ b/resilience4j-commons-configuration/src/test/java/io/github/resilience4j/commons/configuration/bulkhead/configure/CommonsConfigurationBulkHeadConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023: Deepak Kumar
+ *   Copyright 2026: Deepak Kumar
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -22,16 +22,16 @@ import io.github.resilience4j.commons.configuration.util.TestConstants;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.configuration2.YAMLConfiguration;
-import org.apache.commons.configuration2.ex.ConfigurationException;
-import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.Map;
 
-public class CommonsConfigurationBulkHeadConfigurationTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommonsConfigurationBulkHeadConfigurationTest {
     @Test
-    public void testFromPropertiesFile() throws ConfigurationException {
+    void fromPropertiesFile() throws Exception {
         Configuration config = CommonsConfigurationUtil.getConfiguration(PropertiesConfiguration.class, TestConstants.RESILIENCE_CONFIG_PROPERTIES_FILE_NAME);
 
         CommonsConfigurationBulkHeadConfiguration bulkHeadConfiguration  = CommonsConfigurationBulkHeadConfiguration.of(config);
@@ -41,7 +41,7 @@ public class CommonsConfigurationBulkHeadConfigurationTest {
     }
 
     @Test
-    public void testFromYamlFile() throws ConfigurationException {
+    void fromYamlFile() throws Exception {
         Configuration config = CommonsConfigurationUtil.getConfiguration(YAMLConfiguration.class, TestConstants.RESILIENCE_CONFIG_YAML_FILE_NAME);
 
         CommonsConfigurationBulkHeadConfiguration bulkHeadConfiguration  = CommonsConfigurationBulkHeadConfiguration.of(config);
@@ -51,36 +51,38 @@ public class CommonsConfigurationBulkHeadConfigurationTest {
     }
 
     private static void assertConfigs(Map<String, CommonBulkheadConfigurationProperties.InstanceProperties> config) {
-        Assertions.assertThat(config.size()).isEqualTo(1);
-        Assertions.assertThat(config.containsKey(TestConstants.DEFAULT)).isTrue();
+        assertThat(config)
+                .hasSize(1)
+                .containsKey(TestConstants.DEFAULT);
         assertConfigDefault(config.get(TestConstants.DEFAULT));
     }
 
     private static void assertConfigDefault(CommonBulkheadConfigurationProperties.InstanceProperties configDefault) {
-        Assertions.assertThat(configDefault.getMaxWaitDuration()).isNull();
-        Assertions.assertThat(configDefault.getMaxConcurrentCalls()).isEqualTo(100);
-        Assertions.assertThat(configDefault.getEventConsumerBufferSize()).isNull();
-        Assertions.assertThat(configDefault.isWritableStackTraceEnabled()).isNull();
+        assertThat(configDefault.getMaxWaitDuration()).isNull();
+        assertThat(configDefault.getMaxConcurrentCalls()).isEqualTo(100);
+        assertThat(configDefault.getEventConsumerBufferSize()).isNull();
+        assertThat(configDefault.isWritableStackTraceEnabled()).isNull();
     }
 
     private static void assertInstances(Map<String, CommonBulkheadConfigurationProperties.InstanceProperties> instances) {
-        Assertions.assertThat(instances.size()).isEqualTo(2);
-        Assertions.assertThat(instances.containsKey(TestConstants.BACKEND_A)).isTrue();
+        assertThat(instances)
+                .hasSize(2)
+                .containsKey(TestConstants.BACKEND_A);
         assertInstanceBackendA(instances.get(TestConstants.BACKEND_A));
         assertInstanceBackendB(instances.get(TestConstants.BACKEND_B));
     }
 
     private static void assertInstanceBackendA(CommonBulkheadConfigurationProperties.InstanceProperties instanceBackendA) {
-        Assertions.assertThat(instanceBackendA.getMaxWaitDuration()).isNull();
-        Assertions.assertThat(instanceBackendA.getMaxConcurrentCalls()).isEqualTo(10);
-        Assertions.assertThat(instanceBackendA.getEventConsumerBufferSize()).isNull();
-        Assertions.assertThat(instanceBackendA.isWritableStackTraceEnabled()).isNull();
+        assertThat(instanceBackendA.getMaxWaitDuration()).isNull();
+        assertThat(instanceBackendA.getMaxConcurrentCalls()).isEqualTo(10);
+        assertThat(instanceBackendA.getEventConsumerBufferSize()).isNull();
+        assertThat(instanceBackendA.isWritableStackTraceEnabled()).isNull();
     }
 
     private static void assertInstanceBackendB(CommonBulkheadConfigurationProperties.InstanceProperties instanceBackendB) {
-        Assertions.assertThat(instanceBackendB.getMaxWaitDuration()).isEqualTo(Duration.ofMillis(10));
-        Assertions.assertThat(instanceBackendB.getMaxConcurrentCalls()).isEqualTo(20);
-        Assertions.assertThat(instanceBackendB.getEventConsumerBufferSize()).isEqualTo(15);
-        Assertions.assertThat(instanceBackendB.isWritableStackTraceEnabled()).isTrue();
+        assertThat(instanceBackendB.getMaxWaitDuration()).isEqualTo(Duration.ofMillis(10));
+        assertThat(instanceBackendB.getMaxConcurrentCalls()).isEqualTo(20);
+        assertThat(instanceBackendB.getEventConsumerBufferSize()).isEqualTo(15);
+        assertThat(instanceBackendB.isWritableStackTraceEnabled()).isTrue();
     }
 }

--- a/resilience4j-commons-configuration/src/test/java/io/github/resilience4j/commons/configuration/bulkhead/configure/CommonsConfigurationBulkheadRegistryTest.java
+++ b/resilience4j-commons-configuration/src/test/java/io/github/resilience4j/commons/configuration/bulkhead/configure/CommonsConfigurationBulkheadRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023: Deepak Kumar
+ *   Copyright 2026: Deepak Kumar
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -23,31 +23,31 @@ import io.github.resilience4j.commons.configuration.util.TestConstants;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.configuration2.YAMLConfiguration;
-import org.apache.commons.configuration2.ex.ConfigurationException;
-import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-public class CommonsConfigurationBulkheadRegistryTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommonsConfigurationBulkheadRegistryTest {
 
     @Test
-    public void testBulkheadRegistryFromPropertiesFile() throws ConfigurationException {
+    void bulkheadRegistryFromPropertiesFile() throws Exception {
         Configuration config = CommonsConfigurationUtil.getConfiguration(PropertiesConfiguration.class, TestConstants.RESILIENCE_CONFIG_PROPERTIES_FILE_NAME);
 
         BulkheadRegistry registry = CommonsConfigurationBulkheadRegistry.of(config, new CompositeCustomizer<>(List.of()));
 
-        Assertions.assertThat(registry.bulkhead(TestConstants.BACKEND_A).getName()).isEqualTo(TestConstants.BACKEND_A);
-        Assertions.assertThat(registry.bulkhead(TestConstants.BACKEND_B).getName()).isEqualTo(TestConstants.BACKEND_B);
+        assertThat(registry.bulkhead(TestConstants.BACKEND_A).getName()).isEqualTo(TestConstants.BACKEND_A);
+        assertThat(registry.bulkhead(TestConstants.BACKEND_B).getName()).isEqualTo(TestConstants.BACKEND_B);
     }
 
     @Test
-    public void testBulkheadRegistryFromYamlFile() throws ConfigurationException {
+    void bulkheadRegistryFromYamlFile() throws Exception {
         Configuration config = CommonsConfigurationUtil.getConfiguration(YAMLConfiguration.class, TestConstants.RESILIENCE_CONFIG_YAML_FILE_NAME);
 
         BulkheadRegistry registry = CommonsConfigurationBulkheadRegistry.of(config, new CompositeCustomizer<>(List.of()));
 
-        Assertions.assertThat(registry.bulkhead(TestConstants.BACKEND_A).getName()).isEqualTo(TestConstants.BACKEND_A);
-        Assertions.assertThat(registry.bulkhead(TestConstants.BACKEND_B).getName()).isEqualTo(TestConstants.BACKEND_B);
+        assertThat(registry.bulkhead(TestConstants.BACKEND_A).getName()).isEqualTo(TestConstants.BACKEND_A);
+        assertThat(registry.bulkhead(TestConstants.BACKEND_B).getName()).isEqualTo(TestConstants.BACKEND_B);
     }
 }

--- a/resilience4j-commons-configuration/src/test/java/io/github/resilience4j/commons/configuration/circuitbreaker/configure/CommonsConfigurationCircuitBreakerConfigurationTest.java
+++ b/resilience4j-commons-configuration/src/test/java/io/github/resilience4j/commons/configuration/circuitbreaker/configure/CommonsConfigurationCircuitBreakerConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023: Deepak Kumar
+ *   Copyright 2026: Deepak Kumar
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -26,17 +26,17 @@ import io.github.resilience4j.commons.configuration.util.TestConstants;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.configuration2.YAMLConfiguration;
-import org.apache.commons.configuration2.ex.ConfigurationException;
-import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.Map;
 
-public class CommonsConfigurationCircuitBreakerConfigurationTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommonsConfigurationCircuitBreakerConfigurationTest {
 
     @Test
-    public void testFromPropertiesFile() throws ConfigurationException {
+    void fromPropertiesFile() throws Exception {
         Configuration config = CommonsConfigurationUtil.getConfiguration(PropertiesConfiguration.class, TestConstants.RESILIENCE_CONFIG_PROPERTIES_FILE_NAME);
 
         CommonsConfigurationCircuitBreakerConfiguration commonsConfigurationCircuitBreakerConfiguration =
@@ -47,7 +47,7 @@ public class CommonsConfigurationCircuitBreakerConfigurationTest {
     }
 
     @Test
-    public void testFromYamlFile() throws ConfigurationException {
+    void fromYamlFile() throws Exception {
         Configuration config = CommonsConfigurationUtil.getConfiguration(YAMLConfiguration.class, TestConstants.RESILIENCE_CONFIG_YAML_FILE_NAME);
 
         CommonsConfigurationCircuitBreakerConfiguration commonsConfigurationCircuitBreakerConfiguration =
@@ -58,67 +58,69 @@ public class CommonsConfigurationCircuitBreakerConfigurationTest {
     }
 
     private static void assertConfigs(Map<String, CommonCircuitBreakerConfigurationProperties.InstanceProperties> config) {
-        Assertions.assertThat(config.size()).isEqualTo(2);
-        Assertions.assertThat(config.containsKey(TestConstants.DEFAULT)).isTrue();
+        assertThat(config)
+                .hasSize(2)
+                .containsKey(TestConstants.DEFAULT);
         assertConfigDefault(config.get(TestConstants.DEFAULT));
-        Assertions.assertThat(config.containsKey(TestConstants.SHARED)).isTrue();
+        assertThat(config).containsKey(TestConstants.SHARED);
         assertConfigShared(config.get(TestConstants.SHARED));
     }
 
     private static void assertConfigDefault(CommonCircuitBreakerConfigurationProperties.InstanceProperties configDefault) {
-        Assertions.assertThat(configDefault.getSlidingWindowSize()).isEqualTo(100);
-        Assertions.assertThat(configDefault.getPermittedNumberOfCallsInHalfOpenState()).isEqualTo(10);
-        Assertions.assertThat(configDefault.getWaitDurationInOpenState()).isEqualTo(Duration.ofMinutes(1));
-        Assertions.assertThat(configDefault.getFailureRateThreshold()).isEqualTo(50f);
-        Assertions.assertThat(configDefault.getSlowCallRateThreshold()).isEqualTo(50f);
-        Assertions.assertThat(configDefault.getSlowCallDurationThreshold()).isEqualTo(Duration.ofSeconds(2));
-        Assertions.assertThat(configDefault.getWritableStackTraceEnabled()).isEqualTo(true);
-        Assertions.assertThat(configDefault.getMaxWaitDurationInHalfOpenState()).isEqualTo(Duration.ofSeconds(10));
-        Assertions.assertThat(configDefault.getTransitionToStateAfterWaitDuration()).isEqualTo(CircuitBreaker.State.OPEN);
-        Assertions.assertThat(configDefault.getAutomaticTransitionFromOpenToHalfOpenEnabled()).isEqualTo(true);
-        Assertions.assertThat(configDefault.getInitialState()).isEqualTo(CircuitBreaker.State.CLOSED);
-        Assertions.assertThat(configDefault.getSlidingWindowType()).isEqualTo(CircuitBreakerConfig.SlidingWindowType.TIME_BASED);
-        Assertions.assertThat(configDefault.getMinimumNumberOfCalls()).isEqualTo(5);
-        Assertions.assertThat(configDefault.getEventConsumerBufferSize()).isEqualTo(10);
-        Assertions.assertThat(configDefault.getRegisterHealthIndicator()).isEqualTo(true);
-        Assertions.assertThat(configDefault.getRecordFailurePredicate()).isEqualTo(DummyPredicateThrowable.class);
-        Assertions.assertThat(configDefault.getRecordExceptions()).containsExactly(IllegalArgumentException.class, NullPointerException.class);
-        Assertions.assertThat(configDefault.getIgnoreExceptionPredicate()).isEqualTo(DummyPredicateThrowable.class);
-        Assertions.assertThat(configDefault.getIgnoreExceptions()).containsExactly(IllegalStateException.class, IndexOutOfBoundsException.class);
+        assertThat(configDefault.getSlidingWindowSize()).isEqualTo(100);
+        assertThat(configDefault.getPermittedNumberOfCallsInHalfOpenState()).isEqualTo(10);
+        assertThat(configDefault.getWaitDurationInOpenState()).isEqualTo(Duration.ofMinutes(1));
+        assertThat(configDefault.getFailureRateThreshold()).isEqualTo(50f);
+        assertThat(configDefault.getSlowCallRateThreshold()).isEqualTo(50f);
+        assertThat(configDefault.getSlowCallDurationThreshold()).isEqualTo(Duration.ofSeconds(2));
+        assertThat(configDefault.getWritableStackTraceEnabled()).isTrue();
+        assertThat(configDefault.getMaxWaitDurationInHalfOpenState()).isEqualTo(Duration.ofSeconds(10));
+        assertThat(configDefault.getTransitionToStateAfterWaitDuration()).isEqualTo(CircuitBreaker.State.OPEN);
+        assertThat(configDefault.getAutomaticTransitionFromOpenToHalfOpenEnabled()).isTrue();
+        assertThat(configDefault.getInitialState()).isEqualTo(CircuitBreaker.State.CLOSED);
+        assertThat(configDefault.getSlidingWindowType()).isEqualTo(CircuitBreakerConfig.SlidingWindowType.TIME_BASED);
+        assertThat(configDefault.getMinimumNumberOfCalls()).isEqualTo(5);
+        assertThat(configDefault.getEventConsumerBufferSize()).isEqualTo(10);
+        assertThat(configDefault.getRegisterHealthIndicator()).isTrue();
+        assertThat(configDefault.getRecordFailurePredicate()).isEqualTo(DummyPredicateThrowable.class);
+        assertThat(configDefault.getRecordExceptions()).containsExactly(IllegalArgumentException.class, NullPointerException.class);
+        assertThat(configDefault.getIgnoreExceptionPredicate()).isEqualTo(DummyPredicateThrowable.class);
+        assertThat(configDefault.getIgnoreExceptions()).containsExactly(IllegalStateException.class, IndexOutOfBoundsException.class);
     }
 
     private static void assertConfigShared(CommonCircuitBreakerConfigurationProperties.InstanceProperties configShared) {
-        Assertions.assertThat(configShared.getSlidingWindowType()).isEqualTo(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED);
-        Assertions.assertThat(configShared.getSlidingWindowSize()).isEqualTo(100);
-        Assertions.assertThat(configShared.getPermittedNumberOfCallsInHalfOpenState()).isEqualTo(30);
-        Assertions.assertThat(configShared.getWaitDurationInOpenState()).isEqualTo(Duration.ofSeconds(10));
-        Assertions.assertThat(configShared.getFailureRateThreshold()).isEqualTo(50f);
-        Assertions.assertThat(configShared.getEventConsumerBufferSize()).isEqualTo(10);
-        Assertions.assertThat(configShared.getIgnoreExceptions()).containsExactly(DummyIgnoredException.class);
+        assertThat(configShared.getSlidingWindowType()).isEqualTo(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED);
+        assertThat(configShared.getSlidingWindowSize()).isEqualTo(100);
+        assertThat(configShared.getPermittedNumberOfCallsInHalfOpenState()).isEqualTo(30);
+        assertThat(configShared.getWaitDurationInOpenState()).isEqualTo(Duration.ofSeconds(10));
+        assertThat(configShared.getFailureRateThreshold()).isEqualTo(50f);
+        assertThat(configShared.getEventConsumerBufferSize()).isEqualTo(10);
+        assertThat(configShared.getIgnoreExceptions()).containsExactly(DummyIgnoredException.class);
     }
 
     private static void assertInstances(Map<String, CommonCircuitBreakerConfigurationProperties.InstanceProperties> instances) {
-        Assertions.assertThat(instances.size()).isEqualTo(2);
-        Assertions.assertThat(instances.containsKey(TestConstants.BACKEND_A)).isTrue();
+        assertThat(instances)
+                .hasSize(2)
+                .containsKey(TestConstants.BACKEND_A);
         assertInstanceBackendA(instances.get(TestConstants.BACKEND_A));
         assertInstanceBackendB(instances.get(TestConstants.BACKEND_B));
     }
 
     private static void assertInstanceBackendA(CommonCircuitBreakerConfigurationProperties.InstanceProperties instanceBackendA) {
-        Assertions.assertThat(instanceBackendA.getBaseConfig()).isEqualTo(TestConstants.DEFAULT);
-        Assertions.assertThat(instanceBackendA.getWaitDurationInOpenState()).isEqualTo(Duration.ofSeconds(5));
+        assertThat(instanceBackendA.getBaseConfig()).isEqualTo(TestConstants.DEFAULT);
+        assertThat(instanceBackendA.getWaitDurationInOpenState()).isEqualTo(Duration.ofSeconds(5));
     }
 
     private static void assertInstanceBackendB(CommonCircuitBreakerConfigurationProperties.InstanceProperties instanceBackendB) {
-        Assertions.assertThat(instanceBackendB.getBaseConfig()).isEqualTo(TestConstants.SHARED);
-        Assertions.assertThat(instanceBackendB.getRegisterHealthIndicator()).isEqualTo(true);
-        Assertions.assertThat(instanceBackendB.getSlidingWindowSize()).isEqualTo(10);
-        Assertions.assertThat(instanceBackendB.getMinimumNumberOfCalls()).isEqualTo(10);
-        Assertions.assertThat(instanceBackendB.getFailureRateThreshold()).isEqualTo(60f);
-        Assertions.assertThat(instanceBackendB.getPermittedNumberOfCallsInHalfOpenState()).isEqualTo(3);
-        Assertions.assertThat(instanceBackendB.getWaitDurationInOpenState()).isEqualTo(Duration.ofSeconds(5));
-        Assertions.assertThat(instanceBackendB.getEventConsumerBufferSize()).isEqualTo(20);
-        Assertions.assertThat(instanceBackendB.getRecordFailurePredicate()).isEqualTo(DummyPredicateThrowable.class);
-        Assertions.assertThat(instanceBackendB.getInitialState()).isEqualTo(CircuitBreaker.State.METRICS_ONLY);
+        assertThat(instanceBackendB.getBaseConfig()).isEqualTo(TestConstants.SHARED);
+        assertThat(instanceBackendB.getRegisterHealthIndicator()).isTrue();
+        assertThat(instanceBackendB.getSlidingWindowSize()).isEqualTo(10);
+        assertThat(instanceBackendB.getMinimumNumberOfCalls()).isEqualTo(10);
+        assertThat(instanceBackendB.getFailureRateThreshold()).isEqualTo(60f);
+        assertThat(instanceBackendB.getPermittedNumberOfCallsInHalfOpenState()).isEqualTo(3);
+        assertThat(instanceBackendB.getWaitDurationInOpenState()).isEqualTo(Duration.ofSeconds(5));
+        assertThat(instanceBackendB.getEventConsumerBufferSize()).isEqualTo(20);
+        assertThat(instanceBackendB.getRecordFailurePredicate()).isEqualTo(DummyPredicateThrowable.class);
+        assertThat(instanceBackendB.getInitialState()).isEqualTo(CircuitBreaker.State.METRICS_ONLY);
     }
 }

--- a/resilience4j-commons-configuration/src/test/java/io/github/resilience4j/commons/configuration/circuitbreaker/configure/CommonsConfigurationCircuitBreakerRegistryTest.java
+++ b/resilience4j-commons-configuration/src/test/java/io/github/resilience4j/commons/configuration/circuitbreaker/configure/CommonsConfigurationCircuitBreakerRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023: Deepak Kumar
+ *   Copyright 2026: Deepak Kumar
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -23,31 +23,31 @@ import io.github.resilience4j.commons.configuration.util.TestConstants;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.configuration2.YAMLConfiguration;
-import org.apache.commons.configuration2.ex.ConfigurationException;
-import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-public class CommonsConfigurationCircuitBreakerRegistryTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommonsConfigurationCircuitBreakerRegistryTest {
 
     @Test
-    public void testCircuitBreakerRegistryFromPropertiesFile() throws ConfigurationException {
+    void circuitBreakerRegistryFromPropertiesFile() throws Exception {
         Configuration config = CommonsConfigurationUtil.getConfiguration(PropertiesConfiguration.class, TestConstants.RESILIENCE_CONFIG_PROPERTIES_FILE_NAME);
 
         CircuitBreakerRegistry circuitBreakerRegistry = CommonsConfigurationCircuitBreakerRegistry.of(config, new CompositeCustomizer<>(List.of()));
 
-        Assertions.assertThat(circuitBreakerRegistry.circuitBreaker(TestConstants.BACKEND_A).getName()).isEqualTo(TestConstants.BACKEND_A);
-        Assertions.assertThat(circuitBreakerRegistry.circuitBreaker(TestConstants.BACKEND_B).getName()).isEqualTo(TestConstants.BACKEND_B);
+        assertThat(circuitBreakerRegistry.circuitBreaker(TestConstants.BACKEND_A).getName()).isEqualTo(TestConstants.BACKEND_A);
+        assertThat(circuitBreakerRegistry.circuitBreaker(TestConstants.BACKEND_B).getName()).isEqualTo(TestConstants.BACKEND_B);
     }
 
     @Test
-    public void testCircuitBreakerRegistryFromYamlFile() throws ConfigurationException {
+    void circuitBreakerRegistryFromYamlFile() throws Exception {
         Configuration config = CommonsConfigurationUtil.getConfiguration(YAMLConfiguration.class, TestConstants.RESILIENCE_CONFIG_YAML_FILE_NAME);
 
         CircuitBreakerRegistry circuitBreakerRegistry = CommonsConfigurationCircuitBreakerRegistry.of(config, new CompositeCustomizer<>(List.of()));
 
-        Assertions.assertThat(circuitBreakerRegistry.circuitBreaker(TestConstants.BACKEND_A).getName()).isEqualTo(TestConstants.BACKEND_A);
-        Assertions.assertThat(circuitBreakerRegistry.circuitBreaker(TestConstants.BACKEND_B).getName()).isEqualTo(TestConstants.BACKEND_B);
+        assertThat(circuitBreakerRegistry.circuitBreaker(TestConstants.BACKEND_A).getName()).isEqualTo(TestConstants.BACKEND_A);
+        assertThat(circuitBreakerRegistry.circuitBreaker(TestConstants.BACKEND_B).getName()).isEqualTo(TestConstants.BACKEND_B);
     }
 }

--- a/resilience4j-commons-configuration/src/test/java/io/github/resilience4j/commons/configuration/ratelimiter/configure/CommonsConfigurationRateLimiterConfigurationTest.java
+++ b/resilience4j-commons-configuration/src/test/java/io/github/resilience4j/commons/configuration/ratelimiter/configure/CommonsConfigurationRateLimiterConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023: Deepak Kumar
+ *   Copyright 2026: Deepak Kumar
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -22,16 +22,16 @@ import io.github.resilience4j.commons.configuration.util.TestConstants;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.configuration2.YAMLConfiguration;
-import org.apache.commons.configuration2.ex.ConfigurationException;
-import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.Map;
 
-public class CommonsConfigurationRateLimiterConfigurationTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommonsConfigurationRateLimiterConfigurationTest {
     @Test
-    public void testFromPropertiesFile() throws ConfigurationException {
+    void fromPropertiesFile() throws Exception {
         Configuration config = CommonsConfigurationUtil.getConfiguration(PropertiesConfiguration.class, TestConstants.RESILIENCE_CONFIG_PROPERTIES_FILE_NAME);
 
         CommonsConfigurationRateLimiterConfiguration bulkHeadConfiguration  = CommonsConfigurationRateLimiterConfiguration.of(config);
@@ -41,7 +41,7 @@ public class CommonsConfigurationRateLimiterConfigurationTest {
     }
 
     @Test
-    public void testFromYamlFile() throws ConfigurationException {
+    void fromYamlFile() throws Exception {
         Configuration config = CommonsConfigurationUtil.getConfiguration(YAMLConfiguration.class, TestConstants.RESILIENCE_CONFIG_YAML_FILE_NAME);
 
         CommonsConfigurationRateLimiterConfiguration bulkHeadConfiguration  = CommonsConfigurationRateLimiterConfiguration.of(config);
@@ -51,52 +51,54 @@ public class CommonsConfigurationRateLimiterConfigurationTest {
     }
 
     private void assertConfigs(Map<String, CommonRateLimiterConfigurationProperties.InstanceProperties> config) {
-        Assertions.assertThat(config.size()).isEqualTo(1);
-        Assertions.assertThat(config.containsKey(TestConstants.DEFAULT)).isTrue();
+        assertThat(config)
+                .hasSize(1)
+                .containsKey(TestConstants.DEFAULT);
         assertConfigDefault(config.get(TestConstants.DEFAULT));
     }
 
     private void assertInstances(Map<String, CommonRateLimiterConfigurationProperties.InstanceProperties> instances) {
-        Assertions.assertThat(instances.size()).isEqualTo(2);
-        Assertions.assertThat(instances.containsKey(TestConstants.BACKEND_A)).isTrue();
-        Assertions.assertThat(instances.containsKey(TestConstants.BACKEND_B)).isTrue();
+        assertThat(instances)
+                .hasSize(2)
+                .containsKey(TestConstants.BACKEND_A)
+                .containsKey(TestConstants.BACKEND_B);
         assertInstanceBackendA(instances.get(TestConstants.BACKEND_A));
         assertInstanceBackendB(instances.get(TestConstants.BACKEND_B));
     }
 
     private void assertConfigDefault(CommonRateLimiterConfigurationProperties.InstanceProperties configDefault) {
-        Assertions.assertThat(configDefault.getLimitForPeriod()).isEqualTo(10);
-        Assertions.assertThat(configDefault.getLimitRefreshPeriod()).isEqualTo(Duration.ofSeconds(1));
-        Assertions.assertThat(configDefault.getTimeoutDuration()).isEqualTo(Duration.ofSeconds(10));
-        Assertions.assertThat(configDefault.getSubscribeForEvents()).isNull();
-        Assertions.assertThat(configDefault.getAllowHealthIndicatorToFail()).isNull();
-        Assertions.assertThat(configDefault.getRegisterHealthIndicator()).isFalse();
-        Assertions.assertThat(configDefault.getEventConsumerBufferSize()).isEqualTo(100);
-        Assertions.assertThat(configDefault.getWritableStackTraceEnabled()).isNull();
+        assertThat(configDefault.getLimitForPeriod()).isEqualTo(10);
+        assertThat(configDefault.getLimitRefreshPeriod()).isEqualTo(Duration.ofSeconds(1));
+        assertThat(configDefault.getTimeoutDuration()).isEqualTo(Duration.ofSeconds(10));
+        assertThat(configDefault.getSubscribeForEvents()).isNull();
+        assertThat(configDefault.getAllowHealthIndicatorToFail()).isNull();
+        assertThat(configDefault.getRegisterHealthIndicator()).isFalse();
+        assertThat(configDefault.getEventConsumerBufferSize()).isEqualTo(100);
+        assertThat(configDefault.getWritableStackTraceEnabled()).isNull();
 
     }
 
     private void assertInstanceBackendA(CommonRateLimiterConfigurationProperties.InstanceProperties instanceBackendA) {
-        Assertions.assertThat(instanceBackendA.getBaseConfig()).isEqualTo(TestConstants.DEFAULT);
-        Assertions.assertThat(instanceBackendA.getLimitForPeriod()).isNull();
-        Assertions.assertThat(instanceBackendA.getLimitRefreshPeriod()).isNull();
-        Assertions.assertThat(instanceBackendA.getTimeoutDuration()).isNull();
-        Assertions.assertThat(instanceBackendA.getSubscribeForEvents()).isNull();
-        Assertions.assertThat(instanceBackendA.getAllowHealthIndicatorToFail()).isNull();
-        Assertions.assertThat(instanceBackendA.getRegisterHealthIndicator()).isNull();
-        Assertions.assertThat(instanceBackendA.getEventConsumerBufferSize()).isNull();
-        Assertions.assertThat(instanceBackendA.getWritableStackTraceEnabled()).isNull();
+        assertThat(instanceBackendA.getBaseConfig()).isEqualTo(TestConstants.DEFAULT);
+        assertThat(instanceBackendA.getLimitForPeriod()).isNull();
+        assertThat(instanceBackendA.getLimitRefreshPeriod()).isNull();
+        assertThat(instanceBackendA.getTimeoutDuration()).isNull();
+        assertThat(instanceBackendA.getSubscribeForEvents()).isNull();
+        assertThat(instanceBackendA.getAllowHealthIndicatorToFail()).isNull();
+        assertThat(instanceBackendA.getRegisterHealthIndicator()).isNull();
+        assertThat(instanceBackendA.getEventConsumerBufferSize()).isNull();
+        assertThat(instanceBackendA.getWritableStackTraceEnabled()).isNull();
     }
 
     private void assertInstanceBackendB(CommonRateLimiterConfigurationProperties.InstanceProperties instanceBackendB) {
-        Assertions.assertThat(instanceBackendB.getBaseConfig()).isNull();
-        Assertions.assertThat(instanceBackendB.getLimitForPeriod()).isEqualTo(6);
-        Assertions.assertThat(instanceBackendB.getLimitRefreshPeriod()).isEqualTo(Duration.ofMillis(500));
-        Assertions.assertThat(instanceBackendB.getTimeoutDuration()).isEqualTo(Duration.ofSeconds(3));
-        Assertions.assertThat(instanceBackendB.getSubscribeForEvents()).isTrue();
-        Assertions.assertThat(instanceBackendB.getAllowHealthIndicatorToFail()).isFalse();
-        Assertions.assertThat(instanceBackendB.getRegisterHealthIndicator()).isTrue();
-        Assertions.assertThat(instanceBackendB.getEventConsumerBufferSize()).isEqualTo(10);
-        Assertions.assertThat(instanceBackendB.getWritableStackTraceEnabled()).isFalse();
+        assertThat(instanceBackendB.getBaseConfig()).isNull();
+        assertThat(instanceBackendB.getLimitForPeriod()).isEqualTo(6);
+        assertThat(instanceBackendB.getLimitRefreshPeriod()).isEqualTo(Duration.ofMillis(500));
+        assertThat(instanceBackendB.getTimeoutDuration()).isEqualTo(Duration.ofSeconds(3));
+        assertThat(instanceBackendB.getSubscribeForEvents()).isTrue();
+        assertThat(instanceBackendB.getAllowHealthIndicatorToFail()).isFalse();
+        assertThat(instanceBackendB.getRegisterHealthIndicator()).isTrue();
+        assertThat(instanceBackendB.getEventConsumerBufferSize()).isEqualTo(10);
+        assertThat(instanceBackendB.getWritableStackTraceEnabled()).isFalse();
     }
 }

--- a/resilience4j-commons-configuration/src/test/java/io/github/resilience4j/commons/configuration/ratelimiter/configure/CommonsConfigurationRateLimiterRegistryTest.java
+++ b/resilience4j-commons-configuration/src/test/java/io/github/resilience4j/commons/configuration/ratelimiter/configure/CommonsConfigurationRateLimiterRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023: Deepak Kumar
+ *   Copyright 2026: Deepak Kumar
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -23,30 +23,30 @@ import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.configuration2.YAMLConfiguration;
-import org.apache.commons.configuration2.ex.ConfigurationException;
-import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-public class CommonsConfigurationRateLimiterRegistryTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommonsConfigurationRateLimiterRegistryTest {
     @Test
-    public void testRateLimiterRegistryFromPropertiesFile() throws ConfigurationException {
+    void rateLimiterRegistryFromPropertiesFile() throws Exception {
         Configuration config = CommonsConfigurationUtil.getConfiguration(PropertiesConfiguration.class, TestConstants.RESILIENCE_CONFIG_PROPERTIES_FILE_NAME);
 
         RateLimiterRegistry registry = CommonsConfigurationRateLimiterRegistry.of(config, new CompositeCustomizer<>(List.of()));
 
-        Assertions.assertThat(registry.rateLimiter(TestConstants.BACKEND_A).getName()).isEqualTo(TestConstants.BACKEND_A);
-        Assertions.assertThat(registry.rateLimiter(TestConstants.BACKEND_B).getName()).isEqualTo(TestConstants.BACKEND_B);
+        assertThat(registry.rateLimiter(TestConstants.BACKEND_A).getName()).isEqualTo(TestConstants.BACKEND_A);
+        assertThat(registry.rateLimiter(TestConstants.BACKEND_B).getName()).isEqualTo(TestConstants.BACKEND_B);
     }
 
     @Test
-    public void testRateLimiterRegistryFromYamlFile() throws ConfigurationException {
+    void rateLimiterRegistryFromYamlFile() throws Exception {
         Configuration config = CommonsConfigurationUtil.getConfiguration(YAMLConfiguration.class, TestConstants.RESILIENCE_CONFIG_YAML_FILE_NAME);
 
         RateLimiterRegistry registry = CommonsConfigurationRateLimiterRegistry.of(config, new CompositeCustomizer<>(List.of()));
 
-        Assertions.assertThat(registry.rateLimiter(TestConstants.BACKEND_A).getName()).isEqualTo(TestConstants.BACKEND_A);
-        Assertions.assertThat(registry.rateLimiter(TestConstants.BACKEND_B).getName()).isEqualTo(TestConstants.BACKEND_B);
+        assertThat(registry.rateLimiter(TestConstants.BACKEND_A).getName()).isEqualTo(TestConstants.BACKEND_A);
+        assertThat(registry.rateLimiter(TestConstants.BACKEND_B).getName()).isEqualTo(TestConstants.BACKEND_B);
     }
 }

--- a/resilience4j-commons-configuration/src/test/java/io/github/resilience4j/commons/configuration/retry/configure/CommonsConfigurationRetryConfigurationTest.java
+++ b/resilience4j-commons-configuration/src/test/java/io/github/resilience4j/commons/configuration/retry/configure/CommonsConfigurationRetryConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023: Deepak Kumar
+ *   Copyright 2026: Deepak Kumar
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -25,19 +25,19 @@ import io.github.resilience4j.commons.configuration.util.TestConstants;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.configuration2.YAMLConfiguration;
-import org.apache.commons.configuration2.ex.ConfigurationException;
-import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
-public class CommonsConfigurationRetryConfigurationTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommonsConfigurationRetryConfigurationTest {
 
     @Test
-    public void testFromPropertiesFile() throws ConfigurationException {
+    void fromPropertiesFile() throws Exception {
         Configuration config = CommonsConfigurationUtil.getConfiguration(PropertiesConfiguration.class, TestConstants.RESILIENCE_CONFIG_PROPERTIES_FILE_NAME);
 
         CommonsConfigurationRetryConfiguration retryConfiguration = CommonsConfigurationRetryConfiguration.of(config);
@@ -47,7 +47,7 @@ public class CommonsConfigurationRetryConfigurationTest {
     }
 
     @Test
-    public void testFromYamlFile() throws ConfigurationException {
+    void fromYamlFile() throws Exception {
         Configuration config = CommonsConfigurationUtil.getConfiguration(YAMLConfiguration.class, TestConstants.RESILIENCE_CONFIG_YAML_FILE_NAME);
 
         CommonsConfigurationRetryConfiguration retryConfiguration = CommonsConfigurationRetryConfiguration.of(config);
@@ -57,49 +57,51 @@ public class CommonsConfigurationRetryConfigurationTest {
     }
 
     private void assertConfigs(Map<String, CommonRetryConfigurationProperties.InstanceProperties> configs) {
-        Assertions.assertThat(configs.size()).isEqualTo(1);
-        Assertions.assertThat(configs.containsKey(TestConstants.DEFAULT)).isTrue();
+        assertThat(configs)
+                .hasSize(1)
+                .containsKey(TestConstants.DEFAULT);
         assertConfigDefault(configs.get(TestConstants.DEFAULT));
     }
 
     private void assertConfigDefault(CommonRetryConfigurationProperties.InstanceProperties instanceProperties) {
-        Assertions.assertThat(instanceProperties.getMaxAttempts()).isEqualTo(3);
-        Assertions.assertThat(instanceProperties.getWaitDuration()).isEqualTo(Duration.ofSeconds(10));
-        Assertions.assertThat(instanceProperties.getRetryExceptions()).containsExactlyInAnyOrder(TimeoutException.class,
+        assertThat(instanceProperties.getMaxAttempts()).isEqualTo(3);
+        assertThat(instanceProperties.getWaitDuration()).isEqualTo(Duration.ofSeconds(10));
+        assertThat(instanceProperties.getRetryExceptions()).containsExactlyInAnyOrder(TimeoutException.class,
                 IOException.class);
-        Assertions.assertThat(instanceProperties.getIgnoreExceptions()).containsExactlyInAnyOrder(DummyIgnoredException.class, RuntimeException.class);
+        assertThat(instanceProperties.getIgnoreExceptions()).containsExactlyInAnyOrder(DummyIgnoredException.class, RuntimeException.class);
     }
 
     private void assertInstances(Map<String, CommonRetryConfigurationProperties.InstanceProperties> instances) {
-        Assertions.assertThat(instances.size()).isEqualTo(2);
-        Assertions.assertThat(instances.containsKey(TestConstants.BACKEND_A)).isTrue();
-        Assertions.assertThat(instances.containsKey(TestConstants.BACKEND_B)).isTrue();
+        assertThat(instances)
+                .hasSize(2)
+                .containsKey(TestConstants.BACKEND_A)
+                .containsKey(TestConstants.BACKEND_B);
         assertInstanceBackendA(instances.get(TestConstants.BACKEND_A));
         assertInstanceBackendB(instances.get(TestConstants.BACKEND_B));
     }
 
     private void assertInstanceBackendA(CommonRetryConfigurationProperties.InstanceProperties instanceBackendA) {
-        Assertions.assertThat(instanceBackendA.getBaseConfig()).isEqualTo(TestConstants.DEFAULT);
-        Assertions.assertThat(instanceBackendA.getMaxAttempts()).isNull();
-        Assertions.assertThat(instanceBackendA.getWaitDuration()).isNull();
-        Assertions.assertThat(instanceBackendA.getIgnoreExceptions()).isNull();
-        Assertions.assertThat(instanceBackendA.getRetryExceptions()).isNull();
+        assertThat(instanceBackendA.getBaseConfig()).isEqualTo(TestConstants.DEFAULT);
+        assertThat(instanceBackendA.getMaxAttempts()).isNull();
+        assertThat(instanceBackendA.getWaitDuration()).isNull();
+        assertThat(instanceBackendA.getIgnoreExceptions()).isNull();
+        assertThat(instanceBackendA.getRetryExceptions()).isNull();
         ;
     }
 
     private void assertInstanceBackendB(CommonRetryConfigurationProperties.InstanceProperties instanceBackendB) {
-        Assertions.assertThat(instanceBackendB.getBaseConfig()).isNull();
-        Assertions.assertThat(instanceBackendB.getMaxAttempts()).isEqualTo(5);
-        Assertions.assertThat(instanceBackendB.getRetryExceptionPredicate()).isEqualTo(DummyPredicateThrowable.class);
-        Assertions.assertThat(instanceBackendB.getResultPredicate()).isEqualTo(DummyPredicateObject.class);
-        Assertions.assertThat(instanceBackendB.getRetryExceptions()).containsExactlyInAnyOrder(TimeoutException.class, IOException.class);
-        Assertions.assertThat(instanceBackendB.getIgnoreExceptions()).containsExactlyInAnyOrder(DummyIgnoredException.class, RuntimeException.class);
-        Assertions.assertThat(instanceBackendB.getEventConsumerBufferSize()).isEqualTo(10);
-        Assertions.assertThat(instanceBackendB.getEnableExponentialBackoff()).isTrue();
-        Assertions.assertThat(instanceBackendB.getExponentialBackoffMultiplier()).isEqualTo(2);
-        Assertions.assertThat(instanceBackendB.getExponentialMaxWaitDuration()).isEqualTo(Duration.ofSeconds(10));
-        Assertions.assertThat(instanceBackendB.getEnableRandomizedWait()).isFalse();
-        Assertions.assertThat(instanceBackendB.getFailAfterMaxAttempts()).isTrue();
+        assertThat(instanceBackendB.getBaseConfig()).isNull();
+        assertThat(instanceBackendB.getMaxAttempts()).isEqualTo(5);
+        assertThat(instanceBackendB.getRetryExceptionPredicate()).isEqualTo(DummyPredicateThrowable.class);
+        assertThat(instanceBackendB.getResultPredicate()).isEqualTo(DummyPredicateObject.class);
+        assertThat(instanceBackendB.getRetryExceptions()).containsExactlyInAnyOrder(TimeoutException.class, IOException.class);
+        assertThat(instanceBackendB.getIgnoreExceptions()).containsExactlyInAnyOrder(DummyIgnoredException.class, RuntimeException.class);
+        assertThat(instanceBackendB.getEventConsumerBufferSize()).isEqualTo(10);
+        assertThat(instanceBackendB.getEnableExponentialBackoff()).isTrue();
+        assertThat(instanceBackendB.getExponentialBackoffMultiplier()).isEqualTo(2);
+        assertThat(instanceBackendB.getExponentialMaxWaitDuration()).isEqualTo(Duration.ofSeconds(10));
+        assertThat(instanceBackendB.getEnableRandomizedWait()).isFalse();
+        assertThat(instanceBackendB.getFailAfterMaxAttempts()).isTrue();
     }
 
 

--- a/resilience4j-commons-configuration/src/test/java/io/github/resilience4j/commons/configuration/retry/configure/CommonsConfigurationRetryRegistryTest.java
+++ b/resilience4j-commons-configuration/src/test/java/io/github/resilience4j/commons/configuration/retry/configure/CommonsConfigurationRetryRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023: Deepak Kumar
+ *   Copyright 2026: Deepak Kumar
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -23,31 +23,31 @@ import io.github.resilience4j.retry.RetryRegistry;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.configuration2.YAMLConfiguration;
-import org.apache.commons.configuration2.ex.ConfigurationException;
-import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-public class CommonsConfigurationRetryRegistryTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommonsConfigurationRetryRegistryTest {
 
     @Test
-    public void testRetryRegistryFromPropertiesFile() throws ConfigurationException {
+    void retryRegistryFromPropertiesFile() throws Exception {
         Configuration config = CommonsConfigurationUtil.getConfiguration(PropertiesConfiguration.class, TestConstants.RESILIENCE_CONFIG_PROPERTIES_FILE_NAME);
 
         RetryRegistry registry = CommonsConfigurationRetryRegistry.of(config, new CompositeCustomizer<>(List.of()));
 
-        Assertions.assertThat(registry.retry(TestConstants.BACKEND_A).getName()).isEqualTo(TestConstants.BACKEND_A);
-        Assertions.assertThat(registry.retry(TestConstants.BACKEND_B).getName()).isEqualTo(TestConstants.BACKEND_B);
+        assertThat(registry.retry(TestConstants.BACKEND_A).getName()).isEqualTo(TestConstants.BACKEND_A);
+        assertThat(registry.retry(TestConstants.BACKEND_B).getName()).isEqualTo(TestConstants.BACKEND_B);
     }
 
     @Test
-    public void testRetryRegistryFromYamlFile() throws ConfigurationException {
+    void retryRegistryFromYamlFile() throws Exception {
         Configuration config = CommonsConfigurationUtil.getConfiguration(YAMLConfiguration.class, TestConstants.RESILIENCE_CONFIG_YAML_FILE_NAME);
 
         RetryRegistry registry = CommonsConfigurationRetryRegistry.of(config, new CompositeCustomizer<>(List.of()));
 
-        Assertions.assertThat(registry.retry(TestConstants.BACKEND_A).getName()).isEqualTo(TestConstants.BACKEND_A);
-        Assertions.assertThat(registry.retry(TestConstants.BACKEND_B).getName()).isEqualTo(TestConstants.BACKEND_B);
+        assertThat(registry.retry(TestConstants.BACKEND_A).getName()).isEqualTo(TestConstants.BACKEND_A);
+        assertThat(registry.retry(TestConstants.BACKEND_B).getName()).isEqualTo(TestConstants.BACKEND_B);
     }
 }

--- a/resilience4j-commons-configuration/src/test/java/io/github/resilience4j/commons/configuration/timelimiter/configure/CommonsConfigurationTimeLimiterConfigurationTest.java
+++ b/resilience4j-commons-configuration/src/test/java/io/github/resilience4j/commons/configuration/timelimiter/configure/CommonsConfigurationTimeLimiterConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023: Deepak Kumar
+ *   Copyright 2026: Deepak Kumar
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -22,16 +22,16 @@ import io.github.resilience4j.commons.configuration.util.TestConstants;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.configuration2.YAMLConfiguration;
-import org.apache.commons.configuration2.ex.ConfigurationException;
-import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.Map;
 
-public class CommonsConfigurationTimeLimiterConfigurationTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommonsConfigurationTimeLimiterConfigurationTest {
     @Test
-    public void testFromPropertiesFile() throws ConfigurationException {
+    void fromPropertiesFile() throws Exception {
         Configuration config = CommonsConfigurationUtil.getConfiguration(PropertiesConfiguration.class, TestConstants.RESILIENCE_CONFIG_PROPERTIES_FILE_NAME);
 
         CommonsConfigurationTimeLimiterConfiguration timeLimiterConfiguration  = CommonsConfigurationTimeLimiterConfiguration.of(config);
@@ -41,7 +41,7 @@ public class CommonsConfigurationTimeLimiterConfigurationTest {
     }
 
     @Test
-    public void testFromYamlFile() throws ConfigurationException {
+    void fromYamlFile() throws Exception {
         Configuration config = CommonsConfigurationUtil.getConfiguration(YAMLConfiguration.class, TestConstants.RESILIENCE_CONFIG_YAML_FILE_NAME);
 
         CommonsConfigurationTimeLimiterConfiguration timeLimiterConfiguration  = CommonsConfigurationTimeLimiterConfiguration.of(config);
@@ -51,36 +51,38 @@ public class CommonsConfigurationTimeLimiterConfigurationTest {
     }
 
     private void assertConfigs(Map<String, CommonTimeLimiterConfigurationProperties.InstanceProperties> config) {
-        Assertions.assertThat(config.size()).isEqualTo(1);
-        Assertions.assertThat(config.containsKey(TestConstants.DEFAULT)).isTrue();
+        assertThat(config)
+                .hasSize(1)
+                .containsKey(TestConstants.DEFAULT);
         assertConfigDefault(config.get(TestConstants.DEFAULT));
     }
 
     private void assertConfigDefault(CommonTimeLimiterConfigurationProperties.InstanceProperties configDefault) {
-        Assertions.assertThat(configDefault.getTimeoutDuration()).isEqualTo(Duration.ofSeconds(10));
-        Assertions.assertThat(configDefault.getCancelRunningFuture()).isTrue();
-        Assertions.assertThat(configDefault.getEventConsumerBufferSize()).isEqualTo(100);
+        assertThat(configDefault.getTimeoutDuration()).isEqualTo(Duration.ofSeconds(10));
+        assertThat(configDefault.getCancelRunningFuture()).isTrue();
+        assertThat(configDefault.getEventConsumerBufferSize()).isEqualTo(100);
     }
 
     private void assertInstances(Map<String, CommonTimeLimiterConfigurationProperties.InstanceProperties> instances) {
-        Assertions.assertThat(instances.size()).isEqualTo(2);
-        Assertions.assertThat(instances.containsKey(TestConstants.BACKEND_A)).isTrue();
-        Assertions.assertThat(instances.containsKey(TestConstants.BACKEND_B)).isTrue();
+        assertThat(instances)
+                .hasSize(2)
+                .containsKey(TestConstants.BACKEND_A)
+                .containsKey(TestConstants.BACKEND_B);
         assertInstanceBackendA(instances.get(TestConstants.BACKEND_A));
         assertInstanceBackendB(instances.get(TestConstants.BACKEND_B));
     }
 
     private void assertInstanceBackendA(CommonTimeLimiterConfigurationProperties.InstanceProperties instanceBackendA) {
-        Assertions.assertThat(instanceBackendA.getBaseConfig()).isEqualTo(TestConstants.DEFAULT);
-        Assertions.assertThat(instanceBackendA.getTimeoutDuration()).isEqualTo(Duration.ofSeconds(5));
-        Assertions.assertThat(instanceBackendA.getCancelRunningFuture()).isNull();
-        Assertions.assertThat(instanceBackendA.getEventConsumerBufferSize()).isNull();
+        assertThat(instanceBackendA.getBaseConfig()).isEqualTo(TestConstants.DEFAULT);
+        assertThat(instanceBackendA.getTimeoutDuration()).isEqualTo(Duration.ofSeconds(5));
+        assertThat(instanceBackendA.getCancelRunningFuture()).isNull();
+        assertThat(instanceBackendA.getEventConsumerBufferSize()).isNull();
     }
 
     private void assertInstanceBackendB(CommonTimeLimiterConfigurationProperties.InstanceProperties instanceBackendB) {
-        Assertions.assertThat(instanceBackendB.getBaseConfig()).isNull();
-        Assertions.assertThat(instanceBackendB.getTimeoutDuration()).isEqualTo(Duration.ofSeconds(15));
-        Assertions.assertThat(instanceBackendB.getCancelRunningFuture()).isFalse();
-        Assertions.assertThat(instanceBackendB.getEventConsumerBufferSize()).isEqualTo(10);
+        assertThat(instanceBackendB.getBaseConfig()).isNull();
+        assertThat(instanceBackendB.getTimeoutDuration()).isEqualTo(Duration.ofSeconds(15));
+        assertThat(instanceBackendB.getCancelRunningFuture()).isFalse();
+        assertThat(instanceBackendB.getEventConsumerBufferSize()).isEqualTo(10);
     }
 }

--- a/resilience4j-commons-configuration/src/test/java/io/github/resilience4j/commons/configuration/timelimiter/configure/CommonsConfigurationTimeLimiterRegistryTest.java
+++ b/resilience4j-commons-configuration/src/test/java/io/github/resilience4j/commons/configuration/timelimiter/configure/CommonsConfigurationTimeLimiterRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023: Deepak Kumar
+ *   Copyright 2026: Deepak Kumar
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -23,30 +23,30 @@ import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.configuration2.YAMLConfiguration;
-import org.apache.commons.configuration2.ex.ConfigurationException;
-import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-public class CommonsConfigurationTimeLimiterRegistryTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommonsConfigurationTimeLimiterRegistryTest {
     @Test
-    public void testRateLimiterRegistryFromPropertiesFile() throws ConfigurationException {
+    void rateLimiterRegistryFromPropertiesFile() throws Exception {
         Configuration config = CommonsConfigurationUtil.getConfiguration(PropertiesConfiguration.class, TestConstants.RESILIENCE_CONFIG_PROPERTIES_FILE_NAME);
 
         TimeLimiterRegistry registry = CommonsConfigurationTimeLimiterRegistry.of(config, new CompositeCustomizer<>(List.of()));
 
-        Assertions.assertThat(registry.timeLimiter(TestConstants.BACKEND_A).getName()).isEqualTo(TestConstants.BACKEND_A);
-        Assertions.assertThat(registry.timeLimiter(TestConstants.BACKEND_B).getName()).isEqualTo(TestConstants.BACKEND_B);
+        assertThat(registry.timeLimiter(TestConstants.BACKEND_A).getName()).isEqualTo(TestConstants.BACKEND_A);
+        assertThat(registry.timeLimiter(TestConstants.BACKEND_B).getName()).isEqualTo(TestConstants.BACKEND_B);
     }
 
     @Test
-    public void testRateLimiterRegistryFromYamlFile() throws ConfigurationException {
+    void rateLimiterRegistryFromYamlFile() throws Exception {
         Configuration config = CommonsConfigurationUtil.getConfiguration(YAMLConfiguration.class, TestConstants.RESILIENCE_CONFIG_YAML_FILE_NAME);
 
         TimeLimiterRegistry registry = CommonsConfigurationTimeLimiterRegistry.of(config, new CompositeCustomizer<>(List.of()));
 
-        Assertions.assertThat(registry.timeLimiter(TestConstants.BACKEND_A).getName()).isEqualTo(TestConstants.BACKEND_A);
-        Assertions.assertThat(registry.timeLimiter(TestConstants.BACKEND_B).getName()).isEqualTo(TestConstants.BACKEND_B);
+        assertThat(registry.timeLimiter(TestConstants.BACKEND_A).getName()).isEqualTo(TestConstants.BACKEND_A);
+        assertThat(registry.timeLimiter(TestConstants.BACKEND_B).getName()).isEqualTo(TestConstants.BACKEND_B);
     }
 }

--- a/resilience4j-commons-configuration/src/test/java/io/github/resilience4j/commons/configuration/util/ClassParseUtilTest.java
+++ b/resilience4j-commons-configuration/src/test/java/io/github/resilience4j/commons/configuration/util/ClassParseUtilTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023: Deepak Kumar
+ *   Copyright 2026: Deepak Kumar
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -18,43 +18,44 @@ package io.github.resilience4j.commons.configuration.util;
 
 import io.github.resilience4j.commons.configuration.dummy.DummyPredicateThrowable;
 import io.github.resilience4j.commons.configuration.exception.ConfigParseException;
-import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import java.util.function.Predicate;
 
-public class ClassParseUtilTest {
+class ClassParseUtilTest {
     @Test
-    public void testConvertStringsToClassesList() {
+    void convertStringsToClassesList() {
         List<String> recordExceptionsList = List.of("java.lang.Exception", "java.lang.RuntimeException");
 
         Class<? extends Throwable>[] recordExceptions = ClassParseUtil
                 .convertStringListToClassTypeArray(recordExceptionsList, Throwable.class);
 
-        Assertions.assertThat(recordExceptions).containsExactlyInAnyOrder(Exception.class, RuntimeException.class);
+        assertThat(recordExceptions).containsExactlyInAnyOrder(Exception.class, RuntimeException.class);
     }
 
     @Test
-    public void testConvertStringToClass() {
+    void convertStringToClass() {
         Class<? extends Throwable> clazz = ClassParseUtil.convertStringToClassType("java.lang.Exception", Throwable.class);
 
-        Assertions.assertThat(clazz).isEqualTo(Exception.class);
+        assertThat(clazz).isEqualTo(Exception.class);
     }
 
     @Test
-    public void testConvertPredicate() {
+    void convertPredicate() {
         String predicateString = "io.github.resilience4j.commons.configuration.dummy.DummyPredicateThrowable";
 
         Class<Predicate<Throwable>> clazz = (Class<Predicate<Throwable>>) ClassParseUtil.convertStringToClassType(predicateString, Predicate.class);
 
-        Assertions.assertThat(clazz).isEqualTo(DummyPredicateThrowable.class);
+        assertThat(clazz).isEqualTo(DummyPredicateThrowable.class);
     }
 
-    @Test(expected = ConfigParseException.class)
-    public void testConvertPredicateInvalidType() {
-        String predicateString = "java.lang.Exception";
-
-        ClassParseUtil.convertStringToClassType(predicateString, Predicate.class);
+    @Test
+    void convertPredicateInvalidType() {
+        assertThatThrownBy(() -> ClassParseUtil.convertStringToClassType("java.lang.Exception", Predicate.class))
+            .isInstanceOf(ConfigParseException.class);
     }
 }

--- a/resilience4j-commons-configuration/src/test/java/io/github/resilience4j/commons/configuration/util/StringParseUtilTest.java
+++ b/resilience4j-commons-configuration/src/test/java/io/github/resilience4j/commons/configuration/util/StringParseUtilTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023: Deepak Kumar
+ *   Copyright 2026: Deepak Kumar
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -16,20 +16,21 @@
 
 package io.github.resilience4j.commons.configuration.util;
 
-import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-public class StringParseUtilTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StringParseUtilTest {
     @Test
-    public void testExtractUniquePrefixes() {
+    void extractUniquePrefixes() {
         Iterator<String> iterator = List.of("backendA.circuitBreaker.test1", "backendA.circuitBreaker.test2", "backendB.circuitBreaker.test3").iterator();
 
         Set<String> prefixes = StringParseUtil.extractUniquePrefixes(iterator, ".");
 
-        Assertions.assertThat(prefixes).containsExactlyInAnyOrder("backendA", "backendB");
+        assertThat(prefixes).containsExactlyInAnyOrder("backendA", "backendB");
     }
 }


### PR DESCRIPTION
## Changes

* Migrated JUnit 4.13 annotations to Junit Jupiter equivalents
* Applied OpenRewrite recipes
    * [JUnit 6 best practices](https://docs.openrewrite.org/recipes/java/testing/junit/junit6bestpractices)
    * [Mockito best practices](https://docs.openrewrite.org/recipes/java/testing/mockito/mockitobestpractices)
    * [Migrate JUnit asserts to AssertJ](https://docs.openrewrite.org/recipes/java/testing/assertj/junittoassertj)
    * [AssertJ best practices](https://docs.openrewrite.org/recipes/java/testing/assertj/assertj-best-practices)
* Removed `public` modifiers
* Removed outdated `test*` prefix
* Converted `try/catch/fail` blocks to `assertThatThrownBy`
* Updated Copyright to 2026
## Coverage

| Metric      | Before | After |
|-------------|--------|-------|
| Instruction | 87.8%  | 87.8% |
| Line        | 87.6%  | 87.6% |
| Branch      | 88.1%  | 88.1% |

## Test runtime

| Metric | Before | After |
|--------|--------|-------|
| Tests  | 25     | 25    |
| Time   | 4.4s   | 4.3s  |
