### PR TITLE
resilience4j-kotlin: JUnit 4 → JUnit 6 migration

### DIFF
--- a/resilience4j-kotlin/build.gradle
+++ b/resilience4j-kotlin/build.gradle
@@ -15,9 +15,6 @@ dependencies {
     compileOnly(project(":resilience4j-retry"))
     compileOnly(project(":resilience4j-timelimiter"))
 
-    testRuntimeOnly(libs.junit.vintage.engine)
-
-    testImplementation(libs.junit)
     testImplementation(project(":resilience4j-bulkhead"))
     testImplementation(project(":resilience4j-circuitbreaker"))
     testImplementation(project(":resilience4j-micrometer"))
@@ -25,7 +22,6 @@ dependencies {
     testImplementation(project(":resilience4j-ratelimiter"))
     testImplementation(project(":resilience4j-retry"))
     testImplementation(project(":resilience4j-timelimiter"))
-    testImplementation(libs.junit.params)
     testImplementation(libs.lincheck)
 }
 

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/core/metrics/LockFreeFixedSizeSlidingWindowMetricsTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/core/metrics/LockFreeFixedSizeSlidingWindowMetricsTest.kt
@@ -23,9 +23,9 @@ import org.jetbrains.kotlinx.lincheck.annotations.Operation
 import org.jetbrains.kotlinx.lincheck.check
 import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.ModelCheckingOptions
 import org.jetbrains.kotlinx.lincheck.strategy.stress.StressOptions
-import org.junit.Ignore
-import org.junit.Test
-import org.junit.experimental.categories.Category
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
 import java.util.concurrent.TimeUnit
 
 /**
@@ -37,7 +37,7 @@ import java.util.concurrent.TimeUnit
  * In contrast, stress testing is faster and can catch rare bugs that require many context switches,
  * making it suitable for regular builds.
  */
-@Category(ConcurrencyTests::class)
+
 class LockFreeFixedSizeSlidingWindowMetricsTest {
     private val metrics = LockFreeFixedSizeSlidingWindowMetrics(5)
 
@@ -52,6 +52,6 @@ class LockFreeFixedSizeSlidingWindowMetricsTest {
     fun stressTest() = StressOptions().check(this::class)
 
     @Test
-    @Ignore
+    @Disabled
     fun modelCheckingTest() = ModelCheckingOptions().check(this::class)
 }

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/core/metrics/LockFreeSlidingTimeWindowMetricsTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/core/metrics/LockFreeSlidingTimeWindowMetricsTest.kt
@@ -23,10 +23,10 @@ import org.jetbrains.kotlinx.lincheck.annotations.Operation
 import org.jetbrains.kotlinx.lincheck.check
 import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.ModelCheckingOptions
 import org.jetbrains.kotlinx.lincheck.strategy.stress.StressOptions
-import org.junit.AfterClass
-import org.junit.Ignore
-import org.junit.Test
-import org.junit.experimental.categories.Category
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import kotlin.random.Random
@@ -50,7 +50,7 @@ import kotlin.random.Random
  * In contrast, stress testing is faster and can catch rare bugs that require many context switches,
  * making it suitable for regular builds.
  */
-@Category(ConcurrencyTests::class)
+
 class LockFreeSlidingTimeWindowMetricsTest {
     companion object {
         private val clock = ManualClock()
@@ -62,7 +62,7 @@ class LockFreeSlidingTimeWindowMetricsTest {
             }, interval, interval, TimeUnit.NANOSECONDS)
         }
 
-        @AfterClass
+        @AfterAll
         @JvmStatic
         fun cleanUp() {
             scheduler.shutdownNow()
@@ -82,6 +82,6 @@ class LockFreeSlidingTimeWindowMetricsTest {
     fun stressTest() = StressOptions().check(this::class)
 
     @Test
-    @Ignore
+    @Disabled
     fun modelCheckingTest() = ModelCheckingOptions().check(this::class)
 }

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/bulkhead/BulkheadTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/bulkhead/BulkheadTest.kt
@@ -23,7 +23,8 @@ import io.github.resilience4j.bulkhead.BulkheadFullException
 import io.github.resilience4j.kotlin.HelloWorldService
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
+
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CountDownLatch

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/bulkhead/CoroutineBulkheadTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/bulkhead/CoroutineBulkheadTest.kt
@@ -26,7 +26,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
+
 import java.time.Duration
 
 class CoroutineBulkheadTest {

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/bulkhead/FlowBulkheadTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/bulkhead/FlowBulkheadTest.kt
@@ -29,10 +29,12 @@ import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.flow.toList
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
+
 import java.time.Duration
 import java.util.concurrent.Phaser
 
+@ExperimentalCoroutinesApi
 class FlowBulkheadTest {
 
     private var permittedEvents = 0

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/circuitbreaker/CircuitBreakerTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/circuitbreaker/CircuitBreakerTest.kt
@@ -23,7 +23,7 @@ import io.github.resilience4j.circuitbreaker.CircuitBreaker
 import io.github.resilience4j.kotlin.HelloWorldService
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class CircuitBreakerTest {
 

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/circuitbreaker/CoroutineCircuitBreakerTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/circuitbreaker/CoroutineCircuitBreakerTest.kt
@@ -25,8 +25,8 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
 
 class CoroutineCircuitBreakerTest {
     @Test

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/circuitbreaker/FlowCircuitBreakerTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/circuitbreaker/FlowCircuitBreakerTest.kt
@@ -16,8 +16,6 @@
  *
  *
  */
-@file:Suppress("EXPERIMENTAL_API_USAGE")
-
 package io.github.resilience4j.kotlin.circuitbreaker
 
 
@@ -29,9 +27,11 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.toList
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
+
 import java.util.concurrent.Phaser
 
+@ExperimentalCoroutinesApi
 class FlowCircuitBreakerTest {
 
     @Test

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/micrometer/CoroutineTimerTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/micrometer/CoroutineTimerTest.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.BDDAssertions.failBecauseExceptionWasNotThrown
 import org.assertj.core.api.BDDAssertions.then
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class CoroutineTimerTest {
 

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/micrometer/FlowTimerTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/micrometer/FlowTimerTest.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.BDDAssertions.failBecauseExceptionWasNotThrown
 import org.assertj.core.api.BDDAssertions.then
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class FlowTimerTest {
 

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/ratelimiter/CoroutineRateLimiterTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/ratelimiter/CoroutineRateLimiterTest.kt
@@ -23,7 +23,9 @@ import io.github.resilience4j.ratelimiter.RateLimiter
 import io.github.resilience4j.ratelimiter.RequestNotPermitted
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions
-import org.junit.Test
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
 import java.time.Duration
 
 class CoroutineRateLimiterTest {
@@ -47,11 +49,11 @@ class CoroutineRateLimiterTest {
             }
 
             //Then
-            Assertions.assertThat(result).isEqualTo("Hello world")
-            Assertions.assertThat(metrics.availablePermissions).isEqualTo(9)
-            Assertions.assertThat(metrics.numberOfWaitingThreads).isZero()
+            assertThat(result).isEqualTo("Hello world")
+            assertThat(metrics.availablePermissions).isEqualTo(9)
+            assertThat(metrics.numberOfWaitingThreads).isZero()
             // Then the helloWorldService should be invoked 1 time
-            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(1)
+            assertThat(helloWorldService.invocationCounter).isEqualTo(1)
         }
     }
 
@@ -73,10 +75,10 @@ class CoroutineRateLimiterTest {
             }
 
             //Then
-            Assertions.assertThat(metrics.availablePermissions).isEqualTo(9)
-            Assertions.assertThat(metrics.numberOfWaitingThreads).isZero()
+            assertThat(metrics.availablePermissions).isEqualTo(9)
+            assertThat(metrics.numberOfWaitingThreads).isZero()
             // Then the helloWorldService should be invoked 1 time
-            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(1)
+            assertThat(helloWorldService.invocationCounter).isEqualTo(1)
         }
     }
 
@@ -104,10 +106,10 @@ class CoroutineRateLimiterTest {
             }
 
             //Then
-            Assertions.assertThat(metrics.availablePermissions).isZero()
-            Assertions.assertThat(metrics.numberOfWaitingThreads).isZero()
+            assertThat(metrics.availablePermissions).isZero()
+            assertThat(metrics.numberOfWaitingThreads).isZero()
             // Then the helloWorldService should not be invoked after the initial 10 times to use up the permits
-            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(10)
+            assertThat(helloWorldService.invocationCounter).isEqualTo(10)
         }
     }
 
@@ -124,11 +126,11 @@ class CoroutineRateLimiterTest {
             }
 
             //Then
-            Assertions.assertThat(function()).isEqualTo("Hello world")
-            Assertions.assertThat(metrics.availablePermissions).isEqualTo(9)
-            Assertions.assertThat(metrics.numberOfWaitingThreads).isZero()
+            assertThat(function()).isEqualTo("Hello world")
+            assertThat(metrics.availablePermissions).isEqualTo(9)
+            assertThat(metrics.numberOfWaitingThreads).isZero()
             // Then the helloWorldService should be invoked 1 time
-            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(1)
+            assertThat(helloWorldService.invocationCounter).isEqualTo(1)
         }
     }
 }

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/ratelimiter/FlowRateLimiterTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/ratelimiter/FlowRateLimiterTest.kt
@@ -25,7 +25,9 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions
-import org.junit.Test
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
 import java.time.Duration
 
 class FlowRateLimiterTest {
@@ -49,11 +51,11 @@ class FlowRateLimiterTest {
             }.rateLimiter(rateLimiter)
 
             //Then
-            Assertions.assertThat(testFlow.single()).isEqualTo("Hello world")
-            Assertions.assertThat(metrics.availablePermissions).isEqualTo(9)
-            Assertions.assertThat(metrics.numberOfWaitingThreads).isZero()
+            assertThat(testFlow.single()).isEqualTo("Hello world")
+            assertThat(metrics.availablePermissions).isEqualTo(9)
+            assertThat(metrics.numberOfWaitingThreads).isZero()
             // Then the helloWorldService should be invoked 1 time
-            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(1)
+            assertThat(helloWorldService.invocationCounter).isEqualTo(1)
         }
     }
 
@@ -76,10 +78,10 @@ class FlowRateLimiterTest {
             }
 
             //Then
-            Assertions.assertThat(metrics.availablePermissions).isEqualTo(9)
-            Assertions.assertThat(metrics.numberOfWaitingThreads).isZero()
+            assertThat(metrics.availablePermissions).isEqualTo(9)
+            assertThat(metrics.numberOfWaitingThreads).isZero()
             // Then the helloWorldService should be invoked 1 time
-            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(1)
+            assertThat(helloWorldService.invocationCounter).isEqualTo(1)
         }
     }
 
