### PR TITLE
resilience4j-metrics: JUnit 4 → JUnit 6 migration

### DIFF
--- a/resilience4j-metrics/build.gradle
+++ b/resilience4j-metrics/build.gradle
@@ -1,3 +1,5 @@
+ext.moduleName = "io.github.resilience4j.metrics"
+
 dependencies {
     compileOnly(project(":resilience4j-bulkhead"))
     compileOnly(project(":resilience4j-circuitbreaker"))
@@ -6,11 +8,6 @@ dependencies {
     compileOnly(project(":resilience4j-timelimiter"))
     compileOnly(libs.metrics.core)
 
-    testRuntimeOnly(libs.junit.vintage.engine)
-
-    testImplementation(libs.junit)
-    testImplementation(libs.awaitility.old)
-    testImplementation(libs.vavr)
     testImplementation(project(":resilience4j-bulkhead"))
     testImplementation(project(":resilience4j-circuitbreaker"))
     testImplementation(project(":resilience4j-ratelimiter"))
@@ -19,4 +16,3 @@ dependencies {
     testImplementation(project(":resilience4j-timelimiter"))
     testImplementation(libs.metrics.core)
 }
-ext.moduleName = "io.github.resilience4j.metrics"

--- a/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/AbstractBulkheadMetricsTest.java
+++ b/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/AbstractBulkheadMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Ingyu Hwang
+ * Copyright 2026 Ingyu Hwang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,11 +20,15 @@ import com.codahale.metrics.MetricRegistry;
 import io.github.resilience4j.bulkhead.Bulkhead;
 import io.github.resilience4j.bulkhead.BulkheadConfig;
 import io.github.resilience4j.test.HelloWorldService;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -40,14 +44,14 @@ public abstract class AbstractBulkheadMetricsTest {
     private HelloWorldService helloWorldService;
     private ExecutorService executorService;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         metricRegistry = new MetricRegistry();
         helloWorldService = mock(HelloWorldService.class);
         executorService = Executors.newSingleThreadExecutor();
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         executorService.shutdown();
     }

--- a/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/AbstractCircuitBreakerMetricsTest.java
+++ b/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/AbstractCircuitBreakerMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Ingyu Hwang
+ * Copyright 2026 Ingyu Hwang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package io.github.resilience4j.metrics;
 import com.codahale.metrics.MetricRegistry;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.test.HelloWorldService;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;

--- a/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/AbstractRateLimiterMetricsTest.java
+++ b/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/AbstractRateLimiterMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Ingyu Hwang
+ * Copyright 2026 Ingyu Hwang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@ import com.codahale.metrics.MetricRegistry;
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
 import io.github.resilience4j.test.HelloWorldService;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -36,7 +36,7 @@ public abstract class AbstractRateLimiterMetricsTest {
     private MetricRegistry metricRegistry;
     private HelloWorldService helloWorldService;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         metricRegistry = new MetricRegistry();
         helloWorldService = mock(HelloWorldService.class);

--- a/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/AbstractRetryMetricsTest.java
+++ b/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/AbstractRetryMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Ingyu Hwang
+ * Copyright 2026 Ingyu Hwang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,11 +20,13 @@ import com.codahale.metrics.MetricRegistry;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.test.HelloWorldException;
 import io.github.resilience4j.test.HelloWorldService;
-import io.vavr.control.Try;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static io.github.resilience4j.retry.utils.MetricNames.*;
+import static io.github.resilience4j.retry.utils.MetricNames.FAILED_CALLS_WITH_RETRY;
+import static io.github.resilience4j.retry.utils.MetricNames.FAILED_CALLS_WITHOUT_RETRY;
+import static io.github.resilience4j.retry.utils.MetricNames.SUCCESSFUL_CALLS_WITH_RETRY;
+import static io.github.resilience4j.retry.utils.MetricNames.SUCCESSFUL_CALLS_WITHOUT_RETRY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -36,7 +38,7 @@ public abstract class AbstractRetryMetricsTest {
     private MetricRegistry metricRegistry;
     private HelloWorldService helloWorldService;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         metricRegistry = new MetricRegistry();
         helloWorldService = mock(HelloWorldService.class);
@@ -81,7 +83,10 @@ public abstract class AbstractRetryMetricsTest {
             .willThrow(new HelloWorldException());
         String value1 = retry.executeSupplier(helloWorldService::returnHelloWorld);
 
-        Try.ofSupplier(Retry.decorateSupplier(retry, helloWorldService::returnHelloWorld));
+        try {
+            Retry.decorateSupplier(retry, helloWorldService::returnHelloWorld).get();
+        } catch (Exception ignored) {
+        }
 
         assertThat(value1).isEqualTo("Hello world");
         then(helloWorldService).should(times(5)).returnHelloWorld();

--- a/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/AbstractTimeLimiterMetricsTest.java
+++ b/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/AbstractTimeLimiterMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Ingyu Hwang
+ * Copyright 2026 Ingyu Hwang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ package io.github.resilience4j.metrics;
 
 import com.codahale.metrics.MetricRegistry;
 import io.github.resilience4j.timelimiter.TimeLimiter;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
@@ -37,7 +37,7 @@ public abstract class AbstractTimeLimiterMetricsTest {
     // fix visibility
     protected volatile MetricRegistry metricRegistry;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         metricRegistry = new MetricRegistry();
     }

--- a/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/RetryMetricsTest.java
+++ b/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/RetryMetricsTest.java
@@ -1,3 +1,19 @@
+/*
+ *
+ * Copyright 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *
+ */
 package io.github.resilience4j.metrics;
 
 import com.codahale.metrics.MetricRegistry;
@@ -7,19 +23,26 @@ import io.github.resilience4j.retry.RetryRegistry;
 import io.github.resilience4j.test.AsyncHelloWorldService;
 import io.github.resilience4j.test.HelloWorldException;
 import io.github.resilience4j.test.HelloWorldService;
-import io.vavr.control.Try;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.time.Duration;
-import java.util.concurrent.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
+
 public class RetryMetricsTest extends AbstractRetryMetricsTest {
 
     @Override
@@ -44,7 +67,7 @@ public class RetryMetricsTest extends AbstractRetryMetricsTest {
 
     // returns only success
     @Test
-    public void shouldReturnTotalNumberOfRequestsAs1ForSuccess() {
+    void shouldReturnTotalNumberOfRequestsAs1ForSuccess() {
         HelloWorldService helloWorldService = mock(HelloWorldService.class);
 
         Retry retry = Retry.of("metrics", RetryConfig.<String>custom()
@@ -54,12 +77,12 @@ public class RetryMetricsTest extends AbstractRetryMetricsTest {
 
         given(helloWorldService.returnHelloWorld()).willReturn("Success");
         String result = Retry.decorateSupplier(retry, helloWorldService::returnHelloWorld).get();
-        assertThat(retry.getMetrics().getNumberOfTotalCalls()).isEqualTo(1);
+        assertThat(retry.getMetrics().getNumberOfTotalCalls()).isOne();
         assertThat(result).isEqualTo("Success");
     }
 
     @Test
-    public void shouldReturnTotalNumberOfRequestsAs1ForSuccessVoid() {
+    void shouldReturnTotalNumberOfRequestsAs1ForSuccessVoid() {
         HelloWorldService helloWorldService = mock(HelloWorldService.class);
 
         Retry retry = Retry.of("metrics", RetryConfig.custom()
@@ -69,12 +92,12 @@ public class RetryMetricsTest extends AbstractRetryMetricsTest {
 
         retry.executeRunnable(helloWorldService::sayHelloWorld);
 
-        assertThat(retry.getMetrics().getNumberOfTotalCalls()).isEqualTo(1);
+        assertThat(retry.getMetrics().getNumberOfTotalCalls()).isOne();
     }
 
     // returns fail twice and then success
     @Test
-    public void shouldReturnTotalNumberOfRequestsAs3ForFail() {
+    void shouldReturnTotalNumberOfRequestsAs3ForFail() {
         HelloWorldService helloWorldService = mock(HelloWorldService.class);
 
         Retry retry = Retry.of("metrics", RetryConfig.<String>custom()
@@ -95,7 +118,7 @@ public class RetryMetricsTest extends AbstractRetryMetricsTest {
 
     // throws only exception finally
     @Test
-    public void shouldReturnTotalNumberOfRequestsAs5OnlyFails() {
+    void shouldReturnTotalNumberOfRequestsAs5OnlyFails() {
 
         HelloWorldService helloWorldService = mock(HelloWorldService.class);
 
@@ -108,15 +131,15 @@ public class RetryMetricsTest extends AbstractRetryMetricsTest {
         given(helloWorldService.returnHelloWorld())
             .willThrow(new HelloWorldException());
 
-        Try<String> supplier = Try.ofSupplier(Retry.decorateSupplier(retry, helloWorldService::returnHelloWorld));
+        assertThatThrownBy(() -> Retry.decorateSupplier(retry, helloWorldService::returnHelloWorld).get())
+            .isInstanceOf(Exception.class);
 
         assertThat(retry.getMetrics().getNumberOfTotalCalls()).isEqualTo(5);
-        assertThat(supplier.isFailure()).isTrue();
     }
 
     // throws only checked exception finally
     @Test
-    public void shouldReturnTotalNumberOfRequestsAs5OnlyFailsChecked() throws IOException {
+    void shouldReturnTotalNumberOfRequestsAs5OnlyFailsChecked() throws Exception {
 
         HelloWorldService helloWorldService = mock(HelloWorldService.class);
 
@@ -130,16 +153,16 @@ public class RetryMetricsTest extends AbstractRetryMetricsTest {
 
         Callable<String> retryableCallable = Retry.decorateCallable(retry, helloWorldService::returnHelloWorldWithException);
 
-        Try<Void> run = Try.run(retryableCallable::call);
+        assertThatThrownBy(retryableCallable::call)
+            .isInstanceOf(Exception.class);
 
         assertThat(retry.getMetrics().getNumberOfTotalCalls()).isEqualTo(5);
-        assertThat(run.isFailure()).isTrue();
     }
 
 
     // returns async success
     @Test
-    public void shouldReturnTotalNumberOfRequestsAs1ForSuccessAsync() {
+    void shouldReturnTotalNumberOfRequestsAs1ForSuccessAsync() {
         AsyncHelloWorldService helloWorldService = mock(AsyncHelloWorldService.class);
         ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
 
@@ -155,13 +178,13 @@ public class RetryMetricsTest extends AbstractRetryMetricsTest {
 
         String result = awaitResult(supplier.get(), 5);
 
-        assertThat(retry.getMetrics().getNumberOfTotalCalls()).isEqualTo(1);
+        assertThat(retry.getMetrics().getNumberOfTotalCalls()).isOne();
         assertThat(result).isEqualTo("Success");
     }
 
     // returns 1 failed and then 1 success async
     @Test
-    public void shouldReturnTotalNumberOfRequestsAs3ForFailAsync() {
+    void shouldReturnTotalNumberOfRequestsAs3ForFailAsync() {
         AsyncHelloWorldService helloWorldService = mock(AsyncHelloWorldService.class);
         ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
 
@@ -187,7 +210,7 @@ public class RetryMetricsTest extends AbstractRetryMetricsTest {
 
     // throws only exception async
     @Test
-    public void shouldReturnTotalNumberOfRequestsAs5ForFailAsync() {
+    void shouldReturnTotalNumberOfRequestsAs5ForFailAsync() {
         AsyncHelloWorldService helloWorldService = mock(AsyncHelloWorldService.class);
         ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
 

--- a/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/RetryMetricsTest.java
+++ b/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/RetryMetricsTest.java
@@ -132,7 +132,7 @@ public class RetryMetricsTest extends AbstractRetryMetricsTest {
             .willThrow(new HelloWorldException());
 
         assertThatThrownBy(() -> Retry.decorateSupplier(retry, helloWorldService::returnHelloWorld).get())
-            .isInstanceOf(Exception.class);
+            .isInstanceOf(HelloWorldException.class);
 
         assertThat(retry.getMetrics().getNumberOfTotalCalls()).isEqualTo(5);
     }
@@ -154,7 +154,7 @@ public class RetryMetricsTest extends AbstractRetryMetricsTest {
         Callable<String> retryableCallable = Retry.decorateCallable(retry, helloWorldService::returnHelloWorldWithException);
 
         assertThatThrownBy(retryableCallable::call)
-            .isInstanceOf(Exception.class);
+            .isInstanceOf(HelloWorldException.class);
 
         assertThat(retry.getMetrics().getNumberOfTotalCalls()).isEqualTo(5);
     }

--- a/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/StateTransitionMetricsTest.java
+++ b/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/StateTransitionMetricsTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2019 authors
+ *  Copyright 2026 authors
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -25,58 +25,54 @@ import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.metrics.publisher.CircuitBreakerMetricsPublisher;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.SortedMap;
 import java.util.concurrent.TimeUnit;
 
-import static com.jayway.awaitility.Awaitility.await;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
-public class StateTransitionMetricsTest {
+class StateTransitionMetricsTest {
 
     @SuppressWarnings("rawtypes")
     private static void circuitBreakerMetricsUsesFirstStateObjectInstance(
         CircuitBreaker circuitBreaker, MetricRegistry metricRegistry) throws Exception {
         SortedMap<String, Gauge> gauges = metricRegistry.getGauges();
 
-        assertThat(circuitBreaker.getState(), equalTo(CircuitBreaker.State.CLOSED));
-        assertThat(circuitBreaker.getMetrics().getNumberOfBufferedCalls(), equalTo(0));
-        assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls(), equalTo(0));
-        assertThat(circuitBreaker.getMetrics().getNumberOfSuccessfulCalls(), equalTo(0));
-        assertThat(gauges.get("resilience4j.circuitbreaker.test.state").getValue(), equalTo(0));
-        assertThat(gauges.get("resilience4j.circuitbreaker.test.buffered").getValue(), equalTo(0));
-        assertThat(gauges.get("resilience4j.circuitbreaker.test.failed").getValue(), equalTo(0));
-        assertThat(gauges.get("resilience4j.circuitbreaker.test.successful").getValue(),
-            equalTo(0));
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
+        assertThat(circuitBreaker.getMetrics().getNumberOfBufferedCalls()).isZero();
+        assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls()).isZero();
+        assertThat(circuitBreaker.getMetrics().getNumberOfSuccessfulCalls()).isZero();
+        assertThat(gauges.get("resilience4j.circuitbreaker.test.state").getValue()).isEqualTo(0);
+        assertThat(gauges.get("resilience4j.circuitbreaker.test.buffered").getValue()).isEqualTo(0);
+        assertThat(gauges.get("resilience4j.circuitbreaker.test.failed").getValue()).isEqualTo(0);
+        assertThat(gauges.get("resilience4j.circuitbreaker.test.successful").getValue()).isEqualTo(0);
 
         circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new RuntimeException());
 
-        assertThat(circuitBreaker.getState(), equalTo(CircuitBreaker.State.CLOSED));
-        assertThat(circuitBreaker.getMetrics().getNumberOfBufferedCalls(), equalTo(1));
-        assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls(), equalTo(1));
-        assertThat(circuitBreaker.getMetrics().getNumberOfSuccessfulCalls(), equalTo(0));
-        assertThat(gauges.get("resilience4j.circuitbreaker.test.state").getValue(), equalTo(0));
-        assertThat(gauges.get("resilience4j.circuitbreaker.test.buffered").getValue(), equalTo(1));
-        assertThat(gauges.get("resilience4j.circuitbreaker.test.failed").getValue(), equalTo(1));
-        assertThat(gauges.get("resilience4j.circuitbreaker.test.successful").getValue(),
-            equalTo(0));
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
+        assertThat(circuitBreaker.getMetrics().getNumberOfBufferedCalls()).isOne();
+        assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls()).isOne();
+        assertThat(circuitBreaker.getMetrics().getNumberOfSuccessfulCalls()).isZero();
+        assertThat(gauges.get("resilience4j.circuitbreaker.test.state").getValue()).isEqualTo(0);
+        assertThat(gauges.get("resilience4j.circuitbreaker.test.buffered").getValue()).isEqualTo(1);
+        assertThat(gauges.get("resilience4j.circuitbreaker.test.failed").getValue()).isEqualTo(1);
+        assertThat(gauges.get("resilience4j.circuitbreaker.test.successful").getValue()).isEqualTo(0);
 
         for (int i = 0; i < 9; i++) {
             circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new RuntimeException());
         }
 
-        assertThat(circuitBreaker.getState(), equalTo(CircuitBreaker.State.OPEN));
-        assertThat(circuitBreaker.getMetrics().getNumberOfBufferedCalls(), equalTo(10));
-        assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls(), equalTo(10));
-        assertThat(circuitBreaker.getMetrics().getNumberOfSuccessfulCalls(), equalTo(0));
-        assertThat(gauges.get("resilience4j.circuitbreaker.test.state").getValue(), equalTo(1));
-        assertThat(gauges.get("resilience4j.circuitbreaker.test.buffered").getValue(), equalTo(10));
-        assertThat(gauges.get("resilience4j.circuitbreaker.test.failed").getValue(), equalTo(10));
-        assertThat(gauges.get("resilience4j.circuitbreaker.test.successful").getValue(),
-            equalTo(0));
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.OPEN);
+        assertThat(circuitBreaker.getMetrics().getNumberOfBufferedCalls()).isEqualTo(10);
+        assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls()).isEqualTo(10);
+        assertThat(circuitBreaker.getMetrics().getNumberOfSuccessfulCalls()).isZero();
+        assertThat(gauges.get("resilience4j.circuitbreaker.test.state").getValue()).isEqualTo(1);
+        assertThat(gauges.get("resilience4j.circuitbreaker.test.buffered").getValue()).isEqualTo(10);
+        assertThat(gauges.get("resilience4j.circuitbreaker.test.failed").getValue()).isEqualTo(10);
+        assertThat(gauges.get("resilience4j.circuitbreaker.test.successful").getValue()).isEqualTo(0);
 
         await().atMost(1500, TimeUnit.MILLISECONDS)
             .until(() -> {
@@ -85,42 +81,39 @@ public class StateTransitionMetricsTest {
             });
 
         circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
-        assertThat(circuitBreaker.getState(), equalTo(CircuitBreaker.State.HALF_OPEN));
-        assertThat(circuitBreaker.getMetrics().getNumberOfBufferedCalls(), equalTo(1));
-        assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls(), equalTo(0));
-        assertThat(circuitBreaker.getMetrics().getNumberOfSuccessfulCalls(), equalTo(1));
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.HALF_OPEN);
+        assertThat(circuitBreaker.getMetrics().getNumberOfBufferedCalls()).isOne();
+        assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls()).isZero();
+        assertThat(circuitBreaker.getMetrics().getNumberOfSuccessfulCalls()).isOne();
 
-        assertThat(gauges.get("resilience4j.circuitbreaker.test.state").getValue(), equalTo(2));
-        assertThat(gauges.get("resilience4j.circuitbreaker.test.buffered").getValue(), equalTo(1));
-        assertThat(gauges.get("resilience4j.circuitbreaker.test.failed").getValue(), equalTo(0));
-        assertThat(gauges.get("resilience4j.circuitbreaker.test.successful").getValue(),
-            equalTo(1));
+        assertThat(gauges.get("resilience4j.circuitbreaker.test.state").getValue()).isEqualTo(2);
+        assertThat(gauges.get("resilience4j.circuitbreaker.test.buffered").getValue()).isEqualTo(1);
+        assertThat(gauges.get("resilience4j.circuitbreaker.test.failed").getValue()).isEqualTo(0);
+        assertThat(gauges.get("resilience4j.circuitbreaker.test.successful").getValue()).isEqualTo(1);
         circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
-        assertThat(circuitBreaker.getState(), equalTo(CircuitBreaker.State.HALF_OPEN));
-        assertThat(circuitBreaker.getMetrics().getNumberOfBufferedCalls(), equalTo(2));
-        assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls(), equalTo(0));
-        assertThat(circuitBreaker.getMetrics().getNumberOfSuccessfulCalls(), equalTo(2));
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.HALF_OPEN);
+        assertThat(circuitBreaker.getMetrics().getNumberOfBufferedCalls()).isEqualTo(2);
+        assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls()).isZero();
+        assertThat(circuitBreaker.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(2);
 
-        assertThat(gauges.get("resilience4j.circuitbreaker.test.state").getValue(), equalTo(2));
-        assertThat(gauges.get("resilience4j.circuitbreaker.test.buffered").getValue(), equalTo(2));
-        assertThat(gauges.get("resilience4j.circuitbreaker.test.failed").getValue(), equalTo(0));
-        assertThat(gauges.get("resilience4j.circuitbreaker.test.successful").getValue(),
-            equalTo(2));
+        assertThat(gauges.get("resilience4j.circuitbreaker.test.state").getValue()).isEqualTo(2);
+        assertThat(gauges.get("resilience4j.circuitbreaker.test.buffered").getValue()).isEqualTo(2);
+        assertThat(gauges.get("resilience4j.circuitbreaker.test.failed").getValue()).isEqualTo(0);
+        assertThat(gauges.get("resilience4j.circuitbreaker.test.successful").getValue()).isEqualTo(2);
         circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
-        assertThat(circuitBreaker.getState(), equalTo(CircuitBreaker.State.CLOSED));
-        assertThat(circuitBreaker.getMetrics().getNumberOfBufferedCalls(), equalTo(0));
-        assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls(), equalTo(0));
-        assertThat(circuitBreaker.getMetrics().getNumberOfSuccessfulCalls(), equalTo(0));
+        assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
+        assertThat(circuitBreaker.getMetrics().getNumberOfBufferedCalls()).isZero();
+        assertThat(circuitBreaker.getMetrics().getNumberOfFailedCalls()).isZero();
+        assertThat(circuitBreaker.getMetrics().getNumberOfSuccessfulCalls()).isZero();
 
-        assertThat(gauges.get("resilience4j.circuitbreaker.test.state").getValue(), equalTo(0));
-        assertThat(gauges.get("resilience4j.circuitbreaker.test.buffered").getValue(), equalTo(0));
-        assertThat(gauges.get("resilience4j.circuitbreaker.test.failed").getValue(), equalTo(0));
-        assertThat(gauges.get("resilience4j.circuitbreaker.test.successful").getValue(),
-            equalTo(0));
+        assertThat(gauges.get("resilience4j.circuitbreaker.test.state").getValue()).isEqualTo(0);
+        assertThat(gauges.get("resilience4j.circuitbreaker.test.buffered").getValue()).isEqualTo(0);
+        assertThat(gauges.get("resilience4j.circuitbreaker.test.failed").getValue()).isEqualTo(0);
+        assertThat(gauges.get("resilience4j.circuitbreaker.test.successful").getValue()).isEqualTo(0);
     }
 
     @Test
-    public void testWithCircuitBreakerMetrics() throws Exception {
+    void withCircuitBreakerMetrics() throws Exception {
         CircuitBreakerConfig config =
             CircuitBreakerConfig.custom()
                 .waitDurationInOpenState(Duration.ofMillis(150))
@@ -137,7 +130,7 @@ public class StateTransitionMetricsTest {
     }
 
     @Test
-    public void testWithCircuitBreakerMetricsPublisher() throws Exception {
+    void withCircuitBreakerMetricsPublisher() throws Exception {
         CircuitBreakerConfig config =
             CircuitBreakerConfig.custom()
                 .waitDurationInOpenState(Duration.ofSeconds(1))

--- a/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/TimeLimiterMetricsTest.java
+++ b/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/TimeLimiterMetricsTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2019 authors
+ *  Copyright 2026 authors
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -22,14 +22,14 @@ import com.codahale.metrics.MetricRegistry;
 import io.github.resilience4j.timelimiter.TimeLimiter;
 import io.github.resilience4j.timelimiter.TimeLimiterConfig;
 import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.concurrent.TimeoutException;
 
 import static io.github.resilience4j.metrics.assertion.MetricRegistryAssert.assertThat;
 
-public class TimeLimiterMetricsTest extends AbstractTimeLimiterMetricsTest {
+class TimeLimiterMetricsTest extends AbstractTimeLimiterMetricsTest {
 
     @Override
     protected TimeLimiter given(String prefix, MetricRegistry metricRegistry) {
@@ -51,7 +51,7 @@ public class TimeLimiterMetricsTest extends AbstractTimeLimiterMetricsTest {
     }
 
     @Test
-    public void shouldRecordSuccesses() {
+    void shouldRecordSuccesses() {
         TimeLimiter timeLimiter = TimeLimiter.of(TimeLimiterConfig.ofDefaults());
         metricRegistry.registerAll(TimeLimiterMetrics.ofTimeLimiter(timeLimiter));
 
@@ -68,7 +68,7 @@ public class TimeLimiterMetricsTest extends AbstractTimeLimiterMetricsTest {
     }
 
     @Test
-    public void shouldRecordErrors() {
+    void shouldRecordErrors() {
         TimeLimiter timeLimiter = TimeLimiter.of(TimeLimiterConfig.ofDefaults());
         metricRegistry.registerAll(TimeLimiterMetrics.ofTimeLimiter(timeLimiter));
 
@@ -85,7 +85,7 @@ public class TimeLimiterMetricsTest extends AbstractTimeLimiterMetricsTest {
     }
 
     @Test
-    public void shouldRecordTimeouts() {
+    void shouldRecordTimeouts() {
         TimeLimiter timeLimiter = TimeLimiter.of(TimeLimiterConfig.custom()
             .timeoutDuration(Duration.ZERO)
             .build());

--- a/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/TimerTest.java
+++ b/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/TimerTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2017: Robert Winkler
+ *  Copyright 2026: Robert Winkler
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -24,10 +24,8 @@ import io.github.resilience4j.core.functions.CheckedRunnable;
 import io.github.resilience4j.core.functions.CheckedSupplier;
 import io.github.resilience4j.test.HelloWorldException;
 import io.github.resilience4j.test.HelloWorldService;
-import io.vavr.collection.Stream;
-import io.vavr.control.Try;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -35,8 +33,9 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.IntStream;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -45,7 +44,7 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 
-public class TimerTest {
+class TimerTest {
 
     private HelloWorldService helloWorldService;
 
@@ -53,54 +52,54 @@ public class TimerTest {
 
     private MetricRegistry metricRegistry;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         metricRegistry = new MetricRegistry();
         timer = Timer.ofMetricRegistry(TimerTest.class.getName(), metricRegistry);
         helloWorldService = mock(HelloWorldService.class);
     }
 
     @Test
-    public void shouldDecorateCheckedSupplier() throws Throwable {
+    void shouldDecorateCheckedSupplier() throws Throwable {
         given(helloWorldService.returnHelloWorldWithException()).willReturn("Hello world");
         CheckedSupplier<String> timedSupplier = Timer
             .decorateCheckedSupplier(timer, helloWorldService::returnHelloWorldWithException);
 
         String value = timedSupplier.get();
 
-        assertThat(timer.getMetrics().getNumberOfTotalCalls()).isEqualTo(1);
-        assertThat(timer.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(1);
+        assertThat(timer.getMetrics().getNumberOfTotalCalls()).isOne();
+        assertThat(timer.getMetrics().getNumberOfSuccessfulCalls()).isOne();
         assertThat(timer.getMetrics().getNumberOfFailedCalls()).isZero();
         assertThat(metricRegistry.getCounters()).hasSize(2);
-        assertThat(metricRegistry.getTimers().size()).isEqualTo(1);
+        assertThat(metricRegistry.getTimers()).hasSize(1);
         assertThat(value).isEqualTo("Hello world");
         then(helloWorldService).should(times(1)).returnHelloWorldWithException();
     }
 
     @Test
-    public void shouldDecorateCallable() throws Throwable {
+    void shouldDecorateCallable() throws Throwable {
         given(helloWorldService.returnHelloWorldWithException()).willReturn("Hello world");
         Callable<String> timedSupplier = Timer
             .decorateCallable(timer, helloWorldService::returnHelloWorldWithException);
 
         String value = timedSupplier.call();
 
-        assertThat(timer.getMetrics().getNumberOfTotalCalls()).isEqualTo(1);
-        assertThat(timer.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(1);
+        assertThat(timer.getMetrics().getNumberOfTotalCalls()).isOne();
+        assertThat(timer.getMetrics().getNumberOfSuccessfulCalls()).isOne();
         assertThat(timer.getMetrics().getNumberOfFailedCalls()).isZero();
         assertThat(value).isEqualTo("Hello world");
         then(helloWorldService).should(times(1)).returnHelloWorldWithException();
     }
 
     @Test
-    public void shouldExecuteCallable() throws Throwable {
+    void shouldExecuteCallable() throws Throwable {
         given(helloWorldService.returnHelloWorldWithException()).willReturn("Hello world");
 
         String value = timer
             .executeCallable(helloWorldService::returnHelloWorldWithException);
 
-        assertThat(timer.getMetrics().getNumberOfTotalCalls()).isEqualTo(1);
-        assertThat(timer.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(1);
+        assertThat(timer.getMetrics().getNumberOfTotalCalls()).isOne();
+        assertThat(timer.getMetrics().getNumberOfSuccessfulCalls()).isOne();
         assertThat(timer.getMetrics().getNumberOfFailedCalls()).isZero();
         assertThat(value).isEqualTo("Hello world");
         then(helloWorldService).should(times(1)).returnHelloWorldWithException();
@@ -108,29 +107,29 @@ public class TimerTest {
 
 
     @Test
-    public void shouldDecorateRunnable() throws Throwable {
+    void shouldDecorateRunnable() throws Throwable {
         Runnable timedRunnable = Timer.decorateRunnable(timer, helloWorldService::sayHelloWorld);
 
         timedRunnable.run();
 
-        assertThat(timer.getMetrics().getNumberOfTotalCalls()).isEqualTo(1);
-        assertThat(timer.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(1);
+        assertThat(timer.getMetrics().getNumberOfTotalCalls()).isOne();
+        assertThat(timer.getMetrics().getNumberOfSuccessfulCalls()).isOne();
         assertThat(timer.getMetrics().getNumberOfFailedCalls()).isZero();
         then(helloWorldService).should(times(1)).sayHelloWorld();
     }
 
     @Test
-    public void shouldExecuteRunnable() throws Throwable {
+    void shouldExecuteRunnable() throws Throwable {
         timer.executeRunnable(helloWorldService::sayHelloWorld);
 
-        assertThat(timer.getMetrics().getNumberOfTotalCalls()).isEqualTo(1);
-        assertThat(timer.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(1);
+        assertThat(timer.getMetrics().getNumberOfTotalCalls()).isOne();
+        assertThat(timer.getMetrics().getNumberOfSuccessfulCalls()).isOne();
         assertThat(timer.getMetrics().getNumberOfFailedCalls()).isZero();
         then(helloWorldService).should(times(1)).sayHelloWorld();
     }
 
     @Test
-    public void shouldExecuteCompletionStageSupplier() throws Throwable {
+    void shouldExecuteCompletionStageSupplier() throws Throwable {
         given(helloWorldService.returnHelloWorld()).willReturn("Hello world");
         Supplier<CompletionStage<String>> completionStageSupplier =
             () -> CompletableFuture.supplyAsync(helloWorldService::returnHelloWorld);
@@ -140,16 +139,16 @@ public class TimerTest {
         String value = stringCompletionStage.toCompletableFuture().get();
         assertThat(value).isEqualTo("Hello world");
         await().atMost(1, SECONDS)
-            .until(() -> {
-                assertThat(timer.getMetrics().getNumberOfTotalCalls()).isEqualTo(1);
-                assertThat(timer.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(1);
+            .untilAsserted(() -> {
+            assertThat(timer.getMetrics().getNumberOfTotalCalls()).isOne();
+            assertThat(timer.getMetrics().getNumberOfSuccessfulCalls()).isOne();
                 assertThat(timer.getMetrics().getNumberOfFailedCalls()).isZero();
             });
         then(helloWorldService).should(times(1)).returnHelloWorld();
     }
 
     @Test
-    public void shouldExecuteCompletionStageAndReturnWithExceptionAtSyncStage() throws Throwable {
+    void shouldExecuteCompletionStageAndReturnWithExceptionAtSyncStage() throws Throwable {
         Supplier<CompletionStage<String>> completionStageSupplier = () -> {
             throw new HelloWorldException();
         };
@@ -157,14 +156,14 @@ public class TimerTest {
         assertThatThrownBy(() -> timer.executeCompletionStageSupplier(completionStageSupplier))
             .isInstanceOf(HelloWorldException.class);
 
-        assertThat(timer.getMetrics().getNumberOfTotalCalls()).isEqualTo(1);
+        assertThat(timer.getMetrics().getNumberOfTotalCalls()).isOne();
         assertThat(timer.getMetrics().getNumberOfSuccessfulCalls()).isZero();
-        assertThat(timer.getMetrics().getNumberOfFailedCalls()).isEqualTo(1);
+        assertThat(timer.getMetrics().getNumberOfFailedCalls()).isOne();
     }
 
 
     @Test
-    public void shouldExecuteCompletionStageAndReturnWithExceptionAtASyncStage() throws Throwable {
+    void shouldExecuteCompletionStageAndReturnWithExceptionAtASyncStage() throws Throwable {
         given(helloWorldService.returnHelloWorld()).willThrow(new HelloWorldException());
         Supplier<CompletionStage<String>> completionStageSupplier =
             () -> CompletableFuture.supplyAsync(helloWorldService::returnHelloWorld);
@@ -174,50 +173,49 @@ public class TimerTest {
         assertThatThrownBy(() -> stringCompletionStage.toCompletableFuture().get())
             .isInstanceOf(ExecutionException.class).hasCause(new HelloWorldException());
 
-        assertThat(timer.getMetrics().getNumberOfTotalCalls()).isEqualTo(1);
+        assertThat(timer.getMetrics().getNumberOfTotalCalls()).isOne();
         assertThat(timer.getMetrics().getNumberOfSuccessfulCalls()).isZero();
-        assertThat(timer.getMetrics().getNumberOfFailedCalls()).isEqualTo(1);
+        assertThat(timer.getMetrics().getNumberOfFailedCalls()).isOne();
         then(helloWorldService).should().returnHelloWorld();
     }
 
 
     @Test
-    public void shouldDecorateCheckedRunnableAndReturnWithSuccess() throws Throwable {
+    void shouldDecorateCheckedRunnableAndReturnWithSuccess() throws Throwable {
         CheckedRunnable timedRunnable = Timer
             .decorateCheckedRunnable(timer, helloWorldService::sayHelloWorldWithException);
 
         timedRunnable.run();
 
-        assertThat(timer.getMetrics().getNumberOfTotalCalls()).isEqualTo(1);
-        assertThat(timer.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(1);
+        assertThat(timer.getMetrics().getNumberOfTotalCalls()).isOne();
+        assertThat(timer.getMetrics().getNumberOfSuccessfulCalls()).isOne();
         assertThat(timer.getMetrics().getNumberOfFailedCalls()).isZero();
         then(helloWorldService).should().sayHelloWorldWithException();
     }
 
     @Test
-    public void shouldDecorateSupplierAndReturnWithException() throws Throwable {
+    void shouldDecorateSupplierAndReturnWithException() throws Throwable {
         given(helloWorldService.returnHelloWorld()).willThrow(new RuntimeException("BAM!"));
         Supplier<String> supplier = Timer
             .decorateSupplier(timer, helloWorldService::returnHelloWorld);
 
-        Try<String> result = Try.of(supplier::get);
+        assertThatThrownBy(supplier::get)
+            .isInstanceOf(RuntimeException.class);
 
-        assertThat(result.isFailure()).isTrue();
-        assertThat(result.failed().get()).isInstanceOf(RuntimeException.class);
-        assertThat(timer.getMetrics().getNumberOfTotalCalls()).isEqualTo(1);
+        assertThat(timer.getMetrics().getNumberOfTotalCalls()).isOne();
         assertThat(timer.getMetrics().getNumberOfSuccessfulCalls()).isZero();
-        assertThat(timer.getMetrics().getNumberOfFailedCalls()).isEqualTo(1);
+        assertThat(timer.getMetrics().getNumberOfFailedCalls()).isOne();
         then(helloWorldService).should(times(1)).returnHelloWorld();
 
     }
 
     @Test
-    public void shouldDecorateSupplier() throws Throwable {
+    void shouldDecorateSupplier() throws Throwable {
         given(helloWorldService.returnHelloWorld()).willReturn("Hello world");
         Supplier<String> timedSupplier = Timer
             .decorateSupplier(timer, helloWorldService::returnHelloWorld);
 
-        Stream.range(0, 2).forEach((i) -> timedSupplier.get());
+        IntStream.range(0, 2).forEach((i) -> timedSupplier.get());
 
         assertThat(timer.getMetrics().getNumberOfTotalCalls()).isEqualTo(2);
         assertThat(timer.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(2);
@@ -226,11 +224,11 @@ public class TimerTest {
     }
 
     @Test
-    public void shouldExecuteSupplier() throws Throwable {
+    void shouldExecuteSupplier() throws Throwable {
         given(helloWorldService.returnHelloWorld()).willReturn("Hello world")
             .willThrow(new IllegalArgumentException("BAM!"));
 
-        Stream.range(0, 2).forEach((i) -> {
+        IntStream.range(0, 2).forEach((i) -> {
             try {
                 timer.executeSupplier(helloWorldService::returnHelloWorld);
             } catch (Exception e) {
@@ -239,14 +237,14 @@ public class TimerTest {
         });
 
         assertThat(timer.getMetrics().getNumberOfTotalCalls()).isEqualTo(2);
-        assertThat(timer.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(1);
-        assertThat(timer.getMetrics().getNumberOfFailedCalls()).isEqualTo(1);
+        assertThat(timer.getMetrics().getNumberOfSuccessfulCalls()).isOne();
+        assertThat(timer.getMetrics().getNumberOfFailedCalls()).isOne();
         then(helloWorldService).should(times(2)).returnHelloWorld();
     }
 
 
     @Test
-    public void shouldDecorateFunctionAndReturnWithSuccess() throws Throwable {
+    void shouldDecorateFunctionAndReturnWithSuccess() throws Throwable {
         given(helloWorldService.returnHelloWorldWithName("Tom")).willReturn("Hello world Tom");
         Function<String, String> function = Timer
             .decorateFunction(timer, helloWorldService::returnHelloWorldWithName);
@@ -254,14 +252,14 @@ public class TimerTest {
         String result = function.apply("Tom");
 
         assertThat(result).isEqualTo("Hello world Tom");
-        assertThat(timer.getMetrics().getNumberOfTotalCalls()).isEqualTo(1);
-        assertThat(timer.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(1);
+        assertThat(timer.getMetrics().getNumberOfTotalCalls()).isOne();
+        assertThat(timer.getMetrics().getNumberOfSuccessfulCalls()).isOne();
         assertThat(timer.getMetrics().getNumberOfFailedCalls()).isZero();
         then(helloWorldService).should().returnHelloWorldWithName("Tom");
     }
 
     @Test
-    public void shouldDecorateCheckedFunctionAndReturnWithSuccess() throws Throwable {
+    void shouldDecorateCheckedFunctionAndReturnWithSuccess() throws Throwable {
         given(helloWorldService.returnHelloWorldWithNameWithException("Tom"))
             .willReturn("Hello world Tom");
         CheckedFunction<String, String> function = Timer.decorateCheckedFunction(timer,
@@ -270,8 +268,8 @@ public class TimerTest {
         String result = function.apply("Tom");
 
         assertThat(result).isEqualTo("Hello world Tom");
-        assertThat(timer.getMetrics().getNumberOfTotalCalls()).isEqualTo(1);
-        assertThat(timer.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(1);
+        assertThat(timer.getMetrics().getNumberOfTotalCalls()).isOne();
+        assertThat(timer.getMetrics().getNumberOfSuccessfulCalls()).isOne();
         assertThat(timer.getMetrics().getNumberOfFailedCalls()).isZero();
         then(helloWorldService).should().returnHelloWorldWithNameWithException("Tom");
     }

--- a/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/publisher/CircuitBreakerMetricsPublisherTest.java
+++ b/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/publisher/CircuitBreakerMetricsPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Ingyu Hwang
+ * Copyright 2026 Ingyu Hwang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,14 +21,14 @@ import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.metrics.AbstractCircuitBreakerMetricsTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
-public class CircuitBreakerMetricsPublisherTest extends AbstractCircuitBreakerMetricsTest {
+class CircuitBreakerMetricsPublisherTest extends AbstractCircuitBreakerMetricsTest {
 
     private CircuitBreakerRegistry circuitBreakerRegistry;
     @Override
@@ -48,7 +48,7 @@ public class CircuitBreakerMetricsPublisherTest extends AbstractCircuitBreakerMe
     }
 
     @Test
-    public void shouldRemoveAllMetrics() {
+    void shouldRemoveAllMetrics() {
         CircuitBreaker circuitBreaker = givenMetricRegistry("testPrefix", metricRegistry);
         given(helloWorldService.returnHelloWorld()).willReturn("Hello world");
 


### PR DESCRIPTION
## Changes

* Migrated JUnit 4.13 annotations to Junit Jupiter equivalents
* Migrated to awaitility 4.x
* Applied OpenRewrite recipes
    * [JUnit 6 best practices](https://docs.openrewrite.org/recipes/java/testing/junit/junit6bestpractices)
    * [Mockito best practices](https://docs.openrewrite.org/recipes/java/testing/mockito/mockitobestpractices)
    * [Migrate JUnit asserts to AssertJ](https://docs.openrewrite.org/recipes/java/testing/assertj/junittoassertj)
    * [AssertJ best practices](https://docs.openrewrite.org/recipes/java/testing/assertj/assertj-best-practices)
* Removed `public` modifiers
* Expanded star imports to explicit imports
* Removed outdated `test*` prefix
* Removed unnecessary vavr usages
* Updated Copyright to 2026

## Coverage

| Metric      | Before | After |
|-------------|--------|-------|
| Instruction | 77.2%  | 77.2% |
| Line        | 74.2%  | 74.2% |
| Branch      | 75.0%  | 75.0% |

## Test runtime

| Metric | Before | After |
|--------|--------|-------|
| Tests  | 52     | 52    |
| Time   | 19.0s  | 18.7s |
