### PR TITLE
resilience4j-framework-common: JUnit 4 → JUnit 6 migration

### DIFF
--- a/resilience4j-framework-common/build.gradle
+++ b/resilience4j-framework-common/build.gradle
@@ -6,9 +6,6 @@ dependencies {
     api(project(":resilience4j-retry"))
     api(project(":resilience4j-timelimiter"))
 
-    testRuntimeOnly(libs.junit.vintage.engine)
-
-    testImplementation(libs.junit)
     testImplementation(project(":resilience4j-test"))
 }
 

--- a/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/ratelimiter/configuration/CommonRateLimiterConfigurationProperties.java
+++ b/resilience4j-framework-common/src/main/java/io/github/resilience4j/common/ratelimiter/configuration/CommonRateLimiterConfigurationProperties.java
@@ -16,7 +16,6 @@
 package io.github.resilience4j.common.ratelimiter.configuration;
 
 import java.time.Duration;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/bulkhead/monitoring/endpoint/BulkheadEventDTOFactoryTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/bulkhead/monitoring/endpoint/BulkheadEventDTOFactoryTest.java
@@ -1,19 +1,38 @@
+/*
+ *
+ * Copyright 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *
+ */
 package io.github.resilience4j.bulkhead.monitoring.endpoint;
+
+import org.junit.jupiter.api.Test;
 
 import io.github.resilience4j.bulkhead.event.BulkheadOnCallFinishedEvent;
 import io.github.resilience4j.bulkhead.event.BulkheadOnCallPermittedEvent;
 import io.github.resilience4j.bulkhead.event.BulkheadOnCallRejectedEvent;
 import io.github.resilience4j.common.bulkhead.monitoring.endpoint.BulkheadEventDTO;
 import io.github.resilience4j.common.bulkhead.monitoring.endpoint.BulkheadEventDTOFactory;
-import org.junit.Test;
 