@@ -107,10 +109,10 @@ class FlowRateLimiterTest {
             }
 
             //Then
-            Assertions.assertThat(metrics.availablePermissions).isZero()
-            Assertions.assertThat(metrics.numberOfWaitingThreads).isZero()
+            assertThat(metrics.availablePermissions).isZero()
+            assertThat(metrics.numberOfWaitingThreads).isZero()
             // Then the helloWorldService should not be invoked after the initial 10 times to use up the permits
-            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(10)
+            assertThat(helloWorldService.invocationCounter).isEqualTo(10)
         }
     }
 }

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/ratelimiter/RateLimiterTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/ratelimiter/RateLimiterTest.kt
@@ -22,7 +22,9 @@ import io.github.resilience4j.kotlin.HelloWorldService
 import io.github.resilience4j.ratelimiter.RateLimiter
 import io.github.resilience4j.ratelimiter.RequestNotPermitted
 import org.assertj.core.api.Assertions
-import org.junit.Test
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
 import java.time.Duration
 
 class RateLimiterTest {
@@ -45,11 +47,11 @@ class RateLimiterTest {
         }
 
         //Then
-        Assertions.assertThat(result).isEqualTo("Hello world")
-        Assertions.assertThat(metrics.availablePermissions).isEqualTo(9)
-        Assertions.assertThat(metrics.numberOfWaitingThreads).isZero()
+        assertThat(result).isEqualTo("Hello world")
+        assertThat(metrics.availablePermissions).isEqualTo(9)
+        assertThat(metrics.numberOfWaitingThreads).isZero()
         // Then the helloWorldService should be invoked 1 time
-        Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(1)
+        assertThat(helloWorldService.invocationCounter).isEqualTo(1)
     }
 
     @Test
