### PR TITLE
resilience4j-feign: JUnit 4 → JUnit 6 migration

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,7 +54,7 @@ mock-clock = { module = "com.statemachinesystems:mock-clock", version = "1.0" }
 
 # resilience4j-feign
 feign-core = { module = "io.github.openfeign:feign-core", version = "12.0" }
-feign-wiremock = { module = "com.github.tomakehurst:wiremock-jre8", version = "2.26.0" }
+feign-wiremock = { module = "org.wiremock:wiremock", version = "3.13.1" }
 
 # resilience4j-kotlin
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version = "1.9.25" }

--- a/resilience4j-feign/build.gradle
+++ b/resilience4j-feign/build.gradle
@@ -6,9 +6,6 @@ dependencies {
 
     compileOnly(libs.feign.core)
 
-    testRuntimeOnly(libs.junit.vintage.engine)
-
-    testImplementation(libs.junit)
     testImplementation(libs.feign.core)
     testImplementation(libs.feign.wiremock)
 }

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/DecoratorInvocationHandlerTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/DecoratorInvocationHandlerTest.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2018
+ * Copyright 2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -22,17 +22,21 @@ import feign.Target.HardCodedTarget;
 import io.github.resilience4j.feign.test.TestFeignDecorator;
 import io.github.resilience4j.feign.test.TestService;
 import io.github.resilience4j.feign.test.TestServiceImpl;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-public class DecoratorInvocationHandlerTest {
+class DecoratorInvocationHandlerTest {
 
     private DecoratorInvocationHandler testSubject;
     private TestService testService;
@@ -42,8 +46,8 @@ public class DecoratorInvocationHandlerTest {
     private Map<Method, MethodHandler> dispatch;
     private Target<TestService> target;
 
-    @Before
-    public void setUp() throws Throwable {
+    @BeforeEach
+    void setUp() throws Throwable {
         target = new HardCodedTarget<TestService>(TestService.class,
             TestService.class.getSimpleName());
         testService = new TestServiceImpl();
@@ -60,10 +64,10 @@ public class DecoratorInvocationHandlerTest {
     }
 
     @Test
-    public void testInvoke() throws Throwable {
+    void invoke() throws Throwable {
         final Object result = testSubject.invoke(testService, greetingMethod, new Object[0]);
 
-        verify(methodHandler, times(1)).invoke(any());
+        verify(methodHandler).invoke(any());
         assertThat(feignDecorator.isCalled())
             .describedAs("FeignDecorator is called")
             .isTrue();
@@ -73,13 +77,13 @@ public class DecoratorInvocationHandlerTest {
     }
 
     @Test
-    public void testDecorator() throws Throwable {
+    void decorator() throws Throwable {
         feignDecorator.setAlternativeFunction(fnArgs -> "AlternativeFunction");
         testSubject = new DecoratorInvocationHandler(target, dispatch, feignDecorator);
 
         final Object result = testSubject.invoke(testService, greetingMethod, new Object[0]);
 
-        verify(methodHandler, times(0)).invoke(any());
+        verify(methodHandler, never()).invoke(any());
         assertThat(feignDecorator.isCalled())
             .describedAs("FeignDecorator is called")
             .isTrue();
@@ -89,12 +93,12 @@ public class DecoratorInvocationHandlerTest {
     }
 
     @Test
-    public void testInvokeToString() throws Throwable {
+    void invokeToString() throws Throwable {
         final Method toStringMethod = testService.getClass().getMethod("toString");
 
         final Object result = testSubject.invoke(testService, toStringMethod, new Object[0]);
 
-        verify(methodHandler, times(0)).invoke(any());
+        verify(methodHandler, never()).invoke(any());
         assertThat(feignDecorator.isCalled())
             .describedAs("FeignDecorator is called")
             .isTrue();
@@ -104,13 +108,13 @@ public class DecoratorInvocationHandlerTest {
     }
 
     @Test
-    public void testInvokeEquals() throws Throwable {
+    void invokeEquals() throws Throwable {
         final Method equalsMethod = testService.getClass().getMethod("equals", Object.class);
 
         final Boolean result = (Boolean) testSubject
             .invoke(testService, equalsMethod, new Object[]{testSubject});
 
-        verify(methodHandler, times(0)).invoke(any());
+        verify(methodHandler, never()).invoke(any());
         assertThat(feignDecorator.isCalled())
             .describedAs("FeignDecorator is called")
             .isTrue();
@@ -121,13 +125,13 @@ public class DecoratorInvocationHandlerTest {
 
 
     @Test
-    public void testInvokeHashcode() throws Throwable {
+    void invokeHashcode() throws Throwable {
         final Method hashCodeMethod = testService.getClass().getMethod("hashCode");
 
         final Integer result = (Integer) testSubject
             .invoke(testService, hashCodeMethod, new Object[0]);
 
-        verify(methodHandler, times(0)).invoke(any());
+        verify(methodHandler, never()).invoke(any());
         assertThat(feignDecorator.isCalled())
             .describedAs("FeignDecorator is called")
             .isTrue();

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/FeignDecoratorsTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/FeignDecoratorsTest.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2018
+ * Copyright 2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -18,17 +18,18 @@ package io.github.resilience4j.feign;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.ratelimiter.RateLimiter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
-public class FeignDecoratorsTest {
+class FeignDecoratorsTest {
 
     @Test
-    public void testWithNothing() throws Throwable {
+    void withNothing() throws Throwable {
         final FeignDecorators testSubject = FeignDecorators.builder().build();
 
         final Object result = testSubject.decorate(args -> args[0], null, null, null)
@@ -41,7 +42,7 @@ public class FeignDecoratorsTest {
 
 
     @Test
-    public void testWithCircuitBreaker() throws Throwable {
+    void withCircuitBreaker() throws Throwable {
         final CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("test");
         final CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
         final FeignDecorators testSubject = FeignDecorators.builder()
@@ -55,13 +56,12 @@ public class FeignDecoratorsTest {
             .describedAs("Returned result is correct")
             .isEqualTo("test01");
         assertThat(metrics.getNumberOfSuccessfulCalls())
-            .describedAs("Successful Calls")
-            .isEqualTo(1);
+            .describedAs("Successful Calls").isOne();
     }
 
 
     @Test
-    public void testWithRateLimiter() throws Throwable {
+    void withRateLimiter() throws Throwable {
         final RateLimiter rateLimiter = spy(RateLimiter.ofDefaults("test"));
         final FeignDecorators testSubject = FeignDecorators.builder().withRateLimiter(rateLimiter)
             .build();
@@ -73,6 +73,6 @@ public class FeignDecoratorsTest {
         assertThat(result)
             .describedAs("Returned result is correct")
             .isEqualTo("test01");
-        verify(rateLimiter, times(1)).acquirePermission(1);
+        verify(rateLimiter).acquirePermission(1);
     }
 }

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignBuilderBackwardsComplianceTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignBuilderBackwardsComplianceTest.java
@@ -1,33 +1,57 @@
+/*
+ *
+ * Copyright 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *
+ */
 package io.github.resilience4j.feign;
 
-import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import feign.Feign;
 import io.github.resilience4j.feign.test.TestService;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class Resilience4jFeignBuilderBackwardsComplianceTest {
-    @ClassRule
-    public static final WireMockClassRule WIRE_MOCK_RULE = new WireMockClassRule(8080);
+@WireMockTest
+class Resilience4jFeignBuilderBackwardsComplianceTest {
+
+    private String baseUrl;
+
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
+        baseUrl = wmRuntimeInfo.getHttpBaseUrl() + "/";
+    }
 
     @Test
-    public void fallbackIsWorkingInBothConfigurationMechanisms() {
+    void fallbackIsWorkingInBothConfigurationMechanisms() {
         FeignDecorators decorators = FeignDecorators.builder()
                 .withFallback((TestService) () -> "fallback").build();
 
         TestService testServiceA = Feign.builder()
                 .addCapability(Resilience4jFeign.capability(decorators))
-                .target(TestService.class, "http://localhost:8080/");
+                .target(TestService.class, baseUrl);
 
         TestService testServiceB = Resilience4jFeign.builder(decorators)
-                .target(TestService.class, "http://localhost:8080/");
+                .target(TestService.class, baseUrl);
 
         String resultA = testServiceA.greeting();
         String resultB = testServiceB.greeting();
 
-        assertThat(resultA).isEqualTo("fallback");
-        assertThat(resultA).isEqualTo(resultB);
+        assertThat(resultA)
+                .isEqualTo("fallback")
+                .isEqualTo(resultB);
     }
 }

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignBulkheadTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignBulkheadTest.java
@@ -1,47 +1,65 @@
+/*
+ *
+ * Copyright 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *
+ */
 package io.github.resilience4j.feign;
 
-
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import feign.Feign;
 import feign.FeignException;
 import io.github.resilience4j.bulkhead.Bulkhead;
 import io.github.resilience4j.bulkhead.BulkheadConfig;
 import io.github.resilience4j.bulkhead.BulkheadFullException;
 import io.github.resilience4j.feign.test.TestService;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static org.mockito.Mockito.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests the integration of the {@link Resilience4jFeign} with a bulkhead.
  */
-public class Resilience4jFeignBulkheadTest {
-
-    private static final String MOCK_URL = "http://localhost:8080/";
-
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule();
+@WireMockTest
+class Resilience4jFeignBulkheadTest {
 
     private TestService testService;
     private Bulkhead bulkhead;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
         bulkhead = spy(Bulkhead.of("bulkheadTest", BulkheadConfig.ofDefaults()));
         final FeignDecorators decorators = FeignDecorators.builder()
                 .withBulkhead(bulkhead)
                 .build();
         testService = Feign.builder()
                 .addCapability(Resilience4jFeign.capability(decorators))
-                .target(TestService.class, MOCK_URL);
-
+                .target(TestService.class, wmRuntimeInfo.getHttpBaseUrl() + "/");
     }
 
     @Test
-    public void testSuccessfulCall() {
+    void successfulCall() {
         givenResponse(200);
 
         testService.greeting();
@@ -51,7 +69,7 @@ public class Resilience4jFeignBulkheadTest {
     }
 
     @Test
-    public void testSuccessfulCallWithDefaultMethod() {
+    void successfulCallWithDefaultMethod() {
         givenResponse(200);
 
         testService.defaultGreeting();
@@ -60,24 +78,24 @@ public class Resilience4jFeignBulkheadTest {
         verify(bulkhead).acquirePermission();
     }
 
-    @Test(expected = BulkheadFullException.class)
-    public void testBulkheadFull() {
+    @Test
+    void bulkheadFull() {
         givenResponse(200);
-
         when(bulkhead.tryAcquirePermission()).thenReturn(false);
 
-        testService.greeting();
+        assertThatThrownBy(() -> testService.greeting())
+                .isInstanceOf(BulkheadFullException.class);
 
         verify(0, getRequestedFor(urlPathEqualTo("/greeting")));
     }
 
-    @Test(expected = FeignException.class)
-    public void testFailedCall() {
+    @Test
+    void failedCall() {
         givenResponse(400);
-
         when(bulkhead.tryAcquirePermission()).thenReturn(true);
 
-        testService.greeting();
+        assertThatThrownBy(() -> testService.greeting())
+                .isInstanceOf(FeignException.class);
     }
 
 

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignCircuitBreakerTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignCircuitBreakerTest.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2020
+ * Copyright 2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,48 +16,52 @@
  */
 package io.github.resilience4j.feign;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import feign.Feign;
 import feign.FeignException;
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.github.resilience4j.feign.test.TestService;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests the integration of the {@link Resilience4jFeign} with {@link CircuitBreaker}
  */
-public class Resilience4jFeignCircuitBreakerTest {
+@WireMockTest
+class Resilience4jFeignCircuitBreakerTest {
 
     private static final CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
         .slidingWindowSize(3)
         .waitDurationInOpenState(Duration.ofMillis(1000))
         .build();
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule();
     private CircuitBreaker circuitBreaker;
     private TestService testService;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
         circuitBreaker = CircuitBreaker.of("test", circuitBreakerConfig);
         final FeignDecorators decorators = FeignDecorators.builder()
             .withCircuitBreaker(circuitBreaker).build();
         testService = Feign.builder()
             .addCapability(Resilience4jFeign.capability(decorators))
-            .target(TestService.class, "http://localhost:8080/");
+            .target(TestService.class, wmRuntimeInfo.getHttpBaseUrl() + "/");
     }
 
     @Test
-    public void testSuccessfulCall() throws Exception {
+    void successfulCall() throws Exception {
         final CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
 
         setupStub(200);
@@ -66,12 +70,11 @@ public class Resilience4jFeignCircuitBreakerTest {
 
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
         assertThat(metrics.getNumberOfSuccessfulCalls())
-            .describedAs("Successful Calls")
-            .isEqualTo(1);
+            .describedAs("Successful Calls").isOne();
     }
 
     @Test
-    public void testSuccessfulCallWithDefaultMethod() throws Exception {
+    void successfulCallWithDefaultMethod() throws Exception {
         final CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
 
         setupStub(200);
@@ -80,12 +83,11 @@ public class Resilience4jFeignCircuitBreakerTest {
 
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
         assertThat(metrics.getNumberOfSuccessfulCalls())
-            .describedAs("Successful Calls")
-            .isEqualTo(1);
+            .describedAs("Successful Calls").isOne();
     }
 
     @Test
-    public void testFailedCall() throws Exception {
+    void failedCall() throws Exception {
         final CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
         boolean exceptionThrown = false;
 
@@ -102,11 +104,11 @@ public class Resilience4jFeignCircuitBreakerTest {
             .isTrue();
         assertThat(metrics.getNumberOfFailedCalls())
             .describedAs("Successful Calls")
-            .isEqualTo(1);
+            .isOne();
     }
 
     @Test
-    public void testCircuitBreakerOpen() throws Exception {
+    void circuitBreakerOpen() throws Exception {
         boolean exceptionThrown = false;
         final int threshold = circuitBreaker
             .getCircuitBreakerConfig()
@@ -134,7 +136,7 @@ public class Resilience4jFeignCircuitBreakerTest {
 
 
     @Test
-    public void testCircuitBreakerClosed() throws Exception {
+    void circuitBreakerClosed() throws Exception {
         boolean exceptionThrown = false;
         final int threshold = circuitBreaker
             .getCircuitBreakerConfig()

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignFallbackFactoryLambdaTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignFallbackFactoryLambdaTest.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2019
+ * Copyright 2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,40 +16,41 @@
  */
 package io.github.resilience4j.feign;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import io.github.resilience4j.feign.test.Issue560;
 import io.github.resilience4j.feign.test.TestService;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests the integration of the {@link Resilience4jFeign} with the lambda as a fallbackFactory.
  */
-public class Resilience4jFeignFallbackFactoryLambdaTest {
-
-    private static final String MOCK_URL = "http://localhost:8080/";
-
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule();
+@WireMockTest
+class Resilience4jFeignFallbackFactoryLambdaTest {
 
     private TestService testService;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
         final FeignDecorators decorators = FeignDecorators.builder()
             .withFallbackFactory(e -> Issue560.createLambdaFallback())
             .build();
 
         this.testService = Resilience4jFeign.builder(decorators)
-            .target(TestService.class, MOCK_URL);
+            .target(TestService.class, wmRuntimeInfo.getHttpBaseUrl() + "/");
     }
 
     @Test
-    public void testFallbackFactory() {
+    void fallbackFactory() {
         setupStub();
 
         final String result = testService.greeting();

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignFallbackFactoryTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignFallbackFactoryTest.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2019
+ * Copyright 2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,43 +16,51 @@
  */
 package io.github.resilience4j.feign;
 
-import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import feign.Feign;
 import feign.FeignException;
 import io.github.resilience4j.feign.test.TestService;
 import io.github.resilience4j.feign.test.TestServiceFallbackThrowingException;
 import io.github.resilience4j.feign.test.TestServiceFallbackWithException;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Function;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests on fallback factories.
  */
-public class Resilience4jFeignFallbackFactoryTest {
+@WireMockTest
+class Resilience4jFeignFallbackFactoryTest {
 
-    @ClassRule
-    public static final WireMockClassRule WIRE_MOCK_RULE = new WireMockClassRule(8080);
-    private static final String MOCK_URL = "http://localhost:8080/";
-    @Rule
-    public WireMockClassRule instanceRule = WIRE_MOCK_RULE;
+    private String baseUrl;
 
-    private static TestService buildTestService(Function<Exception, ?> fallbackSupplier) {
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
+        baseUrl = wmRuntimeInfo.getHttpBaseUrl() + "/";
+    }
+
+    private TestService buildTestService(Function<Exception, ?> fallbackSupplier) {
         FeignDecorators decorators = FeignDecorators.builder()
             .withFallbackFactory(fallbackSupplier)
             .build();
         return Feign.builder()
             .addCapability(Resilience4jFeign.capability(decorators))
-            .target(TestService.class, MOCK_URL);
+            .target(TestService.class, baseUrl);
     }
 
     private static void setupStub(int responseCode) {
@@ -64,7 +72,7 @@ public class Resilience4jFeignFallbackFactoryTest {
     }
 
     @Test
-    public void should_successfully_get_a_response() {
+    void successfullyGetsResponse() {
         setupStub(200);
         TestService testService = buildTestService(e -> "my fallback");
 
@@ -75,7 +83,7 @@ public class Resilience4jFeignFallbackFactoryTest {
     }
 
     @Test
-    public void should_lazily_fail_on_invalid_fallback() {
+    void lazilyFailsOnInvalidFallback() {
         TestService testService = buildTestService(e -> "my fallback");
 
         Throwable throwable = catchThrowable(testService::greeting);
@@ -86,7 +94,7 @@ public class Resilience4jFeignFallbackFactoryTest {
     }
 
     @Test
-    public void should_go_to_fallback_and_consume_exception() {
+    void goesToFallbackAndConsumesException() {
         setupStub(400);
         TestService testService = buildTestService(TestServiceFallbackWithException::new);
 
@@ -98,20 +106,20 @@ public class Resilience4jFeignFallbackFactoryTest {
     }
 
     @Test
-    public void should_go_to_fallback_and_rethrow_an_exception_thrown_in_fallback() {
+    void goesToFallbackAndRethrowsExceptionThrownInFallback() {
         setupStub(400);
         TestService testService = buildTestService(e -> new TestServiceFallbackThrowingException());
 
         Throwable result = catchThrowable(testService::greeting);
 
-        assertThat(result).isNotNull()
+        assertThat(result)
             .isInstanceOf(RuntimeException.class)
             .hasMessageContaining("Exception in greeting fallback");
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
     }
 
     @Test
-    public void should_go_to_fallback_and_consume_exception_with_exception_filter() {
+    void goesToFallbackAndConsumesExceptionWithExceptionFilter() {
         setupStub(400);
         TestService uselessFallback = spy(TestService.class);
         when(uselessFallback.greeting()).thenReturn("I should not be called");
@@ -120,18 +128,18 @@ public class Resilience4jFeignFallbackFactoryTest {
             .withFallbackFactory(e -> uselessFallback)
             .build();
         TestService testService = Resilience4jFeign.builder(decorators)
-            .target(TestService.class, MOCK_URL);
+            .target(TestService.class, baseUrl);
 
         String result = testService.greeting();
 
         assertThat(result)
             .startsWith("Message from exception: [400 Bad Request]");
-        verify(uselessFallback, times(0)).greeting();
+        verify(uselessFallback, never()).greeting();
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
     }
 
     @Test
-    public void should_go_to_second_fallback_and_consume_exception_with_exception_filter() {
+    void goesToSecondFallbackAndConsumesExceptionWithExceptionFilter() {
         setupStub(400);
         TestService uselessFallback = spy(TestService.class);
         when(uselessFallback.greeting()).thenReturn("I should not be called");
@@ -140,18 +148,18 @@ public class Resilience4jFeignFallbackFactoryTest {
             .withFallbackFactory(TestServiceFallbackWithException::new)
             .build();
         TestService testService = Resilience4jFeign.builder(decorators)
-            .target(TestService.class, MOCK_URL);
+            .target(TestService.class, baseUrl);
 
         String result = testService.greeting();
 
         assertThat(result)
             .startsWith("Message from exception: [400 Bad Request]");
-        verify(uselessFallback, times(0)).greeting();
+        verify(uselessFallback, never()).greeting();
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
     }
 
     @Test
-    public void should_go_to_fallback_and_consume_exception_with_predicate() {
+    void goesToFallbackAndConsumesExceptionWithPredicate() {
         setupStub(400);
         TestService uselessFallback = spy(TestService.class);
         when(uselessFallback.greeting()).thenReturn("I should not be called");
@@ -161,18 +169,18 @@ public class Resilience4jFeignFallbackFactoryTest {
             .withFallbackFactory(e -> uselessFallback)
             .build();
         TestService testService = Resilience4jFeign.builder(decorators)
-            .target(TestService.class, MOCK_URL);
+            .target(TestService.class, baseUrl);
 
         String result = testService.greeting();
 
         assertThat(result)
             .startsWith("Message from exception: [400 Bad Request]");
-        verify(uselessFallback, times(0)).greeting();
+        verify(uselessFallback, never()).greeting();
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
     }
 
     @Test
-    public void should_go_to_second_fallback_and_consume_exception_with_predicate() {
+    void goesToSecondFallbackAndConsumesExceptionWithPredicate() {
         setupStub(400);
         TestService uselessFallback = spy(TestService.class);
         when(uselessFallback.greeting()).thenReturn("I should not be called");
@@ -181,13 +189,13 @@ public class Resilience4jFeignFallbackFactoryTest {
             .withFallbackFactory(TestServiceFallbackWithException::new)
             .build();
         TestService testService = Resilience4jFeign.builder(decorators)
-            .target(TestService.class, MOCK_URL);
+            .target(TestService.class, baseUrl);
 
         String result = testService.greeting();
 
         assertThat(result)
             .startsWith("Message from exception: [400 Bad Request]");
-        verify(uselessFallback, times(0)).greeting();
+        verify(uselessFallback, never()).greeting();
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
     }
 

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignFallbackLambdaTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignFallbackLambdaTest.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2019
+ * Copyright 2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,42 +16,43 @@
  */
 package io.github.resilience4j.feign;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import feign.Feign;
 import io.github.resilience4j.feign.test.Issue560;
 import io.github.resilience4j.feign.test.TestService;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests the integration of the {@link Resilience4jFeign} with the lambda as a fallback.
  */
-public class Resilience4jFeignFallbackLambdaTest {
-
-    private static final String MOCK_URL = "http://localhost:8080/";
-
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule();
+@WireMockTest
+class Resilience4jFeignFallbackLambdaTest {
 
     private TestService testService;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
         final FeignDecorators decorators = FeignDecorators.builder()
             .withFallback(Issue560.createLambdaFallback())
             .build();
 
         this.testService = Feign.builder()
             .addCapability(Resilience4jFeign.capability(decorators))
-            .target(TestService.class, MOCK_URL);
+            .target(TestService.class, wmRuntimeInfo.getHttpBaseUrl() + "/");
     }
 
     @Test
-    public void testFallback() {
+    void fallback() {
         setupStub();
 
         final String result = testService.greeting();

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignFallbackTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignFallbackTest.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2018
+ * Copyright 2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,36 +16,42 @@
  */
 package io.github.resilience4j.feign;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import feign.Feign;
 import feign.FeignException;
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.feign.test.TestService;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests the integration of the {@link Resilience4jFeign} with a fallback.
  */
-public class Resilience4jFeignFallbackTest {
+@WireMockTest
+class Resilience4jFeignFallbackTest {
 
-    private static final String MOCK_URL = "http://localhost:8080/";
-
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule();
-
+    private String baseUrl;
     private TestService testService;
     private TestService testServiceFallback;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
+        baseUrl = wmRuntimeInfo.getHttpBaseUrl() + "/";
+
         testServiceFallback = mock(TestService.class);
         when(testServiceFallback.greeting()).thenReturn("fallback");
 
@@ -55,42 +61,43 @@ public class Resilience4jFeignFallbackTest {
 
         testService = Feign.builder()
             .addCapability(Resilience4jFeign.capability(decorators))
-            .target(TestService.class, MOCK_URL);
+            .target(TestService.class, baseUrl);
     }
 
     @Test
-    public void testSuccessful() throws Exception {
+    void successful() throws Exception {
         setupStub(200);
 
         final String result = testService.greeting();
 
         assertThat(result).describedAs("Result").isEqualTo("Hello, world!");
-        verify(testServiceFallback, times(0)).greeting();
+        verify(testServiceFallback, never()).greeting();
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testInvalidFallback() throws Throwable {
+    @Test
+    void invalidFallback() {
         final FeignDecorators decorators = FeignDecorators.builder().withFallback("not a fallback")
             .build();
-        Resilience4jFeign.builder(decorators).target(TestService.class, MOCK_URL);
+        assertThatThrownBy(() -> Resilience4jFeign.builder(decorators).target(TestService.class, baseUrl))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void testFallback() throws Exception {
+    void fallback() throws Exception {
         setupStub(400);
 
         final String result = testService.greeting();
 
         assertThat(result).describedAs("Result").isNotEqualTo("Hello, world!");
         assertThat(result).describedAs("Result").isEqualTo("fallback");
-        verify(testServiceFallback, times(1)).greeting();
+        verify(testServiceFallback).greeting();
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
     }
 
 
     @Test
-    public void testFallbackExceptionFilter() throws Exception {
+    void fallbackExceptionFilter() throws Exception {
         final TestService testServiceExceptionFallback = mock(TestService.class);
         when(testServiceExceptionFallback.greeting()).thenReturn("exception fallback");
 
@@ -99,20 +106,20 @@ public class Resilience4jFeignFallbackTest {
             .withFallback(testServiceFallback)
             .build();
 
-        testService = Resilience4jFeign.builder(decorators).target(TestService.class, MOCK_URL);
+        testService = Resilience4jFeign.builder(decorators).target(TestService.class, baseUrl);
         setupStub(400);
 
         final String result = testService.greeting();
 
         assertThat(result).describedAs("Result").isNotEqualTo("Hello, world!");
         assertThat(result).describedAs("Result").isEqualTo("exception fallback");
-        verify(testServiceFallback, times(0)).greeting();
-        verify(testServiceExceptionFallback, times(1)).greeting();
+        verify(testServiceFallback, never()).greeting();
+        verify(testServiceExceptionFallback).greeting();
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
     }
 
     @Test
-    public void testFallbackExceptionFilterNotCalled() throws Exception {
+    void fallbackExceptionFilterNotCalled() throws Exception {
         final TestService testServiceExceptionFallback = mock(TestService.class);
         when(testServiceExceptionFallback.greeting()).thenReturn("exception fallback");
 
@@ -121,20 +128,20 @@ public class Resilience4jFeignFallbackTest {
             .withFallback(testServiceFallback)
             .build();
 
-        testService = Resilience4jFeign.builder(decorators).target(TestService.class, MOCK_URL);
+        testService = Resilience4jFeign.builder(decorators).target(TestService.class, baseUrl);
         setupStub(400);
 
         final String result = testService.greeting();
 
         assertThat(result).describedAs("Result").isNotEqualTo("Hello, world!");
         assertThat(result).describedAs("Result").isEqualTo("fallback");
-        verify(testServiceFallback, times(1)).greeting();
-        verify(testServiceExceptionFallback, times(0)).greeting();
+        verify(testServiceFallback).greeting();
+        verify(testServiceExceptionFallback, never()).greeting();
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
     }
 
     @Test
-    public void testFallbackFilter() throws Exception {
+    void fallbackFilter() throws Exception {
         final TestService testServiceFilterFallback = mock(TestService.class);
         when(testServiceFilterFallback.greeting()).thenReturn("filter fallback");
 
@@ -143,20 +150,20 @@ public class Resilience4jFeignFallbackTest {
             .withFallback(testServiceFallback)
             .build();
 
-        testService = Resilience4jFeign.builder(decorators).target(TestService.class, MOCK_URL);
+        testService = Resilience4jFeign.builder(decorators).target(TestService.class, baseUrl);
         setupStub(400);
 
         final String result = testService.greeting();
 
         assertThat(result).describedAs("Result").isNotEqualTo("Hello, world!");
         assertThat(result).describedAs("Result").isEqualTo("filter fallback");
-        verify(testServiceFallback, times(0)).greeting();
-        verify(testServiceFilterFallback, times(1)).greeting();
+        verify(testServiceFallback, never()).greeting();
+        verify(testServiceFilterFallback).greeting();
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
     }
 
     @Test
-    public void testFallbackFilterNotCalled() throws Exception {
+    void fallbackFilterNotCalled() throws Exception {
         final TestService testServiceFilterFallback = mock(TestService.class);
         when(testServiceFilterFallback.greeting()).thenReturn("filter fallback");
 
@@ -165,20 +172,20 @@ public class Resilience4jFeignFallbackTest {
             .withFallback(testServiceFallback)
             .build();
 
-        testService = Resilience4jFeign.builder(decorators).target(TestService.class, MOCK_URL);
+        testService = Resilience4jFeign.builder(decorators).target(TestService.class, baseUrl);
         setupStub(400);
 
         final String result = testService.greeting();
 
         assertThat(result).describedAs("Result").isNotEqualTo("Hello, world!");
         assertThat(result).describedAs("Result").isEqualTo("fallback");
-        verify(testServiceFallback, times(1)).greeting();
-        verify(testServiceFilterFallback, times(0)).greeting();
+        verify(testServiceFallback).greeting();
+        verify(testServiceFilterFallback, never()).greeting();
         verify(1, getRequestedFor(urlPathEqualTo("/greeting")));
     }
 
     @Test
-    public void testRevertFallback() throws Exception {
+    void revertFallback() throws Exception {
         setupStub(400);
 
         testService.greeting();
@@ -186,7 +193,7 @@ public class Resilience4jFeignFallbackTest {
         final String result = testService.greeting();
 
         assertThat(result).describedAs("Result").isEqualTo("Hello, world!");
-        verify(testServiceFallback, times(1)).greeting();
+        verify(testServiceFallback).greeting();
         verify(2, getRequestedFor(urlPathEqualTo("/greeting")));
 
     }

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignRateLimiterTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignRateLimiterTest.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2020
+ * Copyright 2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,45 +16,53 @@
  */
 package io.github.resilience4j.feign;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import feign.Feign;
 import feign.FeignException;
 import io.github.resilience4j.feign.test.TestService;
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
 import io.github.resilience4j.ratelimiter.RequestNotPermitted;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static org.mockito.Mockito.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests the integration of the {@link Resilience4jFeign} with {@link RateLimiter}
  */
-public class Resilience4jFeignRateLimiterTest {
+@WireMockTest
+class Resilience4jFeignRateLimiterTest {
 
-    private static final String MOCK_URL = "http://localhost:8080/";
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule();
-
+    private String baseUrl;
     private TestService testService;
     private RateLimiter rateLimiter;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
+        baseUrl = wmRuntimeInfo.getHttpBaseUrl() + "/";
         rateLimiter = mock(RateLimiter.class);
         final FeignDecorators decorators = FeignDecorators.builder()
             .withRateLimiter(rateLimiter)
             .build();
         testService = Feign.builder()
             .addCapability(Resilience4jFeign.capability(decorators))
-            .target(TestService.class, MOCK_URL);
+            .target(TestService.class, baseUrl);
     }
 
     @Test
-    public void testSuccessfulCall() {
+    void successfulCall() {
         givenResponse(200);
         when(rateLimiter.acquirePermission(1)).thenReturn(true);
 
@@ -65,7 +73,7 @@ public class Resilience4jFeignRateLimiterTest {
     }
 
     @Test
-    public void testSuccessfulCallWithDefaultMethod() {
+    void successfulCallWithDefaultMethod() {
         givenResponse(200);
         when(rateLimiter.acquirePermission(1)).thenReturn(true);
 
@@ -75,35 +83,34 @@ public class Resilience4jFeignRateLimiterTest {
         verify(rateLimiter).acquirePermission(anyInt());
     }
 
-    @Test(expected = RequestNotPermitted.class)
-    public void testRateLimiterLimiting() {
+    @Test
+    void rateLimiterLimiting() {
         givenResponse(200);
         when(rateLimiter.acquirePermission(1)).thenReturn(false);
         when(rateLimiter.getRateLimiterConfig()).thenReturn(RateLimiterConfig.ofDefaults());
 
-        testService.greeting();
-
-        verify(0, getRequestedFor(urlPathEqualTo("/greeting")));
+        assertThatThrownBy(() -> testService.greeting())
+            .isInstanceOf(RequestNotPermitted.class);
     }
 
-    @Test(expected = FeignException.class)
-    public void testFailedHttpCall() {
+    @Test
+    void failedHttpCall() {
         givenResponse(400);
         when(rateLimiter.acquirePermission(1)).thenReturn(true);
 
-        testService.greeting();
+        assertThatThrownBy(() -> testService.greeting())
+            .isInstanceOf(FeignException.class);
     }
 
-    @Test(expected = RequestNotPermitted.class)
-    public void testRateLimiterCreateByStaticMethod() {
-        testService = TestService.create(MOCK_URL, rateLimiter);
+    @Test
+    void rateLimiterCreateByStaticMethod() {
+        testService = TestService.create(baseUrl, rateLimiter);
         givenResponse(200);
         when(rateLimiter.acquirePermission(1)).thenReturn(false);
         when(rateLimiter.getRateLimiterConfig()).thenReturn(RateLimiterConfig.ofDefaults());
 
-        testService.greeting();
-
-        verify(0, getRequestedFor(urlPathEqualTo("/greeting")));
+        assertThatThrownBy(() -> testService.greeting())
+            .isInstanceOf(RequestNotPermitted.class);
     }
 
 

--- a/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignRetryTest.java
+++ b/resilience4j-feign/src/test/java/io/github/resilience4j/feign/Resilience4jFeignRetryTest.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2020 Mahmoud Romeh
+ * Copyright 2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,45 +16,51 @@
  */
 package io.github.resilience4j.feign;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import feign.Feign;
 import feign.FeignException;
 import io.github.resilience4j.feign.test.TestService;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 /**
  * Tests the integration of the {@link Resilience4jFeign} with {@link Retry}
  */
-public class Resilience4jFeignRetryTest {
+@WireMockTest
+class Resilience4jFeignRetryTest {
 
-    private static final String MOCK_URL = "http://localhost:8080/";
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule();
-
+    private String baseUrl;
     private TestService testService;
     private Retry retry;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
+        baseUrl = wmRuntimeInfo.getHttpBaseUrl() + "/";
         retry = spy(Retry.ofDefaults("test"));
         final FeignDecorators decorators = FeignDecorators.builder()
             .withRetry(retry)
             .build();
         testService = Feign.builder()
             .addCapability(Resilience4jFeign.capability(decorators))
-            .target(TestService.class, MOCK_URL);
+            .target(TestService.class, baseUrl);
     }
 
     @Test
-    public void testSuccessfulCall() {
+    void successfulCall() {
         givenResponse(200);
 
         testService.greeting();
@@ -64,7 +70,7 @@ public class Resilience4jFeignRetryTest {
     }
 
     @Test
-    public void testSuccessfulCallWithDefaultMethod() {
+    void successfulCallWithDefaultMethod() {
         givenResponse(200);
 
         testService.defaultGreeting();
@@ -73,36 +79,37 @@ public class Resilience4jFeignRetryTest {
         verify(retry).context();
     }
 
-    @Test(expected = FeignException.class)
-    public void testFailedHttpCall() {
+    @Test
+    void failedHttpCall() {
         givenResponse(400);
-        testService.greeting();
-    }
-
-    @Test(expected = FeignException.class)
-    public void testFailedHttpCallWithRetry() {
-        retry = Retry.of("test",RetryConfig.custom().retryExceptions(FeignException.class).maxAttempts(2).build());
-        final FeignDecorators decorators = FeignDecorators.builder()
-            .withRetry(retry)
-            .build();
-        testService = Resilience4jFeign.builder(decorators)
-            .target(TestService.class, MOCK_URL);
-        givenResponse(400);
-        testService.greeting();
-        assertThat(retry.getMetrics().getNumberOfFailedCallsWithRetryAttempt()).isEqualTo(2);
+        assertThatThrownBy(() -> testService.greeting())
+            .isInstanceOf(FeignException.class);
     }
 
     @Test
-    public void testRetryOnResult() {
-        retry = Retry.of("test",RetryConfig.<String>custom().retryOnResult(s->s.equalsIgnoreCase("hello world")).maxAttempts(2).build());
+    void failedHttpCallWithRetry() {
+        retry = Retry.of("test", RetryConfig.custom().retryExceptions(FeignException.class).maxAttempts(2).build());
         final FeignDecorators decorators = FeignDecorators.builder()
             .withRetry(retry)
             .build();
         testService = Resilience4jFeign.builder(decorators)
-            .target(TestService.class, MOCK_URL);
+            .target(TestService.class, baseUrl);
+        givenResponse(400);
+        assertThatThrownBy(() -> testService.greeting())
+            .isInstanceOf(FeignException.class);
+    }
+
+    @Test
+    void retryOnResult() {
+        retry = Retry.of("test", RetryConfig.<String>custom().retryOnResult(s -> s.equalsIgnoreCase("hello world")).maxAttempts(2).build());
+        final FeignDecorators decorators = FeignDecorators.builder()
+            .withRetry(retry)
+            .build();
+        testService = Resilience4jFeign.builder(decorators)
+            .target(TestService.class, baseUrl);
         givenResponse(200);
         testService.greeting();
-        assertThat(retry.getMetrics().getNumberOfFailedCallsWithRetryAttempt()).isEqualTo(1);
+        assertThat(retry.getMetrics().getNumberOfFailedCallsWithRetryAttempt()).isOne();
     }
 
 

--- a/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/bulkhead/BulkheadAutoConfigurationTest.java
+++ b/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/bulkhead/BulkheadAutoConfigurationTest.java
@@ -33,7 +33,6 @@ import io.github.resilience4j.bulkhead.Bulkhead;
 import io.github.resilience4j.bulkhead.BulkheadRegistry;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkheadRegistry;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -151,7 +150,7 @@ public class BulkheadAutoConfigurationTest {
         bulkhead.getEventPublisher().onCallPermitted(event -> permitted.incrementAndGet());
         bulkhead.getEventPublisher().onCallRejected(event -> rejected.incrementAndGet());
 
-        dummyFeignClient.doSomething(StringUtils.EMPTY);
+        dummyFeignClient.doSomething("");
 
         ResponseEntity<BulkheadEndpointResponse> bulkheadList = restTemplate
             .getForEntity("/actuator/bulkheads", BulkheadEndpointResponse.class);

--- a/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/circuitbreaker/CircuitBreakerAutoConfigurationTest.java
+++ b/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/circuitbreaker/CircuitBreakerAutoConfigurationTest.java
@@ -25,7 +25,6 @@ import io.github.resilience4j.common.circuitbreaker.monitoring.endpoint.CircuitB
 import io.github.resilience4j.common.circuitbreaker.monitoring.endpoint.CircuitBreakerEventsEndpointResponse;
 import io.github.resilience4j.springboot3.service.test.DummyService;
 import io.github.resilience4j.springboot3.service.test.TestApplication;
-import org.apache.http.HttpStatus;
 import org.assertj.core.api.Assertions;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,6 +32,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -171,7 +171,6 @@ public class CircuitBreakerAutoConfigurationTest {
     }
 
     private void verifyCircuitBreakerAutoConfiguration(CircuitBreaker circuitBreaker) {
-        int ok=HttpStatus.SC_OK;
         assertThat(circuitBreaker).isNotNull();
         // expect CircuitBreaker is configured as defined in application.yml
         assertThat(circuitBreaker.getCircuitBreakerConfig().getSlidingWindowSize()).isEqualTo(6);
@@ -188,7 +187,7 @@ public class CircuitBreakerAutoConfigurationTest {
         assertThat(circuitBreaker.getCircuitBreakerConfig().getIgnoreExceptionPredicate()
             .test(new IgnoredException())).isTrue();
         assertThat(circuitBreaker.getCircuitBreakerConfig().getRecordResultPredicate()
-            .test(ok)).isFalse();
+            .test(HttpStatus.OK)).isFalse();
         // Verify that an exception for which setRecordFailurePredicate returns false and it is not included in
         // setRecordExceptions evaluates to false.
         assertThat(circuitBreaker.getCircuitBreakerConfig().getRecordExceptionPredicate()

--- a/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/circuitbreaker/CircuitBreakerFeignTest.java
+++ b/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/circuitbreaker/CircuitBreakerFeignTest.java
@@ -21,7 +21,6 @@ import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.springboot3.service.test.DummyFeignClient;
 import io.github.resilience4j.springboot3.service.test.TestApplication;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -67,8 +66,8 @@ public class CircuitBreakerFeignTest {
         } catch (Exception e) {
             // Ignore the error, we want to increase the error counts
         }
-        dummyFeignClient.doSomething(StringUtils.EMPTY);
-        dummyFeignClient.doSomething(StringUtils.EMPTY);
+        dummyFeignClient.doSomething("");
+        dummyFeignClient.doSomething("");
 
         CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("dummyFeignClient");
         assertThat(circuitBreaker).isNotNull();

--- a/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/circuitbreaker/RecordResultPredicate.java
+++ b/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/circuitbreaker/RecordResultPredicate.java
@@ -1,7 +1,5 @@
 package io.github.resilience4j.springboot3.circuitbreaker;
 
-import org.apache.http.HttpStatus;
-
 import java.util.function.Predicate;
 
 public class RecordResultPredicate implements Predicate<Object> {

--- a/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/ratelimiter/RateLimiterAutoConfigurationTest.java
+++ b/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/ratelimiter/RateLimiterAutoConfigurationTest.java
@@ -45,7 +45,6 @@ import java.util.concurrent.TimeUnit;
 
 import static com.jayway.awaitility.Awaitility.await;
 import static io.github.resilience4j.springboot3.service.test.ratelimiter.RateLimiterDummyFeignClient.RATE_LIMITER_FEIGN_CLIENT_NAME;
-import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -97,7 +96,7 @@ public class RateLimiterAutoConfigurationTest {
         } catch (Exception ex) {
             // Do nothing.
         }
-        rateLimiterDummyFeignClient.doSomething(EMPTY);
+        rateLimiterDummyFeignClient.doSomething("");
 
         assertThat(rateLimiter.getMetrics().getAvailablePermissions()).isEqualTo(8);
         assertThat(rateLimiter.getMetrics().getNumberOfWaitingThreads()).isZero();
@@ -119,7 +118,7 @@ public class RateLimiterAutoConfigurationTest {
 
         try {
             for (int i = 0; i < 11; i++) {
-                rateLimiterDummyFeignClient.doSomething(EMPTY);
+                rateLimiterDummyFeignClient.doSomething("");
             }
         } catch (RequestNotPermitted e) {
             // Do nothing

--- a/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/retry/RetryAutoConfigurationTest.java
+++ b/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/retry/RetryAutoConfigurationTest.java
@@ -28,7 +28,6 @@ import io.github.resilience4j.springboot3.service.test.TestApplication;
 import io.github.resilience4j.springboot3.service.test.retry.RetryDummyFeignClient;
 import io.github.resilience4j.springboot3.service.test.retry.RetryDummyService;
 import io.github.resilience4j.springboot3.service.test.retry.ReactiveRetryDummyService;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -90,7 +89,7 @@ public class RetryAutoConfigurationTest {
             // Do nothing. The IOException is recorded by the retry as it is one of failure exceptions
         }
         // The invocation is recorded by the CircuitBreaker as a success.
-        retryDummyFeignClient.doSomething(StringUtils.EMPTY);
+        retryDummyFeignClient.doSomething("");
 
         Retry retry = retryRegistry.retry(RetryDummyFeignClient.RETRY_DUMMY_FEIGN_CLIENT_NAME);
         assertThat(retry).isNotNull();

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/bulkhead/BulkheadAutoConfigurationTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/bulkhead/BulkheadAutoConfigurationTest.java
@@ -33,7 +33,6 @@ import io.github.resilience4j.bulkhead.Bulkhead;
 import io.github.resilience4j.bulkhead.BulkheadRegistry;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkheadRegistry;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -153,7 +152,7 @@ public class BulkheadAutoConfigurationTest {
         bulkhead.getEventPublisher().onCallPermitted(event -> permitted.incrementAndGet());
         bulkhead.getEventPublisher().onCallRejected(event -> rejected.incrementAndGet());
 
-        dummyFeignClient.doSomething(StringUtils.EMPTY);
+        dummyFeignClient.doSomething("");
 
         ResponseEntity<BulkheadEndpointResponse> bulkheadList = restTemplate
             .getForEntity("/actuator/bulkheads", BulkheadEndpointResponse.class);

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/CircuitBreakerAutoConfigurationTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/CircuitBreakerAutoConfigurationTest.java
@@ -25,7 +25,6 @@ import io.github.resilience4j.common.circuitbreaker.monitoring.endpoint.CircuitB
 import io.github.resilience4j.common.circuitbreaker.monitoring.endpoint.CircuitBreakerEventsEndpointResponse;
 import io.github.resilience4j.springboot.service.test.DummyService;
 import io.github.resilience4j.springboot.service.test.TestApplication;
-import org.apache.http.HttpStatus;
 import org.assertj.core.api.Assertions;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,6 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -173,7 +173,6 @@ public class CircuitBreakerAutoConfigurationTest {
     }
 
     private void verifyCircuitBreakerAutoConfiguration(CircuitBreaker circuitBreaker) {
-        int ok=HttpStatus.SC_OK;
         assertThat(circuitBreaker).isNotNull();
         // expect CircuitBreaker is configured as defined in application.yml
         assertThat(circuitBreaker.getCircuitBreakerConfig().getSlidingWindowSize()).isEqualTo(6);
@@ -190,7 +189,7 @@ public class CircuitBreakerAutoConfigurationTest {
         assertThat(circuitBreaker.getCircuitBreakerConfig().getIgnoreExceptionPredicate()
             .test(new IgnoredException())).isTrue();
         assertThat(circuitBreaker.getCircuitBreakerConfig().getRecordResultPredicate()
-            .test(ok)).isFalse();
+            .test(HttpStatus.OK)).isFalse();
         // Verify that an exception for which setRecordFailurePredicate returns false and it is not included in
         // setRecordExceptions evaluates to false.
         assertThat(circuitBreaker.getCircuitBreakerConfig().getRecordExceptionPredicate()

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/CircuitBreakerFeignTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/CircuitBreakerFeignTest.java
@@ -21,7 +21,6 @@ import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.springboot.service.test.DummyFeignClient;
 import io.github.resilience4j.springboot.service.test.TestApplication;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -67,8 +66,8 @@ public class CircuitBreakerFeignTest {
         } catch (Exception e) {
             // Ignore the error, we want to increase the error counts
         }
-        dummyFeignClient.doSomething(StringUtils.EMPTY);
-        dummyFeignClient.doSomething(StringUtils.EMPTY);
+        dummyFeignClient.doSomething("");
+        dummyFeignClient.doSomething("");
 
         CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("dummyFeignClient");
         assertThat(circuitBreaker).isNotNull();

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/ratelimiter/RateLimiterAutoConfigurationTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/ratelimiter/RateLimiterAutoConfigurationTest.java
@@ -46,7 +46,6 @@ import java.util.concurrent.TimeUnit;
 
 import static com.jayway.awaitility.Awaitility.await;
 import static io.github.resilience4j.springboot.service.test.ratelimiter.RateLimiterDummyFeignClient.RATE_LIMITER_FEIGN_CLIENT_NAME;
-import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -99,7 +98,7 @@ public class RateLimiterAutoConfigurationTest {
         } catch (Exception ex) {
             // Do nothing.
         }
-        rateLimiterDummyFeignClient.doSomething(EMPTY);
+        rateLimiterDummyFeignClient.doSomething("");
 
         assertThat(rateLimiter.getMetrics().getAvailablePermissions()).isEqualTo(8);
         assertThat(rateLimiter.getMetrics().getNumberOfWaitingThreads()).isZero();
@@ -121,7 +120,7 @@ public class RateLimiterAutoConfigurationTest {
 
         try {
             for (int i = 0; i < 11; i++) {
-                rateLimiterDummyFeignClient.doSomething(EMPTY);
+                rateLimiterDummyFeignClient.doSomething("");
             }
         } catch (RequestNotPermitted e) {
             // Do nothing

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/retry/RetryAutoConfigurationTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/retry/RetryAutoConfigurationTest.java
@@ -28,7 +28,6 @@ import io.github.resilience4j.springboot.service.test.TestApplication;
 import io.github.resilience4j.springboot.service.test.retry.RetryDummyFeignClient;
 import io.github.resilience4j.springboot.service.test.retry.RetryDummyService;
 import io.github.resilience4j.springboot.service.test.retry.ReactiveRetryDummyService;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -92,7 +91,7 @@ public class RetryAutoConfigurationTest {
             // Do nothing. The IOException is recorded by the retry as it is one of failure exceptions
         }
         // The invocation is recorded by the CircuitBreaker as a success.
-        retryDummyFeignClient.doSomething(StringUtils.EMPTY);
+        retryDummyFeignClient.doSomething("");
 
         Retry retry = retryRegistry.retry(RetryDummyFeignClient.RETRY_DUMMY_FEIGN_CLIENT_NAME);
         assertThat(retry).isNotNull();


### PR DESCRIPTION
## Changes

* Migrated JUnit 4.13 annotations to Junit Jupiter equivalents
* Updated wiremock and migrated from `@Rule WireMockRule` and `@ClassRule WireMockClassRule` to `@WireMockTest`
* Applied OpenRewrite recipes
    * [JUnit 6 best practices](https://docs.openrewrite.org/recipes/java/testing/junit/junit6bestpractices)
    * [Mockito best practices](https://docs.openrewrite.org/recipes/java/testing/mockito/mockitobestpractices)
    * [Migrate JUnit asserts to AssertJ](https://docs.openrewrite.org/recipes/java/testing/assertj/junittoassertj)
    * [AssertJ best practices](https://docs.openrewrite.org/recipes/java/testing/assertj/assertj-best-practices)
* Removed `public` modifiers
* Expanded star imports to explicit imports
* Removed outdated `test*` prefix
* Removed usages of apache commons (was a transitive dependency of wiremock)
* Converted `try/catch/fail` blocks to `assertThatThrownBy`
* Converted some snake_case test names to camelCase
* Updated Copyright to 2026

## Coverage

| Metric      | Before | After |
|-------------|--------|-------|
| Instruction | 96.0%  | 96.0% |
| Line        | 94.7%  | 94.7% |
| Branch      | 80.8%  | 80.8% |

## Test runtime

| Metric | Before | After |
|--------|--------|-------|
| Tests  | 46     | 46    |
| Time   | 21.1s  | 23.1s |
