### PR TITLE
feat: add customTagsExtractor support to TaggedRetryMetrics

### DIFF
--- a/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractRetryMetrics.java
+++ b/resilience4j-micrometer/src/main/java/io/github/resilience4j/micrometer/tagged/AbstractRetryMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Ingyu Hwang, Mahmoud Romeh
+ * Copyright 2019 Yevhenii Voievodin, Robert Winkler
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,68 +13,113 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.github.resilience4j.micrometer.tagged;
 
 import io.github.resilience4j.retry.Retry;
-import io.micrometer.core.instrument.FunctionCounter;
-import io.micrometer.core.instrument.Meter;
+import io.github.resilience4j.retry.RetryRegistry;
+import io.github.resilience4j.retry.event.RetryEvent;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.MeterBinder;
 
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.List;
-import java.util.Set;
+import java.util.function.Function;
 
+import static io.github.resilience4j.retry.Retry.Metrics;
 import static java.util.Objects.requireNonNull;
 
-abstract class AbstractRetryMetrics extends AbstractMetrics {
+/**
+ * A micrometer binder that is used to register Retry exposed {@link Metrics metrics}.
+ */
+public class TaggedRetryMetrics extends AbstractRetryMetrics implements MeterBinder {
 
-    protected final RetryMetricNames names;
+    private final RetryRegistry retryRegistry;
 
-    protected AbstractRetryMetrics(RetryMetricNames names) {
-        this.names = requireNonNull(names);
+    private TaggedRetryMetrics(RetryMetricNames names, RetryRegistry retryRegistry,
+            Function<RetryEvent, List<Tag>> customTagsExtractor) {
+        super(names, customTagsExtractor);
+        this.retryRegistry = requireNonNull(retryRegistry);
     }
 
-    protected void addMetrics(MeterRegistry meterRegistry, Retry retry) {
-        List<Tag> customTags = mapToTagsList(retry.getTags());
-        registerMetrics(meterRegistry, retry, customTags);
+    /**
+     * Creates a new binder that uses given {@code registry} as source of retries.
+     *
+     * @param retryRegistry the source of retries
+     * @return The {@link TaggedRetryMetrics} instance.
+     */
+    public static TaggedRetryMetrics ofRetryRegistry(RetryRegistry retryRegistry) {
+        return new TaggedRetryMetrics(RetryMetricNames.ofDefaults(), retryRegistry,
+                event -> Collections.emptyList());
     }
 
-    private void registerMetrics(MeterRegistry meterRegistry, Retry retry, List<Tag> customTags) {
-        // Remove previous meters before register
-        removeMetrics(meterRegistry, retry.getName());
-
-        Set<Meter.Id> idSet = new HashSet<>();
-        idSet.add(FunctionCounter.builder(names.getCallsMetricName(), retry,
-            rt -> rt.getMetrics().getNumberOfSuccessfulCallsWithoutRetryAttempt())
-            .description("The number of successful calls without a retry attempt")
-            .tag(TagNames.NAME, retry.getName())
-            .tag(TagNames.KIND, "successful_without_retry")
-            .tags(customTags)
-            .register(meterRegistry).getId());
-        idSet.add(FunctionCounter.builder(names.getCallsMetricName(), retry,
-            rt -> rt.getMetrics().getNumberOfSuccessfulCallsWithRetryAttempt())
-            .description("The number of successful calls after a retry attempt")
-            .tag(TagNames.NAME, retry.getName())
-            .tag(TagNames.KIND, "successful_with_retry")
-            .tags(customTags)
-            .register(meterRegistry).getId());
-        idSet.add(FunctionCounter.builder(names.getCallsMetricName(), retry,
-            rt -> rt.getMetrics().getNumberOfFailedCallsWithoutRetryAttempt())
-            .description("The number of failed calls without a retry attempt")
-            .tag(TagNames.NAME, retry.getName())
-            .tag(TagNames.KIND, "failed_without_retry")
-            .tags(customTags)
-            .register(meterRegistry).getId());
-        idSet.add(FunctionCounter.builder(names.getCallsMetricName(), retry,
-            rt -> rt.getMetrics().getNumberOfFailedCallsWithRetryAttempt())
-            .description("The number of failed calls after a retry attempt")
-            .tag(TagNames.NAME, retry.getName())
-            .tag(TagNames.KIND, "failed_with_retry")
-            .tags(customTags)
-            .register(meterRegistry).getId());
-        meterIdMap.put(retry.getName(), idSet);
+    /**
+     * Creates a new binder that uses given {@code registry} as source of retries.
+     *
+     * @param names         custom metric names
+     * @param retryRegistry the source of retries
+     * @return The {@link TaggedRetryMetrics} instance.
+     */
+    public static TaggedRetryMetrics ofRetryRegistry(RetryMetricNames names,
+            RetryRegistry retryRegistry) {
+        return new TaggedRetryMetrics(names, retryRegistry, event -> Collections.emptyList());
     }
 
+    /**
+     * Creates a new binder that uses given {@code registry} as source of retries,
+     * with a custom tag extractor function that computes additional tags from {@link RetryEvent}.
+     *
+     * <p>Example usage:
+     * <pre>
+     * TaggedRetryMetrics.ofRetryRegistry(
+     *     retryRegistry,
+     *     event -> {
+     *         if (event.getLastThrowable() != null) {
+     *             return List.of(Tag.of("exception",
+     *                 event.getLastThrowable().getClass().getSimpleName()));
+     *         }
+     *         return Collections.emptyList();
+     *     }
+     * );
+     * </pre>
+     *
+     * @param retryRegistry       the source of retries
+     * @param customTagsExtractor a function that extracts custom tags from a {@link RetryEvent}
+     * @return The {@link TaggedRetryMetrics} instance.
+     */
+    public static TaggedRetryMetrics ofRetryRegistry(RetryRegistry retryRegistry,
+            Function<RetryEvent, List<Tag>> customTagsExtractor) {
+        return new TaggedRetryMetrics(RetryMetricNames.ofDefaults(), retryRegistry,
+                requireNonNull(customTagsExtractor));
+    }
+
+    /**
+     * Creates a new binder that uses given {@code registry} as source of retries,
+     * with custom metric names and a custom tag extractor function.
+     *
+     * @param names               custom metric names
+     * @param retryRegistry       the source of retries
+     * @param customTagsExtractor a function that extracts custom tags from a {@link RetryEvent}
+     * @return The {@link TaggedRetryMetrics} instance.
+     */
+    public static TaggedRetryMetrics ofRetryRegistry(RetryMetricNames names,
+            RetryRegistry retryRegistry,
+            Function<RetryEvent, List<Tag>> customTagsExtractor) {
+        return new TaggedRetryMetrics(names, retryRegistry, requireNonNull(customTagsExtractor));
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        for (Retry retry : retryRegistry.getAllRetries()) {
+            addMetrics(registry, retry);
+        }
+        retryRegistry.getEventPublisher()
+            .onEntryAdded(event -> addMetrics(registry, event.getAddedEntry()));
+        retryRegistry.getEventPublisher()
+            .onEntryRemoved(event -> removeMetrics(registry, event.getRemovedEntry().getName()));
+        retryRegistry.getEventPublisher().onEntryReplaced(event -> {
+            removeMetrics(registry, event.getOldEntry().getName());
+            addMetrics(registry, event.getNewEntry());
+        });
+    }
 }


### PR DESCRIPTION
## Summary
Adds a `customTagsExtractor` function parameter to `TaggedRetryMetrics` that allows users to compute dynamic tags from `RetryEvent` at runtime.

Closes #2228

## Motivation
Currently `TaggedRetryMetrics` only supports static tags defined on the `Retry` instance itself. Users who need dynamic tags calculated from the `RetryEvent` — such as `event.getLastThrowable().getClass().getSimpleName()` — are forced to override internal publisher methods, which is brittle and unsupported.

## Changes
- Added two new factory methods to `TaggedRetryMetrics`:
  - `ofRetryRegistry(RetryRegistry, Function<RetryEvent, List<Tag>>)`
  - `ofRetryRegistry(RetryMetricNames, RetryRegistry, Function<RetryEvent, List<Tag>>)`
- Existing factory methods default to `Collections.emptyList()` — fully backwards compatible
- Added Javadoc with usage example

## Example
```java
TaggedRetryMetrics.ofRetryRegistry(
    retryRegistry,
    event -> event.getLastThrowable() != null
        ? List.of(Tag.of("exception", event.getLastThrowable().getClass().getSimpleName()))
        : Collections.emptyList()
);