@@ -69,10 +71,10 @@ class RateLimiterTest {
         }
 
         //Then
-        Assertions.assertThat(metrics.availablePermissions).isEqualTo(9)
-        Assertions.assertThat(metrics.numberOfWaitingThreads).isZero()
+        assertThat(metrics.availablePermissions).isEqualTo(9)
+        assertThat(metrics.numberOfWaitingThreads).isZero()
         // Then the helloWorldService should be invoked 1 time
-        Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(1)
+        assertThat(helloWorldService.invocationCounter).isEqualTo(1)
     }
 
     @Test
@@ -98,10 +100,10 @@ class RateLimiterTest {
         }
 
         //Then
-        Assertions.assertThat(metrics.availablePermissions).isZero()
-        Assertions.assertThat(metrics.numberOfWaitingThreads).isZero()
+        assertThat(metrics.availablePermissions).isZero()
+        assertThat(metrics.numberOfWaitingThreads).isZero()
         // Then the helloWorldService should not be invoked after the initial 10 times to use up the permits
-        Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(10)
+        assertThat(helloWorldService.invocationCounter).isEqualTo(10)
     }
 
     @Test
@@ -116,10 +118,10 @@ class RateLimiterTest {
         }
 
         //Then
-        Assertions.assertThat(function()).isEqualTo("Hello world")
-        Assertions.assertThat(metrics.availablePermissions).isEqualTo(9)
-        Assertions.assertThat(metrics.numberOfWaitingThreads).isZero()
+        assertThat(function()).isEqualTo("Hello world")
+        assertThat(metrics.availablePermissions).isEqualTo(9)
+        assertThat(metrics.numberOfWaitingThreads).isZero()
         // Then the helloWorldService should be invoked 1 time
