### PR TITLE
(draft) Upgrade to jdk25 to completely resolve pinned issue of virtual threads

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -30,10 +30,10 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
           cache: 'gradle'
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ allprojects {
     }
 
     jacoco {
-        toolVersion = "0.8.12"
+        toolVersion = "0.8.14"
     }
 }
 
@@ -89,8 +89,8 @@ configure(project.coreProjects) {
     }
 
     tasks.withType(JavaCompile) {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
+        sourceCompatibility = JavaVersion.VERSION_25
+        targetCompatibility = JavaVersion.VERSION_25
         options.deprecation = true
         options.encoding = "UTF-8"
         options.compilerArgs += ["-Xlint:unchecked", "-parameters"]

--- a/docs/superpowers/plans/2026-04-22-jdk25-spring-bump-plan.md
+++ b/docs/superpowers/plans/2026-04-22-jdk25-spring-bump-plan.md
@@ -1,0 +1,387 @@
+# JDK 25 Spring Bump Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `resilience4j-spring6` / `resilience4j-spring-boot3` 모듈의 JDK 25 테스트 실패(ASM "Unsupported class file major version 69")를 Spring 6 / Spring Boot 3 / Spring Cloud 3 라이브러리 버전 bump으로 해결한다.
+
+**Architecture:** `gradle/libs.versions.toml`의 3개 버전 변수(`spring6`, `spring-boot3`, `spring-cloud3`)를 JDK 25를 지원하는 현행 최신 GA 버전으로 올린 뒤, 버전 점프 과정에서 발생하는 테스트 코드 fallout을 최소 범위로 수정한다. 프로덕션 코드는 수정하지 않는다.
+
+**Tech Stack:** Gradle 9.2.1, Java 25, Spring Framework 6.2.18, Spring Boot 3.5.13, Spring Cloud 4.3.2 (Northfields 2025.0 release train), JUnit 5 (Jupiter 5.x via JUnit BOM 6.0.3)
+
+**Working directory:** `/Users/al02628768/private/resilience4j` (branch `feature/2343-bump-up-jdk-to-25`, worktree 아님 - 기존 feature branch 직접 작업)
+
+**Design doc:** `docs/superpowers/specs/2026-04-22-jdk25-spring-bump-design.md`
+
+---
+
+## File Structure
+
+Primary change:
+- **Modify:** `gradle/libs.versions.toml` (versions block, 3 lines)
+
+Potentially touched during fallout fixes (실제 실패 발생 시에만):
+- `resilience4j-spring6/src/test/java/**/*.java` (테스트 코드)
+- `resilience4j-spring-boot3/src/test/java/**/*.java` (테스트 코드)
+- `resilience4j-spring-boot3/src/main/java/**/*.java` (autoconfigure spring.factories 경로 변경 등 필요시)
+- `resilience4j-spring6/src/main/java/**/*.java` (불가피할 경우만)
+- `resilience4j-spring-boot3/src/test/resources/application*.yml` 또는 `.properties` (property key deprecation)
+
+프로덕션 코어 코드(`resilience4j-core` 등)는 건드리지 않는다.
+
+---
+
+## Task 1: Record baseline failures
+
+`spring6`와 `spring-boot3` 모듈의 현재 실패 상태를 기록한다. 이후 수정이 의도한 에러만 해결하는지 검증 기준이 된다.
+
+**Files:**
+- Read-only. 결과는 터미널 출력으로만 기록.
+
+- [ ] **Step 1: Run spring6 tests, capture failure summary**
+
+Run:
+```bash
+./gradlew :resilience4j-spring6:test --no-daemon --continue 2>&1 | tail -40
+```
+
+Expected: FAIL. 실패 메시지에 다음 문자열이 반드시 포함되어야 한다:
+```
+java.lang.IllegalArgumentException: Unsupported class file major version 69
+```
+
+검증: `grep -c 'Unsupported class file major version 69' resilience4j-spring6/build/test-results/test/*.xml` 결과 ≥ 1.
+
+- [ ] **Step 2: Run spring-boot3 tests, capture failure summary**
+
+Run:
+```bash
+./gradlew :resilience4j-spring-boot3:test --no-daemon --continue 2>&1 | tail -60
+```
+
+Expected: FAIL. "80 failed" 수준의 대량 실패, root cause는 동일하게 version 69.
+
+검증: `grep -c 'Unsupported class file major version 69' resilience4j-spring-boot3/build/test-results/test/*.xml` 결과 ≥ 1.
+
+- [ ] **Step 3: Record baseline snapshot**
+
+기록만 하고 커밋하지 않는다. 이후 Task 5에서 비교 대상으로 사용.
+
+```bash
+echo "Baseline recorded: spring6 failing, spring-boot3 failing with class version 69"
+```
+
+---
+
+## Task 2: Apply the version bump
+
+`libs.versions.toml`의 3개 버전을 JDK 25 지원 최신으로 동시 변경한다. 3개가 한 릴리즈 트레인으로 묶여 있어 한 커밋에서 함께 바꾼다.
+
+**Files:**
+- Modify: `gradle/libs.versions.toml` (versions block)
+
+- [ ] **Step 1: Apply the diff**
+
+`gradle/libs.versions.toml`의 다음 3줄을 수정:
+
+```diff
+-spring6 = "6.1.1"
+-spring-boot3 = "3.2.0"
+-spring-cloud3 = "3.1.5"
++spring6 = "6.2.18"
++spring-boot3 = "3.5.13"
++spring-cloud3 = "4.3.2"
+```
+
+최종 3줄 상태(파일의 현재 위치에서):
+
+```toml
+spring6 = "6.2.18"
+spring-boot3 = "3.5.13"
+spring-cloud3 = "4.3.2"
+```
+
+다른 라인(예: `spring7 = "7.0.2"`)은 건드리지 않는다.
+
+- [ ] **Step 2: Verify compilation succeeds across all modules**
+
+Run:
+```bash
+./gradlew compileJava compileTestJava --no-daemon 2>&1 | tail -20
+```
+
+Expected: `BUILD SUCCESSFUL`. 컴파일 에러가 나면 에러를 읽고 minimal 수정 후 재시도. 단, 이 Task에서는 테스트 실행까지 가지 않는다.
+
+- [ ] **Step 3: Do NOT commit yet**
+
+테스트가 통과하는지 확인 전에는 커밋하지 않는다. Task 3~5 완료 후 전체를 한 커밋으로 묶는다.
+
+---
+
+## Task 3: Get `resilience4j-spring6` tests green
+
+spring6 모듈 테스트를 실행하고, 발생하는 실패를 하나씩 최소 범위로 수정하는 루프.
+
+**Files:**
+- Test: `resilience4j-spring6/src/test/java/**/*.java` (수정 대상)
+- Test resources: `resilience4j-spring6/src/test/resources/**` (수정 대상)
+
+- [ ] **Step 1: Run spring6 tests**
+
+Run:
+```bash
+./gradlew :resilience4j-spring6:test --no-daemon --continue 2>&1 | tail -60
+```
+
+Expected 결과 2가지 중 하나:
+- (A) `BUILD SUCCESSFUL` → Step 5로 건너뛰기.
+- (B) `FAILED` → Step 2로.
+
+- [ ] **Step 2: Confirm version-69 errors are GONE**
+
+```bash
+grep -c 'Unsupported class file major version 69' resilience4j-spring6/build/test-results/test/*.xml
+```
+
+Expected: `0`. 여전히 > 0이면 버전 bump가 제대로 반영되지 않은 것. `./gradlew --stop` 후 `./gradlew clean :resilience4j-spring6:test` 재실행.
+
+- [ ] **Step 3: Enumerate remaining failures**
+
+```bash
+grep -l 'failures="[1-9]\|errors="[1-9]' resilience4j-spring6/build/test-results/test/*.xml | xargs -I{} basename {} .xml
+grep -h 'Caused by' resilience4j-spring6/build/test-results/test/*.xml | sort -u
+```
+
+실패가 없으면 Step 5로. 있으면 Step 4로.
+
+- [ ] **Step 4: Fix failures using the playbook below, then re-run Step 1**
+
+다음 유형별 minimal 수정을 적용하고 다시 Step 1로 돌아간다. 수정 범위는 **이 실행에서 관찰된 실패만**으로 제한한다. 사전에 "예방적으로" 바꾸지 않는다.
+
+**Playbook — 흔한 fallout 유형:**
+
+| 실패 증상 (테스트 XML의 `<failure>` 메시지) | 원인 | 최소 수정 |
+|---|---|---|
+| `NoSuchMethodError: org.springframework.test.context...` | Spring 6.1→6.2에서 시그니처가 바뀐 내부 API 사용 | 테스트 유틸을 6.2 API로 교체 |
+| `MockitoException: ... MockMaker cannot mock final class` | Mockito 5.16→5.23에서 inline mock 동작 변경 | 테스트에서 `@MockitoSettings(strictness=LENIENT)` 또는 mock 방식 수정 |
+| `Cannot resolve property ...` in `@ConfigurationProperties` | Spring Boot 3.2→3.5 프로퍼티 키 이름 변경 | `application*.yml`/`.properties`의 키를 새 이름으로 |
+| `FeignClientBuilder ...` / `Contract ...` API 변경 | Spring Cloud OpenFeign 3.1→4.3 breaking change | 새 API로 설정 업데이트 (Spring Cloud 2025.0 가이드 참조) |
+| `BeanDefinitionStoreException: Failed to import autoconfiguration ...` | `spring.factories` 경로 deprecation (Spring Boot 2.7에서 이미 deprecated, 3.x에서도 유지됨) → 2.7 이후 권장: `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` | main 모듈의 `META-INF/spring.factories` 가 있으면 `AutoConfiguration.imports` 로 마이그레이션 |
+| `@MockBean` deprecation warning은 무시 (WARN, not ERROR) | Spring Boot 3.4에서 deprecated (`@MockitoBean` 권장) | 테스트가 통과하면 수정 안 함 — scope 제한 |
+
+**Fix의 scope 원칙:**
+- 실제로 실패한 테스트가 있는 경우에만 해당 테스트 파일 / 해당 property 파일을 수정.
+- 한 번에 한 유형의 fallout만 수정하고 Step 1로 돌아가 재실행. 여러 종류를 batch로 바꾸지 않는다.
+- 프로덕션 Java 코드(`src/main/java/...`)는 최후의 수단. 대부분 테스트/리소스 수정으로 해결된다.
+
+- [ ] **Step 5: Verify spring6 all green**
+
+Run:
+```bash
+./gradlew :resilience4j-spring6:test --no-daemon 2>&1 | tail -5
+```
+
+Expected: `BUILD SUCCESSFUL`. `n tests completed, 0 failed`.
+
+검증: `grep -l 'failures="[1-9]\|errors="[1-9]' resilience4j-spring6/build/test-results/test/*.xml` 결과 empty.
+
+- [ ] **Step 6: Do NOT commit yet**
+
+다음 Task에서 spring-boot3까지 마친 후 일괄 커밋.
+
+---
+
+## Task 4: Get `resilience4j-spring-boot3` tests green
+
+spring-boot3 모듈에 대해 Task 3과 동일한 루프를 적용. spring-boot3는 Spring Boot 3.2→3.5와 Spring Cloud 3.1→4.3 동시 bump라 fallout이 spring6보다 많을 수 있다.
+
+**Files:**
+- Test: `resilience4j-spring-boot3/src/test/java/**/*.java`
+- Test resources: `resilience4j-spring-boot3/src/test/resources/**`
+- 필요 시: `resilience4j-spring-boot3/src/main/resources/META-INF/spring/*.imports`
+
+- [ ] **Step 1: Run spring-boot3 tests**
+
+Run:
+```bash
+./gradlew :resilience4j-spring-boot3:test --no-daemon --continue 2>&1 | tail -100
+```
+
+Expected 결과 2가지:
+- (A) `BUILD SUCCESSFUL` → Step 5로.
+- (B) `FAILED` → Step 2로.
+
+- [ ] **Step 2: Confirm version-69 errors are GONE**
+
+```bash
+grep -c 'Unsupported class file major version 69' resilience4j-spring-boot3/build/test-results/test/*.xml
+```
+
+Expected: `0`.
+
+- [ ] **Step 3: Enumerate remaining failures and identify the FIRST (root) failure**
+
+ApplicationContext failure threshold 패턴은 연쇄 실패이므로, 가장 먼저 발생한 실제 원인을 찾아야 한다.
+
+```bash
+# Find tests with real root causes, not "threshold exceeded" cascades
+grep -l 'Caused by' resilience4j-spring-boot3/build/test-results/test/*.xml | head -3
+
+# Print the first Caused by chain from each
+for f in $(grep -l 'Caused by' resilience4j-spring-boot3/build/test-results/test/*.xml | head -3); do
+  echo "=== $f ==="
+  grep -A 2 'Caused by' "$f" | head -20
+done
+```
+
+- [ ] **Step 4: Fix failures using Task 3 Step 4 playbook**
+
+Task 3 Step 4의 playbook을 그대로 적용. spring-boot3에서 추가로 흔한 유형:
+
+| 추가 증상 | 원인 | 최소 수정 |
+|---|---|---|
+| `Failed to load ApplicationContext` with `ClassNotFoundException: jakarta.servlet...` | Tomcat 10.1→11 API 변경 | 보통 직접 수정 불필요, dependency 정리로 해결됨. `./gradlew --stop && ./gradlew :resilience4j-spring-boot3:clean test` |
+| `application.yml` 의 `management.endpoints.web.exposure.*` 키 인식 불가 | Actuator property 경로는 안 바뀜, 하지만 일부 observability 키는 변경됨 | 실패 메시지의 제안 키로 교체 |
+| `CircuitBreakerFeignTest`의 FeignClient 설정 에러 | Spring Cloud OpenFeign 3.1→4.3 | `FeignClientsConfiguration` import / `Contract` 변경 |
+| `TestApplication` 로드 실패, `WebSecurityConfigurerAdapter` 관련 | Spring Security 6.x 완전 제거된 API | 영향 없어야 함 (resilience4j는 security 미사용), 만약 transitively 등장하면 의존성 확인 |
+| `ConfigurationPropertySource ... not bound` | `@ConstructorBinding` 위치 변경 (Spring Boot 3에서 class 레벨만 허용) | 이미 적용되어 있을 것. 아니라면 class 레벨로 이동 |
+
+한 번에 한 유형만 수정 → Step 1 재실행 반복.
+
+- [ ] **Step 5: Verify spring-boot3 all green**
+
+Run:
+```bash
+./gradlew :resilience4j-spring-boot3:test --no-daemon 2>&1 | tail -5
+```
+
+Expected: `BUILD SUCCESSFUL`. `101 tests completed, 0 failed, 6 skipped` 또는 유사 (테스트 개수는 실제와 일치하면 OK).
+
+검증: `grep -l 'failures="[1-9]\|errors="[1-9]' resilience4j-spring-boot3/build/test-results/test/*.xml` 결과 empty.
+
+- [ ] **Step 6: Do NOT commit yet**
+
+Task 5에서 전체 회귀 검증 후 일괄 커밋.
+
+---
+
+## Task 5: Full-build regression check
+
+이전에 통과하던 모든 모듈이 여전히 통과하는지 확인. Spring Boot 3.5가 다른 모듈로 누수되진 않지만, `resilience4j-all` / `resilience4j-consumer` 등 cross-module 경계에서 transitives 영향이 있을 수 있음.
+
+**Files:**
+- Read-only (추가 수정 없음이 목표)
+
+- [ ] **Step 1: Clean incremental test cache**
+
+Run:
+```bash
+./gradlew --stop
+```
+
+Expected: `Stopping Daemon(s)` 또는 daemon이 없다는 메시지. 에러 없이 종료.
+
+- [ ] **Step 2: Run full build with tests**
+
+Run:
+```bash
+./gradlew build --continue 2>&1 | tail -40
+```
+
+Expected: `BUILD SUCCESSFUL`. 전체 task 중 실패한 테스트 task 없음.
+
+- [ ] **Step 3: Verify no regression in previously passing modules**
+
+```bash
+# List any test result files with failures in modules OTHER than spring6/spring-boot3
+for dir in resilience4j-*/build/test-results/test; do
+  mod=$(echo "$dir" | cut -d/ -f1)
+  if [ "$mod" = "resilience4j-spring6" ] || [ "$mod" = "resilience4j-spring-boot3" ]; then
+    continue
+  fi
+  fails=$(grep -l 'failures="[1-9]\|errors="[1-9]' "$dir"/*.xml 2>/dev/null)
+  if [ -n "$fails" ]; then
+    echo "REGRESSION in $mod:"
+    echo "$fails"
+  fi
+done
+```
+
+Expected: 출력 empty. 다른 모듈에서 실패 발생 시 해당 모듈 failure 로그 분석 후 minimal 수정 (단, 본 plan의 scope는 spring6/spring-boot3 이므로 타 모듈 실패는 "의외의 회귀"로 취급 — 원인 파악 후 user와 상의할지 판단).
+
+- [ ] **Step 4: Final confirmation**
+
+```bash
+echo "spring6:"
+./gradlew :resilience4j-spring6:test --no-daemon 2>&1 | grep -E '(BUILD|tests completed)'
+echo "spring-boot3:"
+./gradlew :resilience4j-spring-boot3:test --no-daemon 2>&1 | grep -E '(BUILD|tests completed)'
+```
+
+Expected: 양쪽 모두 `BUILD SUCCESSFUL`, `0 failed`.
+
+---
+
+## Task 6: Commit the bump + any fallout fixes
+
+**Files:**
+- Staged: `gradle/libs.versions.toml` + Task 3/4에서 수정한 모든 파일
+
+- [ ] **Step 1: Review the diff**
+
+```bash
+git status
+git diff --stat
+git diff gradle/libs.versions.toml
+```
+
+Expected:
+- `gradle/libs.versions.toml` 정확히 3줄 변경 (spring6/spring-boot3/spring-cloud3).
+- 기타 수정 파일들이 있다면 각각 Task 3/4에서 의도한 fallout 수정인지 재확인.
+
+- [ ] **Step 2: Stage explicitly (no `git add -A`)**
+
+```bash
+git add gradle/libs.versions.toml
+# Task 3/4에서 수정한 개별 파일들을 명시적으로 add
+# 예: git add resilience4j-spring-boot3/src/test/resources/application.yml
+```
+
+민감 파일이나 비관련 파일이 들어가지 않도록 명시적 add.
+
+- [ ] **Step 3: Commit with a descriptive message**
+
+```bash
+git commit -m "$(cat <<'EOF'
+bump Spring 6 / Boot 3 / Cloud 3 baselines for JDK 25
+
+- spring6: 6.1.1 -> 6.2.18 (final 6.x LTS, JDK 25 supported)
+- spring-boot3: 3.2.0 -> 3.5.13 (official JDK 25 support since 3.5.5)
+- spring-cloud3: 3.1.5 -> 4.3.2 (Northfields 2025.0 train, Boot 3.5 compat)
+
+Fixes "Unsupported class file major version 69" errors in
+resilience4j-spring6 and resilience4j-spring-boot3 test suites
+caused by older Spring-bundled ASM not supporting JDK 25 class files.
+
+Design: docs/superpowers/specs/2026-04-22-jdk25-spring-bump-design.md
+EOF
+)"
+```
+
+- [ ] **Step 4: Verify commit**
+
+```bash
+git log -1 --stat
+```
+
+Expected: 방금 만든 커밋이 HEAD. 변경 파일 목록이 의도와 일치.
+
+---
+
+## Done Criteria
+
+- [ ] `./gradlew :resilience4j-spring6:test` — BUILD SUCCESSFUL, 0 failed
+- [ ] `./gradlew :resilience4j-spring-boot3:test` — BUILD SUCCESSFUL, 0 failed
+- [ ] `./gradlew build` — BUILD SUCCESSFUL, 전체 회귀 없음
+- [ ] `libs.versions.toml` 3줄만 의도대로 변경
+- [ ] 프로덕션 core 코드(`resilience4j-core/src/main/...` 등) 건드리지 않음
+- [ ] 하나의 커밋에 bump + fallout fix 묶임

--- a/docs/superpowers/specs/2026-04-22-jdk25-spring-bump-design.md
+++ b/docs/superpowers/specs/2026-04-22-jdk25-spring-bump-design.md
@@ -1,0 +1,110 @@
+# JDK 25 호환을 위한 Spring / Spring Boot / Spring Cloud 3.x 버전 bump
+
+- Date: 2026-04-22
+- Branch: `feature/2343-bump-up-jdk-to-25`
+- Related commit: `784c33c3 bump up jdk to 25`
+
+## Problem
+
+`bump up jdk to 25` 커밋 이후 다음 두 모듈의 테스트가 대량으로 실패한다.
+
+- `resilience4j-spring6`
+- `resilience4j-spring-boot3` (101 tests, 80 failed, 6 skipped)
+
+다른 모든 모듈(`core`, `bulkhead`, `kotlin`, `metrics`, `ratelimiter`, `micrometer`, `micronaut`, `spring-boot4`, `feign`, `cache`, `retry`, `circuitbreaker`, `timelimiter`, `reactor`, `rxjava2/3`, `circularbuffer`, `commons-configuration`, `consumer`, `framework-common`, `hedge`, `vavr`, `all`)은 정상 통과한다.
+
+## Root Cause
+
+테스트 로그의 핵심 예외:
+
+```
+java.io.IOException: ASM ClassReader failed to parse class file - probably
+  due to a new Java class file version that isn't supported yet
+Caused by: java.lang.IllegalArgumentException: Unsupported class file major version 69
+  at org.springframework.asm.ClassReader.<init>(ClassReader.java:199)
+```
+
+- Class file major version **69 = JDK 25** 바이트코드 포맷.
+- 두 모듈이 의존하는 `spring6 = "6.1.1"` 및 `spring-boot3 = "3.2.0"` (내부 Spring 6.1.x)에 repackage 된 `org.springframework.asm`이 JDK 25 class 포맷을 파싱하지 못함.
+- ASM 9.8부터 version 69가 지원되며, Spring Framework 6.2.x LTS 후기 패치 / Spring Boot 3.5.5+에서 해당 ASM을 repackage하여 동봉.
+- `resilience4j-spring-boot4`(Spring Boot 4.0.0 → Spring 7.x)는 이미 신규 ASM이 포함되어 있어 통과한다.
+
+## Scope
+
+변경은 `gradle/libs.versions.toml`의 버전 변수 3개에 국한한다. 프로덕션 Java 코드는 수정하지 않는다. 단, 버전 점프로 인한 Spring/Spring Boot/Spring Cloud의 API/프로퍼티 변경에 대응하는 최소한의 테스트 코드 수정은 scope 내에 있다.
+
+Out of scope:
+- 다른 모듈의 테스트/코드 수정
+- `spring7`/`spring-boot4`/`spring-cloud5` 버전 변경
+- Kotlin, Micronaut, Mockito, JUnit 등 기타 의존성 변경
+
+## Design
+
+### 버전 매트릭스
+
+| 변수 | 현재 | 변경 후 | 근거 |
+|---|---|---|---|
+| `spring6` | `6.1.1` | `6.2.18` | Spring Framework 6.x 세대 최종 feature branch. JDK 25를 LTS로 공식 지원. 6.2.x 후기 패치는 ASM 9.8 repackage 포함 |
+| `spring-boot3` | `3.2.0` | `3.5.13` | Spring Boot 3.5.5+가 JDK 25 공식 지원. 3.5.13은 최신 GA 패치 |
+| `spring-cloud3` | `3.1.5` | `4.3.2` | Spring Boot 3.5.x와 pair인 Spring Cloud 2025.0 (Northfields) 릴리즈 트레인의 최신 패치. `spring-cloud-context`, `spring-cloud-openfeign-core`, `spring-cloud-starter-openfeign` 공통 |
+
+### 변경 대상 파일
+
+`gradle/libs.versions.toml` 상단 versions 블록의 아래 3줄만 수정:
+
+```diff
+-spring6 = "6.1.1"
+-spring-boot3 = "3.2.0"
+-spring-cloud3 = "3.1.5"
++spring6 = "6.2.18"
++spring-boot3 = "3.5.13"
++spring-cloud3 = "4.3.2"
+```
+
+### 예상 추가 수정(실제 테스트 실행 후 필요시)
+
+버전 점프 폭이 크므로 다음 유형의 후속 수정이 발생할 수 있다. 실제 실패가 관찰될 때만 최소 범위로 수정한다.
+
+1. **Spring Boot 3.2 → 3.5 프로퍼티/어노테이션 변경**
+   - `spring.factories` / `META-INF/spring/*.imports` 경로의 autoconfigure 등록
+   - `@MockBean`의 deprecation (`@MockitoBean`으로 대체 권장)
+   - actuator / observation 프로퍼티 키 변경
+2. **Spring Cloud 2022.0 → 2025.0 OpenFeign API 변경**
+   - `CircuitBreakerFeignTest` 주변의 FeignClient 설정
+3. **Spring Framework 6.1 → 6.2 minor API deprecation**
+   - `TestExecutionListener` / `ApplicationContextFailureProcessor` 관련
+4. **번들 라이브러리 변경**
+   - Jackson 2.17 → 2.19, Tomcat 10.1.x → 11, Netty 등
+
+이 수정들은 본 설계의 부수 작업이며, 테스트 실행 → 실패 메시지 확인 → 최소 수정 → 재실행의 반복으로 처리한다.
+
+## Verification
+
+성공 기준:
+1. `./gradlew :resilience4j-spring6:test` — 100% 통과, 회귀 없음
+2. `./gradlew :resilience4j-spring-boot3:test` — 100% 통과, 회귀 없음
+3. `./gradlew build` — 전체 회귀 없이 통과
+
+검증 순서:
+1. `libs.versions.toml` 3줄 수정 후 compile 확인 (`./gradlew compileTestJava`)
+2. `spring6`, `spring-boot3` 단위 테스트 실행
+3. 실패가 있으면 로그 분석 후 최소 수정, 2번으로 복귀
+4. 두 모듈 통과 시 전체 빌드로 회귀 검증
+
+## Rollback
+
+변경이 단일 파일 3줄이므로 `git revert` 또는 해당 라인을 이전 값(`6.1.1` / `3.2.0` / `3.1.5`)으로 원복한다. 추가 테스트 코드 수정이 발생한 경우 같은 커밋 범위 내에서 함께 revert.
+
+## Risks
+
+- **낮음:** `libs.versions.toml` 외 프로덕션 코드 변경 없음
+- **중간:** 버전 점프 폭이 커서 테스트 코드 일부 조정이 필요할 가능성이 있음 (추가 수정 범위는 실제 실패 로그로 결정)
+- **낮음:** `spring-boot4`/`spring-cloud5` 모듈은 독립 변수를 쓰므로 간섭 없음
+
+## References
+
+- Spring Framework Versions wiki — https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-Versions
+- Spring Boot Java 25 지원 issue (#47245) — https://github.com/spring-projects/spring-boot/issues/47245
+- Spring Boot 3.5.7 release note — https://spring.io/blog/2025/10/23/spring-boot-3-5-7-available-now/
+- Spring Cloud 2025.0.0 Northfields GA — https://spring.io/blog/2025/05/29/spring-cloud-2025-0-0-is-abvailable/
+- Spring Cloud Supported Versions — https://github.com/spring-cloud/spring-cloud-release/wiki/Supported-Versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,5 @@ kotlin.code.style=official
 systemProp.file.encoding=UTF-8
 systemProp.sun.jnu.encoding=UTF-8
 org.gradle.caching=true
+# Allow mixed Java 25 / Kotlin 21 compilation (Kotlin doesn't support JVM 25 yet)
+kotlin.jvm.target.validation.mode=IGNORE

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,22 +2,22 @@
 micrometer = "1.16.0"
 reactor = "3.4.24"
 
-spring6 = "6.1.1"
-spring-boot3 = "3.2.0"
-spring-cloud3 = "3.1.5"
+spring6 = "6.2.18"
+spring-boot3 = "3.5.13"
+spring-cloud3 = "4.3.2"
 
 spring7 = "7.0.2"
 spring-boot4 = "4.0.0"
 spring-cloud5 = "5.0.0"
 
 [plugins]
-asciidoctor = { id = "org.asciidoctor.jvm.convert", version = "2.4.0" }
+asciidoctor = { id = "org.asciidoctor.jvm.convert", version = "4.0.4" }
 bnd-builder = { id = "biz.aQute.bnd.builder", version = "7.1.0" }
-jmh = { id = "me.champeau.jmh", version = "0.6.8" }
-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.1.21" }
+jmh = { id = "me.champeau.jmh", version = "0.7.3" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.3.0" }
 nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }
-sonarqube = { id = "org.sonarqube", version = "3.5.0.2730" }
-test-retry = { id = "org.gradle.test-retry", version = "1.5.10" }
+sonarqube = { id = "org.sonarqube", version = "6.0.1.5171" }
+test-retry = { id = "org.gradle.test-retry", version = "1.6.4" }
 
 [libraries]
 # Common dependencies
@@ -32,8 +32,8 @@ awaitility = { module = "org.awaitility:awaitility", version = "4.3.0" }
 awaitility-old = { module = "com.jayway.awaitility:awaitility", version = "1.7.0" }
 junit = { module = "junit:junit", version = "4.13.2" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version = "1.2.3" }
-mockito-core = { module = "org.mockito:mockito-core", version = "5.16.1" }
-mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version = "5.16.1" }
+mockito-core = { module = "org.mockito:mockito-core", version = "5.23.0" }
+mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version = "5.23.0" }
 junit-bom = { module = "org.junit:junit-bom", version = "6.0.3" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
@@ -57,8 +57,8 @@ feign-core = { module = "io.github.openfeign:feign-core", version = "12.0" }
 feign-wiremock = { module = "com.github.tomakehurst:wiremock-jre8", version = "2.26.0" }
 
 # resilience4j-kotlin
-kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version = "1.9.25" }
-kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.6.4" }
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version = "2.3.0" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.10.2" }
 
 # resilience4j-metrics (Dropwizard)
 metrics-core = { module = "io.dropwizard.metrics:metrics-core", version = "4.1.16" }
