### PR TITLE
resilience4j-consumer: JUnit 4 → JUnit 6 migration

### DIFF
--- a/resilience4j-consumer/build.gradle
+++ b/resilience4j-consumer/build.gradle
@@ -2,9 +2,6 @@ dependencies {
     implementation(project(":resilience4j-circularbuffer"))
     implementation(project(":resilience4j-core"))
 
-    testRuntimeOnly(libs.junit.vintage.engine)
-
-    testImplementation(libs.junit)
     testImplementation(project(":resilience4j-circuitbreaker"))
 }
 ext.moduleName = "io.github.resilience4j.consumer"

--- a/resilience4j-consumer/src/test/java/io/github/resilience4j/consumer/CircularEventConsumerTest.java
+++ b/resilience4j-consumer/src/test/java/io/github/resilience4j/consumer/CircularEventConsumerTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2016 Robert Winkler
+ *  Copyright 2026 Robert Winkler
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ package io.github.resilience4j.consumer;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.github.resilience4j.circuitbreaker.event.CircuitBreakerEvent;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
@@ -29,10 +29,10 @@ import java.util.concurrent.TimeUnit;
 import static io.github.resilience4j.circuitbreaker.event.CircuitBreakerEvent.Type;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CircularEventConsumerTest {
+class CircularEventConsumerTest {
 
     @Test
-    public void shouldBufferErrorEvents() {
+    void shouldBufferErrorEvents() {
         // tag::shouldBufferEvents[]
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
         CircularEventConsumer<CircuitBreakerEvent> ringBuffer = new CircularEventConsumer<>(2);
@@ -54,7 +54,7 @@ public class CircularEventConsumerTest {
     }
 
     @Test
-    public void shouldBufferAllEvents() {
+    void shouldBufferAllEvents() {
         CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
             .slidingWindowSize(3)
             .ignoreExceptions(IOException.class)
@@ -91,7 +91,7 @@ public class CircularEventConsumerTest {
     }
 
     @Test
-    public void shouldNotBufferEvents() {
+    void shouldNotBufferEvents() {
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
         CircularEventConsumer<CircuitBreakerEvent> ringBuffer = new CircularEventConsumer<>(2);
         assertThat(ringBuffer.getBufferedEvents()).isEmpty();

--- a/resilience4j-consumer/src/test/java/io/github/resilience4j/consumer/EventConsumerRegistryTest.java
+++ b/resilience4j-consumer/src/test/java/io/github/resilience4j/consumer/EventConsumerRegistryTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2016 Robert Winkler
+ *  Copyright 2026 Robert Winkler
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -20,14 +20,14 @@ package io.github.resilience4j.consumer;
 
 import io.github.resilience4j.circuitbreaker.event.CircuitBreakerEvent;
 import io.github.resilience4j.core.EventConsumer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class EventConsumerRegistryTest {
+class EventConsumerRegistryTest {
 
     @Test
-    public void shouldCreateAnEventConsumer() {
+    void shouldCreateAnEventConsumer() {
         EventConsumerRegistry<CircuitBreakerEvent> registry = new DefaultEventConsumerRegistry<>();
         EventConsumer<CircuitBreakerEvent> eventEventConsumer = registry
             .createEventConsumer("testName", 5);
@@ -36,7 +36,7 @@ public class EventConsumerRegistryTest {
     }
 
     @Test
-    public void shouldRemoveAnEventConsumer() {
+    void shouldRemoveAnEventConsumer() {
         EventConsumerRegistry<CircuitBreakerEvent> registry = new DefaultEventConsumerRegistry<>();
         String eventConsumerId = "testName";
 
@@ -52,7 +52,7 @@ public class EventConsumerRegistryTest {
         assertThat(eventEventConsumer).isNull();
     }
     @Test
-    public void shouldReturnTheSameEventConsumer() {
+    void shouldReturnTheSameEventConsumer() {
         EventConsumerRegistry<CircuitBreakerEvent> registry = new DefaultEventConsumerRegistry<>();
         EventConsumer<CircuitBreakerEvent> eventEventConsumer1 = registry
             .createEventConsumer("testName", 5);
@@ -63,7 +63,7 @@ public class EventConsumerRegistryTest {
     }
 
     @Test
-    public void shouldReturnAllEventConsumer() {
+    void shouldReturnAllEventConsumer() {
         EventConsumerRegistry<CircuitBreakerEvent> registry = new DefaultEventConsumerRegistry<>();
         registry.createEventConsumer("testName1", 5);
         registry.createEventConsumer("testName2", 2);


### PR DESCRIPTION
## Changes

* Migrated JUnit 4.13 annotations to Junit Jupiter equivalents
* Applied OpenRewrite recipes
    * [JUnit 6 best practices](https://docs.openrewrite.org/recipes/java/testing/junit/junit6bestpractices)
    * [Mockito best practices](https://docs.openrewrite.org/recipes/java/testing/mockito/mockitobestpractices)
    * [Migrate JUnit asserts to AssertJ](https://docs.openrewrite.org/recipes/java/testing/assertj/junittoassertj)
    * [AssertJ best practices](https://docs.openrewrite.org/recipes/java/testing/assertj/assertj-best-practices)
* Removed `public` modifiers
* Updated Copyright to 2026

## Coverage

| Metric      | Before  | After   |
|-------------|---------|---------|
| Instruction | 100.0%  | 100.0%  |
| Line        | 100.0%  | 100.0%  |
| Branch      | N/A     | N/A     |

## Test runtime

| Metric | Before | After |
|--------|--------|-------|
| Tests  | 7      | 7     |
| Time   | 1.1s   | 1.8s  |