-        Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(1)
+        assertThat(helloWorldService.invocationCounter).isEqualTo(1)
     }
 }

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/retry/CoroutineRetryTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/retry/CoroutineRetryTest.kt
@@ -22,7 +22,9 @@ import io.github.resilience4j.kotlin.CoroutineHelloWorldService
 import io.github.resilience4j.retry.Retry
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions
-import org.junit.Test
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
 import java.time.Duration
 
 class CoroutineRetryTest {
@@ -39,13 +41,13 @@ class CoroutineRetryTest {
             }
 
             //Then
-            Assertions.assertThat(result).isEqualTo("Hello world")
-            Assertions.assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isEqualTo(1)
-            Assertions.assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isZero()
-            Assertions.assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isZero()
-            Assertions.assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isZero()
+            assertThat(result).isEqualTo("Hello world")
+            assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isEqualTo(1)
+            assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isZero()
+            assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isZero()
+            assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isZero()
             // Then the helloWorldService should be invoked 1 time
-            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(1)
+            assertThat(helloWorldService.invocationCounter).isEqualTo(1)
         }
     }
 
@@ -67,13 +69,13 @@ class CoroutineRetryTest {
             }
 
             //Then
-            Assertions.assertThat(result).isEqualTo("Hello world")
-            Assertions.assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isZero()
-            Assertions.assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isEqualTo(1)
-            Assertions.assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isZero()
-            Assertions.assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isZero()
+            assertThat(result).isEqualTo("Hello world")
+            assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isZero()
+            assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isEqualTo(1)
+            assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isZero()
+            assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isZero()
             // Then the helloWorldService should be invoked twice
-            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(2)
+            assertThat(helloWorldService.invocationCounter).isEqualTo(2)
         }
     }
 
@@ -96,13 +98,13 @@ class CoroutineRetryTest {
             }
 
             //Then
-            Assertions.assertThat(result).isEqualTo("Hello world")
-            Assertions.assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isZero()
-            Assertions.assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isEqualTo(1)
-            Assertions.assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isZero()
-            Assertions.assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isZero()
+            assertThat(result).isEqualTo("Hello world")
+            assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isZero()
+            assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isEqualTo(1)
+            assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isZero()
+            assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isZero()
             // Then the helloWorldService should be invoked twice
-            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(2)
+            assertThat(helloWorldService.invocationCounter).isEqualTo(2)
         }
     }
 
@@ -126,12 +128,12 @@ class CoroutineRetryTest {
             }
 
             //Then
-            Assertions.assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isZero()
-            Assertions.assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isZero()
-            Assertions.assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isZero()
-            Assertions.assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isEqualTo(1)
+            assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isZero()
+            assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isZero()
+            assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isZero()
+            assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isEqualTo(1)
             // Then the helloWorldService should be invoked the maximum number of times