@@ -71,6 +71,7 @@ micrometer-registry-prometheus = { module = "io.micrometer:micrometer-registry-p
 
 # resilience4j-micronaut, resilience4j-micronaut-annotation
 cglib-nodep = { module = "cglib:cglib-nodep", version = "3.3.0" }
+groovy-bom = { module = "org.apache.groovy:groovy-bom", version = "4.0.30" }
 micronaut-aop = { module = "io.micronaut:micronaut-aop" }
 micronaut-core-processor = { module = "io.micronaut:micronaut-core-processor" }
 micronaut-discovery-core = { module = "io.micronaut:micronaut-discovery-core" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip

--- a/resilience4j-all/src/test/java/io/github/resilience4j/decorators/DecoratorsTest.java
+++ b/resilience4j-all/src/test/java/io/github/resilience4j/decorators/DecoratorsTest.java
@@ -21,16 +21,14 @@ package io.github.resilience4j.decorators;
 import io.github.resilience4j.bulkhead.Bulkhead;
 import io.github.resilience4j.bulkhead.BulkheadFullException;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
-import io.github.resilience4j.bulkhead.ThreadPoolBulkheadConfig;
-import io.github.resilience4j.bulkhead.ThreadPoolBulkheadRegistry;
 import io.github.resilience4j.cache.Cache;
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
 import io.github.resilience4j.core.functions.CheckedConsumer;
 import io.github.resilience4j.core.functions.CheckedFunction;
 import io.github.resilience4j.core.functions.CheckedRunnable;
 import io.github.resilience4j.core.functions.CheckedSupplier;
-import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
 import io.github.resilience4j.ratelimiter.RequestNotPermitted;
@@ -52,15 +50,12 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.*;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-import static com.jayway.awaitility.Awaitility.matches;
-import static com.jayway.awaitility.Awaitility.waitAtMost;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.*;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.BDDMockito.*;
-import static org.mockito.Mockito.*;
 
 public class DecoratorsTest {
 
@@ -133,8 +128,8 @@ public class DecoratorsTest {
             return null;
         });
 
-        waitAtMost(2, TimeUnit.SECONDS).until(matches(() ->
-            assertThat(completableFuture).isCompletedWithValue("ValueShouldCrossThreadBoundary")));
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() ->
+            assertThat(completableFuture).isCompletedWithValue("ValueShouldCrossThreadBoundary"));
 
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
         assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
@@ -176,8 +171,8 @@ public class DecoratorsTest {
             return null;
         });
 
-        waitAtMost(2, TimeUnit.SECONDS).until(matches(() ->
-            assertThat(completableFuture).isCompletedWithValue("ValueShouldPropagateThreadBoundary")));
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() ->
+            assertThat(completableFuture).isCompletedWithValue("ValueShouldPropagateThreadBoundary"));
 
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
         assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(1);
@@ -757,8 +752,8 @@ public class DecoratorsTest {
             return null;
         });
 
-        waitAtMost(2, TimeUnit.SECONDS).until(matches(() ->
-            assertThat(completableFuture).isCompletedWithValue("ValueShouldCrossThreadBoundary")));
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() ->
+            assertThat(completableFuture).isCompletedWithValue("ValueShouldCrossThreadBoundary"));
 
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
         assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(3);
@@ -800,8 +795,8 @@ public class DecoratorsTest {
             return null;
         });
 
