### PR TITLE
Fix AspectJ ambiguous binding in pointcuts (Closes #2230)

### DIFF
--- a/resilience4j-spring/src/main/java/io/github/resilience4j/bulkhead/configure/BulkheadAspect.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/bulkhead/configure/BulkheadAspect.java
@@ -94,18 +94,15 @@ public class BulkheadAspect implements Ordered {
         this.spelResolver = spelResolver;
     }
 
-    @Pointcut(value = "@within(Bulkhead) || @annotation(Bulkhead)", argNames = "Bulkhead")
-    public void matchAnnotatedClassOrMethod(Bulkhead Bulkhead) {
+    @Pointcut(value = "@within(io.github.resilience4j.bulkhead.annotation.Bulkhead) || @annotation(io.github.resilience4j.bulkhead.annotation.Bulkhead)")
+    public void matchAnnotatedClassOrMethod() {
     }
 
-    @Around(value = "matchAnnotatedClassOrMethod(bulkheadAnnotation)", argNames = "proceedingJoinPoint, bulkheadAnnotation")
-    public Object bulkheadAroundAdvice(ProceedingJoinPoint proceedingJoinPoint,
-        @Nullable Bulkhead bulkheadAnnotation) throws Throwable {
+    @Around(value = "matchAnnotatedClassOrMethod()", argNames = "proceedingJoinPoint")
+    public Object bulkheadAroundAdvice(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
         Method method = ((MethodSignature) proceedingJoinPoint.getSignature()).getMethod();
         String methodName = method.getDeclaringClass().getName() + "#" + method.getName();
-        if (bulkheadAnnotation == null) {
-            bulkheadAnnotation = getBulkheadAnnotation(proceedingJoinPoint);
-        }
+        Bulkhead bulkheadAnnotation = getBulkheadAnnotation(proceedingJoinPoint);
         if (bulkheadAnnotation == null) { //because annotations wasn't found
             return proceedingJoinPoint.proceed();
         }

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/circuitbreaker/configure/CircuitBreakerAspect.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/circuitbreaker/configure/CircuitBreakerAspect.java
@@ -87,18 +87,15 @@ public class CircuitBreakerAspect implements Ordered {
         this.spelResolver = spelResolver;
     }
 
-    @Pointcut(value = "@within(circuitBreaker) || @annotation(circuitBreaker)", argNames = "circuitBreaker")
-    public void matchAnnotatedClassOrMethod(CircuitBreaker circuitBreaker) {
+    @Pointcut(value = "@within(io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker) || @annotation(io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker)")
+    public void matchAnnotatedClassOrMethod() {
     }
 
-    @Around(value = "matchAnnotatedClassOrMethod(circuitBreakerAnnotation)", argNames = "proceedingJoinPoint, circuitBreakerAnnotation")
-    public Object circuitBreakerAroundAdvice(ProceedingJoinPoint proceedingJoinPoint,
-        @Nullable CircuitBreaker circuitBreakerAnnotation) throws Throwable {
+    @Around(value = "matchAnnotatedClassOrMethod()", argNames = "proceedingJoinPoint")
+    public Object circuitBreakerAroundAdvice(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
         Method method = ((MethodSignature) proceedingJoinPoint.getSignature()).getMethod();
         String methodName = method.getDeclaringClass().getName() + "#" + method.getName();
-        if (circuitBreakerAnnotation == null) {
-            circuitBreakerAnnotation = getCircuitBreakerAnnotation(proceedingJoinPoint);
-        }
+        CircuitBreaker circuitBreakerAnnotation = getCircuitBreakerAnnotation(proceedingJoinPoint);
         if (circuitBreakerAnnotation == null) { //because annotations wasn't found
             return proceedingJoinPoint.proceed();
         }

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/ratelimiter/configure/RateLimiterAspect.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/ratelimiter/configure/RateLimiterAspect.java
@@ -97,14 +97,11 @@ public class RateLimiterAspect implements Ordered {
         // Method used as pointcut
     }
 
-    @Around(value = "matchAnnotatedClassOrMethod(rateLimiterAnnotation)", argNames = "proceedingJoinPoint, rateLimiterAnnotation")
-    public Object rateLimiterAroundAdvice(ProceedingJoinPoint proceedingJoinPoint,
-        @Nullable RateLimiter rateLimiterAnnotation) throws Throwable {
+    @Around(value = "matchAnnotatedClassOrMethod()", argNames = "proceedingJoinPoint")
+    public Object rateLimiterAroundAdvice(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
         Method method = ((MethodSignature) proceedingJoinPoint.getSignature()).getMethod();
         String methodName = method.getDeclaringClass().getName() + "#" + method.getName();
-        if (rateLimiterAnnotation == null) {
-            rateLimiterAnnotation = getRateLimiterAnnotation(proceedingJoinPoint);
-        }
+        RateLimiter rateLimiterAnnotation = getRateLimiterAnnotation(proceedingJoinPoint);
         if (rateLimiterAnnotation == null) { //because annotations wasn't found
             return proceedingJoinPoint.proceed();
         }

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/retry/configure/RetryAspect.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/retry/configure/RetryAspect.java
@@ -96,18 +96,15 @@ public class RetryAspect implements Ordered, AutoCloseable {
             Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
     }
 
-    @Pointcut(value = "@within(retry) || @annotation(retry)", argNames = "retry")
-    public void matchAnnotatedClassOrMethod(Retry retry) {
+    @Pointcut(value = "@within(io.github.resilience4j.retry.annotation.Retry) || @annotation(io.github.resilience4j.retry.annotation.Retry)")
+    public void matchAnnotatedClassOrMethod() {
     }
 
-    @Around(value = "matchAnnotatedClassOrMethod(retryAnnotation)", argNames = "proceedingJoinPoint, retryAnnotation")
-    public Object retryAroundAdvice(ProceedingJoinPoint proceedingJoinPoint,
-        @Nullable Retry retryAnnotation) throws Throwable {
+    @Around(value = "matchAnnotatedClassOrMethod()", argNames = "proceedingJoinPoint")
+    public Object retryAroundAdvice(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
         Method method = ((MethodSignature) proceedingJoinPoint.getSignature()).getMethod();
         String methodName = method.getDeclaringClass().getName() + "#" + method.getName();
-        if (retryAnnotation == null) {
-            retryAnnotation = getRetryAnnotation(proceedingJoinPoint);
-        }
+        Retry retryAnnotation = getRetryAnnotation(proceedingJoinPoint);
         if (retryAnnotation == null) { //because annotations wasn't found
             return proceedingJoinPoint.proceed();
         }

--- a/resilience4j-spring/src/main/java/io/github/resilience4j/timelimiter/configure/TimeLimiterAspect.java
+++ b/resilience4j-spring/src/main/java/io/github/resilience4j/timelimiter/configure/TimeLimiterAspect.java
@@ -67,19 +67,15 @@ public class TimeLimiterAspect implements Ordered, AutoCloseable {
             Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
     }
 
-    @Pointcut(value = "@within(timeLimiter) || @annotation(timeLimiter)", argNames = "timeLimiter")
-    public void matchAnnotatedClassOrMethod(TimeLimiter timeLimiter) {
-        // a marker method
+    @Pointcut(value = "@within(io.github.resilience4j.timelimiter.annotation.TimeLimiter) || @annotation(io.github.resilience4j.timelimiter.annotation.TimeLimiter)")
+    public void matchAnnotatedClassOrMethod() {
     }
 
-    @Around(value = "matchAnnotatedClassOrMethod(timeLimiterAnnotation)", argNames = "proceedingJoinPoint, timeLimiterAnnotation")
-    public Object timeLimiterAroundAdvice(ProceedingJoinPoint proceedingJoinPoint,
-        @Nullable TimeLimiter timeLimiterAnnotation) throws Throwable {
+    @Around(value = "matchAnnotatedClassOrMethod()", argNames = "proceedingJoinPoint")
+    public Object timeLimiterAroundAdvice(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
         Method method = ((MethodSignature) proceedingJoinPoint.getSignature()).getMethod();
         String methodName = method.getDeclaringClass().getName() + "#" + method.getName();
-        if (timeLimiterAnnotation == null) {
-            timeLimiterAnnotation = getTimeLimiterAnnotation(proceedingJoinPoint);
-        }
+        TimeLimiter timeLimiterAnnotation = getTimeLimiterAnnotation(proceedingJoinPoint);
         if(timeLimiterAnnotation == null) {
             return proceedingJoinPoint.proceed();
         }

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/bulkhead/configure/BulkheadAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/bulkhead/configure/BulkheadAspect.java
@@ -95,18 +95,15 @@ public class BulkheadAspect implements Ordered {
         this.spelResolver = spelResolver;
     }
 
-    @Pointcut(value = "@within(Bulkhead) || @annotation(Bulkhead)", argNames = "Bulkhead")
-    public void matchAnnotatedClassOrMethod(Bulkhead Bulkhead) {
+    @Pointcut(value = "@within(io.github.resilience4j.bulkhead.annotation.Bulkhead) || @annotation(io.github.resilience4j.bulkhead.annotation.Bulkhead)")
+    public void matchAnnotatedClassOrMethod() {
     }
 
-    @Around(value = "matchAnnotatedClassOrMethod(bulkheadAnnotation)", argNames = "proceedingJoinPoint, bulkheadAnnotation")
-    public Object bulkheadAroundAdvice(ProceedingJoinPoint proceedingJoinPoint,
-        @Nullable Bulkhead bulkheadAnnotation) throws Throwable {
+    @Around(value = "matchAnnotatedClassOrMethod()", argNames = "proceedingJoinPoint")
+    public Object bulkheadAroundAdvice(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
         Method method = ((MethodSignature) proceedingJoinPoint.getSignature()).getMethod();
         String methodName = method.getDeclaringClass().getName() + "#" + method.getName();
-        if (bulkheadAnnotation == null) {
-            bulkheadAnnotation = getBulkheadAnnotation(proceedingJoinPoint);
-        }
+        Bulkhead bulkheadAnnotation = getBulkheadAnnotation(proceedingJoinPoint);
         if (bulkheadAnnotation == null) { //because annotations wasn't found
             return proceedingJoinPoint.proceed();
         }

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/circuitbreaker/configure/CircuitBreakerAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/circuitbreaker/configure/CircuitBreakerAspect.java
@@ -87,18 +87,15 @@ public class CircuitBreakerAspect implements Ordered {
         this.spelResolver = spelResolver;
     }
 
-    @Pointcut(value = "@within(circuitBreaker) || @annotation(circuitBreaker)", argNames = "circuitBreaker")
-    public void matchAnnotatedClassOrMethod(CircuitBreaker circuitBreaker) {
+    @Pointcut(value = "@within(io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker) || @annotation(io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker)")
+    public void matchAnnotatedClassOrMethod() {
     }
 
-    @Around(value = "matchAnnotatedClassOrMethod(circuitBreakerAnnotation)", argNames = "proceedingJoinPoint, circuitBreakerAnnotation")
-    public Object circuitBreakerAroundAdvice(ProceedingJoinPoint proceedingJoinPoint,
-        @Nullable CircuitBreaker circuitBreakerAnnotation) throws Throwable {
+    @Around(value = "matchAnnotatedClassOrMethod()", argNames = "proceedingJoinPoint")
+    public Object circuitBreakerAroundAdvice(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
         Method method = ((MethodSignature) proceedingJoinPoint.getSignature()).getMethod();
         String methodName = method.getDeclaringClass().getName() + "#" + method.getName();
-        if (circuitBreakerAnnotation == null) {
-            circuitBreakerAnnotation = getCircuitBreakerAnnotation(proceedingJoinPoint);
-        }
+        CircuitBreaker circuitBreakerAnnotation = getCircuitBreakerAnnotation(proceedingJoinPoint);
         if (circuitBreakerAnnotation == null) { //because annotations wasn't found
             return proceedingJoinPoint.proceed();
         }

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/micrometer/configure/TimerAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/micrometer/configure/TimerAspect.java
@@ -65,18 +65,15 @@ public class TimerAspect implements Ordered {
         this.spelResolver = spelResolver;
     }
 
-    @Pointcut(value = "@within(timer) || @annotation(timer)", argNames = "timer")
-    public void matchAnnotatedClassOrMethod(Timer timer) {
-        // a marker method
+    @Pointcut(value = "@within(io.github.resilience4j.micrometer.annotation.Timer) || @annotation(io.github.resilience4j.micrometer.annotation.Timer)")
+    public void matchAnnotatedClassOrMethod() {
     }
 
-    @Around(value = "matchAnnotatedClassOrMethod(timerAnnotation)", argNames = "proceedingJoinPoint, timerAnnotation")
-    public Object timerAroundAdvice(ProceedingJoinPoint proceedingJoinPoint, @Nullable Timer timerAnnotation) throws Throwable {
+    @Around(value = "matchAnnotatedClassOrMethod()", argNames = "proceedingJoinPoint")
+    public Object timerAroundAdvice(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
         Method method = ((MethodSignature) proceedingJoinPoint.getSignature()).getMethod();
         String methodName = method.getDeclaringClass().getName() + "#" + method.getName();
-        if (timerAnnotation == null) {
-            timerAnnotation = getTimerAnnotation(proceedingJoinPoint);
-        }
+        Timer timerAnnotation = getTimerAnnotation(proceedingJoinPoint);
         if (timerAnnotation == null) {
             return proceedingJoinPoint.proceed();
         }

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/ratelimiter/configure/RateLimiterAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/ratelimiter/configure/RateLimiterAspect.java
@@ -97,14 +97,11 @@ public class RateLimiterAspect implements Ordered {
         // Method used as pointcut
     }
 
-    @Around(value = "matchAnnotatedClassOrMethod(rateLimiterAnnotation)", argNames = "proceedingJoinPoint, rateLimiterAnnotation")
-    public Object rateLimiterAroundAdvice(ProceedingJoinPoint proceedingJoinPoint,
-        @Nullable RateLimiter rateLimiterAnnotation) throws Throwable {
+    @Around(value = "matchAnnotatedClassOrMethod()", argNames = "proceedingJoinPoint")
+    public Object rateLimiterAroundAdvice(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
         Method method = ((MethodSignature) proceedingJoinPoint.getSignature()).getMethod();
         String methodName = method.getDeclaringClass().getName() + "#" + method.getName();
-        if (rateLimiterAnnotation == null) {
-            rateLimiterAnnotation = getRateLimiterAnnotation(proceedingJoinPoint);
-        }
+        RateLimiter rateLimiterAnnotation = getRateLimiterAnnotation(proceedingJoinPoint);
         if (rateLimiterAnnotation == null) { //because annotations wasn't found
             return proceedingJoinPoint.proceed();
         }

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/retry/configure/RetryAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/retry/configure/RetryAspect.java
@@ -96,18 +96,15 @@ public class RetryAspect implements Ordered, AutoCloseable {
             Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
     }
 
-    @Pointcut(value = "@within(retry) || @annotation(retry)", argNames = "retry")
-    public void matchAnnotatedClassOrMethod(Retry retry) {
+    @Pointcut(value = "@within(io.github.resilience4j.retry.annotation.Retry) || @annotation(io.github.resilience4j.retry.annotation.Retry)")
+    public void matchAnnotatedClassOrMethod() {
     }
 
-    @Around(value = "matchAnnotatedClassOrMethod(retryAnnotation)", argNames = "proceedingJoinPoint, retryAnnotation")
-    public Object retryAroundAdvice(ProceedingJoinPoint proceedingJoinPoint,
-        @Nullable Retry retryAnnotation) throws Throwable {
+    @Around(value = "matchAnnotatedClassOrMethod()", argNames = "proceedingJoinPoint")
+    public Object retryAroundAdvice(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
         Method method = ((MethodSignature) proceedingJoinPoint.getSignature()).getMethod();
         String methodName = method.getDeclaringClass().getName() + "#" + method.getName();
-        if (retryAnnotation == null) {
-            retryAnnotation = getRetryAnnotation(proceedingJoinPoint);
-        }
+        Retry retryAnnotation = getRetryAnnotation(proceedingJoinPoint);
         if (retryAnnotation == null) { //because annotations wasn't found
             return proceedingJoinPoint.proceed();
         }

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterAspect.java
@@ -67,19 +67,15 @@ public class TimeLimiterAspect implements Ordered, AutoCloseable {
             Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
     }
 
-    @Pointcut(value = "@within(timeLimiter) || @annotation(timeLimiter)", argNames = "timeLimiter")
-    public void matchAnnotatedClassOrMethod(TimeLimiter timeLimiter) {
-        // a marker method
+    @Pointcut(value = "@within(io.github.resilience4j.timelimiter.annotation.TimeLimiter) || @annotation(io.github.resilience4j.timelimiter.annotation.TimeLimiter)")
+    public void matchAnnotatedClassOrMethod() {
     }
 
-    @Around(value = "matchAnnotatedClassOrMethod(timeLimiterAnnotation)", argNames = "proceedingJoinPoint, timeLimiterAnnotation")
-    public Object timeLimiterAroundAdvice(ProceedingJoinPoint proceedingJoinPoint,
-        @Nullable TimeLimiter timeLimiterAnnotation) throws Throwable {
+    @Around(value = "matchAnnotatedClassOrMethod()", argNames = "proceedingJoinPoint")
+    public Object timeLimiterAroundAdvice(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
         Method method = ((MethodSignature) proceedingJoinPoint.getSignature()).getMethod();
         String methodName = method.getDeclaringClass().getName() + "#" + method.getName();
-        if (timeLimiterAnnotation == null) {
-            timeLimiterAnnotation = getTimeLimiterAnnotation(proceedingJoinPoint);
-        }
+        TimeLimiter timeLimiterAnnotation = getTimeLimiterAnnotation(proceedingJoinPoint);
         if(timeLimiterAnnotation == null) {
             return proceedingJoinPoint.proceed();
         }


### PR DESCRIPTION
Closes #2230

### What this PR does
Fixes an `ambiguous binding` compilation error that occurs when users try to compile Resilience4j aspects using the strict AspectJ compiler (post-compile weaving). 

AspectJ throws a `BCException: Impossible! ambiguous binding` when it encounters an annotation parameter that is bound inside an `||` (OR) pointcut condition, since it cannot uniquely map the parameter across both branches of the logical OR.

### The Fix
Refactored the 10 Spring AOP Aspect files across the `resilience4j-spring` and `resilience4j-spring6` modules:

1. Removed the `argNames` parameter binding from the `@Pointcut` and `@Around` advice signatures.
2. Specified the fully qualified annotation class names directly in the `@within` and `@annotation` clauses to resolve the ambiguity.
3. Relied exclusively on the existing, robust fallback logic (`getAnnotation(proceedingJoinPoint)`) to extract the annotation at runtime.

### Verification
- Tested locally that all code compiles cleanly.
- Verified that all existing Spring AOP tests continue to pass perfectly without the explicit parameter binding.