-            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(retry.retryConfig.maxAttempts)
+            assertThat(helloWorldService.invocationCounter).isEqualTo(retry.retryConfig.maxAttempts)
         }
     }
 
@@ -148,13 +150,13 @@ class CoroutineRetryTest {
             }
 
             //Then
-            Assertions.assertThat(function()).isEqualTo("Hello world")
-            Assertions.assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isEqualTo(1)
-            Assertions.assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isZero()
-            Assertions.assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isZero()
-            Assertions.assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isZero()
+            assertThat(function()).isEqualTo("Hello world")
+            assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isEqualTo(1)
+            assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isZero()
+            assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isZero()
+            assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isZero()
             // Then the helloWorldService should be invoked 1 time
-            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(1)
+            assertThat(helloWorldService.invocationCounter).isEqualTo(1)
         }
     }
 }

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/retry/FlowRetryTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/retry/FlowRetryTest.kt
@@ -24,7 +24,9 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions
-import org.junit.Test
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
 import java.time.Duration
 
 class FlowRetryTest {
@@ -48,15 +50,15 @@ class FlowRetryTest {
 
             //Then
             repeat(3) {
-                Assertions.assertThat(resultList[it]).isEqualTo("Hello world$it")
+                assertThat(resultList[it]).isEqualTo("Hello world$it")
             }
-            Assertions.assertThat(resultList.size).isEqualTo(3)
-            Assertions.assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isEqualTo(1)
-            Assertions.assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isZero()
-            Assertions.assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isZero()
-            Assertions.assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isZero()
+            assertThat(resultList.size).isEqualTo(3)
+            assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isEqualTo(1)
+            assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isZero()
+            assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isZero()
+            assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isZero()
             // Then the helloWorldService should be invoked 1 time
-            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(3)
+            assertThat(helloWorldService.invocationCounter).isEqualTo(3)
         }
     }
 
@@ -85,15 +87,15 @@ class FlowRetryTest {
 
             //Then
             repeat(3) {
-                Assertions.assertThat(resultList[it]).isEqualTo("Hello world$it")
+                assertThat(resultList[it]).isEqualTo("Hello world$it")
             }
-            Assertions.assertThat(resultList.size).isEqualTo(3)
-            Assertions.assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isZero()
-            Assertions.assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isEqualTo(1)
-            Assertions.assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isZero()
-            Assertions.assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isZero()
+            assertThat(resultList.size).isEqualTo(3)
+            assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isZero()
+            assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isEqualTo(1)
+            assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isZero()
+            assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isZero()
             // Then the helloWorldService should be invoked twice
-            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(4)
+            assertThat(helloWorldService.invocationCounter).isEqualTo(4)
         }
     }
 
@@ -116,14 +118,14 @@ class FlowRetryTest {
                 .toList(resultList)
 
             //Then
-            Assertions.assertThat(resultList.size).isEqualTo(1)
-            Assertions.assertThat(resultList[0]).isEqualTo("Hello world")
-            Assertions.assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isZero()
-            Assertions.assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isEqualTo(1)
-            Assertions.assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isZero()
-            Assertions.assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isZero()
+            assertThat(resultList.size).isEqualTo(1)
+            assertThat(resultList[0]).isEqualTo("Hello world")
+            assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isZero()
+            assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isEqualTo(1)
+            assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isZero()
+            assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isZero()
             // Then the helloWorldService should be invoked twice
-            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(2)
+            assertThat(helloWorldService.invocationCounter).isEqualTo(2)
         }
     }
 
@@ -152,13 +154,13 @@ class FlowRetryTest {
             }
 
             //Then
-            Assertions.assertThat(resultList).isEmpty()
-            Assertions.assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isZero()
-            Assertions.assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isZero()
-            Assertions.assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isZero()
-            Assertions.assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isEqualTo(1)
+            assertThat(resultList).isEmpty()
+            assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isZero()
+            assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isZero()
+            assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isZero()
+            assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isEqualTo(1)
             // Then the helloWorldService should be invoked the maximum number of times