-import static io.github.resilience4j.bulkhead.event.BulkheadEvent.Type.*;
+import static io.github.resilience4j.bulkhead.event.BulkheadEvent.Type.CALL_FINISHED;
+import static io.github.resilience4j.bulkhead.event.BulkheadEvent.Type.CALL_PERMITTED;
+import static io.github.resilience4j.bulkhead.event.BulkheadEvent.Type.CALL_REJECTED;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BulkheadEventDTOFactoryTest {
+class BulkheadEventDTOFactoryTest {
 
     @Test
-    public void shouldMapBulkheadOnCallFinishedEvent() {
+    void shouldMapBulkheadOnCallFinishedEvent() {
         BulkheadOnCallFinishedEvent event = new BulkheadOnCallFinishedEvent("name");
 
         BulkheadEventDTO eventDTO = BulkheadEventDTOFactory.createBulkheadEventDTO(event);
@@ -24,7 +43,7 @@ public class BulkheadEventDTOFactoryTest {
     }
 
     @Test
-    public void shouldMapBulkheadOnCallPermittedEvent() {
+    void shouldMapBulkheadOnCallPermittedEvent() {
         BulkheadOnCallPermittedEvent event = new BulkheadOnCallPermittedEvent("name");
 
         BulkheadEventDTO eventDTO = BulkheadEventDTOFactory.createBulkheadEventDTO(event);
@@ -35,7 +54,7 @@ public class BulkheadEventDTOFactoryTest {
     }
 
     @Test
-    public void shouldMapBulkheadOnCallRejectedEvent() {
+    void shouldMapBulkheadOnCallRejectedEvent() {
         BulkheadOnCallRejectedEvent event = new BulkheadOnCallRejectedEvent("name");
 
         BulkheadEventDTO eventDTO = BulkheadEventDTOFactory.createBulkheadEventDTO(event);

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/circuitbreaker/monitoring/endpoint/CircuitBreakerEventDTOFactoryTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/circuitbreaker/monitoring/endpoint/CircuitBreakerEventDTOFactoryTest.java
@@ -1,21 +1,49 @@
+/*
+ *
+ * Copyright 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *
+ */
 package io.github.resilience4j.circuitbreaker.monitoring.endpoint;
 
-import io.github.resilience4j.circuitbreaker.event.*;
+import io.github.resilience4j.circuitbreaker.event.CircuitBreakerEvent;
+import io.github.resilience4j.circuitbreaker.event.CircuitBreakerOnCallNotPermittedEvent;
+import io.github.resilience4j.circuitbreaker.event.CircuitBreakerOnErrorEvent;
+import io.github.resilience4j.circuitbreaker.event.CircuitBreakerOnIgnoredErrorEvent;
+import io.github.resilience4j.circuitbreaker.event.CircuitBreakerOnResetEvent;
+import io.github.resilience4j.circuitbreaker.event.CircuitBreakerOnStateTransitionEvent;
+import io.github.resilience4j.circuitbreaker.event.CircuitBreakerOnSuccessEvent;
 import io.github.resilience4j.common.circuitbreaker.monitoring.endpoint.CircuitBreakerEventDTO;
 import io.github.resilience4j.common.circuitbreaker.monitoring.endpoint.CircuitBreakerEventDTOFactory;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.time.Duration;
 
+import org.junit.jupiter.api.Test;
+
 import static io.github.resilience4j.circuitbreaker.CircuitBreaker.StateTransition;
-import static io.github.resilience4j.circuitbreaker.event.CircuitBreakerEvent.Type.*;
+import static io.github.resilience4j.circuitbreaker.event.CircuitBreakerEvent.Type.ERROR;
+import static io.github.resilience4j.circuitbreaker.event.CircuitBreakerEvent.Type.IGNORED_ERROR;
+import static io.github.resilience4j.circuitbreaker.event.CircuitBreakerEvent.Type.NOT_PERMITTED;
+import static io.github.resilience4j.circuitbreaker.event.CircuitBreakerEvent.Type.RESET;
+import static io.github.resilience4j.circuitbreaker.event.CircuitBreakerEvent.Type.STATE_TRANSITION;
+import static io.github.resilience4j.circuitbreaker.event.CircuitBreakerEvent.Type.SUCCESS;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CircuitBreakerEventDTOFactoryTest {
+class CircuitBreakerEventDTOFactoryTest {
 
     @Test
-    public void shouldMapCircuitBreakerOnSuccessEvent() {
+    void shouldMapCircuitBreakerOnSuccessEvent() {
         CircuitBreakerOnSuccessEvent event = new CircuitBreakerOnSuccessEvent("name",
             Duration.ofSeconds(5));
 
@@ -30,7 +58,7 @@ public class CircuitBreakerEventDTOFactoryTest {
     }
 
     @Test
-    public void shouldMapCircuitBreakerOnErrorEvent() {
+    void shouldMapCircuitBreakerOnErrorEvent() {
         CircuitBreakerOnErrorEvent event = new CircuitBreakerOnErrorEvent("name",
             Duration.ofSeconds(5), new IOException("Error Message"));
 
@@ -46,7 +74,7 @@ public class CircuitBreakerEventDTOFactoryTest {
     }
 
     @Test
-    public void shouldMapCircuitBreakerOnCallNotPermittedEvent() {
+    void shouldMapCircuitBreakerOnCallNotPermittedEvent() {
         CircuitBreakerOnCallNotPermittedEvent event = new CircuitBreakerOnCallNotPermittedEvent(
             "name");
 
@@ -61,7 +89,7 @@ public class CircuitBreakerEventDTOFactoryTest {
     }
 
     @Test
-    public void shouldMapCircuitBreakerOnStateTransitionEvent() {
+    void shouldMapCircuitBreakerOnStateTransitionEvent() {
         CircuitBreakerOnStateTransitionEvent event = new CircuitBreakerOnStateTransitionEvent(
             "name", StateTransition.CLOSED_TO_OPEN);
 
@@ -79,7 +107,7 @@ public class CircuitBreakerEventDTOFactoryTest {
 
 
     @Test
-    public void shouldMapCircuitBreakerOnIgnoredErrorEvent() {
+    void shouldMapCircuitBreakerOnIgnoredErrorEvent() {
         CircuitBreakerOnIgnoredErrorEvent event = new CircuitBreakerOnIgnoredErrorEvent("name",
             Duration.ofSeconds(5), new IOException("Error Message"));
 
@@ -95,7 +123,7 @@ public class CircuitBreakerEventDTOFactoryTest {
     }
 
     @Test
-    public void shouldMapCircuitBreakerOnResetEvent() {
+    void shouldMapCircuitBreakerOnResetEvent() {
         CircuitBreakerOnResetEvent event = new CircuitBreakerOnResetEvent("name");
 
         CircuitBreakerEventDTO circuitBreakerEventDTO = CircuitBreakerEventDTOFactory

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/bulkhead/configuration/BulkheadConfigurationPropertiesTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/bulkhead/configuration/BulkheadConfigurationPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Mahmoud Romeh
+ * Copyright 2026 Mahmoud Romeh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +18,14 @@ package io.github.resilience4j.common.bulkhead.configuration;
 import io.github.resilience4j.bulkhead.BulkheadConfig;
 import io.github.resilience4j.common.CompositeCustomizer;
 import io.github.resilience4j.core.ConfigurationNotFoundException;
-import org.junit.Test;
 
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -31,10 +33,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * unit test for bulkhead properties
  */
-public class BulkheadConfigurationPropertiesTest {
+class BulkheadConfigurationPropertiesTest {
 
     @Test
-    public void testBulkHeadProperties() {
+    void bulkHeadProperties() {
         //Given
         CommonBulkheadConfigurationProperties.InstanceProperties instanceProperties1 = new CommonBulkheadConfigurationProperties.InstanceProperties();
         instanceProperties1.setMaxConcurrentCalls(3);
@@ -71,7 +73,7 @@ public class BulkheadConfigurationPropertiesTest {
     }
 
     @Test
-    public void testCreateBulkHeadPropertiesWithSharedConfigs() {
+    void createBulkHeadPropertiesWithSharedConfigs() {
         //Given
         CommonBulkheadConfigurationProperties.InstanceProperties defaultProperties = new CommonBulkheadConfigurationProperties.InstanceProperties();
         defaultProperties.setMaxConcurrentCalls(3);
@@ -115,7 +117,7 @@ public class BulkheadConfigurationPropertiesTest {
                 "backendWithDefaultConfig");
         assertThat(bulkhead1).isNotNull();
         assertThat(bulkhead1.getMaxConcurrentCalls()).isEqualTo(3);
-        assertThat(bulkhead1.getMaxWaitDuration().toMillis()).isEqualTo(200L);
+        Assertions.assertThat(bulkhead1.getMaxWaitDuration()).hasMillis(200L);
         assertThat(bulkhead1.isWritableStackTraceEnabled()).isTrue();
 
         // Should get shared config and overwrite wait time
@@ -124,7 +126,7 @@ public class BulkheadConfigurationPropertiesTest {
                 "backendWithSharedConfig");
         assertThat(bulkhead2).isNotNull();
         assertThat(bulkhead2.getMaxConcurrentCalls()).isEqualTo(2);
-        assertThat(bulkhead2.getMaxWaitDuration().toMillis()).isEqualTo(300L);
+        Assertions.assertThat(bulkhead2.getMaxWaitDuration()).hasMillis(300L);
         assertThat(bulkhead2.isWritableStackTraceEnabled()).isFalse();
 
         // Unknown backend should get default config of Registry
@@ -132,13 +134,13 @@ public class BulkheadConfigurationPropertiesTest {
             .createBulkheadConfig(new CommonBulkheadConfigurationProperties.InstanceProperties(),
                 compositeBulkheadCustomizer(), "unknown");
         assertThat(bulkhead3).isNotNull();
-        assertThat(bulkhead3.getMaxWaitDuration().toMillis()).isEqualTo(0L);
+        assertThat(bulkhead3.getMaxWaitDuration().toMillis()).isZero();
         assertThat(bulkhead3.isWritableStackTraceEnabled()).isTrue();
 
     }
 
     @Test
-    public void testCreateBulkHeadPropertiesWithDefaultConfig() {
+    void createBulkHeadPropertiesWithDefaultConfig() {
         //Given
         CommonBulkheadConfigurationProperties.InstanceProperties defaultProperties = new CommonBulkheadConfigurationProperties.InstanceProperties();
         defaultProperties.setMaxConcurrentCalls(3);
@@ -181,7 +183,7 @@ public class BulkheadConfigurationPropertiesTest {
                 "backendWithoutBaseConfig");
         assertThat(bulkhead1).isNotNull();
         assertThat(bulkhead1.getMaxConcurrentCalls()).isEqualTo(3);
-        assertThat(bulkhead1.getMaxWaitDuration().toMillis()).isEqualTo(200L);
+        Assertions.assertThat(bulkhead1.getMaxWaitDuration()).hasMillis(200L);
         assertThat(bulkhead1.isWritableStackTraceEnabled()).isTrue();
 
         // Should get shared config and overwrite wait time
@@ -190,7 +192,7 @@ public class BulkheadConfigurationPropertiesTest {
                 "backendWithSharedConfig");
         assertThat(bulkhead2).isNotNull();
         assertThat(bulkhead2.getMaxConcurrentCalls()).isEqualTo(2);
-        assertThat(bulkhead2.getMaxWaitDuration().toMillis()).isEqualTo(300L);
+        Assertions.assertThat(bulkhead2.getMaxWaitDuration()).hasMillis(300L);
         assertThat(bulkhead2.isWritableStackTraceEnabled()).isFalse();
 
         // Unknown backend should get default config of Registry
@@ -198,13 +200,13 @@ public class BulkheadConfigurationPropertiesTest {
             .createBulkheadConfig(new CommonBulkheadConfigurationProperties.InstanceProperties(),
                 compositeBulkheadCustomizer(), "unknown");
         assertThat(bulkhead3).isNotNull();
-        assertThat(bulkhead3.getMaxWaitDuration().toMillis()).isEqualTo(50L);
+        Assertions.assertThat(bulkhead3.getMaxWaitDuration()).hasMillis(50L);
         assertThat(bulkhead3.isWritableStackTraceEnabled()).isTrue();
 
     }
 
     @Test
-    public void testCreateBulkHeadPropertiesWithUnknownConfig() {
+    void createBulkHeadPropertiesWithUnknownConfig() {
         CommonBulkheadConfigurationProperties bulkheadConfigurationProperties = new CommonBulkheadConfigurationProperties();
 
         CommonBulkheadConfigurationProperties.InstanceProperties instanceProperties = new CommonBulkheadConfigurationProperties.InstanceProperties();
@@ -219,26 +221,29 @@ public class BulkheadConfigurationPropertiesTest {
             .hasMessage("Configuration with name 'unknownConfig' does not exist");
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testIllegalArgumentOnMaxConcurrentCallsLessThanOne() {
-        CommonBulkheadConfigurationProperties.InstanceProperties defaultProperties = new CommonBulkheadConfigurationProperties.InstanceProperties();
-        defaultProperties.setMaxConcurrentCalls(0);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testIllegalArgumentOnMaxWaitDurationNegative() {
-        CommonBulkheadConfigurationProperties.InstanceProperties defaultProperties = new CommonBulkheadConfigurationProperties.InstanceProperties();
-        defaultProperties.setMaxWaitDuration(Duration.ofNanos(-1));
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testBulkheadIllegalArgumentOnEventConsumerBufferSizeLessThanOne() {
-        CommonBulkheadConfigurationProperties.InstanceProperties defaultProperties = new CommonBulkheadConfigurationProperties.InstanceProperties();
-        defaultProperties.setEventConsumerBufferSize(0);
+    @Test
+    void illegalArgumentOnMaxConcurrentCallsLessThanOne() {
+CommonBulkheadConfigurationProperties.InstanceProperties defaultProperties = new CommonBulkheadConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> defaultProperties.setMaxConcurrentCalls(0))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void testBulkheadConfigWithBaseConfig() {
+    void illegalArgumentOnMaxWaitDurationNegative() {
+CommonBulkheadConfigurationProperties.InstanceProperties defaultProperties = new CommonBulkheadConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> defaultProperties.setMaxWaitDuration(Duration.ofNanos(-1)))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void bulkheadIllegalArgumentOnEventConsumerBufferSizeLessThanOne() {
+CommonBulkheadConfigurationProperties.InstanceProperties defaultProperties = new CommonBulkheadConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> defaultProperties.setEventConsumerBufferSize(0))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void bulkheadConfigWithBaseConfig() {
         CommonBulkheadConfigurationProperties.InstanceProperties defaultConfig = new CommonBulkheadConfigurationProperties.InstanceProperties();
         defaultConfig.setMaxConcurrentCalls(2000);
         defaultConfig.setMaxWaitDuration(Duration.ofMillis(100L));
@@ -265,7 +270,7 @@ public class BulkheadConfigurationPropertiesTest {
     }
 
     @Test
-    public void testGetBackendPropertiesPropertiesWithoutDefaultConfig() {
+    void getBackendPropertiesPropertiesWithoutDefaultConfig() {
         //Given
         CommonBulkheadConfigurationProperties.InstanceProperties backendWithoutBaseConfig = new CommonBulkheadConfigurationProperties.InstanceProperties();
 
@@ -283,7 +288,7 @@ public class BulkheadConfigurationPropertiesTest {
     }
 
     @Test
-    public void testGetBackendPropertiesPropertiesWithDefaultConfig() {
+    void getBackendPropertiesPropertiesWithDefaultConfig() {
         //Given
         CommonBulkheadConfigurationProperties.InstanceProperties defaultProperties = new CommonBulkheadConfigurationProperties.InstanceProperties();
         defaultProperties.setEventConsumerBufferSize(99);

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/bulkhead/configuration/ThreadPoolBulkheadConfigurationPropertiesTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/bulkhead/configuration/ThreadPoolBulkheadConfigurationPropertiesTest.java
@@ -1,23 +1,41 @@
+/*
+ *
+ * Copyright 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *
+ */
 package io.github.resilience4j.common.bulkhead.configuration;
 
 import io.github.resilience4j.bulkhead.ThreadPoolBulkheadConfig;
 import io.github.resilience4j.common.CompositeCustomizer;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.jupiter.api.Test;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * unit test for thread pool bulkhead properties
  */
-public class ThreadPoolBulkheadConfigurationPropertiesTest  {
+class ThreadPoolBulkheadConfigurationPropertiesTest  {
 
     @Test
-    public void tesFixedThreadPoolBulkHeadProperties() {
+    void tesFixedThreadPoolBulkHeadProperties() {
         //Given
         CommonThreadPoolBulkheadConfigurationProperties.InstanceProperties backendProperties1 = new CommonThreadPoolBulkheadConfigurationProperties.InstanceProperties();
         backendProperties1.setCoreThreadPoolSize(1);
@@ -43,7 +61,7 @@ public class ThreadPoolBulkheadConfigurationPropertiesTest  {
         ThreadPoolBulkheadConfig bulkhead1 = bulkheadConfigurationProperties
             .createThreadPoolBulkheadConfig("backend1", compositeThreadPoolBulkheadCustomizer());
         assertThat(bulkhead1).isNotNull();
-        assertThat(bulkhead1.getCoreThreadPoolSize()).isEqualTo(1);
+        assertThat(bulkhead1.getCoreThreadPoolSize()).isOne();
 
         ThreadPoolBulkheadConfig bulkhead2 = bulkheadConfigurationProperties
             .createThreadPoolBulkheadConfig("backend2", compositeThreadPoolBulkheadCustomizer());
@@ -58,7 +76,7 @@ public class ThreadPoolBulkheadConfigurationPropertiesTest  {
     }
 
     @Test
-    public void testCreateThreadPoolBulkHeadPropertiesWithSharedConfigs() {
+    void createThreadPoolBulkHeadPropertiesWithSharedConfigs() {
         //Given
         CommonThreadPoolBulkheadConfigurationProperties.InstanceProperties defaultProperties = new CommonThreadPoolBulkheadConfigurationProperties.InstanceProperties();
         defaultProperties.setCoreThreadPoolSize(1);
@@ -90,7 +108,7 @@ public class ThreadPoolBulkheadConfigurationPropertiesTest  {
 
         //When
         //Then
-        assertThat(bulkheadConfigurationProperties.getBackends().size()).isEqualTo(2);
+        assertThat(bulkheadConfigurationProperties.getBackends()).hasSize(2);
         // Should get default config and core number
         ThreadPoolBulkheadConfig bulkhead1 = bulkheadConfigurationProperties
             .createThreadPoolBulkheadConfig("backendWithDefaultConfig",
@@ -98,7 +116,7 @@ public class ThreadPoolBulkheadConfigurationPropertiesTest  {
         assertThat(bulkhead1).isNotNull();
         assertThat(bulkhead1.getCoreThreadPoolSize()).isEqualTo(3);
         assertThat(bulkhead1.getMaxThreadPoolSize()).isEqualTo(10);
-        assertThat(bulkhead1.getQueueCapacity()).isEqualTo(1);
+        assertThat(bulkhead1.getQueueCapacity()).isOne();
         // Should get shared config and overwrite core number
         ThreadPoolBulkheadConfig bulkhead2 = bulkheadConfigurationProperties
             .createThreadPoolBulkheadConfig("backendWithSharedConfig",
@@ -118,7 +136,7 @@ public class ThreadPoolBulkheadConfigurationPropertiesTest  {
     }
 
     @Test
-    public void testCreateThreadPoolBulkHeadPropertiesWithDefaultConfig() {
+    void createThreadPoolBulkHeadPropertiesWithDefaultConfig() {
         //Given
         CommonThreadPoolBulkheadConfigurationProperties.InstanceProperties defaultProperties = new CommonThreadPoolBulkheadConfigurationProperties.InstanceProperties();
         defaultProperties.setCoreThreadPoolSize(1);
@@ -149,7 +167,7 @@ public class ThreadPoolBulkheadConfigurationPropertiesTest  {
 
         //When
         //Then
-        assertThat(bulkheadConfigurationProperties.getBackends().size()).isEqualTo(2);
+        assertThat(bulkheadConfigurationProperties.getBackends()).hasSize(2);
         // Should get default config and core number
         ThreadPoolBulkheadConfig bulkhead1 = bulkheadConfigurationProperties
             .createThreadPoolBulkheadConfig("backendWithoutBaseConfig",
@@ -157,7 +175,7 @@ public class ThreadPoolBulkheadConfigurationPropertiesTest  {
         assertThat(bulkhead1).isNotNull();
         assertThat(bulkhead1.getCoreThreadPoolSize()).isEqualTo(3);
         assertThat(bulkhead1.getMaxThreadPoolSize()).isEqualTo(10);
-        assertThat(bulkhead1.getQueueCapacity()).isEqualTo(1);
+        assertThat(bulkhead1.getQueueCapacity()).isOne();
         // Should get shared config and overwrite core number
         ThreadPoolBulkheadConfig bulkhead2 = bulkheadConfigurationProperties
             .createThreadPoolBulkheadConfig("backendWithSharedConfig",
@@ -171,17 +189,18 @@ public class ThreadPoolBulkheadConfigurationPropertiesTest  {
             .createThreadPoolBulkheadConfig("unknownBackend",
                 compositeThreadPoolBulkheadCustomizer());
         assertThat(bulkhead3).isNotNull();
-        assertThat(bulkhead3.getCoreThreadPoolSize()).isEqualTo(1);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testThreadPoolBulkheadIllegalArgumentOnEventConsumerBufferSizeLessThanOne() {
-        CommonThreadPoolBulkheadConfigurationProperties.InstanceProperties defaultProperties = new CommonThreadPoolBulkheadConfigurationProperties.InstanceProperties();
-        defaultProperties.setEventConsumerBufferSize(0);
+        assertThat(bulkhead3.getCoreThreadPoolSize()).isOne();
     }
 
     @Test
-    public void testThreadPoolBulkheadConfigWithBaseConfig() {
+    void threadPoolBulkheadIllegalArgumentOnEventConsumerBufferSizeLessThanOne() {
+CommonThreadPoolBulkheadConfigurationProperties.InstanceProperties defaultProperties = new CommonThreadPoolBulkheadConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> defaultProperties.setEventConsumerBufferSize(0))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void threadPoolBulkheadConfigWithBaseConfig() {
         CommonThreadPoolBulkheadConfigurationProperties.InstanceProperties defaultConfig = new CommonThreadPoolBulkheadConfigurationProperties.InstanceProperties();
         defaultConfig.setMaxThreadPoolSize(2000);
         defaultConfig.setKeepAliveDuration(Duration.ofMillis(100L));

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationPropertiesTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/circuitbreaker/configuration/CircuitBreakerConfigurationPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Mahmoud Romeh
+ * Copyright 2026 Mahmoud Romeh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import io.github.resilience4j.common.CompositeCustomizer;
 import io.github.resilience4j.common.RecordFailurePredicate;
 import io.github.resilience4j.common.RecordResultPredicate;
 import io.github.resilience4j.core.ConfigurationNotFoundException;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -28,6 +27,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.SlidingWindowSynchronizationStrategy.LOCK_FREE;
 import static io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.SlidingWindowType.TIME_BASED;
@@ -37,11 +39,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * test custom init of circuit breaker registry
  */
-public class CircuitBreakerConfigurationPropertiesTest {
+class CircuitBreakerConfigurationPropertiesTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testCreateCircuitBreakerRegistry() {
+    void createCircuitBreakerRegistry() {
         //Given
         CommonCircuitBreakerConfigurationProperties.InstanceProperties instanceProperties1 = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
         instanceProperties1.setWaitDurationInOpenState(Duration.ofMillis(100));
@@ -74,7 +76,7 @@ public class CircuitBreakerConfigurationPropertiesTest {
         circuitBreakerConfigurationProperties.getInstances().put("backend2", instanceProperties2);
 
         //Then
-        assertThat(circuitBreakerConfigurationProperties.getBackends().size()).isEqualTo(2);
+        assertThat(circuitBreakerConfigurationProperties.getBackends()).hasSize(2);
         assertThat(circuitBreakerConfigurationProperties.getInstances()).hasSize(2);
 
         CircuitBreakerConfig circuitBreaker1 = circuitBreakerConfigurationProperties
@@ -87,8 +89,8 @@ public class CircuitBreakerConfigurationPropertiesTest {
         assertThat(circuitBreaker1.getMinimumNumberOfCalls()).isEqualTo(10);
         assertThat(circuitBreaker1.getPermittedNumberOfCallsInHalfOpenState()).isEqualTo(100);
         assertThat(circuitBreaker1.getFailureRateThreshold()).isEqualTo(50f);
-        assertThat(circuitBreaker1.getSlowCallDurationThreshold().getSeconds()).isEqualTo(5);
-        assertThat(circuitBreaker1.getMaxWaitDurationInHalfOpenState().getSeconds()).isEqualTo(5);
+        assertThat(circuitBreaker1.getSlowCallDurationThreshold()).hasSeconds(5);
+        assertThat(circuitBreaker1.getMaxWaitDurationInHalfOpenState()).hasSeconds(5);
         assertThat(circuitBreaker1.getSlowCallRateThreshold()).isEqualTo(50f);
         assertThat(circuitBreaker1.getWaitIntervalFunctionInOpenState().apply(1)).isEqualTo(100);
         assertThat(circuitBreaker1.isAutomaticTransitionFromOpenToHalfOpenEnabled()).isTrue();
@@ -96,8 +98,7 @@ public class CircuitBreakerConfigurationPropertiesTest {
 
         final CommonCircuitBreakerConfigurationProperties.InstanceProperties backend1 = circuitBreakerConfigurationProperties
             .getBackendProperties("backend1");
-        assertThat(circuitBreakerConfigurationProperties.findCircuitBreakerProperties("backend1"))
-            .isNotEmpty();
+        assertThat(circuitBreakerConfigurationProperties.findCircuitBreakerProperties("backend1")).isPresent();
         assertThat(
             circuitBreakerConfigurationProperties.findCircuitBreakerProperties("backend1").get()
                 .getRegisterHealthIndicator()).isTrue();
@@ -114,7 +115,7 @@ public class CircuitBreakerConfigurationPropertiesTest {
 
 
     @Test
-    public void testCircuitBreakerIntervalFunctionProperties() {
+    void circuitBreakerIntervalFunctionProperties() {
         //Given
         CommonCircuitBreakerConfigurationProperties.InstanceProperties instanceProperties1 = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
         instanceProperties1.setWaitDurationInOpenState(Duration.ofMillis(1000));
@@ -136,7 +137,7 @@ public class CircuitBreakerConfigurationPropertiesTest {
         //Then
         assertThat(circuitBreakerConfigurationProperties.getInstances()).hasSize(2);
         assertThat(circuitBreakerConfigurationProperties.getTags()).isNotEmpty();
-        assertThat(circuitBreakerConfigurationProperties.getBackends().size()).isEqualTo(2);
+        assertThat(circuitBreakerConfigurationProperties.getBackends()).hasSize(2);
         final CircuitBreakerConfig circuitBreakerConfig1 = circuitBreakerConfigurationProperties
             .createCircuitBreakerConfig("backend1", instanceProperties1,
                 compositeCircuitBreakerCustomizer());
@@ -145,8 +146,7 @@ public class CircuitBreakerConfigurationPropertiesTest {
                 compositeCircuitBreakerCustomizer());
         CommonCircuitBreakerConfigurationProperties.InstanceProperties instancePropertiesForRetry1 = circuitBreakerConfigurationProperties
             .getInstances().get("backend1");
-        assertThat(instancePropertiesForRetry1.getWaitDurationInOpenState().toMillis())
-            .isEqualTo(1000);
+        Assertions.assertThat(instancePropertiesForRetry1.getWaitDurationInOpenState()).hasMillis(1000);
         assertThat(circuitBreakerConfig1).isNotNull();
         assertThat(circuitBreakerConfig1.getWaitIntervalFunctionInOpenState()).isNotNull();
         assertThat(circuitBreakerConfig2).isNotNull();
@@ -155,7 +155,7 @@ public class CircuitBreakerConfigurationPropertiesTest {
     }
 
     @Test
-    public void testCreateCircuitBreakerRegistryWithSharedConfigs() {
+    void createCircuitBreakerRegistryWithSharedConfigs() {
         //Given
         CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
         defaultProperties.setSlidingWindowSize(1000);
@@ -217,7 +217,7 @@ public class CircuitBreakerConfigurationPropertiesTest {
     }
 
     @Test
-    public void testCreateCircuitBreakerRegistryWithDefaultConfig() {
+    void createCircuitBreakerRegistryWithDefaultConfig() {
         //Given
         CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
         defaultProperties.setSlidingWindowSize(1000);
@@ -277,7 +277,7 @@ public class CircuitBreakerConfigurationPropertiesTest {
     }
 
     @Test
-    public void testCreateCircuitBreakerRegistryWithUnknownConfig() {
+    void createCircuitBreakerRegistryWithUnknownConfig() {
         CommonCircuitBreakerConfigurationProperties circuitBreakerConfigurationProperties = new CommonCircuitBreakerConfigurationProperties();
 
         CommonCircuitBreakerConfigurationProperties.InstanceProperties instanceProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
@@ -292,101 +292,116 @@ public class CircuitBreakerConfigurationPropertiesTest {
             .hasMessage("Configuration with name 'unknownConfig' does not exist");
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testIllegalArgumentOnEventConsumerBufferSizeLessThanOne() {
-        CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
-        defaultProperties.setEventConsumerBufferSize(0);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testIllegalArgumentOnFailureRateThresholdLessThanOne() {
-        CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
-        defaultProperties.setFailureRateThreshold(0.999f);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testIllegalArgumentOnFailureRateThresholdAboveHundred() {
-        CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
-        defaultProperties.setFailureRateThreshold(100.001f);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testIllegalArgumentOnWaitDurationInOpenStateLessThanMillisecond() {
-        CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
-        defaultProperties.setWaitDurationInOpenState(Duration.ofNanos(999999));
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testIllegalArgumentOnPermittedNumberOfCallsInHalfOpenStateLessThanOne() {
-        CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
-        defaultProperties.setPermittedNumberOfCallsInHalfOpenState(0);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testIllegalArgumentOnMinimumNumberOfCallsLessThanOne() {
-        CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
-        defaultProperties.setMinimumNumberOfCalls(0);
-    }
-
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testIllegalArgumentOnSlidingWindowSizeLessThanOne() {
-        CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
-        defaultProperties.setSlidingWindowSize(0);
-    }
-
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testIllegalArgumentOnSlowCallRateThresholdLessThanOne() {
-        CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
-        defaultProperties.setSlowCallRateThreshold(0.999f);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testIllegalArgumentOnSlowCallRateThresholdAboveHundred() {
-        CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
-        defaultProperties.setSlowCallRateThreshold(100.001f);
-    }
-
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testIllegalArgumentOnSlowCallDurationThresholdLessThanOne() {
-        CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
-        defaultProperties.setSlowCallDurationThreshold(Duration.ZERO);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testIllegalArgumentOnWaitDurationInHalfOpenStateNegative() {
-        CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
-        defaultProperties.setMaxWaitDurationInHalfOpenState(Duration.ofMillis(-1));
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testIllegalArgumentOnExponentialBackoffMultiplierZeroOrLess() {
-        CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
-        defaultProperties.setExponentialBackoffMultiplier(0.0);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testIllegalArgumentOnExponentialMaxWaitDurationInOpenStateLessThanMillisecond() {
-        CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
-        defaultProperties.setExponentialMaxWaitDurationInOpenState(Duration.ofNanos(999999));
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testIllegalArgumentOnRandomizedWaitFactorNegative() {
-        CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
-        defaultProperties.setRandomizedWaitFactor(-0.001);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testIllegalArgumentOnRandomizedWaitFactorBiggerOrEqualOne() {
-        CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
-        defaultProperties.setRandomizedWaitFactor(1.0);
+    @Test
+    void illegalArgumentOnEventConsumerBufferSizeLessThanOne() {
+CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> defaultProperties.setEventConsumerBufferSize(0))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void testCircuitBreakerConfigWithBaseConfig() {
+    void illegalArgumentOnFailureRateThresholdLessThanOne() {
+CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> defaultProperties.setFailureRateThreshold(0.999f))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void illegalArgumentOnFailureRateThresholdAboveHundred() {
+CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> defaultProperties.setFailureRateThreshold(100.001f))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void illegalArgumentOnWaitDurationInOpenStateLessThanMillisecond() {
+CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> defaultProperties.setWaitDurationInOpenState(Duration.ofNanos(999999)))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void illegalArgumentOnPermittedNumberOfCallsInHalfOpenStateLessThanOne() {
+CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> defaultProperties.setPermittedNumberOfCallsInHalfOpenState(0))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void illegalArgumentOnMinimumNumberOfCallsLessThanOne() {
+CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> defaultProperties.setMinimumNumberOfCalls(0))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+
+    @Test
+    void illegalArgumentOnSlidingWindowSizeLessThanOne() {
+CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> defaultProperties.setSlidingWindowSize(0))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+
+    @Test
+    void illegalArgumentOnSlowCallRateThresholdLessThanOne() {
+CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> defaultProperties.setSlowCallRateThreshold(0.999f))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void illegalArgumentOnSlowCallRateThresholdAboveHundred() {
+CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> defaultProperties.setSlowCallRateThreshold(100.001f))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+
+    @Test
+    void illegalArgumentOnSlowCallDurationThresholdLessThanOne() {
+CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> defaultProperties.setSlowCallDurationThreshold(Duration.ZERO))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void illegalArgumentOnWaitDurationInHalfOpenStateNegative() {
+CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> defaultProperties.setMaxWaitDurationInHalfOpenState(Duration.ofMillis(-1)))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void illegalArgumentOnExponentialBackoffMultiplierZeroOrLess() {
+CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> defaultProperties.setExponentialBackoffMultiplier(0.0))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void illegalArgumentOnExponentialMaxWaitDurationInOpenStateLessThanMillisecond() {
+CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> defaultProperties.setExponentialMaxWaitDurationInOpenState(Duration.ofNanos(999999)))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void illegalArgumentOnRandomizedWaitFactorNegative() {
+CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> defaultProperties.setRandomizedWaitFactor(-0.001))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void illegalArgumentOnRandomizedWaitFactorBiggerOrEqualOne() {
+CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> defaultProperties.setRandomizedWaitFactor(1.0))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void circuitBreakerConfigWithBaseConfig() {
         CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultConfig = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
         defaultConfig.setSlidingWindowSize(2000);
         defaultConfig.setWaitDurationInOpenState(Duration.ofMillis(100L));
@@ -414,7 +429,7 @@ public class CircuitBreakerConfigurationPropertiesTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testRecordExceptionWithBaseConfig() {
+    void recordExceptionWithBaseConfig() {
         CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultConfig = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
 
         CommonCircuitBreakerConfigurationProperties.InstanceProperties instanceProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
@@ -428,13 +443,13 @@ public class CircuitBreakerConfigurationPropertiesTest {
         CircuitBreakerConfig circuitBreakerConfig = circuitBreakerConfigurationProperties
             .createCircuitBreakerConfig("instanceWithDefaultConfig", instanceProperties, compositeCircuitBreakerCustomizer());
 
-        assertThat(circuitBreakerConfig.getRecordExceptionPredicate().test(new IllegalArgumentException())).isTrue();
-        assertThat(circuitBreakerConfig.getRecordExceptionPredicate().test(new NullPointerException())).isFalse();
+        Assertions.assertThat(circuitBreakerConfig.getRecordExceptionPredicate()).accepts(new IllegalArgumentException());
+        Assertions.assertThat(circuitBreakerConfig.getRecordExceptionPredicate()).rejects(new NullPointerException());
     }
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testIgnoreExceptionWithBaseConfig() {
+    void ignoreExceptionWithBaseConfig() {
         CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultConfig = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
 
         CommonCircuitBreakerConfigurationProperties.InstanceProperties instanceProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
@@ -448,13 +463,13 @@ public class CircuitBreakerConfigurationPropertiesTest {
         CircuitBreakerConfig circuitBreakerConfig = circuitBreakerConfigurationProperties
             .createCircuitBreakerConfig("instanceWithDefaultConfig", instanceProperties, compositeCircuitBreakerCustomizer());
 
-        assertThat(circuitBreakerConfig.getIgnoreExceptionPredicate().test(new IllegalArgumentException())).isTrue();
-        assertThat(circuitBreakerConfig.getIgnoreExceptionPredicate().test(new NullPointerException())).isFalse();
+        Assertions.assertThat(circuitBreakerConfig.getIgnoreExceptionPredicate()).accepts(new IllegalArgumentException());
+        Assertions.assertThat(circuitBreakerConfig.getIgnoreExceptionPredicate()).rejects(new NullPointerException());
     }
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testIgnoreExceptionPredicateWithBaseConfig() {
+    void ignoreExceptionPredicateWithBaseConfig() {
         CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultConfig = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
 
         CommonCircuitBreakerConfigurationProperties.InstanceProperties instanceProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
@@ -468,23 +483,22 @@ public class CircuitBreakerConfigurationPropertiesTest {
         CircuitBreakerConfig circuitBreakerConfig = circuitBreakerConfigurationProperties
             .createCircuitBreakerConfig("instanceWithDefaultConfig", instanceProperties, compositeCircuitBreakerCustomizer());
 
-        assertThat(circuitBreakerConfig.getIgnoreExceptionPredicate().test(new IOException())).isTrue();
-        assertThat(circuitBreakerConfig.getIgnoreExceptionPredicate().test(new NullPointerException())).isFalse();
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void testCircularReferenceInBaseConfigThrowsIllegalStateException() {
-        CommonCircuitBreakerConfigurationProperties circuitBreakerConfigurationProperties = new CommonCircuitBreakerConfigurationProperties();
-
-        CommonCircuitBreakerConfigurationProperties.InstanceProperties selfReferencingConfig = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
-        selfReferencingConfig.setBaseConfig("selfReferencingConfig");
-        circuitBreakerConfigurationProperties.getConfigs().put("selfReferencingConfig", selfReferencingConfig);
-
-        circuitBreakerConfigurationProperties.createCircuitBreakerConfig("selfReferencingConfig", selfReferencingConfig, compositeCircuitBreakerCustomizer());
+        Assertions.assertThat(circuitBreakerConfig.getIgnoreExceptionPredicate()).accepts(new IOException());
+        Assertions.assertThat(circuitBreakerConfig.getIgnoreExceptionPredicate()).rejects(new NullPointerException());
     }
 
     @Test
-    public void testFindCircuitBreakerPropertiesWithoutDefaultConfig() {
+    void circularReferenceInBaseConfigThrowsIllegalStateException() {
+CommonCircuitBreakerConfigurationProperties circuitBreakerConfigurationProperties = new CommonCircuitBreakerConfigurationProperties();
+        CommonCircuitBreakerConfigurationProperties.InstanceProperties selfReferencingConfig = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
+        selfReferencingConfig.setBaseConfig("selfReferencingConfig");
+        circuitBreakerConfigurationProperties.getConfigs().put("selfReferencingConfig", selfReferencingConfig);
+        assertThatThrownBy(() -> circuitBreakerConfigurationProperties.createCircuitBreakerConfig("selfReferencingConfig", selfReferencingConfig, compositeCircuitBreakerCustomizer()))
+            .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void findCircuitBreakerPropertiesWithoutDefaultConfig() {
         //Given
         CommonCircuitBreakerConfigurationProperties.InstanceProperties backendWithoutBaseConfig = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
 
@@ -504,7 +518,7 @@ public class CircuitBreakerConfigurationPropertiesTest {
     }
 
     @Test
-    public void testFindCircuitBreakerPropertiesWithDefaultConfig() {
+    void findCircuitBreakerPropertiesWithDefaultConfig() {
         //Given
         CommonCircuitBreakerConfigurationProperties.InstanceProperties defaultProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
         defaultProperties.setRegisterHealthIndicator(true);
@@ -529,7 +543,7 @@ public class CircuitBreakerConfigurationPropertiesTest {
     }
 
     @Test
-    public void testCreateCircuitBreakerRegistryWithBaseAndDefaultConfig() {
+    void createCircuitBreakerRegistryWithBaseAndDefaultConfig() {
         CommonCircuitBreakerConfigurationProperties.InstanceProperties baseProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
         baseProperties.setSlidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED);
         baseProperties.setSlidingWindowSize(2000);
@@ -553,7 +567,7 @@ public class CircuitBreakerConfigurationPropertiesTest {
     }
 
     @Test
-    public void shouldRejectLockFreeTimeBasedWithSize1() {
+    void shouldRejectLockFreeTimeBasedWithSize1() {
         assertThatThrownBy(() -> CircuitBreakerConfig.custom()
                 .slidingWindow(1,1, CircuitBreakerConfig.SlidingWindowType.TIME_BASED, LOCK_FREE)
                 .build())

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/circuitbreaker/configuration/CommonCircuitBreakerConfigurationPropertiesTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/circuitbreaker/configuration/CommonCircuitBreakerConfigurationPropertiesTest.java
@@ -1,43 +1,63 @@
+/*
+ *
+ * Copyright 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *
+ */
 package io.github.resilience4j.common.circuitbreaker.configuration;
 
-import org.junit.Test;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import java.time.Duration;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 
-public class CommonCircuitBreakerConfigurationPropertiesTest {
-    @Test(expected = IllegalArgumentException.class)
-    public void maxWaitDurationInHalfOpenStateLessThanSecondShouldFail() {
-        CommonCircuitBreakerConfigurationProperties.InstanceProperties instanceProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
-        instanceProperties.setMaxWaitDurationInHalfOpenState(Duration.ofMillis(-1));
+class CommonCircuitBreakerConfigurationPropertiesTest {
+    @Test
+    void maxWaitDurationInHalfOpenStateLessThanSecondShouldFail() {
+CommonCircuitBreakerConfigurationProperties.InstanceProperties instanceProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> instanceProperties.setMaxWaitDurationInHalfOpenState(Duration.ofMillis(-1)))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void maxWaitDurationInHalfOpenStateEqualZeroShouldPass() {
+    void maxWaitDurationInHalfOpenStateEqualZeroShouldPass() {
         CommonCircuitBreakerConfigurationProperties.InstanceProperties instanceProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
         instanceProperties.setMaxWaitDurationInHalfOpenState(Duration.ofMillis(0));
-        assertThat(instanceProperties.getMaxWaitDurationInHalfOpenState().getSeconds()).isEqualTo(0);
+        assertThat(instanceProperties.getMaxWaitDurationInHalfOpenState().getSeconds()).isZero();
     }
 
     @Test
-    public void transitionToStateAfterWaitDurationEqualOpenShouldPass() {
+    void transitionToStateAfterWaitDurationEqualOpenShouldPass() {
         CommonCircuitBreakerConfigurationProperties.InstanceProperties instanceProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
         instanceProperties.setTransitionToStateAfterWaitDuration(CircuitBreaker.State.OPEN);
         assertThat(instanceProperties.getTransitionToStateAfterWaitDuration()).isEqualTo(CircuitBreaker.State.OPEN);
     }
 
     @Test
-    public void transitionToStateAfterWaitDurationEqualClosedShouldPass() {
+    void transitionToStateAfterWaitDurationEqualClosedShouldPass() {
         CommonCircuitBreakerConfigurationProperties.InstanceProperties instanceProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
         instanceProperties.setTransitionToStateAfterWaitDuration(CircuitBreaker.State.CLOSED);
         assertThat(instanceProperties.getTransitionToStateAfterWaitDuration()).isEqualTo(CircuitBreaker.State.CLOSED);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void transitionToStateAfterWaitDurationEqualHalfOpenShouldFail() {
-        CommonCircuitBreakerConfigurationProperties.InstanceProperties instanceProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
-        instanceProperties.setTransitionToStateAfterWaitDuration(CircuitBreaker.State.HALF_OPEN);
+    @Test
+    void transitionToStateAfterWaitDurationEqualHalfOpenShouldFail() {
+CommonCircuitBreakerConfigurationProperties.InstanceProperties instanceProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> instanceProperties.setTransitionToStateAfterWaitDuration(CircuitBreaker.State.HALF_OPEN))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/circuitbreaker/monitoring/endpoint/CircuitBreakerUpdateStateResponseTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/circuitbreaker/monitoring/endpoint/CircuitBreakerUpdateStateResponseTest.java
@@ -1,16 +1,33 @@
+/*
+ *
+ * Copyright 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *
+ */
 package io.github.resilience4j.common.circuitbreaker.monitoring.endpoint;
 
-import org.junit.Test;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * unit test for CircuitBreakerUpdateStateResponse DTO
  */
-public class CircuitBreakerUpdateStateResponseTest {
+class CircuitBreakerUpdateStateResponseTest {
 
     @Test
-    public void testEquals() {
+    void equals() {
         // Setup
         CircuitBreakerUpdateStateResponse response1 = new CircuitBreakerUpdateStateResponse();
         response1.setCircuitBreakerName("test2");
@@ -23,14 +40,14 @@ public class CircuitBreakerUpdateStateResponseTest {
 
 
         // Verify the results
-        assertEquals(response1.getMessage(), response2.getMessage());
-        assertEquals(response1.getCircuitBreakerName(), response2.getCircuitBreakerName());
-        assertEquals(response1.getCurrentState(), response2.getCurrentState());
-        assertEquals(response1, response2);
+        assertThat(response2.getMessage()).isEqualTo(response1.getMessage());
+        assertThat(response2.getCircuitBreakerName()).isEqualTo(response1.getCircuitBreakerName());
+        assertThat(response2.getCurrentState()).isEqualTo(response1.getCurrentState());
+        assertThat(response2).isEqualTo(response1);
     }
 
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         // Setup
         CircuitBreakerUpdateStateResponse response1 = new CircuitBreakerUpdateStateResponse();
         response1.setCircuitBreakerName("test2");
@@ -42,12 +59,12 @@ public class CircuitBreakerUpdateStateResponseTest {
         response2.setMessage("TestMessage");
 
         // Verify the results
-        assertEquals(response1.hashCode(), response2.hashCode());
+        Assertions.assertThat(response2).hasSameHashCodeAs(response1);
     }
 
 
     @Test
-    public void testToString() {
+    void testToString() {
         // Setup
         CircuitBreakerUpdateStateResponse response1 = new CircuitBreakerUpdateStateResponse();
         response1.setCircuitBreakerName("test2");
@@ -58,6 +75,6 @@ public class CircuitBreakerUpdateStateResponseTest {
         response2.setCurrentState("TESTState");
         response2.setMessage("TestMessage");
         // Verify the results
-        assertEquals(response1.toString(), response2.toString());
+        Assertions.assertThat(response2).hasToString(response1.toString());
     }
 }

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/ratelimiter/configuration/RateLimiterConfigurationPropertiesTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/ratelimiter/configuration/RateLimiterConfigurationPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Mahmoud Romeh
+ * Copyright 2026 Mahmoud Romeh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,19 +24,19 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import org.junit.Test;
-
 import io.github.resilience4j.common.CompositeCustomizer;
+
 import io.github.resilience4j.core.ConfigurationNotFoundException;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
+import org.junit.jupiter.api.Test;
 
 /**
  * test custom init of rate limiter properties
  */
-public class RateLimiterConfigurationPropertiesTest {
+class RateLimiterConfigurationPropertiesTest {
 
     @Test
-    public void testRateLimiterRegistry() {
+    void rateLimiterRegistry() {
         //Given
         CommonRateLimiterConfigurationProperties.InstanceProperties instanceProperties1 = new CommonRateLimiterConfigurationProperties.InstanceProperties();
         instanceProperties1.setLimitForPeriod(2);
@@ -58,9 +58,9 @@ public class RateLimiterConfigurationPropertiesTest {
         globalTagsForRateLimiters.put("testKey1","testKet2");
         rateLimiterConfigurationProperties.setTags(globalTagsForRateLimiters);
         //Then
-        assertThat(rateLimiterConfigurationProperties.getTags().size()).isEqualTo(1);
-        assertThat(rateLimiterConfigurationProperties.getInstances().size()).isEqualTo(2);
-        assertThat(rateLimiterConfigurationProperties.getLimiters().size()).isEqualTo(2);
+        assertThat(rateLimiterConfigurationProperties.getTags()).hasSize(1);
+        assertThat(rateLimiterConfigurationProperties.getInstances()).hasSize(2);
+        assertThat(rateLimiterConfigurationProperties.getLimiters()).hasSize(2);
         RateLimiterConfig rateLimiter = rateLimiterConfigurationProperties
             .createRateLimiterConfig("backend1", compositeRateLimiterCustomizer());
         assertThat(rateLimiter).isNotNull();
@@ -77,7 +77,7 @@ public class RateLimiterConfigurationPropertiesTest {
     }
 
     @Test
-    public void testCreateRateLimiterRegistryWithSharedConfigs() {
+    void createRateLimiterRegistryWithSharedConfigs() {
         //Given
         CommonRateLimiterConfigurationProperties.InstanceProperties defaultProperties = new CommonRateLimiterConfigurationProperties.InstanceProperties();
         defaultProperties.setLimitForPeriod(3);
@@ -112,7 +112,7 @@ public class RateLimiterConfigurationPropertiesTest {
             .put("backendWithSharedConfig", backendWithSharedConfig);
 
         //Then
-        assertThat(rateLimiterConfigurationProperties.getInstances().size()).isEqualTo(2);
+        assertThat(rateLimiterConfigurationProperties.getInstances()).hasSize(2);
 
         // Should get default config and override LimitForPeriod
         RateLimiterConfig rateLimiter1 = rateLimiterConfigurationProperties
@@ -141,7 +141,7 @@ public class RateLimiterConfigurationPropertiesTest {
     }
 
     @Test
-    public void testCreateRateLimiterRegistryWithDefaultConfig() {
+    void createRateLimiterRegistryWithDefaultConfig() {
         //Given
         CommonRateLimiterConfigurationProperties.InstanceProperties defaultProperties = new CommonRateLimiterConfigurationProperties.InstanceProperties();
         defaultProperties.setLimitForPeriod(3);
@@ -175,7 +175,7 @@ public class RateLimiterConfigurationPropertiesTest {
             .put("backendWithSharedConfig", backendWithSharedConfig);
 
         //Then
-        assertThat(rateLimiterConfigurationProperties.getInstances().size()).isEqualTo(2);
+        assertThat(rateLimiterConfigurationProperties.getInstances()).hasSize(2);
 
         // Should get default config and override LimitForPeriod
         RateLimiterConfig rateLimiter1 = rateLimiterConfigurationProperties
@@ -202,7 +202,7 @@ public class RateLimiterConfigurationPropertiesTest {
     }
 
     @Test
-    public void testCreateRateLimiterRegistryWithUnknownConfig() {
+    void createRateLimiterRegistryWithUnknownConfig() {
         CommonRateLimiterConfigurationProperties rateLimiterConfigurationProperties = new CommonRateLimiterConfigurationProperties();
 
         CommonRateLimiterConfigurationProperties.InstanceProperties instanceProperties = new CommonRateLimiterConfigurationProperties.InstanceProperties();
@@ -218,7 +218,7 @@ public class RateLimiterConfigurationPropertiesTest {
     }
 
     @Test
-    public void testFindRateLimiterProperties() {
+    void findRateLimiterProperties() {
         CommonRateLimiterConfigurationProperties rateLimiterConfigurationProperties = new CommonRateLimiterConfigurationProperties();
         CommonRateLimiterConfigurationProperties.InstanceProperties instanceProperties = new CommonRateLimiterConfigurationProperties.InstanceProperties();
         instanceProperties.setLimitForPeriod(3);
@@ -227,16 +227,12 @@ public class RateLimiterConfigurationPropertiesTest {
 
         rateLimiterConfigurationProperties.getInstances().put("default", instanceProperties);
 
-        assertThat(
-            rateLimiterConfigurationProperties.findRateLimiterProperties("default").isPresent())
-            .isTrue();
-        assertThat(
-            rateLimiterConfigurationProperties.findRateLimiterProperties("custom").isPresent())
-            .isFalse();
+        assertThat(rateLimiterConfigurationProperties.findRateLimiterProperties("default")).isPresent();
+        assertThat(rateLimiterConfigurationProperties.findRateLimiterProperties("custom")).isNotPresent();
     }
 
     @Test
-    public void testRateLimiterConfigWithBaseConfig() {
+    void rateLimiterConfigWithBaseConfig() {
         CommonRateLimiterConfigurationProperties.InstanceProperties defaultConfig = new CommonRateLimiterConfigurationProperties.InstanceProperties();
         defaultConfig.setLimitForPeriod(2000);
         defaultConfig.setLimitRefreshPeriod(Duration.ofMillis(100L));
@@ -262,20 +258,22 @@ public class RateLimiterConfigurationPropertiesTest {
         assertThat(instance.getLimitRefreshPeriod()).isEqualTo(Duration.ofMillis(1000L));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testIllegalArgumentOnEventConsumerBufferSizeLessThanOne() {
-        CommonRateLimiterConfigurationProperties.InstanceProperties defaultProperties = new CommonRateLimiterConfigurationProperties.InstanceProperties();
-        defaultProperties.setEventConsumerBufferSize(0);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testIllegalArgumentOnLimitForPeriodLessThanOne() {
-        CommonRateLimiterConfigurationProperties.InstanceProperties defaultProperties = new CommonRateLimiterConfigurationProperties.InstanceProperties();
-        defaultProperties.setLimitForPeriod(0);
+    @Test
+    void illegalArgumentOnEventConsumerBufferSizeLessThanOne() {
+CommonRateLimiterConfigurationProperties.InstanceProperties defaultProperties = new CommonRateLimiterConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> defaultProperties.setEventConsumerBufferSize(0))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void testFindRateLimiterPropertiesWithoutDefaultConfig() {
+    void illegalArgumentOnLimitForPeriodLessThanOne() {
+CommonRateLimiterConfigurationProperties.InstanceProperties defaultProperties = new CommonRateLimiterConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> defaultProperties.setLimitForPeriod(0))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void findRateLimiterPropertiesWithoutDefaultConfig() {
         //Given
         CommonRateLimiterConfigurationProperties.InstanceProperties backendWithoutBaseConfig = new CommonRateLimiterConfigurationProperties.InstanceProperties();
 
@@ -283,7 +281,7 @@ public class RateLimiterConfigurationPropertiesTest {
         rateLimiterConfigurationProperties.getInstances().put("backendWithoutBaseConfig", backendWithoutBaseConfig);
 
         //Then
-        assertThat(rateLimiterConfigurationProperties.getInstances().size()).isEqualTo(1);
+        assertThat(rateLimiterConfigurationProperties.getInstances()).hasSize(1);
 
         // Should get default config and overwrite registerHealthIndicator, allowHealthIndicatorToFail and eventConsumerBufferSize
         Optional<CommonRateLimiterConfigurationProperties.InstanceProperties> rateLimiterProperties =
@@ -295,7 +293,7 @@ public class RateLimiterConfigurationPropertiesTest {
     }
 
     @Test
-    public void testFindCircuitBreakerPropertiesWithDefaultConfig() {
+    void findCircuitBreakerPropertiesWithDefaultConfig() {
         //Given
         CommonRateLimiterConfigurationProperties.InstanceProperties defaultProperties = new CommonRateLimiterConfigurationProperties.InstanceProperties();
         defaultProperties.setRegisterHealthIndicator(true);
@@ -308,7 +306,7 @@ public class RateLimiterConfigurationPropertiesTest {
         rateLimiterConfigurationProperties.getInstances().put("backendWithoutBaseConfig", backendWithoutBaseConfig);
 
         //Then
-        assertThat(rateLimiterConfigurationProperties.getInstances().size()).isEqualTo(1);
+        assertThat(rateLimiterConfigurationProperties.getInstances()).hasSize(1);
 
         // Should get default config and overwrite registerHealthIndicator and eventConsumerBufferSize but not allowHealthIndicatorToFail
         Optional<CommonRateLimiterConfigurationProperties.InstanceProperties> rateLimiterProperties =

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/retry/configuration/CommonRetryConfigurationPropertiesTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/retry/configuration/CommonRetryConfigurationPropertiesTest.java
@@ -1,16 +1,33 @@
+/*
+ *
+ * Copyright 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *
+ */
 package io.github.resilience4j.common.retry.configuration;
 
 import io.github.resilience4j.common.CompositeCustomizer;
 import io.github.resilience4j.retry.RetryConfig;
-import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 
-public class CommonRetryConfigurationPropertiesTest {
+class CommonRetryConfigurationPropertiesTest {
 
     private static final Consumer<CommonRetryConfigurationProperties.InstanceProperties> WITH_WAIT_DURATION = instanceProperties -> instanceProperties.setWaitDuration(Duration.ofSeconds(1));
     private static final Consumer<CommonRetryConfigurationProperties.InstanceProperties> ENABLE_EXPONENTIAL_BACKOFF = instanceProperties -> instanceProperties.setEnableExponentialBackoff(true);
@@ -20,57 +37,57 @@ public class CommonRetryConfigurationPropertiesTest {
     private static final Consumer<CommonRetryConfigurationProperties.InstanceProperties> WITH_RANDOMIZED_FACTOR = instanceProperties -> instanceProperties.setRandomizedWaitFactor(0.5);
 
     @Test
-    public void createRetryConfig_withDefault() {
+    void createRetryConfig_withDefault() {
         testCreateRetryConfig();
     }
 
     @Test
-    public void createRetryConfig_withWaitDuration() {
+    void createRetryConfig_withWaitDuration() {
         testCreateRetryConfig(WITH_WAIT_DURATION);
     }
 
     @Test
-    public void createRetryConfig_withExponentialBackoff() {
+    void createRetryConfig_withExponentialBackoff() {
         testCreateRetryConfig(WITH_WAIT_DURATION, ENABLE_EXPONENTIAL_BACKOFF);
     }
 
     @Test
-    public void createRetryConfig_withBackoffMultiplier() {
+    void createRetryConfig_withBackoffMultiplier() {
         testCreateRetryConfig(WITH_WAIT_DURATION, ENABLE_EXPONENTIAL_BACKOFF, WITH_BACKOFF_MULTIPLIER);
     }
 
     @Test
-    public void createRetryConfig_withExponentialMaxWaitDuration() {
+    void createRetryConfig_withExponentialMaxWaitDuration() {
         testCreateRetryConfig(WITH_WAIT_DURATION, ENABLE_EXPONENTIAL_BACKOFF, WITH_BACKOFF_MULTIPLIER, WITH_EXPONENTIAL_MAX_WAIT_DURATION);
     }
 
     @Test
-    public void createRetryConfig_withRandomizedWait() {
+    void createRetryConfig_withRandomizedWait() {
         testCreateRetryConfig(WITH_WAIT_DURATION, ENABLE_RANDOMIZED_WAIT);
     }
 
     @Test
-    public void createRetryConfig_withRandomizedFactor() {
+    void createRetryConfig_withRandomizedFactor() {
         testCreateRetryConfig(WITH_WAIT_DURATION, ENABLE_RANDOMIZED_WAIT, WITH_RANDOMIZED_FACTOR);
     }
 
     @Test
-    public void createRetryConfig_withRandomizedExponentialBackoff() {
+    void createRetryConfig_withRandomizedExponentialBackoff() {
         testCreateRetryConfig(WITH_WAIT_DURATION, ENABLE_RANDOMIZED_WAIT, ENABLE_EXPONENTIAL_BACKOFF);
     }
 
     @Test
-    public void createRetryConfig_withRandomizedExponentialBackoffMultiplier() {
+    void createRetryConfig_withRandomizedExponentialBackoffMultiplier() {
         testCreateRetryConfig(WITH_WAIT_DURATION, ENABLE_RANDOMIZED_WAIT, ENABLE_EXPONENTIAL_BACKOFF, WITH_BACKOFF_MULTIPLIER);
     }
 
     @Test
-    public void createRetryConfig_withRandomizedFactorExponentialBackoffMultiplier() {
+    void createRetryConfig_withRandomizedFactorExponentialBackoffMultiplier() {
         testCreateRetryConfig(WITH_WAIT_DURATION, ENABLE_RANDOMIZED_WAIT, WITH_RANDOMIZED_FACTOR, ENABLE_EXPONENTIAL_BACKOFF, WITH_BACKOFF_MULTIPLIER);
     }
 
     @Test
-    public void createRetryConfig_withRandomizedExponentialMaxWaitDuration() {
+    void createRetryConfig_withRandomizedExponentialMaxWaitDuration() {
         testCreateRetryConfig(WITH_WAIT_DURATION, ENABLE_RANDOMIZED_WAIT, WITH_RANDOMIZED_FACTOR, ENABLE_EXPONENTIAL_BACKOFF, WITH_BACKOFF_MULTIPLIER, WITH_EXPONENTIAL_MAX_WAIT_DURATION);
     }
 
@@ -88,9 +105,9 @@ public class CommonRetryConfigurationPropertiesTest {
 
         RetryConfig retryConfig = properties.createRetryConfig(testConfigurationName, new CompositeCustomizer<>(List.of()));
 
-        Assertions.assertThat(retryConfig).isNotNull(); // assert that retryConfig does not throw an exception
-        Assertions.assertThat(retryConfig.getIntervalFunction()).isNull();
-        Assertions.assertThat(retryConfig.getIntervalBiFunction()).isNotNull();
+        assertThat(retryConfig).isNotNull(); // assert that retryConfig does not throw an exception
+        assertThat(retryConfig.getIntervalFunction()).isNull();
+        assertThat(retryConfig.getIntervalBiFunction()).isNotNull();
     }
 
 }

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/retry/configuration/RetryConfigurationPropertiesTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/retry/configuration/RetryConfigurationPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Mahmoud Romeh
+ * Copyright 2026 Mahmoud Romeh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,9 +23,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.github.resilience4j.common.CompositeCustomizer;
 import io.github.resilience4j.common.RecordFailurePredicate;
@@ -34,12 +36,12 @@ import io.github.resilience4j.common.utils.ConsumeResultBeforeRetryAttempt;
 import io.github.resilience4j.core.ConfigurationNotFoundException;
 import io.github.resilience4j.retry.RetryConfig;
 
-@RunWith(MockitoJUnitRunner.class)
-public class RetryConfigurationPropertiesTest {
+@ExtendWith(MockitoExtension.class)
+class RetryConfigurationPropertiesTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testRetryProperties() {
+    void retryProperties() {
         CommonRetryConfigurationProperties.InstanceProperties instanceProperties1 = new CommonRetryConfigurationProperties.InstanceProperties();
         instanceProperties1.setMaxAttempts(3);
         instanceProperties1.setWaitDuration(Duration.ofMillis(1000));
@@ -82,14 +84,14 @@ public class RetryConfigurationPropertiesTest {
         assertThat(retry1.getConsumeResultBeforeRetryAttempt().getClass()).isEqualTo(ConsumeResultBeforeRetryAttempt.class);
         assertThat(retry2).isNotNull();
         assertThat(retry2.getMaxAttempts()).isEqualTo(2);
-        assertThat(retry2.getIntervalBiFunction().apply(1,null)).isEqualTo(99L);
-        assertThat(retry2.getIntervalBiFunction().apply(2,null)).isEqualTo(99L);
+        assertThat(retry2.getIntervalBiFunction().apply(1, null)).isEqualTo(99L);
+        assertThat(retry2.getIntervalBiFunction().apply(2, null)).isEqualTo(99L);
         assertThat(retry2.isFailAfterMaxAttempts()).isFalse();
         assertThat(retry2.getConsumeResultBeforeRetryAttempt()).isNull();
     }
 
     @Test
-    public void testExponentialRandomBackoffConfig() {
+    void exponentialRandomBackoffConfig() {
         CommonRetryConfigurationProperties.InstanceProperties instanceProperties1 = new CommonRetryConfigurationProperties.InstanceProperties();
         instanceProperties1.setMaxAttempts(3);
         instanceProperties1.setMaxAttempts(3);
@@ -111,7 +113,7 @@ public class RetryConfigurationPropertiesTest {
     }
 
     @Test
-    public void testCreateRetryPropertiesWithSharedConfigs() {
+    void createRetryPropertiesWithSharedConfigs() {
         CommonRetryConfigurationProperties.InstanceProperties defaultProperties = new CommonRetryConfigurationProperties.InstanceProperties();
         defaultProperties.setMaxAttempts(3);
         defaultProperties.setWaitDuration(Duration.ofMillis(100L));
@@ -157,7 +159,7 @@ public class RetryConfigurationPropertiesTest {
     }
 
     @Test
-    public void testCreateRetryPropertiesWithDefaultConfig() {
+    void createRetryPropertiesWithDefaultConfig() {
         CommonRetryConfigurationProperties.InstanceProperties defaultProperties = new CommonRetryConfigurationProperties.InstanceProperties();
         defaultProperties.setMaxAttempts(3);
         defaultProperties.setWaitDuration(Duration.ofMillis(100L));
@@ -203,7 +205,7 @@ public class RetryConfigurationPropertiesTest {
     }
 
     @Test
-    public void testCreatePropertiesWithUnknownConfig() {
+    void createPropertiesWithUnknownConfig() {
         CommonRetryConfigurationProperties retryConfigurationProperties = new CommonRetryConfigurationProperties();
         CommonRetryConfigurationProperties.InstanceProperties instanceProperties = new CommonRetryConfigurationProperties.InstanceProperties();
         instanceProperties.setBaseConfig("unknownConfig");
@@ -216,7 +218,7 @@ public class RetryConfigurationPropertiesTest {
     }
 
     @Test
-    public void testCreateRetryPropertiesWithWaitDurationSetToZero() {
+    void createRetryPropertiesWithWaitDurationSetToZero() {
         CommonRetryConfigurationProperties retryConfigurationProperties = new CommonRetryConfigurationProperties();
         CommonRetryConfigurationProperties.InstanceProperties instanceProperties = new CommonRetryConfigurationProperties.InstanceProperties();
         instanceProperties.setWaitDuration(Duration.ZERO);
@@ -228,49 +230,57 @@ public class RetryConfigurationPropertiesTest {
         assertThat(retry.getIntervalBiFunction().apply(1, null)).isZero();
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testIllegalArgumentOnEventConsumerBufferSizeLessThanOne() {
+    @Test
+    void illegalArgumentOnEventConsumerBufferSizeLessThanOne() {
         CommonRetryConfigurationProperties.InstanceProperties defaultProperties = new CommonRetryConfigurationProperties.InstanceProperties();
-        defaultProperties.setEventConsumerBufferSize(0);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testIllegalArgumentOnWaitDurationIsNegative() {
-        CommonRetryConfigurationProperties.InstanceProperties defaultProperties = new CommonRetryConfigurationProperties.InstanceProperties();
-        defaultProperties.setWaitDuration(Duration.ofNanos(-1));
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testIllegalArgumentOnMaxAttempts() {
-        CommonRetryConfigurationProperties.InstanceProperties defaultProperties = new CommonRetryConfigurationProperties.InstanceProperties();
-        defaultProperties.setMaxAttempts(0);
-    }
-    @Test(expected = IllegalArgumentException.class)
-    public void testIllegalArgumentOnExponentialBackoffMultiplierZeroOrLess() {
-        CommonRetryConfigurationProperties.InstanceProperties defaultProperties = new CommonRetryConfigurationProperties.InstanceProperties();
-        defaultProperties.setExponentialBackoffMultiplier(0.0);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testIllegalArgumentOnExponentialMaxWaitDurationNegative() {
-        CommonRetryConfigurationProperties.InstanceProperties defaultProperties = new CommonRetryConfigurationProperties.InstanceProperties();
-        defaultProperties.setExponentialMaxWaitDuration(Duration.ofNanos(-1));
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testIllegalArgumentOnRandomizedWaitFactorNegative() {
-        CommonRetryConfigurationProperties.InstanceProperties defaultProperties = new CommonRetryConfigurationProperties.InstanceProperties();
-        defaultProperties.setRandomizedWaitFactor(-0.001);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testIllegalArgumentOnRandomizedWaitFactorBiggerOrEqualOne() {
-        CommonRetryConfigurationProperties.InstanceProperties defaultProperties = new CommonRetryConfigurationProperties.InstanceProperties();
-        defaultProperties.setRandomizedWaitFactor(1.0);
+        assertThatThrownBy(() -> defaultProperties.setEventConsumerBufferSize(0))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void testIntervalBiFunctionConfig() {
+    void illegalArgumentOnWaitDurationIsNegative() {
+        CommonRetryConfigurationProperties.InstanceProperties defaultProperties = new CommonRetryConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> defaultProperties.setWaitDuration(Duration.ofNanos(-1)))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void illegalArgumentOnMaxAttempts() {
+        CommonRetryConfigurationProperties.InstanceProperties defaultProperties = new CommonRetryConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> defaultProperties.setMaxAttempts(0))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void illegalArgumentOnExponentialBackoffMultiplierZeroOrLess() {
+        CommonRetryConfigurationProperties.InstanceProperties defaultProperties = new CommonRetryConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> defaultProperties.setExponentialBackoffMultiplier(0.0))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void illegalArgumentOnExponentialMaxWaitDurationNegative() {
+        CommonRetryConfigurationProperties.InstanceProperties defaultProperties = new CommonRetryConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> defaultProperties.setExponentialMaxWaitDuration(Duration.ofNanos(-1)))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void illegalArgumentOnRandomizedWaitFactorNegative() {
+        CommonRetryConfigurationProperties.InstanceProperties defaultProperties = new CommonRetryConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> defaultProperties.setRandomizedWaitFactor(-0.001))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void illegalArgumentOnRandomizedWaitFactorBiggerOrEqualOne() {
+        CommonRetryConfigurationProperties.InstanceProperties defaultProperties = new CommonRetryConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> defaultProperties.setRandomizedWaitFactor(1.0))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void intervalBiFunctionConfig() {
         CommonRetryConfigurationProperties.InstanceProperties instanceProperties = new CommonRetryConfigurationProperties.InstanceProperties();
         instanceProperties.setIntervalBiFunction(TestIntervalBiFunction.class);
 
@@ -285,7 +295,7 @@ public class RetryConfigurationPropertiesTest {
     }
 
     @Test
-    public void testRetryConfigWithBaseConfig() {
+    void retryConfigWithBaseConfig() {
         CommonRetryConfigurationProperties.InstanceProperties defaultConfig = new CommonRetryConfigurationProperties.InstanceProperties();
         defaultConfig.setMaxAttempts(10);
         defaultConfig.setWaitDuration(Duration.ofMillis(100L));
@@ -312,7 +322,7 @@ public class RetryConfigurationPropertiesTest {
     }
 
     @Test
-    public void testGetBackendPropertiesPropertiesWithoutDefaultConfig() {
+    void getBackendPropertiesPropertiesWithoutDefaultConfig() {
         //Given
         CommonRetryConfigurationProperties.InstanceProperties backendWithoutBaseConfig = new CommonRetryConfigurationProperties.InstanceProperties();
 
@@ -320,7 +330,7 @@ public class RetryConfigurationPropertiesTest {
         retryConfigurationProperties.getInstances().put("backendWithoutBaseConfig", backendWithoutBaseConfig);
 
         //Then
-        assertThat(retryConfigurationProperties.getInstances().size()).isEqualTo(1);
+        assertThat(retryConfigurationProperties.getInstances()).hasSize(1);
 
         // Should get defaults
         CommonRetryConfigurationProperties.InstanceProperties retryProperties =
@@ -331,7 +341,7 @@ public class RetryConfigurationPropertiesTest {
     }
 
     @Test
-    public void testGetBackendPropertiesPropertiesWithDefaultConfig() {
+    void getBackendPropertiesPropertiesWithDefaultConfig() {
         //Given
         CommonRetryConfigurationProperties.InstanceProperties defaultProperties = new CommonRetryConfigurationProperties.InstanceProperties();
         defaultProperties.setEnableExponentialBackoff(true);
@@ -343,7 +353,7 @@ public class RetryConfigurationPropertiesTest {
         retryConfigurationProperties.getInstances().put("backendWithoutBaseConfig", backendWithoutBaseConfig);
 
         //Then
-        assertThat(retryConfigurationProperties.getInstances().size()).isEqualTo(1);
+        assertThat(retryConfigurationProperties.getInstances()).hasSize(1);
 
         // Should get default config and overwrite enableExponentialBackoff but not enableRandomizedWait
         CommonRetryConfigurationProperties.InstanceProperties retryProperties =

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/scheduled/threadpool/configuration/ContextAwareScheduledThreadPoolConfigurationPropertiesTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/scheduled/threadpool/configuration/ContextAwareScheduledThreadPoolConfigurationPropertiesTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2020 krnsaurabh
+ *  Copyright 2026 krnsaurabh
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -18,17 +18,18 @@
  */
 package io.github.resilience4j.common.scheduled.threadpool.configuration;
 
+import org.junit.jupiter.api.Test;
+
 import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
 import io.github.resilience4j.test.TestContextPropagators.TestThreadLocalContextPropagatorWithHolder;
-import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class ContextAwareScheduledThreadPoolConfigurationPropertiesTest {
+class ContextAwareScheduledThreadPoolConfigurationPropertiesTest {
 
     @Test
-    public void buildPropertiesWithValidArguments() {
+    void buildPropertiesWithValidArguments() {
         ContextAwareScheduledThreadPoolConfigurationProperties poolConfigurationProperties = new ContextAwareScheduledThreadPoolConfigurationProperties();
         poolConfigurationProperties.setContextPropagators(TestThreadLocalContextPropagatorWithHolder.class);
         poolConfigurationProperties.setCorePoolSize(10);
@@ -39,15 +40,15 @@ public class ContextAwareScheduledThreadPoolConfigurationPropertiesTest {
     }
 
     @Test
-    public void shouldThrowErrorWhenCorePoolSizeIsLessThanOne() {
+    void shouldThrowErrorWhenCorePoolSizeIsLessThanOne() {
         ContextAwareScheduledThreadPoolConfigurationProperties poolConfigurationProperties = new ContextAwareScheduledThreadPoolConfigurationProperties();
         poolConfigurationProperties.setContextPropagators(TestThreadLocalContextPropagatorWithHolder.class);
-        assertThatExceptionOfType(IllegalArgumentException.class)
-            .isThrownBy(() -> poolConfigurationProperties.setCorePoolSize(0));
+        assertThatThrownBy(() -> poolConfigurationProperties.setCorePoolSize(0))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void buildPropertiesWithNoContextPropagator() {
+    void buildPropertiesWithNoContextPropagator() {
         ContextAwareScheduledThreadPoolConfigurationProperties poolConfigurationProperties = new ContextAwareScheduledThreadPoolConfigurationProperties();
         poolConfigurationProperties.setCorePoolSize(10);
 
@@ -57,10 +58,10 @@ public class ContextAwareScheduledThreadPoolConfigurationPropertiesTest {
     }
 
     @Test
-    public void shouldThrowErrorIfPropertiesNotSet() {
+    void shouldThrowErrorIfPropertiesNotSet() {
         ContextAwareScheduledThreadPoolConfigurationProperties poolConfigurationProperties = new ContextAwareScheduledThreadPoolConfigurationProperties();
-        assertThatExceptionOfType(IllegalArgumentException.class)
-            .isThrownBy(poolConfigurationProperties::build);
+        assertThatThrownBy(poolConfigurationProperties::build)
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
 }

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/timelimiter/configuration/TimeLimiterConfigurationPropertiesTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/timelimiter/configuration/TimeLimiterConfigurationPropertiesTest.java
@@ -1,3 +1,19 @@
+/*
+ *
+ * Copyright 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *
+ */
 package io.github.resilience4j.common.timelimiter.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -8,16 +24,17 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
-
 import io.github.resilience4j.common.CompositeCustomizer;
+
 import io.github.resilience4j.core.ConfigurationNotFoundException;
 import io.github.resilience4j.timelimiter.TimeLimiterConfig;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class TimeLimiterConfigurationPropertiesTest {
+class TimeLimiterConfigurationPropertiesTest {
 
     @Test
-    public void testTimeLimiterProperties() {
+    void timeLimiterProperties() {
         // Given
         CommonTimeLimiterConfigurationProperties.InstanceProperties instanceProperties1 = new CommonTimeLimiterConfigurationProperties.InstanceProperties();
         instanceProperties1.setTimeoutDuration(Duration.ofSeconds(3));
@@ -38,22 +55,22 @@ public class TimeLimiterConfigurationPropertiesTest {
 
         // Then
         assertThat(timeLimiterConfigurationProperties.getTags()).isNotEmpty();
-        assertThat(timeLimiterConfigurationProperties.getInstances().size()).isEqualTo(2);
+        assertThat(timeLimiterConfigurationProperties.getInstances()).hasSize(2);
         final TimeLimiterConfig timeLimiter1 = timeLimiterConfigurationProperties.createTimeLimiterConfig("backend1");
         final TimeLimiterConfig timeLimiter2 = timeLimiterConfigurationProperties.createTimeLimiterConfig("backend2");
 
         CommonTimeLimiterConfigurationProperties.InstanceProperties instancePropertiesForTimeLimiter1 = timeLimiterConfigurationProperties.getInstances().get("backend1");
 
-        assertThat(instancePropertiesForTimeLimiter1.getTimeoutDuration().toMillis()).isEqualTo(3000);
+        Assertions.assertThat(instancePropertiesForTimeLimiter1.getTimeoutDuration()).hasMillis(3000);
         assertThat(timeLimiter1).isNotNull();
         assertThat(timeLimiter1.shouldCancelRunningFuture()).isTrue();
 
         assertThat(timeLimiter2).isNotNull();
-        assertThat(timeLimiter2.getTimeoutDuration().toMillis()).isEqualTo(5000);
+        Assertions.assertThat(timeLimiter2.getTimeoutDuration()).hasMillis(5000);
     }
 
     @Test
-    public void testCreateTimeLimiterPropertiesWithSharedConfigs() {
+    void createTimeLimiterPropertiesWithSharedConfigs() {
         // Given
         CommonTimeLimiterConfigurationProperties.InstanceProperties defaultProperties = new CommonTimeLimiterConfigurationProperties.InstanceProperties();
         defaultProperties.setTimeoutDuration(Duration.ofSeconds(3));
@@ -90,23 +107,23 @@ public class TimeLimiterConfigurationPropertiesTest {
         TimeLimiterConfig timeLimiter1 = timeLimiterConfigurationProperties.createTimeLimiterConfig("backendWithDefaultConfig");
         assertThat(timeLimiter1).isNotNull();
         assertThat(timeLimiter1.shouldCancelRunningFuture()).isTrue();
-        assertThat(timeLimiter1.getTimeoutDuration().toMillis()).isEqualTo(200);
+        Assertions.assertThat(timeLimiter1.getTimeoutDuration()).hasMillis(200);
 
         // Should get shared config and overwrite wait time
         TimeLimiterConfig timeLimiter2 = timeLimiterConfigurationProperties.createTimeLimiterConfig("backendWithSharedConfig");
         assertThat(timeLimiter2).isNotNull();
         assertThat(timeLimiter2.shouldCancelRunningFuture()).isFalse();
-        assertThat(timeLimiter2.getTimeoutDuration().toMillis()).isEqualTo(300);
+        Assertions.assertThat(timeLimiter2.getTimeoutDuration()).hasMillis(300);
 
         // Unknown backend should get default config of Registry
         TimeLimiterConfig timeLimiter3 = timeLimiterConfigurationProperties.createTimeLimiterConfig("unknownBackend");
         assertThat(timeLimiter3).isNotNull();
-        assertThat(timeLimiter3.getTimeoutDuration().toMillis()).isEqualTo(1000);
+        Assertions.assertThat(timeLimiter3.getTimeoutDuration()).hasMillis(1000);
 
     }
 
     @Test
-    public void testCreatePropertiesWithUnknownConfig() {
+    void createPropertiesWithUnknownConfig() {
         CommonTimeLimiterConfigurationProperties timeLimiterConfigurationProperties = new CommonTimeLimiterConfigurationProperties();
 
         CommonTimeLimiterConfigurationProperties.InstanceProperties instanceProperties = new CommonTimeLimiterConfigurationProperties.InstanceProperties();
@@ -119,20 +136,22 @@ public class TimeLimiterConfigurationPropertiesTest {
                 .hasMessage("Configuration with name 'unknownConfig' does not exist");
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testIllegalArgumentOnEventConsumerBufferSizeLessThanOne() {
-        CommonTimeLimiterConfigurationProperties.InstanceProperties defaultProperties = new CommonTimeLimiterConfigurationProperties.InstanceProperties();
-        defaultProperties.setEventConsumerBufferSize(0);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testIllegalArgumentOnTimeoutDurationNegative() {
-        CommonTimeLimiterConfigurationProperties.InstanceProperties defaultProperties = new CommonTimeLimiterConfigurationProperties.InstanceProperties();
-        defaultProperties.setTimeoutDuration(Duration.ofNanos(-1));
+    @Test
+    void illegalArgumentOnEventConsumerBufferSizeLessThanOne() {
+CommonTimeLimiterConfigurationProperties.InstanceProperties defaultProperties = new CommonTimeLimiterConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> defaultProperties.setEventConsumerBufferSize(0))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void testCustomizeTimeLimiterConfig() {
+    void illegalArgumentOnTimeoutDurationNegative() {
+CommonTimeLimiterConfigurationProperties.InstanceProperties defaultProperties = new CommonTimeLimiterConfigurationProperties.InstanceProperties();
+        assertThatThrownBy(() -> defaultProperties.setTimeoutDuration(Duration.ofNanos(-1)))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void customizeTimeLimiterConfig() {
         CommonTimeLimiterConfigurationProperties timeLimiterConfigurationProperties = new CommonTimeLimiterConfigurationProperties();
         TimeLimiterConfigCustomizer customizer = TimeLimiterConfigCustomizer.of("backend",
             builder -> builder.timeoutDuration(Duration.ofSeconds(10)));
@@ -146,7 +165,7 @@ public class TimeLimiterConfigurationPropertiesTest {
     }
 
     @Test
-    public void testTimeLimiterConfigWithBaseConfig() {
+    void timeLimiterConfigWithBaseConfig() {
         CommonTimeLimiterConfigurationProperties.InstanceProperties defaultConfig = new CommonTimeLimiterConfigurationProperties.InstanceProperties();
         defaultConfig.setTimeoutDuration(Duration.ofMillis(4000L));
         defaultConfig.setCancelRunningFuture(false);
@@ -173,7 +192,7 @@ public class TimeLimiterConfigurationPropertiesTest {
     }
 
     @Test
-    public void testTimeLimiterConfigWithDefaultConfig() {
+    void timeLimiterConfigWithDefaultConfig() {
         CommonTimeLimiterConfigurationProperties.InstanceProperties defaultConfig = new CommonTimeLimiterConfigurationProperties.InstanceProperties();
         defaultConfig.setTimeoutDuration(Duration.ofMillis(4000L));
         defaultConfig.setCancelRunningFuture(false);
@@ -206,7 +225,7 @@ public class TimeLimiterConfigurationPropertiesTest {
     }
 
     @Test
-    public void testGetInstancePropertiesPropertiesWithoutDefaultConfig() {
+    void getInstancePropertiesPropertiesWithoutDefaultConfig() {
         //Given
         CommonTimeLimiterConfigurationProperties.InstanceProperties backendWithoutBaseConfig = new CommonTimeLimiterConfigurationProperties.InstanceProperties();
 
@@ -214,7 +233,7 @@ public class TimeLimiterConfigurationPropertiesTest {
         timeLimiterConfigurationProperties.getInstances().put("backendWithoutBaseConfig", backendWithoutBaseConfig);
 
         //Then
-        assertThat(timeLimiterConfigurationProperties.getInstances().size()).isEqualTo(1);
+        assertThat(timeLimiterConfigurationProperties.getInstances()).hasSize(1);
 
         // Should get defaults
         CommonTimeLimiterConfigurationProperties.InstanceProperties timeLimiterProperties =
@@ -224,7 +243,7 @@ public class TimeLimiterConfigurationPropertiesTest {
     }
 
     @Test
-    public void testGetIstancePropertiesPropertiesWithDefaultConfig() {
+    void getIstancePropertiesPropertiesWithDefaultConfig() {
         //Given
         CommonTimeLimiterConfigurationProperties.InstanceProperties defaultProperties = new CommonTimeLimiterConfigurationProperties.InstanceProperties();
         defaultProperties.setEventConsumerBufferSize(99);
@@ -236,7 +255,7 @@ public class TimeLimiterConfigurationPropertiesTest {
         timeLimiterConfigurationProperties.getInstances().put("backendWithoutBaseConfig", backendWithoutBaseConfig);
 
         //Then
-        assertThat(timeLimiterConfigurationProperties.getInstances().size()).isEqualTo(1);
+        assertThat(timeLimiterConfigurationProperties.getInstances()).hasSize(1);
 
         // Should get default config and overwrite enableExponentialBackoff but not enableRandomizedWait
         CommonTimeLimiterConfigurationProperties.InstanceProperties timeLimiterProperties =

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/utils/SpringConfigUtilsTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/common/utils/SpringConfigUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Mahmoud Romeh
+ * Copyright 2026 Mahmoud Romeh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,19 +20,20 @@ import io.github.resilience4j.common.circuitbreaker.configuration.CommonCircuitB
 import io.github.resilience4j.common.ratelimiter.configuration.CommonRateLimiterConfigurationProperties;
 import io.github.resilience4j.common.retry.configuration.CommonRetryConfigurationProperties;
 import io.github.resilience4j.common.timelimiter.configuration.CommonTimeLimiterConfigurationProperties;
-import org.junit.Test;
 
 import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * unit test for spring config merge properties
  */
-public class SpringConfigUtilsTest {
+class SpringConfigUtilsTest {
 
     @Test
-    public void testBulkHeadMergeSpringProperties() {
+    void bulkHeadMergeSpringProperties() {
         CommonBulkheadConfigurationProperties.InstanceProperties shared = new CommonBulkheadConfigurationProperties.InstanceProperties();
         shared.setMaxConcurrentCalls(3);
         shared.setEventConsumerBufferSize(200);
@@ -48,7 +49,7 @@ public class SpringConfigUtilsTest {
     }
 
     @Test
-    public void testCircuitBreakerMergeSpringProperties() {
+    void circuitBreakerMergeSpringProperties() {
 
         CommonCircuitBreakerConfigurationProperties.InstanceProperties sharedProperties = new CommonCircuitBreakerConfigurationProperties.InstanceProperties();
         sharedProperties.setSlidingWindowSize(1337);
@@ -70,7 +71,7 @@ public class SpringConfigUtilsTest {
     }
 
     @Test
-    public void testRetrySpringProperties() {
+    void retrySpringProperties() {
         CommonRetryConfigurationProperties.InstanceProperties sharedProperties = new CommonRetryConfigurationProperties.InstanceProperties();
         sharedProperties.setMaxAttempts(2);
         sharedProperties.setWaitDuration(Duration.ofMillis(100));
@@ -95,7 +96,7 @@ public class SpringConfigUtilsTest {
     }
 
     @Test
-    public void testRateLimiterSpringProperties() {
+    void rateLimiterSpringProperties() {
 
         CommonRateLimiterConfigurationProperties.InstanceProperties sharedProperties = new CommonRateLimiterConfigurationProperties.InstanceProperties();
         sharedProperties.setLimitForPeriod(2);
@@ -118,8 +119,8 @@ public class SpringConfigUtilsTest {
         assertThat(backendWithDefaultConfig.getSubscribeForEvents()).isTrue();
     }
 
-	@Test
-	public void testTimeLimiterSpringProperties() {
+    @Test
+    void timeLimiterSpringProperties() {
 
 		CommonTimeLimiterConfigurationProperties.InstanceProperties sharedProperties = new CommonTimeLimiterConfigurationProperties.InstanceProperties();
 		sharedProperties.setTimeoutDuration(Duration.ofSeconds(20));

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/ratelimiter/monitoring/endpoint/RateLimiterEventDTOTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/ratelimiter/monitoring/endpoint/RateLimiterEventDTOTest.java
@@ -1,18 +1,35 @@
+/*
+ *
+ * Copyright 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *
+ */
 package io.github.resilience4j.ratelimiter.monitoring.endpoint;
+
+import org.junit.jupiter.api.Test;
 
 import io.github.resilience4j.common.ratelimiter.monitoring.endpoint.RateLimiterEventDTO;
 import io.github.resilience4j.ratelimiter.event.RateLimiterOnFailureEvent;
 import io.github.resilience4j.ratelimiter.event.RateLimiterOnSuccessEvent;
-import org.junit.Test;
 
 import static io.github.resilience4j.ratelimiter.event.RateLimiterEvent.Type.FAILED_ACQUIRE;
 import static io.github.resilience4j.ratelimiter.event.RateLimiterEvent.Type.SUCCESSFUL_ACQUIRE;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class RateLimiterEventDTOTest {
+class RateLimiterEventDTOTest {
 
     @Test
-    public void shouldMapRateLimiterOnFailureEvent() {
+    void shouldMapRateLimiterOnFailureEvent() {
         RateLimiterOnFailureEvent event = new RateLimiterOnFailureEvent("name");
 
         RateLimiterEventDTO eventDTO = RateLimiterEventDTO.createRateLimiterEventDTO(event);
@@ -23,7 +40,7 @@ public class RateLimiterEventDTOTest {
     }
 
     @Test
-    public void shouldMapRateLimiterOnSuccessEvent() {
+    void shouldMapRateLimiterOnSuccessEvent() {
         RateLimiterOnSuccessEvent event = new RateLimiterOnSuccessEvent("name");
 
         RateLimiterEventDTO eventDTO = RateLimiterEventDTO.createRateLimiterEventDTO(event);

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/retry/monitoring/endpoint/RetryEventDTOFactoryTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/retry/monitoring/endpoint/RetryEventDTOFactoryTest.java
@@ -1,46 +1,67 @@
+/*
+ *
+ * Copyright 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *
+ */
 package io.github.resilience4j.retry.monitoring.endpoint;
 
 import io.github.resilience4j.common.retry.monitoring.endpoint.RetryEventDTO;
 import io.github.resilience4j.common.retry.monitoring.endpoint.RetryEventDTOFactory;
-import io.github.resilience4j.retry.event.*;
-import org.junit.Test;
+import io.github.resilience4j.retry.event.RetryEvent;
+import io.github.resilience4j.retry.event.RetryOnErrorEvent;
+import io.github.resilience4j.retry.event.RetryOnIgnoredErrorEvent;
+import io.github.resilience4j.retry.event.RetryOnRetryEvent;
+import io.github.resilience4j.retry.event.RetryOnSuccessEvent;
 
 import java.io.IOException;
 
+import org.junit.jupiter.api.Test;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class RetryEventDTOFactoryTest {
+class RetryEventDTOFactoryTest {
 
     @Test
-    public void shouldMapRetryOnSuccessEvent() {
+    void shouldMapRetryOnSuccessEvent() {
         RetryOnSuccessEvent event = new RetryOnSuccessEvent("name", 1,
             new IOException("Error Message"));
 
         RetryEventDTO retryEventDTO = RetryEventDTOFactory.createRetryEventDTO(event);
 
         assertThat(retryEventDTO.getRetryName()).isEqualTo("name");
-        assertThat(retryEventDTO.getNumberOfAttempts()).isEqualTo(1);
+        assertThat(retryEventDTO.getNumberOfAttempts()).isOne();
         assertThat(retryEventDTO.getType()).isEqualTo(RetryEvent.Type.SUCCESS);
         assertThat(retryEventDTO.getErrorMessage()).isEqualTo("java.io.IOException: Error Message");
         assertThat(retryEventDTO.getCreationTime()).isNotNull();
     }
 
     @Test
-    public void shouldMapRetryOnErrorEvent() {
+    void shouldMapRetryOnErrorEvent() {
         RetryOnErrorEvent event = new RetryOnErrorEvent("name", 1,
             new IOException("Error Message"));
 
         RetryEventDTO retryEventDTO = RetryEventDTOFactory.createRetryEventDTO(event);
 
         assertThat(retryEventDTO.getRetryName()).isEqualTo("name");
-        assertThat(retryEventDTO.getNumberOfAttempts()).isEqualTo(1);
+        assertThat(retryEventDTO.getNumberOfAttempts()).isOne();
         assertThat(retryEventDTO.getType()).isEqualTo(RetryEvent.Type.ERROR);
         assertThat(retryEventDTO.getErrorMessage()).isEqualTo("java.io.IOException: Error Message");
         assertThat(retryEventDTO.getCreationTime()).isNotNull();
     }
 
     @Test
-    public void shouldMapRetryOnIgnoredErrorEvent() {
+    void shouldMapRetryOnIgnoredErrorEvent() {
         RetryOnIgnoredErrorEvent event = new RetryOnIgnoredErrorEvent("name",
             new IOException("Error Message"));
 
@@ -54,27 +75,27 @@ public class RetryEventDTOFactoryTest {
     }
 
     @Test
-    public void shouldMapRetryOnRetryEvent() {
+    void shouldMapRetryOnRetryEvent() {
         RetryOnRetryEvent event = new RetryOnRetryEvent("name", 1, new IOException("Error Message"),
             5000);
 
         RetryEventDTO retryEventDTO = RetryEventDTOFactory.createRetryEventDTO(event);
 
         assertThat(retryEventDTO.getRetryName()).isEqualTo("name");
-        assertThat(retryEventDTO.getNumberOfAttempts()).isEqualTo(1);
+        assertThat(retryEventDTO.getNumberOfAttempts()).isOne();
         assertThat(retryEventDTO.getType()).isEqualTo(RetryEvent.Type.RETRY);
         assertThat(retryEventDTO.getErrorMessage()).isEqualTo("java.io.IOException: Error Message");
         assertThat(retryEventDTO.getCreationTime()).isNotNull();
     }
 
     @Test
-    public void shouldMapRetryOnRetryEventWithoutThrowable() {
+    void shouldMapRetryOnRetryEventWithoutThrowable() {
         RetryOnRetryEvent event = new RetryOnRetryEvent("name", 1, null, 5000);
 
         RetryEventDTO retryEventDTO = RetryEventDTOFactory.createRetryEventDTO(event);
 
         assertThat(retryEventDTO.getRetryName()).isEqualTo("name");
-        assertThat(retryEventDTO.getNumberOfAttempts()).isEqualTo(1);
+        assertThat(retryEventDTO.getNumberOfAttempts()).isOne();
         assertThat(retryEventDTO.getType()).isEqualTo(RetryEvent.Type.RETRY);
         assertThat(retryEventDTO.getErrorMessage()).isNull();
         assertThat(retryEventDTO.getCreationTime()).isNotNull();

--- a/resilience4j-framework-common/src/test/java/io/github/resilience4j/timelimiter/monitoring/endpoint/TimeLimiterEventDTOTest.java
+++ b/resilience4j-framework-common/src/test/java/io/github/resilience4j/timelimiter/monitoring/endpoint/TimeLimiterEventDTOTest.java
@@ -1,3 +1,19 @@
+/*
+ *
+ * Copyright 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *
+ */
 package io.github.resilience4j.timelimiter.monitoring.endpoint;
 
 import io.github.resilience4j.common.timelimiter.monitoring.endpoint.TimeLimiterEventDTO;
@@ -5,17 +21,18 @@ import io.github.resilience4j.timelimiter.event.TimeLimiterEvent;
 import io.github.resilience4j.timelimiter.event.TimeLimiterOnErrorEvent;
 import io.github.resilience4j.timelimiter.event.TimeLimiterOnSuccessEvent;
 import io.github.resilience4j.timelimiter.event.TimeLimiterOnTimeoutEvent;
-import org.junit.Test;
 
 import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 
-public class TimeLimiterEventDTOTest {
+class TimeLimiterEventDTOTest {
 
     @Test
-    public void shouldMapTimeLimiterOnSuccessEvent(){
+    void shouldMapTimeLimiterOnSuccessEvent(){
         TimeLimiterOnSuccessEvent event = new TimeLimiterOnSuccessEvent("name");
 
         TimeLimiterEventDTO timeLimiterEventDTO = TimeLimiterEventDTO.createTimeLimiterEventDTO(event);
@@ -26,7 +43,7 @@ public class TimeLimiterEventDTOTest {
     }
 
     @Test
-    public void shouldMapTimeLimiterOnErrorEvent(){
+    void shouldMapTimeLimiterOnErrorEvent(){
         TimeLimiterOnErrorEvent event = new TimeLimiterOnErrorEvent("name", new IOException("Error message"));
 
         TimeLimiterEventDTO timeLimiterEventDTO = TimeLimiterEventDTO.createTimeLimiterEventDTO(event);
@@ -38,7 +55,7 @@ public class TimeLimiterEventDTOTest {
 
 
     @Test
-    public void shouldMapTimeLimiterOnTimeoutEvent(){
+    void shouldMapTimeLimiterOnTimeoutEvent(){
         TimeLimiterOnTimeoutEvent event = new TimeLimiterOnTimeoutEvent("name");
 
         TimeLimiterEventDTO timeLimiterEventDTO = TimeLimiterEventDTO.createTimeLimiterEventDTO(event);


### PR DESCRIPTION
## Changes

* Migrated JUnit 4.13 annotations to Junit Jupiter equivalents
* Applied OpenRewrite recipes
    * [JUnit 6 best practices](https://docs.openrewrite.org/recipes/java/testing/junit/junit6bestpractices)
    * [Mockito best practices](https://docs.openrewrite.org/recipes/java/testing/mockito/mockitobestpractices)
    * [Migrate JUnit asserts to AssertJ](https://docs.openrewrite.org/recipes/java/testing/assertj/junittoassertj)
    * [AssertJ best practices](https://docs.openrewrite.org/recipes/java/testing/assertj/assertj-best-practices)
* Removed `public` modifiers
* Expanded star imports to explicit imports
* Removed outdated `test*` prefix
* Converted `try/catch/fail` blocks to `assertThatThrownBy`
* Updated Copyright to 2026

## Coverage

| Metric      | Before | After |
|-------------|--------|-------|
| Instruction | 73.6%  | 73.6% |
| Line        | 70.2%  | 70.2% |
| Branch      | 77.9%  | 77.9% |

## Test runtime

| Metric | Before | After |
|--------|--------|-------|
| Tests  | 128    | 128   |
| Time   | 1.6s   | 5.4s  |
