### PR TITLE
resilience4j-hedge: JUnit 4 → JUnit 6 migration

### DIFF
--- a/resilience4j-hedge/build.gradle
+++ b/resilience4j-hedge/build.gradle
@@ -1,9 +1,6 @@
 dependencies {
     api(project(":resilience4j-core"))
 
-    testRuntimeOnly(libs.junit.vintage.engine)
-
-    testImplementation(libs.junit)
     testImplementation(project(":resilience4j-test"))
 }
 ext.moduleName = "io.github.resilience4j.hedge"

--- a/resilience4j-hedge/src/test/java/io/github/resilience4j/hedge/HedgeConfigTest.java
+++ b/resilience4j-hedge/src/test/java/io/github/resilience4j/hedge/HedgeConfigTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2021: Matthew Sandoz
+ *  Copyright 2026: Matthew Sandoz
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -18,34 +18,28 @@
  */
 package io.github.resilience4j.hedge;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.BDDAssertions.then;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import io.github.resilience4j.hedge.internal.AverageDurationSupplier;
 import io.github.resilience4j.hedge.internal.HedgeDurationSupplier;
 
-public class HedgeConfigTest {
+class HedgeConfigTest {
 
     private static final String HEDGE_DURATION_MUST_NOT_BE_NULL = "HedgeDuration must not be null";
     private static final String HEDGE_TO_STRING = "HedgeConfig{false,0,true,100,null}";
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
     @Test
-    public void builderTimeoutIsNull() {
-        exception.expect(NullPointerException.class);
-        exception.expectMessage(HEDGE_DURATION_MUST_NOT_BE_NULL);
-
-        HedgeConfig.Builder.fromConfig(HedgeConfig.ofDefaults())
-            .preconfiguredDuration(null);
+    void builderTimeoutIsNull() {
+        assertThatThrownBy(() -> HedgeConfig.Builder.fromConfig(HedgeConfig.ofDefaults()).preconfiguredDuration(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining(HEDGE_DURATION_MUST_NOT_BE_NULL);
     }
 
     @Test
-    public void shouldInitializeFromOtherConfig() {
+    void shouldInitializeFromOtherConfig() {
         HedgeConfig config = HedgeConfig.custom().build();
         HedgeConfig.Builder builder = HedgeConfig.from(config);
 
@@ -53,12 +47,12 @@ public class HedgeConfigTest {
     }
 
     @Test
-    public void configToString() {
+    void configToString() {
         then(HedgeConfig.ofDefaults().toString()).isEqualTo(HEDGE_TO_STRING);
     }
 
     @Test
-    public void shouldCreatePercentCutoff() {
+    void shouldCreatePercentCutoff() {
         HedgeConfig config = HedgeConfig.custom()
             .averagePlusPercentageDuration(100, false).build();
 
@@ -66,7 +60,7 @@ public class HedgeConfigTest {
     }
 
     @Test
-    public void shouldCreateAmountCutoff() {
+    void shouldCreateAmountCutoff() {
         HedgeConfig config = HedgeConfig.custom()
             .averagePlusAmountDuration(200, false, 100).build();
 

--- a/resilience4j-hedge/src/test/java/io/github/resilience4j/hedge/HedgeRegistryTest.java
+++ b/resilience4j-hedge/src/test/java/io/github/resilience4j/hedge/HedgeRegistryTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2021: Matthew Sandoz
+ *  Copyright 2026: Matthew Sandoz
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -26,16 +26,21 @@ import io.github.resilience4j.core.registry.EntryAddedEvent;
 import io.github.resilience4j.core.registry.EntryRemovedEvent;
 import io.github.resilience4j.core.registry.EntryReplacedEvent;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.BDDAssertions.then;
 
-public class HedgeRegistryTest {
+class HedgeRegistryTest {
 
     private static Optional<EventProcessor<?>> getEventProcessor(
         Registry.EventPublisher<Hedge> eventPublisher) {
@@ -47,7 +52,7 @@ public class HedgeRegistryTest {
     }
 
     @Test
-    public void testCreateWithCustomConfig() {
+    void createWithCustomConfig() {
         HedgeConfig config = HedgeConfig.custom()
             .preconfiguredDuration(Duration.ofMillis(500))
             .build();
@@ -59,7 +64,7 @@ public class HedgeRegistryTest {
     }
 
     @Test
-    public void shouldInitRegistryTags() {
+    void shouldInitRegistryTags() {
         HedgeConfig hedgeConfig = HedgeConfig.ofDefaults();
         Map<String, HedgeConfig> hedgeConfigs = Collections
             .singletonMap("default", hedgeConfig);
@@ -73,14 +78,14 @@ public class HedgeRegistryTest {
     }
 
     @Test
-    public void noTagsByDefault() {
+    void noTagsByDefault() {
         Hedge Hedge = HedgeRegistry.builder().build()
             .hedge("testName");
         assertThat(Hedge.getTags()).isEmpty();
     }
 
     @Test
-    public void tagsOfRegistryAddedToInstance() {
+    void tagsOfRegistryAddedToInstance() {
         HedgeConfig hedgeConfig = HedgeConfig.ofDefaults();
         Map<String, HedgeConfig> hedgeConfigs = Collections
             .singletonMap("default", hedgeConfig);
@@ -93,7 +98,7 @@ public class HedgeRegistryTest {
     }
 
     @Test
-    public void tagsAddedToInstance() {
+    void tagsAddedToInstance() {
         HedgeRegistry hedgeRegistry = HedgeRegistry.builder().build();
         Map<String, String> hedgeTags = Map.of("key1", "value1", "key2", "value2");
         Hedge Hedge = hedgeRegistry.hedge("testName", hedgeTags);
@@ -102,7 +107,7 @@ public class HedgeRegistryTest {
     }
 
     @Test
-    public void tagsOfHedgesShouldNotBeMixed() {
+    void tagsOfHedgesShouldNotBeMixed() {
         HedgeRegistry hedgeRegistry = HedgeRegistry.builder().build();
         HedgeConfig hedgeConfig = HedgeConfig.ofDefaults();
         Map<String, String> hedgeTags = Map.of("key1", "value1", "key2", "value2");
@@ -116,7 +121,7 @@ public class HedgeRegistryTest {
     }
 
     @Test
-    public void tagsOfInstanceTagsShouldOverrideRegistryTags() {
+    void tagsOfInstanceTagsShouldOverrideRegistryTags() {
         HedgeConfig hedgeConfig = HedgeConfig.ofDefaults();
         Map<String, HedgeConfig> hedgeConfigs = Collections
             .singletonMap("default", hedgeConfig);
@@ -133,7 +138,7 @@ public class HedgeRegistryTest {
     }
 
     @Test
-    public void testCreateWithConfigurationMap() {
+    void createWithConfigurationMap() {
         Map<String, HedgeConfig> configs = new HashMap<>();
         configs.put("default", HedgeConfig.ofDefaults());
         configs.put("custom", HedgeConfig.ofDefaults());
@@ -145,7 +150,7 @@ public class HedgeRegistryTest {
     }
 
     @Test
-    public void testCreateWithConfigurationMapWithoutDefaultConfig() {
+    void createWithConfigurationMapWithoutDefaultConfig() {
         Map<String, HedgeConfig> configs = new HashMap<>();
         configs.put("custom", HedgeConfig.ofDefaults());
 
@@ -156,7 +161,7 @@ public class HedgeRegistryTest {
     }
 
     @Test
-    public void testCreateWithSingleRegistryEventConsumer() {
+    void createWithSingleRegistryEventConsumer() {
         HedgeRegistry hedgeRegistry = HedgeRegistry.builder()
             .withDefaultConfig(HedgeConfig.ofDefaults())
             .withConsumer(new NoOpHedgeEventConsumer())
@@ -167,7 +172,7 @@ public class HedgeRegistryTest {
     }
 
     @Test
-    public void testCreateWithMultipleRegistryEventConsumer() {
+    void createWithMultipleRegistryEventConsumer() {
         List<RegistryEventConsumer<Hedge>> registryEventConsumers = new ArrayList<>();
         registryEventConsumers.add(new NoOpHedgeEventConsumer());
         registryEventConsumers.add(new NoOpHedgeEventConsumer());
@@ -182,7 +187,7 @@ public class HedgeRegistryTest {
     }
 
     @Test
-    public void testCreateWithConfigurationMapWithSingleRegistryEventConsumer() {
+    void createWithConfigurationMapWithSingleRegistryEventConsumer() {
         Map<String, HedgeConfig> configs = new HashMap<>();
         configs.put("custom", HedgeConfig.ofDefaults());
 
@@ -196,7 +201,7 @@ public class HedgeRegistryTest {
     }
 
     @Test
-    public void testCreateWithConfigurationMapWithMultiRegistryEventConsumer() {
+    void createWithConfigurationMapWithMultiRegistryEventConsumer() {
         Map<String, HedgeConfig> configs = new HashMap<>();
         configs.put("custom", HedgeConfig.ofDefaults());
 
@@ -214,7 +219,7 @@ public class HedgeRegistryTest {
     }
 
     @Test
-    public void testAddConfiguration() {
+    void addConfiguration() {
         HedgeRegistry hedgeRegistry = HedgeRegistry.builder().build();
         hedgeRegistry.addConfiguration("custom", HedgeConfig.custom().build());
 
@@ -223,7 +228,7 @@ public class HedgeRegistryTest {
     }
 
     @Test
-    public void testWithNotExistingConfig() {
+    void withNotExistingConfig() {
         HedgeRegistry hedgeRegistry = HedgeRegistry.builder().build();
 
         assertThatThrownBy(() -> hedgeRegistry.hedge("test", "doesNotExist"))
@@ -231,7 +236,7 @@ public class HedgeRegistryTest {
     }
 
     @Test
-    public void shouldUseCorrectConfig() {
+    void shouldUseCorrectConfig() {
         HedgeRegistry hedgeRegistry = HedgeRegistry.builder().build();
         HedgeConfig config = HedgeConfig.ofDefaults();
 
@@ -242,7 +247,7 @@ public class HedgeRegistryTest {
     }
 
     @Test
-    public void shouldUseCorrectConfigFromStringConfigName() {
+    void shouldUseCorrectConfigFromStringConfigName() {
         HedgeRegistry hedgeRegistry = HedgeRegistry.builder().build();
         HedgeConfig config = HedgeConfig.ofDefaults();
         hedgeRegistry.addConfiguration("test1", config);

--- a/resilience4j-hedge/src/test/java/io/github/resilience4j/hedge/HedgeTest.java
+++ b/resilience4j-hedge/src/test/java/io/github/resilience4j/hedge/HedgeTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2021: Matthew Sandoz
+ *  Copyright 2026: Matthew Sandoz
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -19,16 +19,16 @@
 package io.github.resilience4j.hedge;
 
 import io.github.resilience4j.hedge.internal.HedgeImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
-public class HedgeTest {
+class HedgeTest {
 
     private static final String TEST_HEDGE = "TEST_HEDGE";
 
     @Test
-    public void shouldInitializeOfDefaults() {
+    void shouldInitializeOfDefaults() {
         Hedge hedge = Hedge.ofDefaults();
 
         then(hedge.getHedgeConfig().toString()).isEqualTo(HedgeConfig.ofDefaults().toString());
@@ -36,7 +36,7 @@ public class HedgeTest {
     }
 
     @Test
-    public void shouldInitializeOfName() {
+    void shouldInitializeOfName() {
         Hedge hedge = Hedge.ofDefaults(TEST_HEDGE);
 
         then(hedge.getHedgeConfig().toString()).isEqualTo(HedgeConfig.ofDefaults().toString());
@@ -44,14 +44,14 @@ public class HedgeTest {
     }
 
     @Test
-    public void shouldInitializeOfNameAndDefaults() {
+    void shouldInitializeOfNameAndDefaults() {
         Hedge hedge = Hedge.of(TEST_HEDGE, HedgeConfig.ofDefaults());
 
         then(hedge.getName()).isEqualTo(TEST_HEDGE);
     }
 
     @Test
-    public void shouldInitializeConfig() {
+    void shouldInitializeConfig() {
         HedgeConfig config = HedgeConfig.ofDefaults();
         Hedge hedge = Hedge.of(config);
 

--- a/resilience4j-hedge/src/test/java/io/github/resilience4j/hedge/event/HedgeEventTest.java
+++ b/resilience4j-hedge/src/test/java/io/github/resilience4j/hedge/event/HedgeEventTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2021: Matthew Sandoz
+ *  Copyright 2026: Matthew Sandoz
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -18,13 +18,13 @@
  */
 package io.github.resilience4j.hedge.event;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
-public class HedgeEventTest {
+class HedgeEventTest {
     private static final String HEDGE_NAME = "HEDGE_NAME";
     private static final Duration ONE_SECOND = Duration.ofMillis(1000);
     private static final Throwable THROWABLE = new Throwable(HEDGE_NAME);
@@ -34,7 +34,7 @@ public class HedgeEventTest {
     public static final String FAILED_PRIMARY_TEXT = "Hedge 'HEDGE_NAME' recorded an error: 'java.lang.Throwable: HEDGE_NAME' in 1000ms";
 
     @Test
-    public void shouldCreateCorrectHedgeSuccess() {
+    void shouldCreateCorrectHedgeSuccess() {
         HedgeOnSecondarySuccessEvent event = new HedgeOnSecondarySuccessEvent(HEDGE_NAME, ONE_SECOND);
 
         then(event.getEventType()).isEqualTo(HedgeEvent.Type.SECONDARY_SUCCESS);
@@ -44,7 +44,7 @@ public class HedgeEventTest {
     }
 
     @Test
-    public void shouldCreateCorrectHedgeFailure() {
+    void shouldCreateCorrectHedgeFailure() {
         HedgeOnSecondaryFailureEvent event = new HedgeOnSecondaryFailureEvent(HEDGE_NAME, ONE_SECOND, THROWABLE);
 
         then(event.getEventType()).isEqualTo(HedgeEvent.Type.SECONDARY_FAILURE);
@@ -55,7 +55,7 @@ public class HedgeEventTest {
     }
 
     @Test
-    public void shouldCreateCorrectPrimarySuccess() {
+    void shouldCreateCorrectPrimarySuccess() {
         HedgeOnPrimarySuccessEvent event = new HedgeOnPrimarySuccessEvent(HEDGE_NAME, ONE_SECOND);
 
         then(event.getEventType()).isEqualTo(HedgeEvent.Type.PRIMARY_SUCCESS);
@@ -65,7 +65,7 @@ public class HedgeEventTest {
     }
 
     @Test
-    public void shouldCreateCorrectPrimaryFailure() {
+    void shouldCreateCorrectPrimaryFailure() {
         HedgeOnPrimaryFailureEvent event = new HedgeOnPrimaryFailureEvent(HEDGE_NAME, ONE_SECOND, THROWABLE);
 
         then(event.getEventType()).isEqualTo(HedgeEvent.Type.PRIMARY_FAILURE);

--- a/resilience4j-hedge/src/test/java/io/github/resilience4j/hedge/internal/AveragePlusResponseTimeCutoffTest.java
+++ b/resilience4j-hedge/src/test/java/io/github/resilience4j/hedge/internal/AveragePlusResponseTimeCutoffTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2021: Matthew Sandoz
+ *  Copyright 2026: Matthew Sandoz
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -19,24 +19,21 @@
 package io.github.resilience4j.hedge.internal;
 
 import io.github.resilience4j.hedge.event.HedgeEvent;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+
+import org.junit.jupiter.api.Test;
+
 
 import java.time.Duration;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
-public class AveragePlusResponseTimeCutoffTest {
+class AveragePlusResponseTimeCutoffTest {
 
     private static final Duration LONG_DURATION = Duration.ofMillis(1000);
     private static final Duration SHORT_DURATION = Duration.ofMillis(100);
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
     @Test
-    public void shouldComputeProperlyFromSuccesses() {
+    void shouldComputeProperlyFromSuccesses() {
         AverageDurationSupplier supplier = (AverageDurationSupplier) HedgeDurationSupplier.ofAveragePlus(true, 200, false, 100);
 
         supplier.accept(HedgeEvent.Type.PRIMARY_SUCCESS, LONG_DURATION);
@@ -46,7 +43,7 @@ public class AveragePlusResponseTimeCutoffTest {
     }
 
     @Test
-    public void shouldNotComputeFromHedges() {
+    void shouldNotComputeFromHedges() {
         AverageDurationSupplier supplier = (AverageDurationSupplier) HedgeDurationSupplier.ofAveragePlus(false, 0, false, 100);
 
         supplier.accept(HedgeEvent.Type.SECONDARY_SUCCESS, LONG_DURATION);
@@ -55,7 +52,7 @@ public class AveragePlusResponseTimeCutoffTest {
     }
 
     @Test
-    public void shouldNotComputeFromErrors() {
+    void shouldNotComputeFromErrors() {
         AverageDurationSupplier supplier = (AverageDurationSupplier) HedgeDurationSupplier.ofAveragePlus(false, 0, false, 100);
 
         supplier.accept(HedgeEvent.Type.PRIMARY_FAILURE, LONG_DURATION);
@@ -64,7 +61,7 @@ public class AveragePlusResponseTimeCutoffTest {
     }
 
     @Test
-    public void shouldComputeFromErrorsIfConfigured() {
+    void shouldComputeFromErrorsIfConfigured() {
         AverageDurationSupplier supplier = (AverageDurationSupplier) HedgeDurationSupplier.ofAveragePlus(false, 0, true, 100);
 
         supplier.accept(HedgeEvent.Type.PRIMARY_SUCCESS, SHORT_DURATION);
@@ -74,7 +71,7 @@ public class AveragePlusResponseTimeCutoffTest {
     }
 
     @Test
-    public void shouldUseCorrectAdditiveFactor() {
+    void shouldUseCorrectAdditiveFactor() {
         AverageDurationSupplier supplier = (AverageDurationSupplier) HedgeDurationSupplier.ofAveragePlus(false, 100, false, 100);
 
         supplier.accept(HedgeEvent.Type.PRIMARY_SUCCESS, LONG_DURATION);

--- a/resilience4j-hedge/src/test/java/io/github/resilience4j/hedge/internal/HedgeImplCompletionStageBehaviorsTest.java
+++ b/resilience4j-hedge/src/test/java/io/github/resilience4j/hedge/internal/HedgeImplCompletionStageBehaviorsTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2021: Matthew Sandoz
+ *  Copyright 2026: Matthew Sandoz
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import io.github.resilience4j.hedge.Hedge;
 import io.github.resilience4j.hedge.HedgeConfig;
 import io.github.resilience4j.hedge.event.HedgeEvent;
 import io.github.resilience4j.test.TestContextPropagators;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 
 import java.time.Duration;
@@ -40,7 +40,7 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 
 
-public class HedgeImplCompletionStageBehaviorsTest {
+class HedgeImplCompletionStageBehaviorsTest {
 
     private static final Duration FIFTY_MILLIS = Duration.ofMillis(50);
     private static final String PRIMARY = "Primary";
@@ -63,7 +63,7 @@ public class HedgeImplCompletionStageBehaviorsTest {
     private static final ThreadLocal<String> threadLocal = ThreadLocal.withInitial(() -> "UNINITIALIZED");
 
     @Test
-    public void shouldUsePropagatorsCorrectly() {
+    void shouldUsePropagatorsCorrectly() {
         HedgeBehaviorSpecification[] hedgeBehaviorSpecifications = {SLOW_PRIMARY_SUCCESS, FAST_HEDGE_SUCCESS};
         ContextPropagator propagator = new TestContextPropagators.TestThreadLocalContextPropagator(threadLocal);
         HedgeConfig config = HedgeConfig
@@ -87,7 +87,7 @@ public class HedgeImplCompletionStageBehaviorsTest {
 
 
     @Test
-    public void shouldReturnHedgeSuccessOnSlowPrimarySuccessFastHedgeSuccess() throws Exception {
+    void shouldReturnHedgeSuccessOnSlowPrimarySuccessFastHedgeSuccess() throws Exception {
         HedgeBehaviorSpecification[] hedgeBehaviorSpecifications = {SLOW_PRIMARY_SUCCESS, FAST_HEDGE_SUCCESS};
         Supplier<CompletableFuture<String>> futureSupplier = hedgingCompletionStage(hedgeBehaviorSpecifications);
 
@@ -107,12 +107,12 @@ public class HedgeImplCompletionStageBehaviorsTest {
         assertThat(hedge.getMetrics().getPrimaryFailureCount()).isZero();
         assertThat(hedge.getMetrics().getPrimarySuccessCount()).isZero();
         assertThat(hedge.getMetrics().getSecondaryFailureCount()).isZero();
-        assertThat(hedge.getMetrics().getSecondarySuccessCount()).isEqualTo(1);
+        assertThat(hedge.getMetrics().getSecondarySuccessCount()).isOne();
         assertThat(hedge.getMetrics().getSecondaryPoolActiveCount()).isZero();
     }
 
     @Test
-    public void slowPrimarySuccessFastHedgeFailureReturnsHedgeFailure() throws Exception {
+    void slowPrimarySuccessFastHedgeFailureReturnsHedgeFailure() throws Exception {
         HedgeBehaviorSpecification[] hedgeBehaviorSpecifications = {SLOW_PRIMARY_SUCCESS, FAST_HEDGE_FAILURE};
         Supplier<CompletableFuture<String>> futureSupplier = hedgingCompletionStage(hedgeBehaviorSpecifications);
 
@@ -129,14 +129,14 @@ public class HedgeImplCompletionStageBehaviorsTest {
             assertThat(hedge.getMetrics().getCurrentHedgeDelay().toMillis()).isLessThan(SLOW_SPEED);
             assertThat(hedge.getMetrics().getPrimaryFailureCount()).isZero();
             assertThat(hedge.getMetrics().getPrimarySuccessCount()).isZero();
-            assertThat(hedge.getMetrics().getSecondaryFailureCount()).isEqualTo(1);
+            assertThat(hedge.getMetrics().getSecondaryFailureCount()).isOne();
             assertThat(hedge.getMetrics().getSecondarySuccessCount()).isZero();
             assertThat(hedge.getMetrics().getSecondaryPoolActiveCount()).isZero();
         }
     }
 
     @Test
-    public void slowPrimaryFailureFastHedgeSuccessReturnsHedgeSuccess() throws Exception {
+    void slowPrimaryFailureFastHedgeSuccessReturnsHedgeSuccess() throws Exception {
         HedgeBehaviorSpecification[] hedgeBehaviorSpecifications = {SLOW_PRIMARY_SUCCESS, FAST_HEDGE_SUCCESS};
         Supplier<CompletableFuture<String>> futureSupplier = hedgingCompletionStage(hedgeBehaviorSpecifications);
 
@@ -150,12 +150,12 @@ public class HedgeImplCompletionStageBehaviorsTest {
         assertThat(hedge.getMetrics().getPrimaryFailureCount()).isZero();
         assertThat(hedge.getMetrics().getPrimarySuccessCount()).isZero();
         assertThat(hedge.getMetrics().getSecondaryFailureCount()).isZero();
-        assertThat(hedge.getMetrics().getSecondarySuccessCount()).isEqualTo(1);
+        assertThat(hedge.getMetrics().getSecondarySuccessCount()).isOne();
         assertThat(hedge.getMetrics().getSecondaryPoolActiveCount()).isZero();
     }
 
     @Test
-    public void slowPrimaryFailureFastHedgeFailureReturnsHedgeFailure() throws Exception {
+    void slowPrimaryFailureFastHedgeFailureReturnsHedgeFailure() throws Exception {
         HedgeBehaviorSpecification[] hedgeBehaviorSpecifications = {SLOW_PRIMARY_FAILURE, FAST_HEDGE_FAILURE};
         Supplier<CompletableFuture<String>> futureSupplier = hedgingCompletionStage(hedgeBehaviorSpecifications);
 
@@ -172,14 +172,14 @@ public class HedgeImplCompletionStageBehaviorsTest {
             assertThat(hedge.getMetrics().getCurrentHedgeDelay().toMillis()).isLessThan(SLOW_SPEED);
             assertThat(hedge.getMetrics().getPrimaryFailureCount()).isZero();
             assertThat(hedge.getMetrics().getPrimarySuccessCount()).isZero();
-            assertThat(hedge.getMetrics().getSecondaryFailureCount()).isEqualTo(1);
+            assertThat(hedge.getMetrics().getSecondaryFailureCount()).isOne();
             assertThat(hedge.getMetrics().getSecondarySuccessCount()).isZero();
             assertThat(hedge.getMetrics().getSecondaryPoolActiveCount()).isZero();
         }
     }
 
     @Test
-    public void slowPrimarySuccessSlowHedgeSuccessReturnsPrimarySuccess() throws Exception {
+    void slowPrimarySuccessSlowHedgeSuccessReturnsPrimarySuccess() throws Exception {
         HedgeBehaviorSpecification[] hedgeBehaviorSpecifications = {SLOW_PRIMARY_SUCCESS, SLOW_HEDGE_SUCCESS};
         Supplier<CompletableFuture<String>> futureSupplier = hedgingCompletionStage(hedgeBehaviorSpecifications);
 
@@ -191,14 +191,14 @@ public class HedgeImplCompletionStageBehaviorsTest {
         then(logger).should().info(HedgeEvent.Type.PRIMARY_SUCCESS.toString());
         assertThat(hedge.getMetrics().getCurrentHedgeDelay().toMillis()).isLessThan(SLOW_SPEED);
         assertThat(hedge.getMetrics().getPrimaryFailureCount()).isZero();
-        assertThat(hedge.getMetrics().getPrimarySuccessCount()).isEqualTo(1);
+        assertThat(hedge.getMetrics().getPrimarySuccessCount()).isOne();
         assertThat(hedge.getMetrics().getSecondaryFailureCount()).isZero();
         assertThat(hedge.getMetrics().getSecondarySuccessCount()).isZero();
         assertThat(hedge.getMetrics().getSecondaryPoolActiveCount()).isZero();
     }
 
     @Test
-    public void slowPrimarySuccessSlowHedgeFailureReturnsPrimarySuccess() throws Exception {
+    void slowPrimarySuccessSlowHedgeFailureReturnsPrimarySuccess() throws Exception {
         HedgeBehaviorSpecification[] hedgeBehaviorSpecifications = {SLOW_PRIMARY_SUCCESS, SLOW_HEDGE_FAILURE};
         Supplier<CompletableFuture<String>> futureSupplier = hedgingCompletionStage(hedgeBehaviorSpecifications);
 
@@ -210,14 +210,14 @@ public class HedgeImplCompletionStageBehaviorsTest {
         then(logger).should().info(HedgeEvent.Type.PRIMARY_SUCCESS.toString());
         assertThat(hedge.getMetrics().getCurrentHedgeDelay().toMillis()).isLessThan(SLOW_SPEED);
         assertThat(hedge.getMetrics().getPrimaryFailureCount()).isZero();
-        assertThat(hedge.getMetrics().getPrimarySuccessCount()).isEqualTo(1);
+        assertThat(hedge.getMetrics().getPrimarySuccessCount()).isOne();
         assertThat(hedge.getMetrics().getSecondaryFailureCount()).isZero();
         assertThat(hedge.getMetrics().getSecondarySuccessCount()).isZero();
         assertThat(hedge.getMetrics().getSecondaryPoolActiveCount()).isZero();
     }
 
     @Test
-    public void slowPrimaryFailureSlowHedgeSuccessReturnsPrimaryFailure() throws Exception {
+    void slowPrimaryFailureSlowHedgeSuccessReturnsPrimaryFailure() throws Exception {
         HedgeBehaviorSpecification[] hedgeBehaviorSpecifications = {SLOW_PRIMARY_FAILURE, SLOW_HEDGE_SUCCESS};
         Supplier<CompletableFuture<String>> futureSupplier = hedgingCompletionStage(hedgeBehaviorSpecifications);
 
@@ -232,7 +232,7 @@ public class HedgeImplCompletionStageBehaviorsTest {
             assertThat(e.getCause().getMessage()).isEqualTo(PRIMARY_EXCEPTION_MESSAGE);
             then(logger).should().info(HedgeEvent.Type.PRIMARY_FAILURE.toString());
             assertThat(hedge.getMetrics().getCurrentHedgeDelay().toMillis()).isLessThan(SLOW_SPEED);
-            assertThat(hedge.getMetrics().getPrimaryFailureCount()).isEqualTo(1);
+            assertThat(hedge.getMetrics().getPrimaryFailureCount()).isOne();
             assertThat(hedge.getMetrics().getPrimarySuccessCount()).isZero();
             assertThat(hedge.getMetrics().getSecondaryFailureCount()).isZero();
             assertThat(hedge.getMetrics().getSecondarySuccessCount()).isZero();
@@ -241,7 +241,7 @@ public class HedgeImplCompletionStageBehaviorsTest {
     }
 
     @Test
-    public void slowPrimaryFailureSlowHedgeFailureReturnsPrimaryFailure() throws Exception {
+    void slowPrimaryFailureSlowHedgeFailureReturnsPrimaryFailure() throws Exception {
         HedgeBehaviorSpecification[] hedgeBehaviorSpecifications = {SLOW_PRIMARY_FAILURE, SLOW_HEDGE_FAILURE};
         Supplier<CompletableFuture<String>> futureSupplier = hedgingCompletionStage(hedgeBehaviorSpecifications);
 
@@ -256,7 +256,7 @@ public class HedgeImplCompletionStageBehaviorsTest {
             assertThat(e.getCause().getMessage()).isEqualTo(PRIMARY_EXCEPTION_MESSAGE);
             then(logger).should().info(HedgeEvent.Type.PRIMARY_FAILURE.toString());
             assertThat(hedge.getMetrics().getCurrentHedgeDelay().toMillis()).isLessThan(SLOW_SPEED);
-            assertThat(hedge.getMetrics().getPrimaryFailureCount()).isEqualTo(1);
+            assertThat(hedge.getMetrics().getPrimaryFailureCount()).isOne();
             assertThat(hedge.getMetrics().getPrimarySuccessCount()).isZero();
             assertThat(hedge.getMetrics().getSecondaryFailureCount()).isZero();
             assertThat(hedge.getMetrics().getSecondarySuccessCount()).isZero();
@@ -265,7 +265,7 @@ public class HedgeImplCompletionStageBehaviorsTest {
     }
 
     @Test
-    public void fastPrimaryFailureDoesNotHedge() throws Exception {
+    void fastPrimaryFailureDoesNotHedge() throws Exception {
         HedgeBehaviorSpecification[] hedgeBehaviorSpecifications = {FAST_PRIMARY_FAILURE, FAST_HEDGE_SUCCESS};
         Supplier<CompletableFuture<String>> futureSupplier = hedgingCompletionStage(hedgeBehaviorSpecifications);
 
@@ -280,7 +280,7 @@ public class HedgeImplCompletionStageBehaviorsTest {
             assertThat(e.getCause().getMessage()).isEqualTo(PRIMARY_EXCEPTION_MESSAGE);
             then(logger).should().info(HedgeEvent.Type.PRIMARY_FAILURE.toString());
             assertThat(hedge.getMetrics().getCurrentHedgeDelay().toMillis()).isLessThan(SLOW_SPEED);
-            assertThat(hedge.getMetrics().getPrimaryFailureCount()).isEqualTo(1);
+            assertThat(hedge.getMetrics().getPrimaryFailureCount()).isOne();
             assertThat(hedge.getMetrics().getPrimarySuccessCount()).isZero();
             assertThat(hedge.getMetrics().getSecondaryFailureCount()).isZero();
             assertThat(hedge.getMetrics().getSecondarySuccessCount()).isZero();
@@ -289,7 +289,7 @@ public class HedgeImplCompletionStageBehaviorsTest {
     }
 
     @Test
-    public void fastPrimarySuccessDoesNotHedge() throws Exception {
+    void fastPrimarySuccessDoesNotHedge() throws Exception {
         HedgeBehaviorSpecification[] hedgeBehaviorSpecifications = {FAST_PRIMARY_SUCCESS, FAST_HEDGE_SUCCESS};
         Hedge hedge = Hedge.of(FIFTY_MILLIS);
         hedge.getEventPublisher().onPrimarySuccess(event -> logger.info(event.getEventType().toString()));
@@ -301,7 +301,7 @@ public class HedgeImplCompletionStageBehaviorsTest {
         then(logger).should().info(HedgeEvent.Type.PRIMARY_SUCCESS.toString());
         assertThat(hedge.getMetrics().getCurrentHedgeDelay().toMillis()).isLessThan(SLOW_SPEED);
         assertThat(hedge.getMetrics().getPrimaryFailureCount()).isZero();
-        assertThat(hedge.getMetrics().getPrimarySuccessCount()).isEqualTo(1);
+        assertThat(hedge.getMetrics().getPrimarySuccessCount()).isOne();
         assertThat(hedge.getMetrics().getSecondaryFailureCount()).isZero();
         assertThat(hedge.getMetrics().getSecondarySuccessCount()).isZero();
         assertThat(hedge.getMetrics().getSecondaryPoolActiveCount()).isZero();

--- a/resilience4j-hedge/src/test/java/io/github/resilience4j/hedge/internal/HedgeImplFutureBehaviorsTest.java
+++ b/resilience4j-hedge/src/test/java/io/github/resilience4j/hedge/internal/HedgeImplFutureBehaviorsTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2021: Matthew Sandoz
+ *  Copyright 2026: Matthew Sandoz
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -20,11 +20,15 @@ package io.github.resilience4j.hedge.internal;
 
 import io.github.resilience4j.hedge.Hedge;
 import io.github.resilience4j.hedge.event.HedgeEvent;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 
 import java.time.Duration;
-import java.util.concurrent.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,7 +37,7 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 
 
-public class HedgeImplFutureBehaviorsTest {
+class HedgeImplFutureBehaviorsTest {
 
     private static final Duration HEDGE_ACTIVATION_TIME = Duration.ofMillis(50);
     private static final String PRIMARY = "Primary";
@@ -56,7 +60,7 @@ public class HedgeImplFutureBehaviorsTest {
     private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
 
     @Test
-    public void shouldReturnValueWhenSuppliedExecutor() throws Exception {
+    void shouldReturnValueWhenSuppliedExecutor() throws Exception {
         HedgeBehaviorSpecification[] hedgeBehaviorSpecifications = {SLOW_PRIMARY_SUCCESS, FAST_HEDGE_SUCCESS};
         Hedge hedge = Hedge.of(HEDGE_ACTIVATION_TIME);
         hedge.getEventPublisher().onSecondarySuccess(event -> logger.info(event.getEventType().toString()));
@@ -68,7 +72,7 @@ public class HedgeImplFutureBehaviorsTest {
     }
 
     @Test
-    public void slowPrimarySuccessFastHedgeSuccessReturnsHedgeSuccess() throws Exception {
+    void slowPrimarySuccessFastHedgeSuccessReturnsHedgeSuccess() throws Exception {
         HedgeBehaviorSpecification[] hedgeBehaviorSpecifications = {SLOW_PRIMARY_SUCCESS, FAST_HEDGE_SUCCESS};
         Hedge hedge = Hedge.of(HEDGE_ACTIVATION_TIME);
         hedge.getEventPublisher().onSecondarySuccess(event -> logger.info(event.getEventType().toString()));
@@ -79,7 +83,7 @@ public class HedgeImplFutureBehaviorsTest {
     }
 
     @Test
-    public void slowPrimarySuccessFastHedgeFailureReturnsHedgeFailure() throws Exception {
+    void slowPrimarySuccessFastHedgeFailureReturnsHedgeFailure() throws Exception {
         HedgeBehaviorSpecification[] hedgeBehaviorSpecifications = {SLOW_PRIMARY_SUCCESS, FAST_HEDGE_FAILURE};
         Hedge hedge = Hedge.of(HEDGE_ACTIVATION_TIME);
         hedge.getEventPublisher().onSecondaryFailure(event -> logger.info(event.getEventType().toString()));
@@ -95,7 +99,7 @@ public class HedgeImplFutureBehaviorsTest {
     }
 
     @Test
-    public void slowPrimaryFailureFastHedgeSuccessReturnsHedgeSuccess() throws Exception {
+    void slowPrimaryFailureFastHedgeSuccessReturnsHedgeSuccess() throws Exception {
         HedgeBehaviorSpecification[] hedgeBehaviorSpecifications = {SLOW_PRIMARY_SUCCESS, FAST_HEDGE_SUCCESS};
         Hedge hedge = Hedge.of(HEDGE_ACTIVATION_TIME);
         hedge.getEventPublisher().onSecondarySuccess(event -> logger.info(event.getEventType().toString()));
@@ -105,7 +109,7 @@ public class HedgeImplFutureBehaviorsTest {
     }
 
     @Test
-    public void slowPrimaryFailureFastHedgeFailureReturnsHedgeFailure() throws Exception {
+    void slowPrimaryFailureFastHedgeFailureReturnsHedgeFailure() throws Exception {
         HedgeBehaviorSpecification[] hedgeBehaviorSpecifications = {SLOW_PRIMARY_FAILURE, FAST_HEDGE_FAILURE};
         Hedge hedge = Hedge.of(HEDGE_ACTIVATION_TIME);
         hedge.getEventPublisher().onSecondaryFailure(event -> logger.info(event.getEventType().toString()));
@@ -120,7 +124,7 @@ public class HedgeImplFutureBehaviorsTest {
     }
 
     @Test
-    public void slowPrimarySuccessSlowHedgeSuccessReturnsPrimarySuccess() throws Exception {
+    void slowPrimarySuccessSlowHedgeSuccessReturnsPrimarySuccess() throws Exception {
         HedgeBehaviorSpecification[] hedgeBehaviorSpecifications = {SLOW_PRIMARY_SUCCESS, SLOW_HEDGE_SUCCESS};
         Hedge hedge = Hedge.of(HEDGE_ACTIVATION_TIME);
         hedge.getEventPublisher().onPrimarySuccess(event -> logger.info(event.getEventType().toString()));
@@ -130,7 +134,7 @@ public class HedgeImplFutureBehaviorsTest {
     }
 
     @Test
-    public void slowPrimarySuccessSlowHedgeFailureReturnsPrimarySuccess() throws Exception {
+    void slowPrimarySuccessSlowHedgeFailureReturnsPrimarySuccess() throws Exception {
         HedgeBehaviorSpecification[] hedgeBehaviorSpecifications = {SLOW_PRIMARY_SUCCESS, SLOW_HEDGE_FAILURE};
         Hedge hedge = Hedge.of(HEDGE_ACTIVATION_TIME);
         hedge.getEventPublisher().onPrimarySuccess(event -> logger.info(event.getEventType().toString()));
@@ -140,7 +144,7 @@ public class HedgeImplFutureBehaviorsTest {
     }
 
     @Test
-    public void slowPrimaryFailureSlowHedgeSuccessReturnsPrimaryFailure() throws Exception {
+    void slowPrimaryFailureSlowHedgeSuccessReturnsPrimaryFailure() throws Exception {
         HedgeBehaviorSpecification[] hedgeBehaviorSpecifications = {SLOW_PRIMARY_FAILURE, SLOW_HEDGE_SUCCESS};
         Hedge hedge = Hedge.of(HEDGE_ACTIVATION_TIME);
         hedge.getEventPublisher().onPrimaryFailure(event -> logger.info(event.getEventType().toString()));
@@ -155,7 +159,7 @@ public class HedgeImplFutureBehaviorsTest {
     }
 
     @Test
-    public void slowPrimaryFailureSlowHedgeFailureReturnsPrimaryFailure() throws Exception {
+    void slowPrimaryFailureSlowHedgeFailureReturnsPrimaryFailure() throws Exception {
         HedgeBehaviorSpecification[] hedgeBehaviorSpecifications = {SLOW_PRIMARY_FAILURE, SLOW_HEDGE_FAILURE};
         Hedge hedge = Hedge.of(HEDGE_ACTIVATION_TIME);
         hedge.getEventPublisher().onPrimaryFailure(event -> logger.info(event.getEventType().toString()));
@@ -170,7 +174,7 @@ public class HedgeImplFutureBehaviorsTest {
     }
 
     @Test
-    public void fastPrimaryFailureDoesNotHedge() throws Exception {
+    void fastPrimaryFailureDoesNotHedge() throws Exception {
         HedgeBehaviorSpecification[] hedgeBehaviorSpecifications = {FAST_PRIMARY_FAILURE, FAST_HEDGE_SUCCESS};
         Hedge hedge = Hedge.of(HEDGE_ACTIVATION_TIME);
         hedge.getEventPublisher().onPrimaryFailure(event -> logger.info(event.getEventType().toString()));
@@ -185,7 +189,7 @@ public class HedgeImplFutureBehaviorsTest {
     }
 
     @Test
-    public void fastPrimarySuccessDoesNotHedge() throws Exception {
+    void fastPrimarySuccessDoesNotHedge() throws Exception {
         HedgeBehaviorSpecification[] hedgeBehaviorSpecifications = {FAST_PRIMARY_SUCCESS, FAST_HEDGE_SUCCESS};
         Hedge hedge = Hedge.of(HEDGE_ACTIVATION_TIME);
         hedge.getEventPublisher().onPrimarySuccess(event -> logger.info(event.getEventType().toString()));

--- a/resilience4j-hedge/src/test/java/io/github/resilience4j/hedge/internal/HedgeImplTest.java
+++ b/resilience4j-hedge/src/test/java/io/github/resilience4j/hedge/internal/HedgeImplTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2021: Matthew Sandoz
+ *  Copyright 2026: Matthew Sandoz
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -21,12 +21,12 @@ package io.github.resilience4j.hedge.internal;
 import io.github.resilience4j.hedge.Hedge;
 import io.github.resilience4j.hedge.HedgeConfig;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Duration;
 
@@ -35,7 +35,8 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.mockito.ArgumentMatchers.any;
 
-public class HedgeImplTest {
+@ExtendWith(MockitoExtension.class)
+class HedgeImplTest {
 
     private static final String NAME = "name";
     private final HedgeConfig hedgeConfig = HedgeConfig.custom().preconfiguredDuration(Duration.ZERO).build();
@@ -44,34 +45,29 @@ public class HedgeImplTest {
     @InjectMocks
     private final Hedge hedge = new io.github.resilience4j.hedge.internal.HedgeImpl("name", hedgeConfig);
 
-    @Before
-    public void init() {
-        MockitoAnnotations.initMocks(this);
-    }
-
     @Test
-    public void shouldSetGivenName() {
+    void shouldSetGivenName() {
         Hedge hedge = Hedge.ofDefaults(NAME);
         assertThat(hedge.getName()).isEqualTo(NAME);
     }
 
     @Test
-    public void shouldPropagateConfig() {
+    void shouldPropagateConfig() {
         then(hedge.getHedgeConfig()).isEqualTo(hedgeConfig);
     }
 
     @Test
-    public void shouldPropagateName() {
+    void shouldPropagateName() {
         then(hedge.getName()).isEqualTo(NAME);
     }
 
     @Test
-    public void shouldDefaultToPreconfiguredSupplier() {
+    void shouldDefaultToPreconfiguredSupplier() {
         then(hedge.getDurationSupplier()).isOfAnyClassIn(PreconfiguredDurationSupplier.class);
     }
 
     @Test
-    public void shouldHandleConsumerErrors() {
+    void shouldHandleConsumerErrors() {
         hedge.getEventPublisher().onEvent(event -> {
             throw new RuntimeException("BAD_CONSUMER");
         });
@@ -79,12 +75,12 @@ public class HedgeImplTest {
     }
 
     @Test
-    public void shouldNotPublishWithoutConsumers() {
-        Mockito.doThrow(new RuntimeException("fail")).when(eventProcessor).consumeEvent(any());
-
+    void shouldNotPublishWithoutConsumers() {
         assertThatNoException().isThrownBy(() -> hedge.onPrimarySuccess(Duration.ofMillis(1000)));
         assertThatNoException().isThrownBy(() -> hedge.onSecondarySuccess(Duration.ofMillis(1000)));
         assertThatNoException().isThrownBy(() -> hedge.onPrimaryFailure(Duration.ofMillis(1000), new Throwable()));
         assertThatNoException().isThrownBy(() -> hedge.onSecondaryFailure(Duration.ofMillis(1000), new Throwable()));
+
+        Mockito.verify(eventProcessor, Mockito.never()).consumeEvent(any());
     }
 }

--- a/resilience4j-hedge/src/test/java/io/github/resilience4j/hedge/internal/InMemoryHedgeRegistryTest.java
+++ b/resilience4j-hedge/src/test/java/io/github/resilience4j/hedge/internal/InMemoryHedgeRegistryTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2021: Matthew Sandoz
+ *  Copyright 2026: Matthew Sandoz
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -21,32 +21,33 @@ package io.github.resilience4j.hedge.internal;
 import io.github.resilience4j.hedge.Hedge;
 import io.github.resilience4j.hedge.HedgeConfig;
 import io.github.resilience4j.hedge.HedgeRegistry;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+
+import org.junit.jupiter.api.Test;
+
 
 import java.util.function.Supplier;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
-public class InMemoryHedgeRegistryTest {
+class InMemoryHedgeRegistryTest {
 
     private static final String CONFIG_MUST_NOT_BE_NULL = "Config must not be null";
     private static final String NAME_MUST_NOT_BE_NULL = "Name must not be null";
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
     private HedgeConfig config;
 
-    @Before
-    public void init() {
+    @BeforeEach
+    void init() {
         config = HedgeConfig.ofDefaults();
     }
 
     @Test
-    public void hedgePositive() {
+    void hedgePositive() {
         HedgeRegistry registry = HedgeRegistry.builder().withDefaultConfig(config).build();
 
         Hedge firstHedge = registry.hedge("test");
@@ -59,15 +60,15 @@ public class InMemoryHedgeRegistryTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void hedgePositiveWithSupplier() {
+    void hedgePositiveWithSupplier() {
         HedgeRegistry registry = HedgeRegistry.builder().withDefaultConfig(config).build();
         Supplier<HedgeConfig> hedgeConfigSupplier = mock(Supplier.class);
         given(hedgeConfigSupplier.get()).willReturn(config);
 
         Hedge firstHedge = registry.hedge("test", hedgeConfigSupplier);
-        verify(hedgeConfigSupplier, times(1)).get();
+        verify(hedgeConfigSupplier).get();
         Hedge sameAsFirst = registry.hedge("test", hedgeConfigSupplier);
-        verify(hedgeConfigSupplier, times(1)).get();
+        verify(hedgeConfigSupplier).get();
         Hedge anotherLimit = registry.hedge("test1", hedgeConfigSupplier);
         verify(hedgeConfigSupplier, times(2)).get();
 
@@ -76,65 +77,59 @@ public class InMemoryHedgeRegistryTest {
     }
 
     @Test
-    public void hedgeConfigIsNull() {
-        exception.expect(NullPointerException.class);
-        exception.expectMessage(CONFIG_MUST_NOT_BE_NULL);
-
-        HedgeRegistry.builder().withDefaultConfig(null).build();
+    void hedgeConfigIsNull() {
+        assertThatThrownBy(() -> HedgeRegistry.builder().withDefaultConfig(null).build())
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining(CONFIG_MUST_NOT_BE_NULL);
     }
 
     @Test
-    public void hedgeNewWithNullName() {
-        exception.expect(NullPointerException.class);
-        exception.expectMessage(NAME_MUST_NOT_BE_NULL);
+    void hedgeNewWithNullName() {
         HedgeRegistry registry = HedgeRegistry.builder().withDefaultConfig(config).build();
-
-        registry.hedge(null);
+        assertThatThrownBy(() -> registry.hedge(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining(NAME_MUST_NOT_BE_NULL);
     }
 
     @Test
-    public void hedgeNewWithNullNonDefaultConfig() {
-        exception.expect(NullPointerException.class);
-        exception.expectMessage(CONFIG_MUST_NOT_BE_NULL);
+    void hedgeNewWithNullNonDefaultConfig() {
         HedgeRegistry registry = HedgeRegistry.builder().withDefaultConfig(config).build();
-
-        registry.hedge("name", (HedgeConfig) null);
+        assertThatThrownBy(() -> registry.hedge("name", (HedgeConfig) null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining(CONFIG_MUST_NOT_BE_NULL);
     }
 
     @Test
-    public void hedgeNewWithNullNameAndNonDefaultConfig() {
-        exception.expect(NullPointerException.class);
-        exception.expectMessage(NAME_MUST_NOT_BE_NULL);
+    void hedgeNewWithNullNameAndNonDefaultConfig() {
         HedgeRegistry registry = HedgeRegistry.builder().withDefaultConfig(config).build();
-
-        registry.hedge(null, config);
+        assertThatThrownBy(() -> registry.hedge(null, config))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining(NAME_MUST_NOT_BE_NULL);
     }
 
     @Test
-    public void hedgeNewWithNullNameAndConfigSupplier() {
-        exception.expect(NullPointerException.class);
-        exception.expectMessage(NAME_MUST_NOT_BE_NULL);
+    void hedgeNewWithNullNameAndConfigSupplier() {
         HedgeRegistry registry = HedgeRegistry.builder().withDefaultConfig(config).build();
-
-        registry.hedge(null, () -> config);
+        assertThatThrownBy(() -> registry.hedge(null, () -> config))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining(NAME_MUST_NOT_BE_NULL);
     }
 
     @Test
-    public void hedgeNewWithNullConfigSupplier() {
-        exception.expect(NullPointerException.class);
-        exception.expectMessage("Supplier must not be null");
+    void hedgeNewWithNullConfigSupplier() {
         HedgeRegistry registry = HedgeRegistry.builder().withDefaultConfig(config).build();
-
-        registry.hedge("name", (Supplier<HedgeConfig>) null);
+        assertThatThrownBy(() -> registry.hedge("name", (Supplier<HedgeConfig>) null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("Supplier must not be null");
     }
 
     @Test
-    public void hedgeGetAllHedges() {
+    void hedgeGetAllHedges() {
         HedgeRegistry registry = HedgeRegistry.builder().withDefaultConfig(config).build();
 
         registry.hedge("foo");
 
-        then(registry.getAllHedges().count()).isEqualTo(1);
+        then(registry.getAllHedges().count()).isOne();
         then(registry.getAllHedges().findFirst().orElseThrow().getName()).isEqualTo("foo");
     }
 


### PR DESCRIPTION
## Changes

* Migrated JUnit 4.13 annotations to Junit Jupiter equivalents
* Replaced `@Rule ExpectedException` with `assertThatThrownBy(...)`
* Applied OpenRewrite recipes
    * [JUnit 6 best practices](https://docs.openrewrite.org/recipes/java/testing/junit/junit6bestpractices)
    * [Mockito best practices](https://docs.openrewrite.org/recipes/java/testing/mockito/mockitobestpractices)
    * [Migrate JUnit asserts to AssertJ](https://docs.openrewrite.org/recipes/java/testing/assertj/junittoassertj)
    * [AssertJ best practices](https://docs.openrewrite.org/recipes/java/testing/assertj/assertj-best-practices)
* Removed `public` modifiers
* Expanded star imports to explicit imports
* Removed outdated `test*` prefix
* Updated Copyright to 2026

## Coverage

| Metric      | Before | After |
|-------------|--------|-------|
| Instruction | 97.8%  | 97.8% |
| Line        | 97.2%  | 97.2% |
| Branch      | 89.2%  | 89.2% |

## Test runtime

| Metric | Before | After |
|--------|--------|-------|
| Tests  | 72     | 72    |
| Time   | 5.5s   | 6.6s  |