-            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(retry.retryConfig.maxAttempts)
+            assertThat(helloWorldService.invocationCounter).isEqualTo(retry.retryConfig.maxAttempts)
         }
     }
 }

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/retry/RetryTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/retry/RetryTest.kt
@@ -21,7 +21,9 @@ package io.github.resilience4j.kotlin.retry
 import io.github.resilience4j.kotlin.HelloWorldService
 import io.github.resilience4j.retry.Retry
 import org.assertj.core.api.Assertions
-import org.junit.Test
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
 import java.time.Duration
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.BiConsumer
@@ -41,13 +43,13 @@ class RetryTest {
         }
 
         //Then
-        Assertions.assertThat(result).isEqualTo("Hello world")
-        Assertions.assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isEqualTo(1)
-        Assertions.assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isZero()
-        Assertions.assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isZero()
-        Assertions.assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isZero()
+        assertThat(result).isEqualTo("Hello world")
+        assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isEqualTo(1)
+        assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isZero()
+        assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isZero()
+        assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isZero()
         // Then the helloWorldService should be invoked 1 time
-        Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(1)
+        assertThat(helloWorldService.invocationCounter).isEqualTo(1)
     }
 
     @Test
@@ -67,13 +69,13 @@ class RetryTest {
         }
 
         //Then
-        Assertions.assertThat(result).isEqualTo("Hello world")
-        Assertions.assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isZero()
-        Assertions.assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isEqualTo(1)
-        Assertions.assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isZero()
-        Assertions.assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isZero()
+        assertThat(result).isEqualTo("Hello world")
+        assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isZero()
+        assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isEqualTo(1)
+        assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isZero()
+        assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isZero()
         // Then the helloWorldService should be invoked twice
-        Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(2)
+        assertThat(helloWorldService.invocationCounter).isEqualTo(2)
     }
 
     @Test
@@ -93,13 +95,13 @@ class RetryTest {
         }
 
         //Then
-        Assertions.assertThat(result).isEqualTo("Hello world")
-        Assertions.assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isZero()
-        Assertions.assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isEqualTo(1)
-        Assertions.assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isZero()
-        Assertions.assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isZero()
+        assertThat(result).isEqualTo("Hello world")
+        assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isZero()
+        assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isEqualTo(1)
+        assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isZero()
+        assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isZero()
         // Then the helloWorldService should be invoked twice
-        Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(2)
+        assertThat(helloWorldService.invocationCounter).isEqualTo(2)
     }
 
     @Test
@@ -121,12 +123,12 @@ class RetryTest {
         }
 
         //Then
-        Assertions.assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isZero()
-        Assertions.assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isZero()
-        Assertions.assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isZero()
-        Assertions.assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isEqualTo(1)
+        assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isZero()
+        assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isZero()
+        assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isZero()
+        assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isEqualTo(1)
         // Then the helloWorldService should be invoked the maximum number of times
-        Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(retry.retryConfig.maxAttempts)
+        assertThat(helloWorldService.invocationCounter).isEqualTo(retry.retryConfig.maxAttempts)
     }
 
     @Test
@@ -141,13 +143,13 @@ class RetryTest {
         }
 
         //Then
-        Assertions.assertThat(function()).isEqualTo("Hello world")
-        Assertions.assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isEqualTo(1)
-        Assertions.assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isZero()
-        Assertions.assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isZero()
-        Assertions.assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isZero()
+        assertThat(function()).isEqualTo("Hello world")
+        assertThat(metrics.numberOfSuccessfulCallsWithoutRetryAttempt).isEqualTo(1)
+        assertThat(metrics.numberOfSuccessfulCallsWithRetryAttempt).isZero()
+        assertThat(metrics.numberOfFailedCallsWithoutRetryAttempt).isZero()
+        assertThat(metrics.numberOfFailedCallsWithRetryAttempt).isZero()
         // Then the helloWorldService should be invoked 1 time
-        Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(1)
+        assertThat(helloWorldService.invocationCounter).isEqualTo(1)
     }
 
     @Test