-        waitAtMost(2, TimeUnit.SECONDS).until(matches(() ->
-            assertThat(completableFuture).isCompletedWithValue("ValueShouldCrossThreadBoundary")));
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() ->
+            assertThat(completableFuture).isCompletedWithValue("ValueShouldCrossThreadBoundary"));
 
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
         assertThat(metrics.getNumberOfBufferedCalls()).isEqualTo(3);

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/ScopedValueBulkheadIntegrationTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/ScopedValueBulkheadIntegrationTest.java
@@ -1,0 +1,335 @@
+/*
+ * Copyright 2024 Resilience4j Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.bulkhead;
+
+import io.github.resilience4j.core.ScopedValueContext;
+import io.github.resilience4j.core.ScopedValuePropagator;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests demonstrating Scoped Values (JEP 506) with ThreadPoolBulkhead.
+ *
+ * <p>These tests verify that Scoped Values can be properly propagated across
+ * thread boundaries when using ThreadPoolBulkhead.
+ */
+public class ScopedValueBulkheadIntegrationTest {
+
+    private static final ScopedValue<String> REQUEST_ID = ScopedValue.newInstance();
+    private static final ScopedValue<Integer> USER_ID = ScopedValue.newInstance();
+
+    @Test
+    public void shouldPropagateScopedValueToBulkheadThread() throws Exception {
+        // Create a propagator for our scoped value
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+
+        // Create a ThreadPoolBulkhead with the propagator
+        ThreadPoolBulkheadConfig config = ThreadPoolBulkheadConfig.custom()
+            .maxThreadPoolSize(2)
+            .coreThreadPoolSize(1)
+            .queueCapacity(10)
+            .contextPropagator(propagator)
+            .build();
+
+        ThreadPoolBulkhead bulkhead = ThreadPoolBulkhead.of("testBulkhead", config);
+
+        AtomicReference<String> capturedInBulkhead = new AtomicReference<>();
+
+        // Run with a scoped value bound
+        ScopedValue.where(REQUEST_ID, "integration-test-request-123").run(() -> {
+            try {
+                // The propagator captures the value and makes it available in the bulkhead thread
+                CompletionStage<String> future = bulkhead.executeSupplier(() -> {
+                    // Access the captured value through the propagator
+                    String captured = propagator.getCapturedValue().orElse("not-found");
+                    capturedInBulkhead.set(captured);
+                    return captured;
+                });
+
+                String result = future.toCompletableFuture().get(5, TimeUnit.SECONDS);
+                assertThat(result).isEqualTo("integration-test-request-123");
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        assertThat(capturedInBulkhead.get()).isEqualTo("integration-test-request-123");
+    }
+
+    @Test
+    public void shouldPropagateMultipleScopedValuesToBulkheadThread() throws Exception {
+        // Create propagators for multiple scoped values
+        ScopedValuePropagator<String> requestPropagator = ScopedValuePropagator.of(REQUEST_ID);
+        ScopedValuePropagator<Integer> userPropagator = ScopedValuePropagator.of(USER_ID);
+
+        // Create a ThreadPoolBulkhead with both propagators
+        ThreadPoolBulkheadConfig config = ThreadPoolBulkheadConfig.custom()
+            .maxThreadPoolSize(2)
+            .coreThreadPoolSize(1)
+            .queueCapacity(10)
+            .contextPropagator(requestPropagator, userPropagator)
+            .build();
+
+        ThreadPoolBulkhead bulkhead = ThreadPoolBulkhead.of("multiValueBulkhead", config);
+
+        AtomicReference<String> capturedRequest = new AtomicReference<>();
+        AtomicReference<Integer> capturedUser = new AtomicReference<>();
+
+        // Run with multiple scoped values bound
+        ScopedValue.where(REQUEST_ID, "multi-value-request")
+            .where(USER_ID, 42)
+            .run(() -> {
+                try {
+                    CompletionStage<String> future = bulkhead.executeSupplier(() -> {
+                        capturedRequest.set(requestPropagator.getCapturedValue().orElse("not-found"));
+                        capturedUser.set(userPropagator.getCapturedValue().orElse(-1));
+                        return "completed";
+                    });
+
+                    future.toCompletableFuture().get(5, TimeUnit.SECONDS);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+        assertThat(capturedRequest.get()).isEqualTo("multi-value-request");
+        assertThat(capturedUser.get()).isEqualTo(42);
+    }
+
+    @Test
+    public void shouldWorkWithScopedValueContextAndBulkhead() throws Exception {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+
+        ThreadPoolBulkheadConfig config = ThreadPoolBulkheadConfig.custom()
+            .maxThreadPoolSize(2)
+            .coreThreadPoolSize(1)
+            .queueCapacity(10)
+            .build();
+
+        ThreadPoolBulkhead bulkhead = ThreadPoolBulkhead.of("contextBulkhead", config);
+
+        AtomicReference<String> capturedValue = new AtomicReference<>();
+
+        // Using ScopedValueContext for capturing and rebinding
+        ScopedValue.where(REQUEST_ID, "context-based-request").run(() -> {
+            ScopedValueContext context = ScopedValueContext.capture(propagator);
+
+            try {
+                // Manually decorate the supplier with context rebinding
+                Supplier<String> supplier = () -> {
+                    // Use context to rebind the scoped value
+                    Supplier<String> innerSupplier = () -> {
+                        if (REQUEST_ID.isBound()) {
+                            capturedValue.set(REQUEST_ID.get());
+                            return REQUEST_ID.get();
+                        }
+                        return "not-bound";
+                    };
+                    return context.callWithContext(innerSupplier);
+                };
+
+                CompletionStage<String> future = bulkhead.executeSupplier(supplier);
+                String result = future.toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+                assertThat(result).isEqualTo("context-based-request");
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        assertThat(capturedValue.get()).isEqualTo("context-based-request");
+    }
+
+    @Test
+    public void shouldWorkWithVirtualThreadBulkhead() throws Exception {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+
+        // Configure bulkhead to use virtual threads if available
+        ThreadPoolBulkheadConfig config = ThreadPoolBulkheadConfig.custom()
+            .maxThreadPoolSize(10)
+            .coreThreadPoolSize(5)
+            .queueCapacity(100)
+            .contextPropagator(propagator)
+            .build();
+
+        ThreadPoolBulkhead bulkhead = ThreadPoolBulkhead.of("virtualThreadBulkhead", config);
+
+        List<CompletionStage<String>> futures = new ArrayList<>();
+        int taskCount = 20;
+
+        ScopedValue.where(REQUEST_ID, "virtual-thread-test").run(() -> {
+            for (int i = 0; i < taskCount; i++) {
+                final int taskId = i;
+                CompletionStage<String> future = bulkhead.executeSupplier(() -> {
+                    String value = propagator.getCapturedValue().orElse("not-found");
+                    return "task-" + taskId + "-" + value;
+                });
+                futures.add(future);
+            }
+        });
+
+        // Wait for all tasks to complete
+        CompletableFuture.allOf(futures.stream()
+            .map(CompletionStage::toCompletableFuture)
+            .toArray(CompletableFuture[]::new))
+            .get(30, TimeUnit.SECONDS);
+
+        // Verify all tasks got the scoped value
+        for (int i = 0; i < taskCount; i++) {
+            String result = futures.get(i).toCompletableFuture().get();
+            assertThat(result).isEqualTo("task-" + i + "-virtual-thread-test");
+        }
+    }
+
+    @Test
+    public void shouldHandleUnboundScopedValue() throws Exception {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+
+        ThreadPoolBulkheadConfig config = ThreadPoolBulkheadConfig.custom()
+            .maxThreadPoolSize(2)
+            .coreThreadPoolSize(1)
+            .contextPropagator(propagator)
+            .build();
+
+        ThreadPoolBulkhead bulkhead = ThreadPoolBulkhead.of("unboundBulkhead", config);
+
+        // Execute without binding the scoped value
+        CompletionStage<String> future = bulkhead.executeSupplier(() -> {
+            return propagator.getCapturedValue().orElse("default-value");
+        });
+
+        String result = future.toCompletableFuture().get(5, TimeUnit.SECONDS);
+        assertThat(result).isEqualTo("default-value");
+    }
+
+    @Test
+    public void shouldPreserveScopedValueAcrossNestedScopes() throws Exception {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+
+        ThreadPoolBulkheadConfig config = ThreadPoolBulkheadConfig.custom()
+            .maxThreadPoolSize(2)
+            .coreThreadPoolSize(1)
+            .contextPropagator(propagator)
+            .build();
+
+        ThreadPoolBulkhead bulkhead = ThreadPoolBulkhead.of("nestedScopeBulkhead", config);
+
+        AtomicReference<String> outerCapture = new AtomicReference<>();
+        AtomicReference<String> innerCapture = new AtomicReference<>();
+
+        ScopedValue.where(REQUEST_ID, "outer-value").run(() -> {
+            try {
+                // First capture in outer scope
+                CompletionStage<String> outerFuture = bulkhead.executeSupplier(() -> {
+                    String value = propagator.getCapturedValue().orElse("not-found");
+                    outerCapture.set(value);
+                    return value;
+                });
+                outerFuture.toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+                // Now run with inner scope (different value)
+                ScopedValue.where(REQUEST_ID, "inner-value").run(() -> {
+                    try {
+                        CompletionStage<String> innerFuture = bulkhead.executeSupplier(() -> {
+                            String value = propagator.getCapturedValue().orElse("not-found");
+                            innerCapture.set(value);
+                            return value;
+                        });
+                        innerFuture.toCompletableFuture().get(5, TimeUnit.SECONDS);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        assertThat(outerCapture.get()).isEqualTo("outer-value");
+        assertThat(innerCapture.get()).isEqualTo("inner-value");
+    }
+
+    @Test
+    public void shouldWorkWithConcurrentBulkheadExecutions() throws Exception {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+
+        ThreadPoolBulkheadConfig config = ThreadPoolBulkheadConfig.custom()
+            .maxThreadPoolSize(4)
+            .coreThreadPoolSize(2)
+            .queueCapacity(50)
+            .contextPropagator(propagator)
+            .build();
+
+        ThreadPoolBulkhead bulkhead = ThreadPoolBulkhead.of("concurrentBulkhead", config);
+
+        int concurrentRequests = 10;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(concurrentRequests);
+        List<CompletionStage<String>> futures = new ArrayList<>();
+
+        // Start multiple threads each with their own scoped value
+        for (int i = 0; i < concurrentRequests; i++) {
+            final String requestId = "request-" + i;
+            Thread.ofVirtual().start(() -> {
+                ScopedValue.where(REQUEST_ID, requestId).run(() -> {
+                    try {
+                        startLatch.await(); // Wait for all threads to be ready
+
+                        CompletionStage<String> future = bulkhead.executeSupplier(() -> {
+                            return propagator.getCapturedValue().orElse("not-found");
+                        });
+
+                        synchronized (futures) {
+                            futures.add(future);
+                        }
+                        doneLatch.countDown();
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+            });
+        }
+
+        // Release all threads at once
+        startLatch.countDown();
+
+        // Wait for all submissions
+        boolean allSubmitted = doneLatch.await(10, TimeUnit.SECONDS);
+        assertThat(allSubmitted).isTrue();
+
+        // Wait for all tasks to complete and verify
+        Thread.sleep(1000); // Give time for all tasks to complete
+
+        synchronized (futures) {
+            assertThat(futures).hasSize(concurrentRequests);
+
+            for (CompletionStage<String> future : futures) {
+                String result = future.toCompletableFuture().get(5, TimeUnit.SECONDS);
+                assertThat(result).startsWith("request-");
+            }
+        }
+    }
+}

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadEventPublisherTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadEventPublisherTest.java
@@ -18,17 +18,16 @@
  */
 package io.github.resilience4j.bulkhead;
 
-import com.jayway.awaitility.Awaitility;
-import com.jayway.awaitility.Duration;
 import io.github.resilience4j.test.HelloWorldService;
+import org.awaitility.Awaitility;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.TimeUnit;
 
-import static com.jayway.awaitility.Awaitility.waitAtMost;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -67,7 +66,7 @@ public class ThreadPoolBulkheadEventPublisherTest {
     }
 
     @Test
-    public void shouldConsumeOnCallRejectedEvent() {
+    public void shouldConsumeOnCallRejectedEvent() throws InterruptedException {
         ThreadPoolBulkhead bulkhead = ThreadPoolBulkhead
             .of("test", ThreadPoolBulkheadConfig.custom()
                 .maxThreadPoolSize(1)
@@ -79,35 +78,37 @@ public class ThreadPoolBulkheadEventPublisherTest {
             event -> logger.info(event.getEventType().toString()));
         final Exception exception = new Exception();
 
-        new Thread(() -> {
+        // Occupy the running slot with a task that blocks until we release it.
+        // This is deterministic: the subsequent submissions happen only after the
+        // blocker is confirmed to be executing, so the queue/rejection state is
+        // predictable regardless of thread scheduling.
+        CountDownLatch blockerEntered = new CountDownLatch(1);
+        CountDownLatch blockerRelease = new CountDownLatch(1);
+        bulkhead.executeRunnable(() -> {
+            blockerEntered.countDown();
             try {
-                bulkhead.executeRunnable(() -> {
-                    final AtomicInteger counter = new AtomicInteger(0);
-                    waitAtMost(Duration.TWO_HUNDRED_MILLISECONDS)
-                        .until(() -> counter.incrementAndGet() >= 2);
-                });
-            } catch (Exception e) {
-                exception.initCause(e);
+                blockerRelease.await(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
             }
+        });
+        assertThat(blockerEntered.await(2, TimeUnit.SECONDS))
+            .as("blocker task must be executing inside the bulkhead")
+            .isTrue();
 
-        }).start();
-        new Thread(() -> {
-            try {
-                bulkhead.executeCallable(helloWorldService::returnHelloWorld);
-            } catch (Exception e) {
-                exception.initCause(e);
-            }
-        }).start();
-        new Thread(() -> {
-            try {
-                bulkhead.executeCallable(helloWorldService::returnHelloWorld);
-            } catch (Exception e) {
-                exception.initCause(e);
-            }
-        }).start();
+        // Fill the queue (capacity 1).
+        bulkhead.executeCallable(helloWorldService::returnHelloWorld);
 
-        final AtomicInteger counter = new AtomicInteger(0);
-        waitAtMost(Duration.FIVE_HUNDRED_MILLISECONDS).until(() -> counter.incrementAndGet() >= 2);
+        // Third submission: pool is busy and queue is full, so this must be rejected.
+        try {
+            bulkhead.executeCallable(helloWorldService::returnHelloWorld);
+        } catch (Exception e) {
+            exception.initCause(e);
+        }
+
+        // Allow the blocker to complete so the executor can drain cleanly.
+        blockerRelease.countDown();
+
         assertThat(exception).hasCauseInstanceOf(BulkheadFullException.class);
         then(logger).should(times(1)).info("CALL_REJECTED");
     }

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadTest.java
@@ -18,12 +18,12 @@
  */
 package io.github.resilience4j.bulkhead;
 
-import com.jayway.awaitility.Awaitility;
 import io.github.resilience4j.core.ThreadModeTestBase;
 import io.github.resilience4j.core.ThreadType;
 import io.github.resilience4j.test.HelloWorldService;
 import io.vavr.CheckedRunnable;
 import io.vavr.control.Try;
+import org.awaitility.Awaitility;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/internal/FixedThreadPoolBulkheadTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/internal/FixedThreadPoolBulkheadTest.java
@@ -37,9 +37,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static com.jayway.awaitility.Awaitility.matches;
-import static com.jayway.awaitility.Awaitility.waitAtMost;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 public class FixedThreadPoolBulkheadTest {
 
@@ -67,8 +66,8 @@ public class FixedThreadPoolBulkheadTest {
         CompletableFuture<Object> future = fixedThreadPoolBulkhead
             .submit(() -> TestThreadLocalContextHolder.get().orElse(null));
 
-        waitAtMost(5, TimeUnit.SECONDS).until(matches(() ->
-            assertThat(future).isCompletedWithValue("ValueShouldCrossThreadBoundary")));
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() ->
+            assertThat(future).isCompletedWithValue("ValueShouldCrossThreadBoundary"));
     }
 
     @Test
@@ -80,8 +79,8 @@ public class FixedThreadPoolBulkheadTest {
         fixedThreadPoolBulkhead
             .submit(() -> reference.set((String) TestThreadLocalContextHolder.get().orElse(null)));
 
-        waitAtMost(5, TimeUnit.SECONDS).until(matches(() ->
-            assertThat(reference).hasValue("ValueShouldCrossThreadBoundary")));
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() ->
+            assertThat(reference).hasValue("ValueShouldCrossThreadBoundary"));
     }
 
     @Test

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkheadTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkheadTest.java
@@ -42,7 +42,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
-import static com.jayway.awaitility.Awaitility.await;
 import static io.github.resilience4j.bulkhead.BulkheadConfig.*;
 import static io.github.resilience4j.bulkhead.event.BulkheadEvent.Type.*;
 import static java.lang.Thread.State.*;
@@ -50,6 +49,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 
 @RunWith(Parameterized.class)
 public class SemaphoreBulkheadTest extends ThreadModeTestBase {

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/ScopedValueContext.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/ScopedValueContext.java
@@ -1,0 +1,337 @@
+/*
+ * Copyright 2024 Resilience4j Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.core;
+
+import java.util.*;
+import java.util.concurrent.Callable;
+import java.util.function.Supplier;
+
+/**
+ * Utility class for working with Scoped Values (JEP 506) in conjunction with
+ * Resilience4j's context propagation framework.
+ *
+ * <p>This class provides convenience methods for:
+ * <ul>
+ *   <li>Capturing current scoped values from multiple propagators</li>
+ *   <li>Running code with captured scoped values bound</li>
+ *   <li>Decorating suppliers, callables, and runnables with scoped value bindings</li>
+ * </ul>
+ *
+ * <p><b>Usage Example:</b>
+ * <pre>{@code
+ * // Define scoped values
+ * private static final ScopedValue<String> REQUEST_ID = ScopedValue.newInstance();
+ * private static final ScopedValue<String> USER_ID = ScopedValue.newInstance();
+ *
+ * // Create propagators
+ * List<ScopedValuePropagator<?>> propagators = Arrays.asList(
+ *     ScopedValuePropagator.of(REQUEST_ID),
+ *     ScopedValuePropagator.of(USER_ID)
+ * );
+ *
+ * // Capture current context
+ * ScopedValueContext context = ScopedValueContext.capture(propagators);
+ *
+ * // Run code with captured context
+ * executor.submit(() -> context.runWithContext(() -> {
+ *     // REQUEST_ID and USER_ID are bound here
+ *     return doWork();
+ * }));
+ * }</pre>
+ *
+ * @see ScopedValuePropagator
+ * @see ContextPropagator
+ * @since 3.0.0
+ */
+public final class ScopedValueContext {
+
+    private final Map<ScopedValue<Object>, Object> capturedValues;
+
+    @SuppressWarnings("unchecked")
+    private ScopedValueContext(List<? extends ScopedValuePropagator<?>> propagators) {
+        this.capturedValues = new HashMap<>();
+        for (ScopedValuePropagator<?> propagator : propagators) {
+            Optional<?> value = propagator.retrieve().get();
+            if (value.isPresent()) {
+                capturedValues.put(
+                    (ScopedValue<Object>) propagator.getScopedValue(),
+                    value.get()
+                );
+            }
+        }
+    }
+
+    /**
+     * Captures the current scoped values from the given propagators.
+     *
+     * <p>This method should be called in the source thread before submitting
+     * tasks to an executor. The captured context can then be used to rebind
+     * the scoped values in the target thread.
+     *
+     * @param propagators the list of ScopedValuePropagators to capture from
+     * @return a ScopedValueContext containing the captured values
+     * @throws NullPointerException if propagators is null
+     */
+    public static ScopedValueContext capture(List<? extends ScopedValuePropagator<?>> propagators) {
+        Objects.requireNonNull(propagators, "Propagators list cannot be null");
+        return new ScopedValueContext(propagators);
+    }
+
+    /**
+     * Captures the current scoped values from the given propagators.
+     *
+     * @param propagators the propagators to capture from
+     * @return a ScopedValueContext containing the captured values
+     */
+    @SafeVarargs
+    public static ScopedValueContext capture(ScopedValuePropagator<?>... propagators) {
+        Objects.requireNonNull(propagators, "Propagators cannot be null");
+        return capture(List.of(propagators));
+    }
+
+    /**
+     * Creates an empty context with no captured values.
+     *
+     * @return an empty ScopedValueContext
+     */
+    public static ScopedValueContext empty() {
+        return new ScopedValueContext(List.of());
+    }
+
+    /**
+     * Checks if this context has any captured values.
+     *
+     * @return true if there are captured values, false otherwise
+     */
+    public boolean hasValues() {
+        return !capturedValues.isEmpty();
+    }
+
+    /**
+     * Gets the number of captured values.
+     *
+     * @return the number of captured scoped values
+     */
+    public int size() {
+        return capturedValues.size();
+    }
+
+    /**
+     * Runs the given runnable with all captured scoped values bound.
+     *
+     * @param runnable the runnable to execute
+     */
+    public void runWithContext(Runnable runnable) {
+        Objects.requireNonNull(runnable, "Runnable cannot be null");
+        if (capturedValues.isEmpty()) {
+            runnable.run();
+            return;
+        }
+        buildCarrierAndRun(runnable);
+    }
+
+    /**
+     * Calls the given supplier with all captured scoped values bound.
+     *
+     * @param supplier the supplier to execute
+     * @param <T>      the return type
+     * @return the result of the supplier
+     */
+    public <T> T callWithContext(Supplier<T> supplier) {
+        Objects.requireNonNull(supplier, "Supplier cannot be null");
+        if (capturedValues.isEmpty()) {
+            return supplier.get();
+        }
+        return buildCarrierAndCall(supplier);
+    }
+
+    /**
+     * Calls the given callable with all captured scoped values bound.
+     *
+     * @param callable the callable to execute
+     * @param <T>      the return type
+     * @return the result of the callable
+     * @throws Exception if the callable throws an exception
+     */
+    public <T> T callWithContext(Callable<T> callable) throws Exception {
+        Objects.requireNonNull(callable, "Callable cannot be null");
+        if (capturedValues.isEmpty()) {
+            return callable.call();
+        }
+        return buildCarrierAndCallChecked(callable);
+    }
+
+    /**
+     * Decorates a runnable to execute with this context's scoped values bound.
+     *
+     * @param runnable the runnable to decorate
+     * @return a decorated runnable
+     */
+    public Runnable decorateRunnable(Runnable runnable) {
+        Objects.requireNonNull(runnable, "Runnable cannot be null");
+        if (capturedValues.isEmpty()) {
+            return runnable;
+        }
+        return () -> runWithContext(runnable);
+    }
+
+    /**
+     * Decorates a supplier to execute with this context's scoped values bound.
+     *
+     * @param supplier the supplier to decorate
+     * @param <T>      the return type
+     * @return a decorated supplier
+     */
+    public <T> Supplier<T> decorateSupplier(Supplier<T> supplier) {
+        Objects.requireNonNull(supplier, "Supplier cannot be null");
+        if (capturedValues.isEmpty()) {
+            return supplier;
+        }
+        return () -> callWithContext(supplier);
+    }
+
+    /**
+     * Decorates a callable to execute with this context's scoped values bound.
+     *
+     * @param callable the callable to decorate
+     * @param <T>      the return type
+     * @return a decorated callable
+     */
+    public <T> Callable<T> decorateCallable(Callable<T> callable) {
+        Objects.requireNonNull(callable, "Callable cannot be null");
+        if (capturedValues.isEmpty()) {
+            return callable;
+        }
+        return () -> callWithContext(callable);
+    }
+
+    /**
+     * Builds a ScopedValue.Carrier with all captured values and runs the runnable.
+     */
+    private void buildCarrierAndRun(Runnable runnable) {
+        List<Map.Entry<ScopedValue<Object>, Object>> entries = new ArrayList<>(capturedValues.entrySet());
+        runWithNestedScopes(entries, 0, runnable);
+    }
+
+    /**
+     * Builds a ScopedValue.Carrier with all captured values and calls the supplier.
+     */
+    private <T> T buildCarrierAndCall(Supplier<T> supplier) {
+        List<Map.Entry<ScopedValue<Object>, Object>> entries = new ArrayList<>(capturedValues.entrySet());
+        return callWithNestedScopes(entries, 0, supplier);
+    }
+
+    /**
+     * Builds a ScopedValue.Carrier with all captured values and calls the callable.
+     */
+    private <T> T buildCarrierAndCallChecked(Callable<T> callable) throws Exception {
+        List<Map.Entry<ScopedValue<Object>, Object>> entries = new ArrayList<>(capturedValues.entrySet());
+        return callWithNestedScopesChecked(entries, 0, callable);
+    }
+
+    /**
+     * Recursively nests scoped value bindings to run the runnable.
+     */
+    private void runWithNestedScopes(
+        List<Map.Entry<ScopedValue<Object>, Object>> entries,
+        int index,
+        Runnable runnable
+    ) {
+        if (index >= entries.size()) {
+            runnable.run();
+            return;
+        }
+        Map.Entry<ScopedValue<Object>, Object> entry = entries.get(index);
+        ScopedValue.where(entry.getKey(), entry.getValue())
+            .run(() -> runWithNestedScopes(entries, index + 1, runnable));
+    }
+
+    /**
+     * Recursively nests scoped value bindings to call the supplier.
+     */
+    private <T> T callWithNestedScopes(
+        List<Map.Entry<ScopedValue<Object>, Object>> entries,
+        int index,
+        Supplier<T> supplier
+    ) {
+        if (index >= entries.size()) {
+            return supplier.get();
+        }
+        Map.Entry<ScopedValue<Object>, Object> entry = entries.get(index);
+        try {
+            return ScopedValue.where(entry.getKey(), entry.getValue())
+                .call(() -> callWithNestedScopes(entries, index + 1, supplier));
+        } catch (Exception e) {
+            if (e instanceof RuntimeException re) {
+                throw re;
+            }
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Recursively nests scoped value bindings to call the callable.
+     */
+    private <T> T callWithNestedScopesChecked(
+        List<Map.Entry<ScopedValue<Object>, Object>> entries,
+        int index,
+        Callable<T> callable
+    ) throws Exception {
+        if (index >= entries.size()) {
+            return callable.call();
+        }
+        Map.Entry<ScopedValue<Object>, Object> entry = entries.get(index);
+        return ScopedValue.where(entry.getKey(), entry.getValue())
+            .call(() -> callWithNestedScopesChecked(entries, index + 1, callable));
+    }
+
+    /**
+     * Utility method to run multiple propagators' captured values with proper scope binding.
+     *
+     * <p>This is a convenience method that combines capturing and running in one step.
+     *
+     * @param propagators the propagators to use
+     * @param runnable    the runnable to execute
+     */
+    public static void runWithScopedValues(
+        List<? extends ScopedValuePropagator<?>> propagators,
+        Runnable runnable
+    ) {
+        capture(propagators).runWithContext(runnable);
+    }
+
+    /**
+     * Utility method to call a supplier with multiple propagators' captured values bound.
+     *
+     * @param propagators the propagators to use
+     * @param supplier    the supplier to execute
+     * @param <T>         the return type
+     * @return the result of the supplier
+     */
+    public static <T> T callWithScopedValues(
+        List<? extends ScopedValuePropagator<?>> propagators,
+        Supplier<T> supplier
+    ) {
+        return capture(propagators).callWithContext(supplier);
+    }
+
+    @Override
+    public String toString() {
+        return "ScopedValueContext{" +
+            "capturedValues=" + capturedValues.size() + " entries" +
+            '}';
+    }
+}

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/ScopedValuePropagator.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/ScopedValuePropagator.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2024 Resilience4j Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.core;
+
+import java.util.*;
+import java.util.concurrent.Callable;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * A {@link ContextPropagator} implementation for Java 25+ Scoped Values (JEP 506).
+ *
+ * <p>Scoped Values provide a more efficient alternative to ThreadLocal for passing
+ * immutable data to child tasks, especially in virtual thread environments. Unlike
+ * ThreadLocal, Scoped Values:
+ * <ul>
+ *   <li>Are immutable once bound to a scope</li>
+ *   <li>Are automatically cleaned up when the scope ends</li>
+ *   <li>Don't cause virtual thread pinning</li>
+ *   <li>Have lower memory overhead with virtual threads</li>
+ * </ul>
+ *
+ * <p><b>Usage Example:</b>
+ * <pre>{@code
+ * // Define a ScopedValue
+ * private static final ScopedValue<String> REQUEST_ID = ScopedValue.newInstance();
+ *
+ * // Create a propagator for it
+ * ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+ *
+ * // Use with ThreadPoolBulkhead
+ * ThreadPoolBulkheadConfig config = ThreadPoolBulkheadConfig.custom()
+ *     .contextPropagator(propagator)
+ *     .build();
+ *
+ * // Run code with the scoped value bound
+ * ScopedValue.where(REQUEST_ID, "req-123").run(() -> {
+ *     bulkhead.executeSupplier(() -> {
+ *         // REQUEST_ID is available here via propagator.getCapturedValue()
+ *         return doWork();
+ *     });
+ * });
+ * }</pre>
+ *
+ * <p><b>Integration Notes:</b>
+ * <p>Since Scoped Values use a different binding model than ThreadLocal (scope-based
+ * vs. set/get), this propagator captures the value and makes it available through
+ * {@link #getCapturedValue()}. For automatic rebinding in the target thread, use
+ * {@link ScopedValueContext} utility class which provides proper scope wrapping.
+ *
+ * @param <T> the type of value being propagated
+ * @see ScopedValueContext
+ * @see ContextPropagator
+ * @since 3.0.0
+ */
+public final class ScopedValuePropagator<T> implements ContextPropagator<T> {
+
+    private final ScopedValue<T> scopedValue;
+
+    /**
+     * Thread-local holder for captured scoped values during cross-thread propagation.
+     * This is used as an intermediate storage mechanism because Scoped Values cannot
+     * be directly "set" - they must be bound to a scope.
+     */
+    private static final ThreadLocal<Map<ScopedValue<?>, Object>> capturedValues =
+        ThreadLocal.withInitial(HashMap::new);
+
+    private ScopedValuePropagator(ScopedValue<T> scopedValue) {
+        this.scopedValue = Objects.requireNonNull(scopedValue, "ScopedValue cannot be null");
+    }
+
+    /**
+     * Creates a new ScopedValuePropagator for the given ScopedValue.
+     *
+     * @param scopedValue the ScopedValue to propagate
+     * @param <T>         the type of the scoped value
+     * @return a new ScopedValuePropagator instance
+     * @throws NullPointerException if scopedValue is null
+     */
+    public static <T> ScopedValuePropagator<T> of(ScopedValue<T> scopedValue) {
+        return new ScopedValuePropagator<>(scopedValue);
+    }
+
+    /**
+     * Creates propagators for multiple ScopedValues.
+     *
+     * @param scopedValues the ScopedValues to create propagators for
+     * @return a list of ScopedValuePropagator instances
+     */
+    @SafeVarargs
+    public static List<ContextPropagator<?>> ofAll(ScopedValue<?>... scopedValues) {
+        List<ContextPropagator<?>> propagators = new ArrayList<>(scopedValues.length);
+        for (ScopedValue<?> sv : scopedValues) {
+            propagators.add(new ScopedValuePropagator<>(sv));
+        }
+        return propagators;
+    }
+
+    /**
+     * Retrieves the current value from the ScopedValue if it's bound, or from
+     * the per-thread capture map as a fallback.
+     *
+     * <p>The fallback is what keeps multi-hop propagation working: when the
+     * propagator is used via {@link ContextPropagator#decorateSupplier}, the
+     * worker thread only receives {@link #copy()} — the real {@link ScopedValue}
+     * is not re-bound on that thread. Without the fallback, a second decoration
+     * performed on the worker would read {@link Optional#empty()} from
+     * {@code scopedValue.isBound()} and silently drop the propagated value.
+     *
+     * @return a Supplier that returns an Optional containing the current value,
+     *         or an empty Optional if neither the ScopedValue nor the capture
+     *         map holds a value for this propagator
+     */
+    @Override
+    public Supplier<Optional<T>> retrieve() {
+        return () -> {
+            if (scopedValue.isBound()) {
+                return Optional.of(scopedValue.get());
+            }
+            @SuppressWarnings("unchecked")
+            T carried = (T) capturedValues.get().get(scopedValue);
+            return Optional.ofNullable(carried);
+        };
+    }
+
+    /**
+     * Copies the retrieved value to the target thread's capture storage.
+     *
+     * <p>Note: This stores the value in a ThreadLocal map for later access via
+     * {@link #getCapturedValue()}. For proper Scoped Value rebinding, use
+     * {@link ScopedValueContext#runWithScopedValues(List, Runnable)}.
+     *
+     * @return a Consumer that stores the value in the capture storage
+     */
+    @Override
+    public Consumer<Optional<T>> copy() {
+        return value -> value.ifPresent(v -> capturedValues.get().put(scopedValue, v));
+    }
+
+    /**
+     * Clears the captured value from the target thread's capture storage.
+     *
+     * @return a Consumer that removes the value from the capture storage
+     */
+    @Override
+    public Consumer<Optional<T>> clear() {
+        return value -> capturedValues.get().remove(scopedValue);
+    }
+
+    /**
+     * Gets the ScopedValue that this propagator wraps.
+     *
+     * @return the wrapped ScopedValue
+     */
+    public ScopedValue<T> getScopedValue() {
+        return scopedValue;
+    }
+
+    /**
+     * Gets the captured value from the current thread's capture storage.
+     *
+     * <p>This method should be called in the target thread after {@link #copy()}
+     * has been invoked to retrieve the propagated value.
+     *
+     * @return an Optional containing the captured value, or empty if not captured
+     */
+    @SuppressWarnings("unchecked")
+    public Optional<T> getCapturedValue() {
+        return Optional.ofNullable((T) capturedValues.get().get(scopedValue));
+    }
+
+    /**
+     * Checks if the underlying ScopedValue is currently bound in the current scope.
+     *
+     * @return true if the ScopedValue is bound, false otherwise
+     */
+    public boolean isBound() {
+        return scopedValue.isBound();
+    }
+
+    /**
+     * Gets the current value of the ScopedValue if bound.
+     *
+     * @return an Optional containing the current value, or empty if not bound
+     */
+    public Optional<T> getCurrentValue() {
+        return scopedValue.isBound()
+            ? Optional.of(scopedValue.get())
+            : Optional.empty();
+    }
+
+    /**
+     * Decorates a Supplier to execute within a scope where the captured values are bound.
+     *
+     * <p>This method provides proper Scoped Value rebinding by using
+     * {@code ScopedValue.where().call()} to execute the supplier within a scope
+     * where the captured value is bound to the ScopedValue.
+     *
+     * @param supplier the supplier to decorate
+     * @param <R>      the return type of the supplier
+     * @return a decorated supplier that executes with the scoped value bound
+     */
+    public <R> Supplier<R> decorateSupplierWithScope(Supplier<R> supplier) {
+        final Optional<T> capturedValue = retrieve().get();
+        return () -> {
+            if (capturedValue.isPresent()) {
+                try {
+                    return ScopedValue.where(scopedValue, capturedValue.get())
+                        .call(supplier::get);
+                } catch (Exception e) {
+                    if (e instanceof RuntimeException re) {
+                        throw re;
+                    }
+                    throw new RuntimeException(e);
+                }
+            } else {
+                return supplier.get();
+            }
+        };
+    }
+
+    /**
+     * Decorates a Runnable to execute within a scope where the captured values are bound.
+     *
+     * @param runnable the runnable to decorate
+     * @return a decorated runnable that executes with the scoped value bound
+     */
+    public Runnable decorateRunnableWithScope(Runnable runnable) {
+        final Optional<T> capturedValue = retrieve().get();
+        return () -> {
+            if (capturedValue.isPresent()) {
+                ScopedValue.where(scopedValue, capturedValue.get()).run(runnable);
+            } else {
+                runnable.run();
+            }
+        };
+    }
+
+    /**
+     * Decorates a Callable to execute within a scope where the captured values are bound.
+     *
+     * @param callable the callable to decorate
+     * @param <R>      the return type of the callable
+     * @return a decorated callable that executes with the scoped value bound
+     */
+    public <R> Callable<R> decorateCallableWithScope(Callable<R> callable) {
+        final Optional<T> capturedValue = retrieve().get();
+        return () -> {
+            if (capturedValue.isPresent()) {
+                return ScopedValue.where(scopedValue, capturedValue.get()).call(() -> callable.call());
+            } else {
+                return callable.call();
+            }
+        };
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ScopedValuePropagator<?> that = (ScopedValuePropagator<?>) o;
+        return Objects.equals(scopedValue, that.scopedValue);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(scopedValue);
+    }
+
+    @Override
+    public String toString() {
+        return "ScopedValuePropagator{" +
+            "scopedValue=" + scopedValue +
+            ", isBound=" + scopedValue.isBound() +
+            '}';
+    }
+}

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/registry/AbstractRegistry.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/registry/AbstractRegistry.java
@@ -25,6 +25,7 @@ import io.github.resilience4j.core.RegistryStore;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
 /**
@@ -98,11 +99,20 @@ public class AbstractRegistry<E, C> implements Registry<E, C> {
     }
 
     protected E computeIfAbsent(String name, Supplier<E> supplier) {
-        return entryMap.computeIfAbsent(Objects.requireNonNull(name, NAME_MUST_NOT_BE_NULL), k -> {
-            E entry = supplier.get();
-            eventProcessor.processEvent(new EntryAddedEvent<>(entry));
-            return entry;
+        // Publish EntryAddedEvent after the CHM call returns, not inside the
+        // mapping function. A consumer that touches this registry recursively
+        // (same key or a key that hashes to the same bin) would otherwise trip
+        // ConcurrentHashMap's recursive-update detection and throw
+        // IllegalStateException.
+        AtomicBoolean created = new AtomicBoolean(false);
+        E entry = entryMap.computeIfAbsent(Objects.requireNonNull(name, NAME_MUST_NOT_BE_NULL), k -> {
+            created.set(true);
+            return supplier.get();
         });
+        if (created.get()) {
+            eventProcessor.processEvent(new EntryAddedEvent<>(entry));
+        }
+        return entry;
     }
 
     @Override

--- a/resilience4j-core/src/main/java/io/github/resilience4j/core/registry/InMemoryRegistryStore.java
+++ b/resilience4j-core/src/main/java/io/github/resilience4j/core/registry/InMemoryRegistryStore.java
@@ -22,27 +22,27 @@ import io.github.resilience4j.core.lang.Nullable;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 /**
- * Default Implementation Of RegistryStore using FutureHashMap pattern for virtual thread optimization
+ * Default Implementation Of RegistryStore using ConcurrentHashMap.
+ *
+ * <p>Starting with JDK 25 and JEP 491 (Synchronize Virtual Threads without Pinning),
+ * virtual threads no longer get pinned when executing synchronized blocks or methods.
+ * This means the previous FutureHashMap pattern is no longer necessary, and we can
+ * use the simple and straightforward ConcurrentHashMap.computeIfAbsent() method.
+ *
+ * <p>JEP 491 allows the JVM to release the carrier thread when a virtual thread
+ * blocks on a monitor (synchronized), making virtual threads truly efficient
+ * for all blocking operations without special workarounds.
  */
 public class InMemoryRegistryStore<E> implements RegistryStore<E> {
 
-    // FutureHashMap pattern for virtual thread optimization - avoids blocking inside map operations
-    private final ConcurrentHashMap<String, CompletableFuture<E>> entryMap;
+    private final ConcurrentHashMap<String, E> entryMap;
 
     public InMemoryRegistryStore() {
         this.entryMap = new ConcurrentHashMap<>();
-    }
-
-    /**
-     * Checks if the future is successfully completed (not null, done, and not exceptionally completed)
-     */
-    private boolean isSuccessfullyCompleted(@Nullable CompletableFuture<E> future) {
-        return future != null && future.isDone() && !future.isCompletedExceptionally();
     }
 
     @Override
@@ -51,40 +51,9 @@ public class InMemoryRegistryStore<E> implements RegistryStore<E> {
         Objects.requireNonNull(key, "Key cannot be null");
         Objects.requireNonNull(mappingFunction, "Mapping function cannot be null");
 
-        /*
-         * FutureHashMap pattern to prevent virtual thread pinning.
-         *
-         * We intentionally avoid using ConcurrentHashMap.computeIfAbsent() because:
-         * 1. mappingFunction.apply() can involve blocking I/O, database calls, or expensive initialization
-         * 2. Blocking inside computeIfAbsent holds the segment lock, causing virtual thread pinning
-         * 3. This pattern executes expensive operations outside the map lock
-         *
-         * Pattern explanation:
-         * - Winner thread: Creates the entry, executes mappingFunction outside map lock, completes future
-         * - Loser threads: Wait on future.join(), which is virtual thread friendly (no carrier thread blocking)
-         *
-         * This is a performance optimization for virtual thread environments and should NOT be
-         * "simplified" to standard computeIfAbsent in future JDK versions, as it would reintroduce
-         * the pinning issue.
-         */
-        CompletableFuture<E> created = new CompletableFuture<>();
-        CompletableFuture<E> future = entryMap.putIfAbsent(key, created);
-
-        if (future == null) { // I am the winner
-            future = created;
-            try {
-                E value = mappingFunction.apply(key);     // ***Compute outside map lock*** (no pinning)
-                Objects.requireNonNull(value, "Mapping function must not return null for key: " + key);
-                future.complete(value);
-            } catch (Throwable t) {
-                // Only cleanup if I'm the first to complete exceptionally → retry possible
-                if (future.completeExceptionally(t)) {
-                    entryMap.remove(key, future);
-                }
-                throw t;
-            }
-        }
-        return future.join(); // Losers wait (VT friendly - no carrier thread blocking)
+        // With JEP 491 (JDK 25+), synchronized blocks no longer pin virtual threads.
+        // Simple computeIfAbsent is now efficient for both platform and virtual threads.
+        return entryMap.computeIfAbsent(key, mappingFunction);
     }
 
     @Override
@@ -93,62 +62,27 @@ public class InMemoryRegistryStore<E> implements RegistryStore<E> {
         Objects.requireNonNull(key, "Key cannot be null");
         Objects.requireNonNull(value, "Value cannot be null");
 
-        CompletableFuture<E> future = entryMap.putIfAbsent(key, CompletableFuture.completedFuture(value));
-        if (future != null) {
-            try {
-                // Wait for computation to complete and return existing value
-                // join() uses LockSupport.park() internally - no virtual thread pinning
-                return future.join();
-            } catch (Exception e) {
-                // CompletionException from failed computeIfAbsent - treat as "no valid existing value"
-                return null;
-            }
-        }
-        return null;  // Successfully inserted new value
+        return entryMap.putIfAbsent(key, value);
     }
 
     @Override
     public Optional<E> find(String key) {
-        CompletableFuture<E> future = entryMap.get(key);
-        if (isSuccessfullyCompleted(future)) {
-            return Optional.ofNullable(future.join());
-        }
-        return Optional.empty();
+        return Optional.ofNullable(entryMap.get(key));
     }
 
     @Override
     public Optional<E> remove(String name) {
-        CompletableFuture<E> future = entryMap.remove(name);
-        if (future != null) {
-            try {
-                return Optional.ofNullable(future.join());
-            } catch (Exception e) {
-                // CompletionException from failed computeIfAbsent - treat as "no value"
-                return Optional.empty();
-            }
-        }
-        return Optional.empty();
+        return Optional.ofNullable(entryMap.remove(name));
     }
 
     @Override
     public Optional<E> replace(String name, E newEntry) {
-        CompletableFuture<E> future = entryMap.replace(name, CompletableFuture.completedFuture(newEntry));
-        if (future != null) {
-            try {
-                return Optional.ofNullable(future.join());
-            } catch (Exception e) {
-                // CompletionException from failed computeIfAbsent - treat as "no value"
-                return Optional.empty();
-            }
-        }
-        return Optional.empty();
+        return Optional.ofNullable(entryMap.replace(name, newEntry));
     }
 
     @Override
     public Collection<E> values() {
         return entryMap.values().stream()
-            .filter(this::isSuccessfullyCompleted)
-            .map(CompletableFuture::join)
             .filter(Objects::nonNull)
             .toList();
     }

--- a/resilience4j-core/src/test/java/io/github/resilience4j/core/ContextAwareScheduledThreadPoolExecutorTest.java
+++ b/resilience4j-core/src/test/java/io/github/resilience4j/core/ContextAwareScheduledThreadPoolExecutorTest.java
@@ -18,24 +18,19 @@
  */
 package io.github.resilience4j.core;
 
-import static com.jayway.awaitility.Awaitility.await;
-import static com.jayway.awaitility.Awaitility.matches;
-import static com.jayway.awaitility.Awaitility.waitAtMost;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import io.github.resilience4j.core.TestContextPropagators.TestThreadLocalContextPropagatorWithHolder.TestThreadLocalContextHolder;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.MDC;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import org.assertj.core.api.Assertions;
-import org.junit.Before;
-import org.junit.Test;
-import org.slf4j.MDC;
-
-import io.github.resilience4j.core.TestContextPropagators.TestThreadLocalContextPropagatorWithHolder.TestThreadLocalContextHolder;
+import static org.assertj.core.api.Assertions.*;
+import static org.awaitility.Awaitility.await;
 
 public class ContextAwareScheduledThreadPoolExecutorTest {
 
@@ -81,7 +76,7 @@ public class ContextAwareScheduledThreadPoolExecutorTest {
             TestThreadLocalContextHolder.get().orElseThrow(() -> new RuntimeException("Found No Context"));
         }, 100, TimeUnit.MILLISECONDS);
         try{
-            await().atMost(200, TimeUnit.MILLISECONDS).until(matches(() -> schedule.get()));
+            await().atMost(200, TimeUnit.MILLISECONDS).untilAsserted(() -> schedule.get());
         } catch (Exception exception) {
             Assertions.fail("Must not throw an exception");
         }
@@ -91,24 +86,24 @@ public class ContextAwareScheduledThreadPoolExecutorTest {
     @Test
     public void testThreadFactory() {
         final ScheduledFuture<String> schedule = schedulerService.schedule(() -> Thread.currentThread().getName(), 0, TimeUnit.MILLISECONDS);
-        waitAtMost(1, TimeUnit.SECONDS).until(matches(() ->
-            assertThat(schedule.get()).contains("ContextAwareScheduledThreadPool")));
+        await().atMost(1, TimeUnit.SECONDS).untilAsserted(() ->
+            assertThat(schedule.get()).contains("ContextAwareScheduledThreadPool"));
     }
 
     @Test
     public void testScheduleCallablePropagatesContext() {
         TestThreadLocalContextHolder.put("ValueShouldCrossThreadBoundary");
         final ScheduledFuture<?> schedule = schedulerService.schedule(() -> TestThreadLocalContextHolder.get().orElse(null), 0, TimeUnit.MILLISECONDS);
-        waitAtMost(1, TimeUnit.SECONDS).until(matches(() ->
-            assertThat(schedule.get()).isEqualTo("ValueShouldCrossThreadBoundary")));
+        await().atMost(1, TimeUnit.SECONDS).untilAsserted(() ->
+            assertThat(schedule.get()).isEqualTo("ValueShouldCrossThreadBoundary"));
     }
 
     @Test
     public void testScheduleCallableWithDelayPropagatesContext() {
         TestThreadLocalContextHolder.put("ValueShouldCrossThreadBoundary");
         final ScheduledFuture<?> schedule = schedulerService.schedule(() -> TestThreadLocalContextHolder.get().orElse(null), 100, TimeUnit.MILLISECONDS);
-        waitAtMost(200, TimeUnit.MILLISECONDS).until(matches(() ->
-            assertThat(schedule.get()).isEqualTo("ValueShouldCrossThreadBoundary")));
+        await().atMost(200, TimeUnit.MILLISECONDS).untilAsserted(() ->
+            assertThat(schedule.get()).isEqualTo("ValueShouldCrossThreadBoundary"));
     }
 
     @Test
@@ -118,8 +113,8 @@ public class ContextAwareScheduledThreadPoolExecutorTest {
             assertThat(Thread.currentThread().getName()).contains("ContextAwareScheduledThreadPool");
             return (String) TestThreadLocalContextHolder.get().orElse(null);
         }, schedulerService);
-        waitAtMost(200, TimeUnit.MILLISECONDS).until(matches(() ->
-            assertThat(completableFuture).isCompletedWithValue("ValueShouldCrossThreadBoundary")));
+        await().atMost(200, TimeUnit.MILLISECONDS).untilAsserted(() ->
+            assertThat(completableFuture).isCompletedWithValue("ValueShouldCrossThreadBoundary"));
     }
 
     @Test
@@ -132,8 +127,8 @@ public class ContextAwareScheduledThreadPoolExecutorTest {
             assertThat(MDC.getCopyOfContextMap()).hasSize(2).containsExactlyEntriesOf(contextMap);
             return MDC.getCopyOfContextMap().get("key");
         }, schedulerService);
-        waitAtMost(200, TimeUnit.MILLISECONDS).until(matches(() ->
-            assertThat(completableFuture).isCompletedWithValue("ValueShouldCrossThreadBoundary")));
+        await().atMost(200, TimeUnit.MILLISECONDS).untilAsserted(() ->
+            assertThat(completableFuture).isCompletedWithValue("ValueShouldCrossThreadBoundary"));
     }
 
     @Test
@@ -144,8 +139,8 @@ public class ContextAwareScheduledThreadPoolExecutorTest {
         final ScheduledFuture<Map<String, String>> scheduledFuture = this.schedulerService
             .schedule(MDC::getCopyOfContextMap, 0, TimeUnit.MILLISECONDS);
 
-        waitAtMost(1, TimeUnit.SECONDS).until(matches(() ->
-            assertThat(scheduledFuture.get()).hasSize(2).containsExactlyEntriesOf(contextMap)));
+        await().atMost(1, TimeUnit.SECONDS).untilAsserted(() ->
+            assertThat(scheduledFuture.get()).hasSize(2).containsExactlyEntriesOf(contextMap));
     }
 
     @Test
@@ -161,7 +156,7 @@ public class ContextAwareScheduledThreadPoolExecutorTest {
         final ScheduledFuture<Map<String, String>> scheduledFuture = schedulerService
             .schedule(MDC::getCopyOfContextMap, 0, TimeUnit.MILLISECONDS);
 
-        waitAtMost(1, TimeUnit.SECONDS).until(matches(() ->
-            assertThat(scheduledFuture.get()).hasSize(2).containsExactlyEntriesOf(contextMap)));
+        await().atMost(1, TimeUnit.SECONDS).untilAsserted(() ->
+            assertThat(scheduledFuture.get()).hasSize(2).containsExactlyEntriesOf(contextMap));
     }
 }

--- a/resilience4j-core/src/test/java/io/github/resilience4j/core/ScopedValueContextTest.java
+++ b/resilience4j-core/src/test/java/io/github/resilience4j/core/ScopedValueContextTest.java
@@ -1,0 +1,391 @@
+/*
+ * Copyright 2024 Resilience4j Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.core;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link ScopedValueContext}.
+ */
+public class ScopedValueContextTest {
+
+    private static final ScopedValue<String> REQUEST_ID = ScopedValue.newInstance();
+    private static final ScopedValue<Integer> USER_ID = ScopedValue.newInstance();
+    private static final ScopedValue<String> TRACE_ID = ScopedValue.newInstance();
+
+    @Test
+    public void shouldCaptureEmptyContext() {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+
+        ScopedValueContext context = ScopedValueContext.capture(propagator);
+
+        assertThat(context.hasValues()).isFalse();
+        assertThat(context.size()).isZero();
+    }
+
+    @Test
+    public void shouldCaptureSingleScopedValue() {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+
+        ScopedValue.where(REQUEST_ID, "test-request").run(() -> {
+            ScopedValueContext context = ScopedValueContext.capture(propagator);
+
+            assertThat(context.hasValues()).isTrue();
+            assertThat(context.size()).isEqualTo(1);
+        });
+    }
+
+    @Test
+    public void shouldCaptureMultipleScopedValues() {
+        ScopedValuePropagator<String> requestPropagator = ScopedValuePropagator.of(REQUEST_ID);
+        ScopedValuePropagator<Integer> userPropagator = ScopedValuePropagator.of(USER_ID);
+
+        ScopedValue.where(REQUEST_ID, "test-request")
+            .where(USER_ID, 123)
+            .run(() -> {
+                ScopedValueContext context = ScopedValueContext.capture(
+                    Arrays.asList(requestPropagator, userPropagator)
+                );
+
+                assertThat(context.hasValues()).isTrue();
+                assertThat(context.size()).isEqualTo(2);
+            });
+    }
+
+    @Test
+    public void shouldCreateEmptyContext() {
+        ScopedValueContext context = ScopedValueContext.empty();
+
+        assertThat(context.hasValues()).isFalse();
+        assertThat(context.size()).isZero();
+    }
+
+    @Test
+    public void shouldThrowForNullPropagators() {
+        assertThatThrownBy(() -> ScopedValueContext.capture((List<ScopedValuePropagator<?>>) null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("Propagators list cannot be null");
+    }
+
+    @Test
+    public void shouldRunWithContext() {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+        AtomicReference<String> captured = new AtomicReference<>();
+
+        ScopedValue.where(REQUEST_ID, "context-value").run(() -> {
+            ScopedValueContext context = ScopedValueContext.capture(propagator);
+
+            context.runWithContext(() -> {
+                captured.set(REQUEST_ID.isBound() ? REQUEST_ID.get() : "not-bound");
+            });
+        });
+
+        assertThat(captured.get()).isEqualTo("context-value");
+    }
+
+    @Test
+    public void shouldRunWithMultipleScopedValuesInContext() {
+        ScopedValuePropagator<String> requestPropagator = ScopedValuePropagator.of(REQUEST_ID);
+        ScopedValuePropagator<Integer> userPropagator = ScopedValuePropagator.of(USER_ID);
+        ScopedValuePropagator<String> tracePropagator = ScopedValuePropagator.of(TRACE_ID);
+
+        AtomicReference<String> capturedRequest = new AtomicReference<>();
+        AtomicReference<Integer> capturedUser = new AtomicReference<>();
+        AtomicReference<String> capturedTrace = new AtomicReference<>();
+
+        ScopedValue.where(REQUEST_ID, "multi-request")
+            .where(USER_ID, 456)
+            .where(TRACE_ID, "trace-123")
+            .run(() -> {
+                ScopedValueContext context = ScopedValueContext.capture(
+                    requestPropagator, userPropagator, tracePropagator
+                );
+
+                context.runWithContext(() -> {
+                    capturedRequest.set(REQUEST_ID.get());
+                    capturedUser.set(USER_ID.get());
+                    capturedTrace.set(TRACE_ID.get());
+                });
+            });
+
+        assertThat(capturedRequest.get()).isEqualTo("multi-request");
+        assertThat(capturedUser.get()).isEqualTo(456);
+        assertThat(capturedTrace.get()).isEqualTo("trace-123");
+    }
+
+    @Test
+    public void shouldCallWithContext() {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+
+        String result = ScopedValue.where(REQUEST_ID, "call-value").call(() -> {
+            ScopedValueContext context = ScopedValueContext.capture(propagator);
+
+            return context.callWithContext((Supplier<String>) () ->
+                REQUEST_ID.isBound() ? REQUEST_ID.get() : "not-bound"
+            );
+        });
+
+        assertThat(result).isEqualTo("call-value");
+    }
+
+    @Test
+    public void shouldCallWithContextCallable() throws Exception {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+
+        String result = ScopedValue.where(REQUEST_ID, "callable-value").call(() -> {
+            ScopedValueContext context = ScopedValueContext.capture(propagator);
+
+            return context.callWithContext((Callable<String>) () ->
+                REQUEST_ID.isBound() ? REQUEST_ID.get() : "not-bound"
+            );
+        });
+
+        assertThat(result).isEqualTo("callable-value");
+    }
+
+    @Test
+    public void shouldDecorateRunnable() throws Exception {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+        AtomicReference<String> captured = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        ScopedValue.where(REQUEST_ID, "decorated-runnable").run(() -> {
+            ScopedValueContext context = ScopedValueContext.capture(propagator);
+
+            Runnable decorated = context.decorateRunnable(() -> {
+                captured.set(REQUEST_ID.get());
+                latch.countDown();
+            });
+
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            try {
+                executor.submit(decorated);
+                boolean completed = latch.await(5, TimeUnit.SECONDS);
+                assertThat(completed).isTrue();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            } finally {
+                executor.shutdown();
+            }
+        });
+
+        assertThat(captured.get()).isEqualTo("decorated-runnable");
+    }
+
+    @Test
+    public void shouldDecorateSupplier() throws Exception {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+
+        String result = ScopedValue.where(REQUEST_ID, "decorated-supplier").call(() -> {
+            ScopedValueContext context = ScopedValueContext.capture(propagator);
+
+            Supplier<String> decorated = context.decorateSupplier(() ->
+                REQUEST_ID.isBound() ? REQUEST_ID.get() : "not-bound"
+            );
+
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            try {
+                Future<String> future = executor.submit(decorated::get);
+                return future.get(5, TimeUnit.SECONDS);
+            } finally {
+                executor.shutdown();
+            }
+        });
+
+        assertThat(result).isEqualTo("decorated-supplier");
+    }
+
+    @Test
+    public void shouldDecorateCallable() throws Exception {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+
+        String result = ScopedValue.where(REQUEST_ID, "decorated-callable").call(() -> {
+            ScopedValueContext context = ScopedValueContext.capture(propagator);
+
+            Callable<String> decorated = context.decorateCallable(() ->
+                REQUEST_ID.isBound() ? REQUEST_ID.get() : "not-bound"
+            );
+
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            try {
+                Future<String> future = executor.submit(decorated);
+                return future.get(5, TimeUnit.SECONDS);
+            } finally {
+                executor.shutdown();
+            }
+        });
+
+        assertThat(result).isEqualTo("decorated-callable");
+    }
+
+    @Test
+    public void shouldRunEmptyContextWithoutBinding() {
+        ScopedValueContext context = ScopedValueContext.empty();
+        AtomicReference<Boolean> isBound = new AtomicReference<>();
+
+        context.runWithContext(() -> {
+            isBound.set(REQUEST_ID.isBound());
+        });
+
+        assertThat(isBound.get()).isFalse();
+    }
+
+    @Test
+    public void shouldReturnOriginalRunnableForEmptyContext() {
+        ScopedValueContext context = ScopedValueContext.empty();
+        Runnable original = () -> {};
+
+        Runnable decorated = context.decorateRunnable(original);
+
+        assertThat(decorated).isSameAs(original);
+    }
+
+    @Test
+    public void shouldReturnOriginalSupplierForEmptyContext() {
+        ScopedValueContext context = ScopedValueContext.empty();
+        Supplier<String> original = () -> "test";
+
+        Supplier<String> decorated = context.decorateSupplier(original);
+
+        assertThat(decorated).isSameAs(original);
+    }
+
+    @Test
+    public void shouldReturnOriginalCallableForEmptyContext() {
+        ScopedValueContext context = ScopedValueContext.empty();
+        Callable<String> original = () -> "test";
+
+        Callable<String> decorated = context.decorateCallable(original);
+
+        assertThat(decorated).isSameAs(original);
+    }
+
+    @Test
+    public void shouldUseStaticRunWithScopedValues() {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+        AtomicReference<String> captured = new AtomicReference<>();
+
+        ScopedValue.where(REQUEST_ID, "static-method-test").run(() -> {
+            ScopedValueContext.runWithScopedValues(
+                List.of(propagator),
+                () -> captured.set(REQUEST_ID.get())
+            );
+        });
+
+        assertThat(captured.get()).isEqualTo("static-method-test");
+    }
+
+    @Test
+    public void shouldUseStaticCallWithScopedValues() {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+
+        ScopedValue.where(REQUEST_ID, "static-call-test").run(() -> {
+            String result = ScopedValueContext.callWithScopedValues(
+                List.of(propagator),
+                () -> REQUEST_ID.get()
+            );
+            assertThat(result).isEqualTo("static-call-test");
+        });
+    }
+
+    @Test
+    public void shouldWorkWithVirtualThreads() throws Exception {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+        AtomicReference<String> captured = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        ScopedValue.where(REQUEST_ID, "virtual-thread-context").run(() -> {
+            ScopedValueContext context = ScopedValueContext.capture(propagator);
+
+            Thread.startVirtualThread(() -> {
+                context.runWithContext(() -> {
+                    captured.set(REQUEST_ID.get());
+                    latch.countDown();
+                });
+            });
+
+            try {
+                boolean completed = latch.await(5, TimeUnit.SECONDS);
+                assertThat(completed).isTrue();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        });
+
+        assertThat(captured.get()).isEqualTo("virtual-thread-context");
+    }
+
+    @Test
+    public void shouldHaveDescriptiveToString() {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+
+        ScopedValue.where(REQUEST_ID, "test").run(() -> {
+            ScopedValueContext context = ScopedValueContext.capture(propagator);
+            String toString = context.toString();
+
+            assertThat(toString).contains("ScopedValueContext");
+            assertThat(toString).contains("1 entries");
+        });
+    }
+
+    @Test
+    public void shouldPropagateExceptionFromCallable() {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+
+        ScopedValue.where(REQUEST_ID, "exception-test").run(() -> {
+            ScopedValueContext context = ScopedValueContext.capture(propagator);
+
+            assertThatThrownBy(() -> context.callWithContext((Callable<String>) () -> {
+                throw new IllegalStateException("Test exception");
+            }))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Test exception");
+        });
+    }
+
+    @Test
+    public void shouldOnlyCapturePartiallyBoundValues() {
+        ScopedValuePropagator<String> requestPropagator = ScopedValuePropagator.of(REQUEST_ID);
+        ScopedValuePropagator<Integer> userPropagator = ScopedValuePropagator.of(USER_ID);
+
+        // Only bind REQUEST_ID, not USER_ID
+        ScopedValue.where(REQUEST_ID, "partial-test").run(() -> {
+            ScopedValueContext context = ScopedValueContext.capture(
+                Arrays.asList(requestPropagator, userPropagator)
+            );
+
+            // Should only have 1 captured value
+            assertThat(context.size()).isEqualTo(1);
+
+            context.runWithContext(() -> {
+                assertThat(REQUEST_ID.isBound()).isTrue();
+                assertThat(REQUEST_ID.get()).isEqualTo("partial-test");
+                assertThat(USER_ID.isBound()).isFalse();
+            });
+        });
+    }
+}

--- a/resilience4j-core/src/test/java/io/github/resilience4j/core/ScopedValuePropagatorTest.java
+++ b/resilience4j-core/src/test/java/io/github/resilience4j/core/ScopedValuePropagatorTest.java
@@ -1,0 +1,393 @@
+/*
+ * Copyright 2024 Resilience4j Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.core;
+
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link ScopedValuePropagator}.
+ *
+ * <p>These tests verify that Scoped Values (JEP 506) are properly propagated
+ * across thread boundaries using the ScopedValuePropagator.
+ */
+public class ScopedValuePropagatorTest {
+
+    private static final ScopedValue<String> REQUEST_ID = ScopedValue.newInstance();
+    private static final ScopedValue<Integer> USER_ID = ScopedValue.newInstance();
+
+    @Test
+    public void shouldCreatePropagatorWithScopedValue() {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+
+        assertThat(propagator).isNotNull();
+        assertThat(propagator.getScopedValue()).isEqualTo(REQUEST_ID);
+    }
+
+    @Test
+    public void shouldThrowNullPointerExceptionForNullScopedValue() {
+        assertThatThrownBy(() -> ScopedValuePropagator.of(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("ScopedValue cannot be null");
+    }
+
+    @Test
+    public void shouldRetrieveValueWhenBound() {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+
+        ScopedValue.where(REQUEST_ID, "test-request-123").run(() -> {
+            Optional<String> retrieved = propagator.retrieve().get();
+            assertThat(retrieved).isPresent();
+            assertThat(retrieved.get()).isEqualTo("test-request-123");
+        });
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenNotBound() {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+
+        Optional<String> retrieved = propagator.retrieve().get();
+        assertThat(retrieved).isEmpty();
+    }
+
+    @Test
+    public void shouldCheckIfBound() {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+
+        assertThat(propagator.isBound()).isFalse();
+
+        ScopedValue.where(REQUEST_ID, "test").run(() -> {
+            assertThat(propagator.isBound()).isTrue();
+        });
+
+        assertThat(propagator.isBound()).isFalse();
+    }
+
+    @Test
+    public void shouldGetCurrentValue() {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+
+        assertThat(propagator.getCurrentValue()).isEmpty();
+
+        ScopedValue.where(REQUEST_ID, "current-value").run(() -> {
+            assertThat(propagator.getCurrentValue()).isPresent();
+            assertThat(propagator.getCurrentValue().get()).isEqualTo("current-value");
+        });
+    }
+
+    @Test
+    public void shouldCopyAndClearValue() {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+
+        ScopedValue.where(REQUEST_ID, "value-to-copy").run(() -> {
+            Optional<String> value = propagator.retrieve().get();
+
+            // Copy the value
+            propagator.copy().accept(value);
+
+            // Verify it's captured
+            assertThat(propagator.getCapturedValue()).isPresent();
+            assertThat(propagator.getCapturedValue().get()).isEqualTo("value-to-copy");
+
+            // Clear the value
+            propagator.clear().accept(value);
+
+            // Verify it's cleared
+            assertThat(propagator.getCapturedValue()).isEmpty();
+        });
+    }
+
+    @Test
+    public void shouldDecorateSupplierWithScope() throws Exception {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+        AtomicReference<String> capturedInThread = new AtomicReference<>();
+
+        Supplier<String> supplier = () -> {
+            capturedInThread.set(REQUEST_ID.isBound() ? REQUEST_ID.get() : "not-bound");
+            return REQUEST_ID.isBound() ? REQUEST_ID.get() : "not-bound";
+        };
+
+        ScopedValue.where(REQUEST_ID, "decorated-value").run(() -> {
+            Supplier<String> decoratedSupplier = propagator.decorateSupplierWithScope(supplier);
+
+            // Execute in a different thread
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            try {
+                Future<String> future = executor.submit(decoratedSupplier::get);
+                String result = future.get(5, TimeUnit.SECONDS);
+                assertThat(result).isEqualTo("decorated-value");
+                assertThat(capturedInThread.get()).isEqualTo("decorated-value");
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            } finally {
+                executor.shutdown();
+            }
+        });
+    }
+
+    @Test
+    public void shouldDecorateRunnableWithScope() throws Exception {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+        AtomicReference<String> capturedInThread = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        Runnable runnable = () -> {
+            capturedInThread.set(REQUEST_ID.isBound() ? REQUEST_ID.get() : "not-bound");
+            latch.countDown();
+        };
+
+        ScopedValue.where(REQUEST_ID, "runnable-value").run(() -> {
+            Runnable decoratedRunnable = propagator.decorateRunnableWithScope(runnable);
+
+            // Execute in a different thread
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            try {
+                executor.submit(decoratedRunnable);
+                boolean completed = latch.await(5, TimeUnit.SECONDS);
+                assertThat(completed).isTrue();
+                assertThat(capturedInThread.get()).isEqualTo("runnable-value");
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            } finally {
+                executor.shutdown();
+            }
+        });
+    }
+
+    @Test
+    public void shouldDecorateCallableWithScope() throws Exception {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+        AtomicReference<String> capturedInThread = new AtomicReference<>();
+
+        Callable<String> callable = () -> {
+            capturedInThread.set(REQUEST_ID.isBound() ? REQUEST_ID.get() : "not-bound");
+            return REQUEST_ID.isBound() ? REQUEST_ID.get() : "not-bound";
+        };
+
+        ScopedValue.where(REQUEST_ID, "callable-value").run(() -> {
+            Callable<String> decoratedCallable = propagator.decorateCallableWithScope(callable);
+
+            // Execute in a different thread
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            try {
+                Future<String> future = executor.submit(decoratedCallable);
+                String result = future.get(5, TimeUnit.SECONDS);
+                assertThat(result).isEqualTo("callable-value");
+                assertThat(capturedInThread.get()).isEqualTo("callable-value");
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            } finally {
+                executor.shutdown();
+            }
+        });
+    }
+
+    @Test
+    public void shouldHandleUnboundValueInDecoratedSupplier() {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+
+        Supplier<String> supplier = () -> "default-result";
+        Supplier<String> decorated = propagator.decorateSupplierWithScope(supplier);
+
+        // Should work without any scoped value bound
+        String result = decorated.get();
+        assertThat(result).isEqualTo("default-result");
+    }
+
+    @Test
+    public void shouldCreateMultiplePropagators() {
+        List<ContextPropagator<?>> propagators = ScopedValuePropagator.ofAll(REQUEST_ID, USER_ID);
+
+        assertThat(propagators).hasSize(2);
+        assertThat(propagators.get(0)).isInstanceOf(ScopedValuePropagator.class);
+        assertThat(propagators.get(1)).isInstanceOf(ScopedValuePropagator.class);
+    }
+
+    @Test
+    public void shouldPropagateMultipleScopedValues() {
+        ScopedValuePropagator<String> requestPropagator = ScopedValuePropagator.of(REQUEST_ID);
+        ScopedValuePropagator<Integer> userPropagator = ScopedValuePropagator.of(USER_ID);
+
+        ScopedValue.where(REQUEST_ID, "multi-request")
+            .where(USER_ID, 42)
+            .run(() -> {
+                assertThat(requestPropagator.getCurrentValue()).hasValue("multi-request");
+                assertThat(userPropagator.getCurrentValue()).hasValue(42);
+            });
+    }
+
+    @Test
+    public void shouldWorkWithNestedScopes() {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+
+        ScopedValue.where(REQUEST_ID, "outer").run(() -> {
+            assertThat(propagator.getCurrentValue()).hasValue("outer");
+
+            ScopedValue.where(REQUEST_ID, "inner").run(() -> {
+                assertThat(propagator.getCurrentValue()).hasValue("inner");
+            });
+
+            assertThat(propagator.getCurrentValue()).hasValue("outer");
+        });
+
+        assertThat(propagator.getCurrentValue()).isEmpty();
+    }
+
+    @Test
+    public void shouldHaveCorrectEqualsAndHashCode() {
+        ScopedValuePropagator<String> propagator1 = ScopedValuePropagator.of(REQUEST_ID);
+        ScopedValuePropagator<String> propagator2 = ScopedValuePropagator.of(REQUEST_ID);
+        ScopedValuePropagator<Integer> propagator3 = ScopedValuePropagator.of(USER_ID);
+
+        assertThat(propagator1).isEqualTo(propagator2);
+        assertThat(propagator1.hashCode()).isEqualTo(propagator2.hashCode());
+        assertThat(propagator1).isNotEqualTo(propagator3);
+    }
+
+    @Test
+    public void shouldHaveDescriptiveToString() {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+
+        String toString = propagator.toString();
+        assertThat(toString).contains("ScopedValuePropagator");
+        assertThat(toString).contains("isBound=false");
+    }
+
+    @Test
+    public void shouldWorkWithVirtualThreads() throws Exception {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+        AtomicReference<String> capturedInVirtualThread = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        ScopedValue.where(REQUEST_ID, "virtual-thread-value").run(() -> {
+            Runnable decoratedRunnable = propagator.decorateRunnableWithScope(() -> {
+                capturedInVirtualThread.set(REQUEST_ID.get());
+                latch.countDown();
+            });
+
+            // Execute in a virtual thread
+            Thread.startVirtualThread(decoratedRunnable);
+
+            try {
+                boolean completed = latch.await(5, TimeUnit.SECONDS);
+                assertThat(completed).isTrue();
+                assertThat(capturedInVirtualThread.get()).isEqualTo("virtual-thread-value");
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @Test
+    public void shouldIntegrateWithContextPropagatorDecorateSupplier() {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+
+        ScopedValue.where(REQUEST_ID, "context-propagator-test").run(() -> {
+            // Use the ContextPropagator.decorateSupplier static method
+            Supplier<String> supplier = () -> propagator.getCapturedValue().orElse("not-captured");
+            Supplier<String> decorated = ContextPropagator.decorateSupplier(propagator, supplier);
+
+            // The decorated supplier should have captured the value
+            String result = decorated.get();
+            assertThat(result).isEqualTo("context-propagator-test");
+        });
+    }
+
+    @Test
+    public void shouldIntegrateWithContextPropagatorDecorateRunnable() throws Exception {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+        AtomicReference<String> captured = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        ScopedValue.where(REQUEST_ID, "runnable-context-test").run(() -> {
+            Runnable runnable = () -> {
+                captured.set(propagator.getCapturedValue().orElse("not-captured"));
+                latch.countDown();
+            };
+            Runnable decorated = ContextPropagator.decorateRunnable(propagator, runnable);
+
+            // Execute in another thread
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            try {
+                executor.submit(decorated);
+                boolean completed = latch.await(5, TimeUnit.SECONDS);
+                assertThat(completed).isTrue();
+                assertThat(captured.get()).isEqualTo("runnable-context-test");
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            } finally {
+                executor.shutdown();
+            }
+        });
+    }
+
+    /**
+     * Verifies that the value survives a second hop through
+     * {@link ContextPropagator#decorateSupplier}. The first decoration captures
+     * the value on the source thread; the second decoration is performed on the
+     * worker thread (where the ScopedValue itself is not bound) and must still
+     * observe the same value via {@link ScopedValuePropagator#retrieve()}.
+     */
+    @Test
+    public void shouldPropagateValueAcrossMultipleAsyncHops() throws Exception {
+        ScopedValuePropagator<String> propagator = ScopedValuePropagator.of(REQUEST_ID);
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            AtomicReference<Optional<String>> secondHopValue = new AtomicReference<>(Optional.empty());
+            AtomicBoolean secondHopRan = new AtomicBoolean(false);
+
+            ScopedValue.where(REQUEST_ID, "req-A").run(() -> {
+                Supplier<Void> outer = ContextPropagator.decorateSupplier(
+                    List.<ContextPropagator>of(propagator),
+                    () -> {
+                        // Running on the worker thread; ScopedValue is NOT bound here,
+                        // but copy() has populated the capturedValues side-channel.
+                        Supplier<Optional<String>> inner = ContextPropagator.decorateSupplier(
+                            List.<ContextPropagator>of(propagator),
+                            () -> propagator.retrieve().get()
+                        );
+                        secondHopValue.set(inner.get());
+                        secondHopRan.set(true);
+                        return null;
+                    }
+                );
+                try {
+                    executor.submit(outer::get).get(5, TimeUnit.SECONDS);
+                } catch (InterruptedException | ExecutionException | TimeoutException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            assertThat(secondHopRan).isTrue();
+            assertThat(secondHopValue.get()).contains("req-A");
+        } finally {
+            executor.shutdown();
+        }
+    }
+}

--- a/resilience4j-kotlin/build.gradle
+++ b/resilience4j-kotlin/build.gradle
@@ -31,13 +31,13 @@ dependencies {
 
 compileKotlin {
     compilerOptions {
-        it.jvmTarget.set(JvmTarget.JVM_21)
+        it.jvmTarget.set(JvmTarget.JVM_25)
     }
 }
 
 compileTestKotlin {
     compilerOptions {
-        it.jvmTarget.set(JvmTarget.JVM_21)
+        it.jvmTarget.set(JvmTarget.JVM_25)
     }
 }
 

--- a/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/StateTransitionMetricsTest.java
+++ b/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/StateTransitionMetricsTest.java
@@ -31,7 +31,7 @@ import java.time.Duration;
 import java.util.SortedMap;
 import java.util.concurrent.TimeUnit;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 

--- a/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/TimerTest.java
+++ b/resilience4j-metrics/src/test/java/io/github/resilience4j/metrics/TimerTest.java
@@ -36,10 +36,10 @@ import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import static com.jayway.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
@@ -140,7 +140,7 @@ public class TimerTest {
         String value = stringCompletionStage.toCompletableFuture().get();
         assertThat(value).isEqualTo("Hello world");
         await().atMost(1, SECONDS)
-            .until(() -> {
+            .untilAsserted(() -> {
                 assertThat(timer.getMetrics().getNumberOfTotalCalls()).isEqualTo(1);
                 assertThat(timer.getMetrics().getNumberOfSuccessfulCalls()).isEqualTo(1);
                 assertThat(timer.getMetrics().getNumberOfFailedCalls()).isZero();

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/ObservationsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/ObservationsTest.java
@@ -18,7 +18,6 @@
  */
 package io.github.resilience4j.micrometer;
 
-import com.jayway.awaitility.Awaitility;
 import io.github.resilience4j.core.functions.CheckedFunction;
 import io.github.resilience4j.core.functions.CheckedRunnable;
 import io.github.resilience4j.core.functions.CheckedSupplier;
@@ -27,6 +26,7 @@ import io.github.resilience4j.test.HelloWorldService;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.tck.TestObservationRegistry;
 import io.vavr.control.Try;
+import org.awaitility.Awaitility;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,11 +34,11 @@ import java.util.concurrent.*;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import static com.jayway.awaitility.Awaitility.await;
 import static io.micrometer.observation.tck.TestObservationRegistryAssert.assertThat;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
@@ -127,7 +127,7 @@ public class ObservationsTest {
         String value = stringCompletionStage.toCompletableFuture().get();
         assertThat(value).isEqualTo("Hello world");
         await().atMost(1, SECONDS)
-            .until(() -> {
+            .untilAsserted(() -> {
                 assertThatObservationWasStartedAndFinishedWithoutErrors();
             });
         then(helloWorldService).should(times(1)).returnHelloWorld();
@@ -164,7 +164,7 @@ public class ObservationsTest {
             .isInstanceOf(ExecutionException.class).hasCause(new HelloWorldException());
 
         Awaitility.await()
-            .until(() -> assertThat(observationRegistry)
+            .untilAsserted(() -> assertThat(observationRegistry)
                 .hasSingleObservationThat()
                 .hasNameEqualTo(ObservationsTest.class.getName())
                 .hasBeenStarted()

--- a/resilience4j-micronaut/build.gradle
+++ b/resilience4j-micronaut/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     testAnnotationProcessor(platform(libs.micronaut.platform))
     testAnnotationProcessor(project(":resilience4j-micronaut-annotation"))
 
+    // Force Groovy 4.0.30 (ASM 9.8) to read JDK 25 bytecode during compileTestGroovy.
+    testImplementation(enforcedPlatform(libs.groovy.bom))
+
     testCompileOnly(project(":resilience4j-micronaut-annotation"))
 
     testImplementation(project(":resilience4j-bulkhead"))

--- a/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/RateLimiterTest.java
+++ b/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/RateLimiterTest.java
@@ -26,7 +26,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.time.Duration;
-import java.util.concurrent.Future;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -35,11 +34,11 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import static com.jayway.awaitility.Awaitility.await;
 import static io.vavr.API.*;
 import static io.vavr.Predicates.instanceOf;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;

--- a/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/AtomicRateLimiterTest.java
+++ b/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/AtomicRateLimiterTest.java
@@ -18,9 +18,9 @@
  */
 package io.github.resilience4j.ratelimiter.internal;
 
-import com.jayway.awaitility.core.ConditionFactory;
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
+import org.awaitility.core.ConditionFactory;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -31,9 +31,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static com.jayway.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.BDDAssertions.then;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;

--- a/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/RateLimitersImplementationTest.java
+++ b/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/RateLimitersImplementationTest.java
@@ -10,9 +10,9 @@ import org.junit.Test;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static com.jayway.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.BDDAssertions.then;
+import static org.awaitility.Awaitility.await;
 
 /**
  * Tests for functions that are common in all implementations should go here.

--- a/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/SemaphoreBasedRateLimiterImplTest.java
+++ b/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/SemaphoreBasedRateLimiterImplTest.java
@@ -18,10 +18,10 @@
  */
 package io.github.resilience4j.ratelimiter.internal;
 
-import com.jayway.awaitility.core.ConditionFactory;
 import io.github.resilience4j.core.ThreadType;
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
+import org.awaitility.core.ConditionFactory;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,11 +36,11 @@ import java.time.Duration;
 import java.util.concurrent.*;
 import java.util.function.Function;
 
-import static com.jayway.awaitility.Awaitility.await;
 import static io.vavr.control.Try.run;
 import static java.lang.Thread.State.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.then;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerAutoConfigurationTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerAutoConfigurationTest.java
@@ -15,7 +15,7 @@
  */
 package io.github.resilience4j.circuitbreaker;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/ratelimiter/RateLimiterAutoConfigurationTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/ratelimiter/RateLimiterAutoConfigurationTest.java
@@ -42,7 +42,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static io.github.resilience4j.service.test.ratelimiter.RateLimiterDummyFeignClient.RATE_LIMITER_FEIGN_CLIENT_NAME;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/timelimiter/TimeLimiterAutoConfigurationTest.java
+++ b/resilience4j-spring-boot2/src/test/java/io/github/resilience4j/timelimiter/TimeLimiterAutoConfigurationTest.java
@@ -23,8 +23,8 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import static com.jayway.awaitility.Awaitility.matches;
-import static com.jayway.awaitility.Awaitility.waitAtMost;
+
+import static org.awaitility.Awaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -113,7 +113,7 @@ public class TimeLimiterAutoConfigurationTest {
             return null;
         });
 
-        waitAtMost(3, TimeUnit.SECONDS).until(matches(() ->
+        await().atMost(3, TimeUnit.SECONDS).untilAsserted(() ->
             assertThat(future).isCompletedWithValue("ValueShouldCrossThreadBoundary")));
 
         TimeLimiterEventsEndpointResponse timeLimiterEventList = timeLimiterEvents("/actuator/timelimiterevents");
@@ -151,7 +151,7 @@ public class TimeLimiterAutoConfigurationTest {
             return null;
         });
 
-        waitAtMost(3, TimeUnit.SECONDS).until(matches(() ->
+        await().atMost(3, TimeUnit.SECONDS).untilAsserted(() ->
             assertThat(future).isCompletedWithValue("ValueShouldCrossThreadBoundary")));
 
         TimeLimiterEventsEndpointResponse timeLimiterEventList = timeLimiterEvents("/actuator/timelimiterevents");

--- a/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/bulkhead/BulkheadAutoConfigurationTest.java
+++ b/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/bulkhead/BulkheadAutoConfigurationTest.java
@@ -15,25 +15,25 @@
  */
 package io.github.resilience4j.springboot3.bulkhead;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.util.ReflectionTestUtils.getField;
-
-import java.time.Duration;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-
 import io.github.resilience4j.bulkhead.Bulkhead;
 import io.github.resilience4j.bulkhead.BulkheadRegistry;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkheadRegistry;
-import org.apache.commons.lang3.StringUtils;
+import io.github.resilience4j.common.CompositeCustomizer;
+import io.github.resilience4j.common.bulkhead.configuration.BulkheadConfigCustomizer;
+import io.github.resilience4j.common.bulkhead.configuration.ThreadPoolBulkheadConfigCustomizer;
+import io.github.resilience4j.common.bulkhead.monitoring.endpoint.BulkheadEndpointResponse;
+import io.github.resilience4j.springboot3.TestThreadLocalContextPropagator;
+import io.github.resilience4j.springboot3.TestThreadLocalContextPropagator.TestThreadLocalContextHolder;
+import io.github.resilience4j.springboot3.bulkhead.autoconfigure.BulkheadProperties;
+import io.github.resilience4j.springboot3.bulkhead.autoconfigure.ThreadPoolBulkheadProperties;
+import io.github.resilience4j.springboot3.service.test.BeanContextPropagator;
+import io.github.resilience4j.springboot3.service.test.DummyFeignClient;
+import io.github.resilience4j.springboot3.service.test.TestApplication;
+import io.github.resilience4j.springboot3.service.test.bulkhead.BulkheadDummyService;
+import io.github.resilience4j.springboot3.service.test.bulkhead.BulkheadReactiveDummyService;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,19 +43,16 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import io.github.resilience4j.springboot3.TestThreadLocalContextPropagator;
-import io.github.resilience4j.springboot3.TestThreadLocalContextPropagator.TestThreadLocalContextHolder;
-import io.github.resilience4j.springboot3.bulkhead.autoconfigure.BulkheadProperties;
-import io.github.resilience4j.springboot3.bulkhead.autoconfigure.ThreadPoolBulkheadProperties;
-import io.github.resilience4j.common.CompositeCustomizer;
-import io.github.resilience4j.common.bulkhead.configuration.BulkheadConfigCustomizer;
-import io.github.resilience4j.common.bulkhead.configuration.ThreadPoolBulkheadConfigCustomizer;
-import io.github.resilience4j.common.bulkhead.monitoring.endpoint.BulkheadEndpointResponse;
-import io.github.resilience4j.springboot3.service.test.BeanContextPropagator;
-import io.github.resilience4j.springboot3.service.test.DummyFeignClient;
-import io.github.resilience4j.springboot3.service.test.TestApplication;
-import io.github.resilience4j.springboot3.service.test.bulkhead.BulkheadDummyService;
-import io.github.resilience4j.springboot3.service.test.bulkhead.BulkheadReactiveDummyService;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
@@ -151,7 +148,7 @@ public class BulkheadAutoConfigurationTest {
         bulkhead.getEventPublisher().onCallPermitted(event -> permitted.incrementAndGet());
         bulkhead.getEventPublisher().onCallRejected(event -> rejected.incrementAndGet());
 
-        dummyFeignClient.doSomething(StringUtils.EMPTY);
+        dummyFeignClient.doSomething("");
 
         ResponseEntity<BulkheadEndpointResponse> bulkheadList = restTemplate
             .getForEntity("/actuator/bulkheads", BulkheadEndpointResponse.class);

--- a/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/circuitbreaker/CircuitBreakerAutoConfigurationTest.java
+++ b/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/circuitbreaker/CircuitBreakerAutoConfigurationTest.java
@@ -19,13 +19,12 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
-import io.github.resilience4j.springboot3.circuitbreaker.autoconfigure.CircuitBreakerProperties;
-import io.github.resilience4j.spring6.circuitbreaker.configure.CircuitBreakerAspect;
 import io.github.resilience4j.common.circuitbreaker.monitoring.endpoint.CircuitBreakerEventDTO;
 import io.github.resilience4j.common.circuitbreaker.monitoring.endpoint.CircuitBreakerEventsEndpointResponse;
+import io.github.resilience4j.spring6.circuitbreaker.configure.CircuitBreakerAspect;
+import io.github.resilience4j.springboot3.circuitbreaker.autoconfigure.CircuitBreakerProperties;
 import io.github.resilience4j.springboot3.service.test.DummyService;
 import io.github.resilience4j.springboot3.service.test.TestApplication;
-import org.apache.http.HttpStatus;
 import org.assertj.core.api.Assertions;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,6 +32,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -41,9 +41,9 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static com.jayway.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.equalTo;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -171,7 +171,7 @@ public class CircuitBreakerAutoConfigurationTest {
     }
 
     private void verifyCircuitBreakerAutoConfiguration(CircuitBreaker circuitBreaker) {
-        int ok=HttpStatus.SC_OK;
+        int ok=HttpStatus.OK.value();
         assertThat(circuitBreaker).isNotNull();
         // expect CircuitBreaker is configured as defined in application.yml
         assertThat(circuitBreaker.getCircuitBreakerConfig().getSlidingWindowSize()).isEqualTo(6);

--- a/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/circuitbreaker/CircuitBreakerFeignTest.java
+++ b/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/circuitbreaker/CircuitBreakerFeignTest.java
@@ -21,7 +21,6 @@ import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.springboot3.service.test.DummyFeignClient;
 import io.github.resilience4j.springboot3.service.test.TestApplication;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -67,8 +66,8 @@ public class CircuitBreakerFeignTest {
         } catch (Exception e) {
             // Ignore the error, we want to increase the error counts
         }
-        dummyFeignClient.doSomething(StringUtils.EMPTY);
-        dummyFeignClient.doSomething(StringUtils.EMPTY);
+        dummyFeignClient.doSomething("");
+        dummyFeignClient.doSomething("");
 
         CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("dummyFeignClient");
         assertThat(circuitBreaker).isNotNull();

--- a/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/circuitbreaker/RecordResultPredicate.java
+++ b/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/circuitbreaker/RecordResultPredicate.java
@@ -1,7 +1,5 @@
 package io.github.resilience4j.springboot3.circuitbreaker;
 
-import org.apache.http.HttpStatus;
-
 import java.util.function.Predicate;
 
 public class RecordResultPredicate implements Predicate<Object> {

--- a/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/ratelimiter/RateLimiterAutoConfigurationTest.java
+++ b/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/ratelimiter/RateLimiterAutoConfigurationTest.java
@@ -23,9 +23,9 @@ import io.github.resilience4j.common.ratelimiter.monitoring.endpoint.RateLimiter
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
 import io.github.resilience4j.ratelimiter.RequestNotPermitted;
-import io.github.resilience4j.springboot3.ratelimiter.autoconfigure.RateLimiterProperties;
-import io.github.resilience4j.spring6.ratelimiter.configure.RateLimiterAspect;
 import io.github.resilience4j.ratelimiter.event.RateLimiterEvent;
+import io.github.resilience4j.spring6.ratelimiter.configure.RateLimiterAspect;
+import io.github.resilience4j.springboot3.ratelimiter.autoconfigure.RateLimiterProperties;
 import io.github.resilience4j.springboot3.service.test.DummyService;
 import io.github.resilience4j.springboot3.service.test.TestApplication;
 import io.github.resilience4j.springboot3.service.test.ratelimiter.RateLimiterDummyFeignClient;
@@ -43,10 +43,9 @@ import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static com.jayway.awaitility.Awaitility.await;
 import static io.github.resilience4j.springboot3.service.test.ratelimiter.RateLimiterDummyFeignClient.RATE_LIMITER_FEIGN_CLIENT_NAME;
-import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
@@ -97,7 +96,7 @@ public class RateLimiterAutoConfigurationTest {
         } catch (Exception ex) {
             // Do nothing.
         }
-        rateLimiterDummyFeignClient.doSomething(EMPTY);
+        rateLimiterDummyFeignClient.doSomething("");
 
         assertThat(rateLimiter.getMetrics().getAvailablePermissions()).isEqualTo(8);
         assertThat(rateLimiter.getMetrics().getNumberOfWaitingThreads()).isZero();
@@ -119,7 +118,7 @@ public class RateLimiterAutoConfigurationTest {
 
         try {
             for (int i = 0; i < 11; i++) {
-                rateLimiterDummyFeignClient.doSomething(EMPTY);
+                rateLimiterDummyFeignClient.doSomething("");
             }
         } catch (RequestNotPermitted e) {
             // Do nothing

--- a/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/retry/RetryAutoConfigurationTest.java
+++ b/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/retry/RetryAutoConfigurationTest.java
@@ -17,18 +17,17 @@ package io.github.resilience4j.springboot3.retry;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import io.github.resilience4j.springboot3.circuitbreaker.IgnoredException;
 import io.github.resilience4j.common.retry.monitoring.endpoint.RetryEndpointResponse;
 import io.github.resilience4j.common.retry.monitoring.endpoint.RetryEventsEndpointResponse;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryRegistry;
-import io.github.resilience4j.springboot3.retry.autoconfigure.RetryProperties;
 import io.github.resilience4j.spring6.retry.configure.RetryAspect;
+import io.github.resilience4j.springboot3.circuitbreaker.IgnoredException;
+import io.github.resilience4j.springboot3.retry.autoconfigure.RetryProperties;
 import io.github.resilience4j.springboot3.service.test.TestApplication;
+import io.github.resilience4j.springboot3.service.test.retry.ReactiveRetryDummyService;
 import io.github.resilience4j.springboot3.service.test.retry.RetryDummyFeignClient;
 import io.github.resilience4j.springboot3.service.test.retry.RetryDummyService;
-import io.github.resilience4j.springboot3.service.test.retry.ReactiveRetryDummyService;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -90,7 +89,7 @@ public class RetryAutoConfigurationTest {
             // Do nothing. The IOException is recorded by the retry as it is one of failure exceptions
         }
         // The invocation is recorded by the CircuitBreaker as a success.
-        retryDummyFeignClient.doSomething(StringUtils.EMPTY);
+        retryDummyFeignClient.doSomething("");
 
         Retry retry = retryRegistry.retry(RetryDummyFeignClient.RETRY_DUMMY_FEIGN_CLIENT_NAME);
         assertThat(retry).isNotNull();

--- a/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/timelimiter/TimeLimiterAutoConfigurationTest.java
+++ b/resilience4j-spring-boot3/src/test/java/io/github/resilience4j/springboot3/timelimiter/TimeLimiterAutoConfigurationTest.java
@@ -4,11 +4,11 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.github.resilience4j.common.CompositeCustomizer;
 import io.github.resilience4j.common.timelimiter.configuration.TimeLimiterConfigCustomizer;
 import io.github.resilience4j.common.timelimiter.monitoring.endpoint.TimeLimiterEventsEndpointResponse;
+import io.github.resilience4j.spring6.timelimiter.configure.TimeLimiterAspect;
 import io.github.resilience4j.springboot3.service.test.DummyService;
 import io.github.resilience4j.springboot3.service.test.TestApplication;
-import io.github.resilience4j.test.TestContextPropagators.TestThreadLocalContextPropagatorWithHolder.TestThreadLocalContextHolder;
 import io.github.resilience4j.springboot3.timelimiter.autoconfigure.TimeLimiterProperties;
-import io.github.resilience4j.spring6.timelimiter.configure.TimeLimiterAspect;
+import io.github.resilience4j.test.TestContextPropagators.TestThreadLocalContextPropagatorWithHolder.TestThreadLocalContextHolder;
 import io.github.resilience4j.timelimiter.TimeLimiter;
 import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
 import org.junit.Rule;
@@ -25,9 +25,8 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import static com.jayway.awaitility.Awaitility.matches;
-import static com.jayway.awaitility.Awaitility.waitAtMost;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
@@ -115,8 +114,8 @@ public class TimeLimiterAutoConfigurationTest {
             return null;
         });
 
-        waitAtMost(3, TimeUnit.SECONDS).until(matches(() ->
-            assertThat(future).isCompletedWithValue("ValueShouldCrossThreadBoundary")));
+        await().atMost(3, TimeUnit.SECONDS).untilAsserted(() ->
+            assertThat(future).isCompletedWithValue("ValueShouldCrossThreadBoundary"));
 
         TimeLimiterEventsEndpointResponse timeLimiterEventList = timeLimiterEvents("/actuator/timelimiterevents");
         assertThat(timeLimiterEventList.getTimeLimiterEvents())
@@ -153,8 +152,8 @@ public class TimeLimiterAutoConfigurationTest {
             return null;
         });
 
-        waitAtMost(3, TimeUnit.SECONDS).until(matches(() ->
-            assertThat(future).isCompletedWithValue("ValueShouldCrossThreadBoundary")));
+        await().atMost(3, TimeUnit.SECONDS).untilAsserted(() ->
+            assertThat(future).isCompletedWithValue("ValueShouldCrossThreadBoundary"));
 
         TimeLimiterEventsEndpointResponse timeLimiterEventList = timeLimiterEvents("/actuator/timelimiterevents");
         assertThat(timeLimiterEventList.getTimeLimiterEvents())


### PR DESCRIPTION
Issue #2343

## Background

Resilience4j 3.x upgraded to JDK 21 to support virtual threads. However, on JDK 21–24, virtual threads could get **pinned** to their carrier thread when executing inside a `synchronized` block. To work around this, `InMemoryRegistryStore` adopted a `FutureHashMap`-style pattern that was significantly more complex than the original `ConcurrentHashMap.computeIfAbsent()` implementation.

**JDK 25 ships [JEP 491 (Synchronize Virtual Threads without Pinning)](https://openjdk.org/jeps/491)**, which eliminates that restriction. At the same time, **[JEP 506 (Scoped Values)](https://openjdk.org/jeps/506)** is promoted to a permanent feature, offering a more efficient alternative to `ThreadLocal` for context propagation. This PR raises the project baseline to JDK 25 so that we can actually take advantage of both JEPs.

## Changes

### 1. Toolchain / Dependency Upgrades

| Item | Before | After | Reason |
|------|--------|-------|--------|
| `sourceCompatibility` / `targetCompatibility` | `VERSION_21` | `VERSION_25` | Use JEP 491/506 |
| Gradle Wrapper | 8.10 | **9.2.1** | Official JDK 25 support |
| GitHub Actions JDK | 21 | **25** | Build on 25 in CI |
| Kotlin JVM plugin | 2.1.21 | **2.3.0** | Supports `JvmTarget.JVM_25` |
| `org.sonarqube` | 3.5.0.2730 | 6.0.1.5171 | Gradle 9.x compatibility |
| `org.asciidoctor.jvm.convert` | 2.4.0 | 4.0.4 | Gradle 9.x compatibility |
| `org.gradle.test-retry` | 1.5.10 | **1.6.4** | Bundled ASM 9.9 — without this the plugin crashes with `Unsupported class file major version 69` when parsing Java 25 test classes |
| `me.champeau.jmh` | 0.6.8 | 0.7.3 | Gradle 9.x compatibility |
| `org.mockito:mockito-core` / `mockito-junit-jupiter` | 5.16.1 | **5.23.0** | 5.16.1 inline mock maker (ByteBuddy) fails on JDK 25 with `Could not modify all classes`; 5.23.0 includes the JDK 25 fixes |
| `spring6` | 6.1.1 | **6.2.18** | Spring 6.1.x bundles an older ASM repackage that cannot parse class file major version 69 (JDK 25), causing test-time component scanning of `resilience4j-spring6` classes to fail; 6.2.x bundles ASM 9.8 and 6.2.x is the final 6.x feature branch with JDK 25 as an LTS target |
| `spring-boot3` | 3.2.0 | **3.5.13** | Shares the Spring 6.1.x ASM issue via `spring-context`; Spring Boot officially supports JDK 25 from **3.5.5** (3.5.13 is the latest patch) |
| `spring-cloud3` | 3.1.5 | **4.3.2** | Spring Cloud release train matched to Spring Boot 3.5 is **2025.0 (Northfields)**; individual artifacts (`spring-cloud-context`, `spring-cloud-openfeign-*`) are at 4.3.x |

### 2. JEP 491 — Simplified `InMemoryRegistryStore`

Removed the `FutureHashMap(CompletableFuture<E>)` wrapping that was only there to avoid virtual-thread pinning, and restored the straightforward `ConcurrentHashMap<String, E>` + `computeIfAbsent()` implementation.

**Before (JDK 21–24):**

```java
private final ConcurrentHashMap<String, CompletableFuture<E>> entryMap;

// Winner/Loser pattern so mappingFunction runs outside the map lock
CompletableFuture<E> created = new CompletableFuture<>();
CompletableFuture<E> future = entryMap.putIfAbsent(key, created);
if (future == null) {
    try {
        E value = mappingFunction.apply(key);
        future.complete(value);
    } catch (Throwable t) { ... }
}
return future.join();
```

**After (JDK 25):**

```java
private final ConcurrentHashMap<String, E> entryMap;

// JEP 491: synchronized / computeIfAbsent no longer pins virtual threads
return entryMap.computeIfAbsent(key, mappingFunction);
```

`putIfAbsent`, `remove`, `replace`, and `values` have all been simplified to direct calls without any `CompletableFuture` wrapping. Net deletion: **~102 lines**.

### 3. JEP 506 — Scoped Values Based Context Propagator

The existing `ThreadLocal`-based `ContextPropagator` carried non-trivial overhead in virtual-thread environments (per-thread storage cost, plus the historical pinning concern). Two new types are added as a modern alternative:

* **`ScopedValuePropagator<T>`** — propagates a single `ScopedValue<T>` via the `ContextPropagator<T>` interface.
* **`ScopedValueContext`** — captures multiple `ScopedValuePropagator`s into one scope and exposes `runWithContext(Runnable)` / `callWithContext(Callable)`.

Example usage:

```java
private static final ScopedValue<String> REQUEST_ID = ScopedValue.newInstance();
ScopedValuePropagator<String> p = ScopedValuePropagator.of(REQUEST_ID);

ThreadPoolBulkheadConfig config = ThreadPoolBulkheadConfig.custom()
    .contextPropagator(p)
    .build();

ScopedValue.where(REQUEST_ID, "req-123").run(() ->
    bulkhead.executeSupplier(() -> doWork(p.getCapturedValue().orElse("")))
);
```

Accompanying tests — `ScopedValuePropagatorTest`, `ScopedValueContextTest`, and `ScopedValueBulkheadIntegrationTest` — are added (~1,300 lines total).

### 4. Misc

* Added `kotlin.jvm.target.validation.mode=IGNORE` to `gradle.properties`. Kotlin 2.3.0 supports `JvmTarget.JVM_25`, but strict validation is too aggressive when Kotlin code is consumed by mixed-JVM-target modules in this multi-module build.
* A handful of tests were reworked around `ThreadModeTestBase` so they run parameterized across platform and virtual threads.

### 5. Review Follow-ups

Two review findings on the initial commit were addressed in a follow-up:

* **`ScopedValuePropagator.retrieve()` fallback** — the original `retrieve()` only checked `scopedValue.isBound()`, so once a decorated task ran on a worker thread (where the real `ScopedValue` is never re-bound — `copy()` only writes to a per-thread capture map), any _second_ decoration on that worker thread would read `Optional.empty()` and silently drop the value. `retrieve()` now falls back to the capture map when `isBound()` is false, so multi-hop propagation works. A new test `shouldPropagateValueAcrossMultipleAsyncHops` covers the regression.
* **`AbstractRegistry.computeIfAbsent` event emission** — the simplified `InMemoryRegistryStore.computeIfAbsent` exposed a latent issue where `EntryAddedEvent` was published _inside_ the CHM mapping function. A consumer that recursively added another entry (especially one hashing to the same bin) would trip `ConcurrentHashMap`'s recursive-update detection (`IllegalStateException`). The event is now emitted _after_ the CHM call returns, gated by an `AtomicBoolean` that records whether the mapping function actually ran. A new test `shouldAllowRecursiveRegistrationFromEntryAddedConsumer` covers this. The JEP 491 simplification in `InMemoryRegistryStore` is preserved.

## Known Limitations

* **JaCoCo coverage report temporarily disabled**: JaCoCo 0.8.12 does not yet understand class file major version 69 (Java 25). `jacocoTestReport` and `testCodeCoverageReport` are set to `enabled = false` and will be re-enabled once an upstream JaCoCo release adds Java 25 support. **Tests themselves still execute normally.**
* **Gradle 9.2.1 shutdown NPE**: On JDK 25 + Gradle 9.2.1 we occasionally see an NPE in `GroupingProgressLogEventGenerator.bufferOutput()`. This is an internal Gradle logging-subsystem cleanup bug and does not affect test outcomes. Raw results are still written to `build/test-results/test/*.xml`. Expected to be fixed in Gradle 9.3+. (Note: this is a separate issue from the test-retry ASM crash, which is resolved by the 1.6.4 bump in the table above.)

## Migration / Compatibility

* **Consumer impact**: applications using Resilience4j as a library will now require **JDK 25 or later**.
* **No API breakage**: existing `ContextPropagator`-based `ThreadLocal` code continues to work unchanged. `ScopedValuePropagator` is strictly **additive**.
* **Behavioral compatibility**: the `InMemoryRegistryStore` simplification does not change its externally observable contract (register / find / remove semantics).
* **Spring baseline bumps are test-scope only**: the `spring6` / `spring-boot3` / `spring-cloud3` version upgrades are declared in `compileOnly` and `testImplementation` dependency scopes in the affected modules. Downstream applications do NOT need to upgrade their Spring Framework / Spring Boot / Spring Cloud to the new versions; they only need to continue meeting the modules' existing `compileOnly` contracts (Spring 6.x for `resilience4j-spring6`, Spring Boot 3.x for `resilience4j-spring-boot3`).

## References

* Issue [Bump up from JDK 21 to 25 to avoid virtual thread pinned issue #2343](https://github.com/resilience4j/resilience4j/issues/2343)
* [JEP 491: Synchronize Virtual Threads without Pinning](https://openjdk.org/jeps/491)
* [JEP 506: Scoped Values](https://openjdk.org/jeps/506)
* Preceding virtual thread PR: [Feature #2224 : Apply virtual thread #2335](https://github.com/resilience4j/resilience4j/pull/2335) (already merged into master)

