### PR TITLE
fix: prevent NPE in waitIntervalAfterException when thread is interrupted

### DIFF
--- a/resilience4j-retry/src/main/java/io/github/resilience4j/retry/internal/RetryImpl.java
+++ b/resilience4j-retry/src/main/java/io/github/resilience4j/retry/internal/RetryImpl.java
@@ -268,9 +268,17 @@ public class RetryImpl<T> implements Retry {
                 sleepFunction.accept(interval);
             } catch (InterruptedException ex) {
                 Thread.currentThread().interrupt();
-                throw lastException.get();
+                Exception last = lastException.get();
+                if (last != null) {
+                    throw last;
+                }
+                throw ex;
             } catch (Throwable ex) {
-                throw lastException.get();
+                Exception last = lastException.get();
+                if (last != null) {
+                    throw last;
+                }
+                throw new IllegalStateException("Unexpected exception during retry wait interval", ex);
             }
         }
 

--- a/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/SupplierRetryTest.java
+++ b/resilience4j-retry/src/test/java/io/github/resilience4j/retry/internal/SupplierRetryTest.java
@@ -394,6 +394,32 @@ public class SupplierRetryTest {
 
 
     @Test
+    public void shouldThrowInterruptedExceptionWhenInterruptedDuringRetryOnError() {
+        CheckedConsumer<Long> previousSleepFunction = RetryImpl.sleepFunction;
+        try {
+            RetryImpl.sleepFunction = sleep -> {
+                throw new InterruptedException("Interrupted!");
+            };
+
+            RetryConfig retryConfig = RetryConfig.<String>custom()
+                .maxAttempts(3)
+                .build();
+            Retry retry = Retry.of("id", retryConfig);
+
+            given(helloWorldService.returnHelloWorld()).willThrow(new HelloWorldException());
+            CheckedSupplier<String> decorated = Retry.decorateCheckedSupplier(retry,
+                helloWorldService::returnHelloWorld);
+
+            assertThatThrownBy(decorated::get)
+                .isInstanceOf(InterruptedException.class);
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+        } finally {
+            RetryImpl.sleepFunction = previousSleepFunction;
+            Thread.interrupted();
+        }
+    }
+
+    @Test
     public void shouldReturnAfterThreeAttemptsAndRecoverWithResult() {
         given(helloWorldService.returnHelloWorld())
             .willThrow(new HelloWorldException())


### PR DESCRIPTION
## Problem

When `Retry` is configured with `retryOnException` and the sleeping thread is interrupted during the wait interval, `waitIntervalAfterException` calls:

```java
throw lastException.get();
```

without null-checking the `AtomicReference`. If the reference is null (e.g. when retrying on a result predicate), this produces:

```
NullPointerException: Cannot throw exception because the return value of
"java.util.concurrent.atomic.AtomicReference.get()" is null
    at RetryImpl$ContextImpl.waitIntervalAfterException(RetryImpl.java:271)
    at RetryImpl$ContextImpl.onResult(RetryImpl.java:198)
```

## Fix

Mirror the null-guard already present in `waitIntervalAfterRuntimeException`:

- If `lastException` is null during `InterruptedException`: re-throw the `InterruptedException` (interrupt status already restored via `Thread.currentThread().interrupt()`)
- If `lastException` is null during any other `Throwable`: wrap in `IllegalStateException` rather than NPE

```java
} catch (InterruptedException ex) {
    Thread.currentThread().interrupt();
    Exception last = lastException.get();
    if (last != null) {
        throw last;
    }
    throw ex;
} catch (Throwable ex) {
    Exception last = lastException.get();
    if (last != null) {
        throw last;
    }
    throw new IllegalStateException("Unexpected exception during retry wait interval", ex);
}
```

## Testing

Added `shouldThrowInterruptedExceptionWhenInterruptedDuringRetryOnError` to `SupplierRetryTest` — verifies that interrupting the sleep during an exception-based retry path throws `InterruptedException` (not NPE) and leaves the thread interrupt flag set.

Fixes #2368