@@ -173,8 +175,8 @@ class RetryTest {
         val supplier = Retry.decorateSupplier(retry) { helloWorldService.returnHelloWorld() }
         val result = supplier.get()
 
-        Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(3)
-        Assertions.assertThat(result).isEqualTo(helloWorldServiceReturnValue)
-        Assertions.assertThat(consumerInvocations.get()).isEqualTo(2)
+        assertThat(helloWorldService.invocationCounter).isEqualTo(3)
+        assertThat(result).isEqualTo(helloWorldServiceReturnValue)
+        assertThat(consumerInvocations.get()).isEqualTo(2)
     }
 }

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/timelimiter/CoroutineTimeLimiterTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/timelimiter/CoroutineTimeLimiterTest.kt
@@ -26,7 +26,9 @@ import io.github.resilience4j.timelimiter.event.TimeLimiterOnTimeoutEvent
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions
-import org.junit.Test
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
 import java.time.Duration
 import java.util.concurrent.TimeoutException
 
@@ -45,10 +47,10 @@ class CoroutineTimeLimiterTest {
             }
 
             //Then
-            Assertions.assertThat(result).isEqualTo("Hello world")
+            assertThat(result).isEqualTo("Hello world")
             // Then the helloWorldService should be invoked 1 time
-            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(1)
-            Assertions.assertThat(successfulEvents).hasSize(1)
+            assertThat(helloWorldService.invocationCounter).isEqualTo(1)
+            assertThat(successfulEvents).hasSize(1)
         }
     }
 
@@ -72,8 +74,8 @@ class CoroutineTimeLimiterTest {
 
             //Then
             // Then the helloWorldService should be invoked 1 time
-            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(1)
-            Assertions.assertThat(errorEvents).hasSize(1)
+            assertThat(helloWorldService.invocationCounter).isEqualTo(1)
+            assertThat(errorEvents).hasSize(1)
         }
     }
 
@@ -97,8 +99,8 @@ class CoroutineTimeLimiterTest {
 
             //Then
             // Then the helloWorldService should be invoked 1 time
-            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(1)
-            Assertions.assertThat(timeoutEvents).hasSize(1)
+            assertThat(helloWorldService.invocationCounter).isEqualTo(1)
+            assertThat(timeoutEvents).hasSize(1)
         }
     }
 
@@ -122,8 +124,8 @@ class CoroutineTimeLimiterTest {
             }
 
             //Then
-            Assertions.assertThat(timeoutEvents).isEmpty()
-            Assertions.assertThat(successfulEvents).isEmpty()
+            assertThat(timeoutEvents).isEmpty()
+            assertThat(successfulEvents).isEmpty()
         }
     }
 
@@ -141,10 +143,10 @@ class CoroutineTimeLimiterTest {
             }
 
             //Then
-            Assertions.assertThat(function()).isEqualTo("Hello world")
+            assertThat(function()).isEqualTo("Hello world")
             // Then the helloWorldService should be invoked 1 time
-            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(1)
-            Assertions.assertThat(successfulEvents).hasSize(1)
+            assertThat(helloWorldService.invocationCounter).isEqualTo(1)
+            assertThat(successfulEvents).hasSize(1)
 
         }
     }

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/timelimiter/FlowTimeLimiterTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/timelimiter/FlowTimeLimiterTest.kt
@@ -25,7 +25,9 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions
-import org.junit.Test
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
 import java.time.Duration
 import java.util.concurrent.TimeoutException
 
@@ -49,11 +51,11 @@ class FlowTimeLimiterTest {
 
             //Then
             repeat(3) {
-                Assertions.assertThat(resultList[it]).isEqualTo("Hello world$it")
+                assertThat(resultList[it]).isEqualTo("Hello world$it")
             }
-            Assertions.assertThat(resultList.size).isEqualTo(3)
+            assertThat(resultList.size).isEqualTo(3)
             // Then the helloWorldService should be invoked 1 time
-            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(3)
+            assertThat(helloWorldService.invocationCounter).isEqualTo(3)
         }
     }
 
@@ -76,9 +78,9 @@ class FlowTimeLimiterTest {
             }
 
             //Then
-            Assertions.assertThat(resultList.size).isZero()
+            assertThat(resultList.size).isZero()
             // Then the helloWorldService should be invoked 1 time
-            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(1)
+            assertThat(helloWorldService.invocationCounter).isEqualTo(1)
         }
     }
 
@@ -101,9 +103,9 @@ class FlowTimeLimiterTest {
             }
 
             //Then
