### PR TITLE
Issue #2453: Added Gradle Java Toolchain support for Java 21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,13 @@ nexusPublishing {
 
 configure(project.coreProjects) {
     apply plugin: "java"
+
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(21)
+        }
+    }
+
     apply plugin: "java-library"
     apply plugin: "maven-publish"
     apply plugin: "signing"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.8.0")
+}
+
 buildCache {
     local { enabled = true }
 }


### PR DESCRIPTION
Closes #2453

What changed? Added Gradle Java Toolchain configuration and the Foojay resolver to automatically provision JDK 21.

Why? Resilience4j v3 requires Java 21. Currently, if a contributor's local JAVA_HOME is set to Java 17, the build immediately fails with invalid source release: 21. By configuring Toolchains, Gradle will automatically download and use the correct JDK under the hood. This drastically improves the developer experience and lowers the barrier to entry for new contributors by providing a zero-setup build environment.

How?
Added org.gradle.toolchains.foojay-resolver-convention to settings.gradle.
Added toolchain { languageVersion = JavaLanguageVersion.of(21) } to coreProjects in build.gradle.