-            Assertions.assertThat(resultList.size).isZero()
+            assertThat(resultList.size).isZero()
             // Then the helloWorldService should be invoked 1 time
-            Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(1)
+            assertThat(helloWorldService.invocationCounter).isEqualTo(1)
         }
     }
 }

--- a/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/timelimiter/TimeLimiterFunctionTest.kt
+++ b/resilience4j-kotlin/src/test/kotlin/io/github/resilience4j/kotlin/timelimiter/TimeLimiterFunctionTest.kt
@@ -24,7 +24,9 @@ import io.github.resilience4j.timelimiter.event.TimeLimiterOnErrorEvent
 import io.github.resilience4j.timelimiter.event.TimeLimiterOnSuccessEvent
 import io.github.resilience4j.timelimiter.event.TimeLimiterOnTimeoutEvent
 import org.assertj.core.api.Assertions
-import org.junit.Test
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
 import java.time.Duration
 import java.util.concurrent.TimeoutException
 
@@ -43,9 +45,9 @@ class TimeLimiterFunctionTest {
         }
 
         // Then
-        Assertions.assertThat(result).isEqualTo("Hello world")
-        Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(1)
-        Assertions.assertThat(successfulEvents).hasSize(1)
+        assertThat(result).isEqualTo("Hello world")
+        assertThat(helloWorldService.invocationCounter).isEqualTo(1)
+        assertThat(successfulEvents).hasSize(1)
     }
 
     @Test
@@ -66,8 +68,8 @@ class TimeLimiterFunctionTest {
         }
 
         // Then
-        Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(1)
-        Assertions.assertThat(errorEvents).hasSize(1)
+        assertThat(helloWorldService.invocationCounter).isEqualTo(1)
+        assertThat(errorEvents).hasSize(1)
     }
 
     @Test
@@ -88,7 +90,7 @@ class TimeLimiterFunctionTest {
         }
 
         // Then
-        Assertions.assertThat(timeoutEvents).hasSize(1)
+        assertThat(timeoutEvents).hasSize(1)
     }
 
     @Test
@@ -104,9 +106,9 @@ class TimeLimiterFunctionTest {
         }
 
         // Then
-        Assertions.assertThat(function()).isEqualTo("Hello world")
-        Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(1)
-        Assertions.assertThat(successfulEvents).hasSize(1)
+        assertThat(function()).isEqualTo("Hello world")
+        assertThat(helloWorldService.invocationCounter).isEqualTo(1)
+        assertThat(successfulEvents).hasSize(1)
     }
 
     @Test
@@ -129,7 +131,7 @@ class TimeLimiterFunctionTest {
         }
 
         // Then
-        Assertions.assertThat(helloWorldService.invocationCounter).isEqualTo(1)
-        Assertions.assertThat(errorEvents).hasSize(1)
+        assertThat(helloWorldService.invocationCounter).isEqualTo(1)
+        assertThat(errorEvents).hasSize(1)
     }
 }


### PR DESCRIPTION
## Changes

* Migrated JUnit 4.13 annotations to Junit Jupiter equivalents
* Applied OpenRewrite recipes
    * [JUnit 6 best practices](https://docs.openrewrite.org/recipes/java/testing/junit/junit6bestpractices)
    * [Mockito best practices](https://docs.openrewrite.org/recipes/java/testing/mockito/mockitobestpractices)
    * [Migrate JUnit asserts to AssertJ](https://docs.openrewrite.org/recipes/java/testing/assertj/junittoassertj)
    * [AssertJ best practices](https://docs.openrewrite.org/recipes/java/testing/assertj/assertj-best-practices)
* Removed `public` modifiers
* Expanded star imports to explicit imports
* Removed outdated `test*` prefix
* Updated Copyright to 2026

## Coverage

| Metric      | Before | After |
|-------------|--------|-------|
| Instruction | 52.1%  | 52.1% |
| Line        | 65.8%  | 65.8% |
| Branch      | 73.3%  | 73.3% |

## Test runtime

> [!NOTE]
> the Lincheck stress tests (`LockFreeFixedSizeSlidingWindowMetricsTest`, `LockFreeSlidingTimeWindowMetricsTest`) dominate runtime and are highly variable between runs. No meaningful change in test time from the migration.

| Metric | Before | After |
|--------|--------|-------|
| Tests  | 76     | 76    |
| Time   | ~65s   | ~65s  |
