### PR TITLE
Feature: Add GenericHedge and its registry

### DIFF
--- a/resilience4j-hedge/src/main/java/io/github/resilience4j/hedge/GenericHedge.java
+++ b/resilience4j-hedge/src/main/java/io/github/resilience4j/hedge/GenericHedge.java
@@ -1,0 +1,170 @@
+package io.github.resilience4j.hedge;
+
+import io.github.resilience4j.hedge.internal.ExecutorServiceHedge;
+import io.github.resilience4j.hedge.internal.HedgeDurationSupplier;
+import io.github.resilience4j.hedge.internal.HedgeImpl;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.*;
+import java.util.function.Supplier;
+
+import static java.util.Collections.emptyMap;
+
+/**
+ * A GenericHedge executes extra requests if the main execution does not return in time.
+ */
+public interface GenericHedge {
+
+    /**
+     * Creates a Hedge with a HedgeConfig configuration.
+     *
+     * @param hedgeConfig the HedgeConfig
+     * @param executorService the executor service
+     * @return The Hedge
+     */
+    static GenericHedge of(SimpleHedgeConfig hedgeConfig, ScheduledExecutorService executorService) {
+        return of(Hedge.DEFAULT_NAME, hedgeConfig, executorService);
+    }
+
+    /**
+     * Creates a Hedge with a HedgeConfig configuration.
+     *
+     * @param name        the name of the Hedge
+     * @param hedgeConfig the HedgeConfig
+     * @param executorService the executor service
+     * @return The Hedge
+     */
+    static GenericHedge of(String name, SimpleHedgeConfig hedgeConfig, ScheduledExecutorService executorService) {
+        return new ExecutorServiceHedge<>(name, emptyMap(), hedgeConfig, executorService);
+    }
+
+    /**
+     * Creates a Hedge with a custom Hedge configuration.
+     * <p>
+     * The {@code tags} passed will be appended to the tags already configured for the registry.
+     * When tags (keys) of the two collide the tags passed with this method will override the tags
+     * of the registry.
+     *
+     * @param name        the name of the Hedge
+     * @param hedgeConfig a custom Hedge configuration
+     * @param tags        tags added to the Hedge
+     * @param executorService the executor service
+     * @return a Hedge with a custom Hedge configuration.
+     */
+    static GenericHedge of(String name, SimpleHedgeConfig hedgeConfig,
+                    Map<String, String> tags, ScheduledExecutorService executorService) {
+        return new ExecutorServiceHedge<>(name, tags, hedgeConfig, executorService);
+    }
+
+    /**
+     * Creates a Hedge decorator with a timeout Duration.
+     *
+     * @param hedgeDuration the timeout Duration
+     * @param executorService the executor service
+     * @return The Hedge
+     */
+    static GenericHedge of(Duration hedgeDuration, ScheduledExecutorService executorService) {
+        SimpleHedgeConfig hedgeConfig = new SimpleHedgeConfig.Builder()
+                .preconfiguredDuration(hedgeDuration)
+                .build();
+        return of(Hedge.DEFAULT_NAME, hedgeConfig, executorService);
+    }
+
+    /**
+     * Creates a CompletableFuture that is enhanced by a Hedge.
+     *
+     * @param callable        the callable to submit
+     * @param executorService the executor service to which you are submitting the callable and hedges.
+     * @param <T>             the type of results supplied by the supplier
+     * @return a CompletableFuture which is resolved by the Hedge
+     */
+    <T> CompletableFuture<T> submit(Callable<T> callable, ExecutorService executorService);
+
+    /**
+     * Returns the name of this Hedge.
+     *
+     * @return the name of this Hedge
+     */
+    String getName();
+
+    /**
+     * Returns an unmodifiable map with tags assigned to this Hedge.
+     *
+     * @return the tags assigned to this Hedge in an unmodifiable map
+     */
+    Map<String, String> getTags();
+
+    /**
+     * Creates a CompletionStage supplier which is enhanced by a Hedge
+     *
+     * @param <T>      the type of the returned CompletionStage's result
+     * @param <F>      the CompletionStage type supplied
+     * @param supplier the original CompletionStage supplier
+     * @return a CompletionStage supplier which is decorated by a Hedge
+     */
+    <T, F extends CompletionStage<T>> Supplier<CompletionStage<T>> decorateCompletionStage(
+            Supplier<F> supplier);
+
+    /**
+     * Returns an EventPublisher which can be used to register event consumers.
+     *
+     * @return an EventPublisher
+     */
+    Hedge.EventPublisher getEventPublisher();
+
+    /**
+     * Returns HedgeDurationSupplier which are used to determine whether to hedge.
+     *
+     * @return current Hedge's Duration Supplier
+     */
+    HedgeDurationSupplier getDurationSupplier();
+
+    /**
+     * Returns the current duration that the next hedged call would be expected to wait before hedging.
+     *
+     * @return current Hedge's Duration
+     */
+    Duration getDuration();
+
+    /**
+     * Records a successful call.
+     * <p>
+     *
+     * @param duration the duration the primary took to succeed
+     *                 This method must be invoked when a call was successful.
+     */
+    void onPrimarySuccess(Duration duration);
+
+    /**
+     * Records a successful hedged call.
+     * <p>
+     *
+     * @param duration the duration the hedge took to succeed
+     *                 This method must be invoked when a hedged call was successful.
+     */
+    void onSecondarySuccess(Duration duration);
+
+    /**
+     * Records a failed call. This method must be invoked when a call failed.
+     *
+     * @param duration  the duration the primary took to fail
+     * @param throwable The throwable which must be recorded
+     */
+    void onPrimaryFailure(Duration duration, Throwable throwable);
+
+    /**
+     * Records a failed hedged call. This method must be invoked when a hedged call failed.
+     *
+     * @param duration  the duration the hedge took to fail
+     * @param throwable The throwable which must be recorded
+     */
+    void onSecondaryFailure(Duration duration, Throwable throwable);
+
+    /**
+     * Get the HedgeConfig of this Hedge decorator.
+     *
+     * @return the HedgeConfig of this Hedge decorator
+     */
+    SimpleHedgeConfig getHedgeConfig();
+}

--- a/resilience4j-hedge/src/main/java/io/github/resilience4j/hedge/GenericHedgeRegistry.java
+++ b/resilience4j-hedge/src/main/java/io/github/resilience4j/hedge/GenericHedgeRegistry.java
@@ -19,46 +19,50 @@
 package io.github.resilience4j.hedge;
 
 import io.github.resilience4j.core.Registry;
-import io.github.resilience4j.hedge.internal.InMemoryHedgeRegistry;
+import io.github.resilience4j.hedge.internal.InMemoryGenericHedgeRegistry;
 
 import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 /**
  * Manages all Hedge instances.
+ *
+ * @param <H> the specific Hedge type
+ * @param <C> the specific configuration type
  */
-public interface HedgeRegistry extends GenericHedgeRegistry<Hedge, HedgeConfig> {
+public interface GenericHedgeRegistry<H extends GenericHedge, C extends SimpleHedgeConfig> extends Registry<H, C> {
 
     /**
      * Gets a registry builder.
      *
-     * @return a builder for building {@link InMemoryHedgeRegistry} instances.
+     * @param executorServiceFunction a function to provide an executor service
+     * @return a builder for building {@link InMemoryGenericHedgeRegistry} instances.
      */
-    static InMemoryHedgeRegistry.Builder builder() {
-        return new InMemoryHedgeRegistry.Builder();
+    static InMemoryGenericHedgeRegistry.Builder builder(Function<SimpleHedgeConfig, ScheduledExecutorService> executorServiceFunction) {
+        return new InMemoryGenericHedgeRegistry.Builder(executorServiceFunction);
     }
 
     /**
-     * Returns all managed {@link Hedge} instances.
+     * Returns all managed {@link GenericHedge} instances.
      *
-     * @return all managed {@link Hedge} instances.
+     * @return all managed {@link GenericHedge} instances.
      */
-    @Override
-    Stream<Hedge> getAllHedges();
+    Stream<? extends GenericHedge> getAllHedges();
 
     /**
-     * Returns a managed {@link Hedge} or creates a new one with the default Hedge
+     * Returns a managed {@link GenericHedge} or creates a new one with the default Hedge
      * configuration.
      *
      * @param name the name of the Hedge
-     * @return The {@link Hedge}
+     * @return The {@link GenericHedge}
      */
-    @Override
-    Hedge hedge(String name);
+    GenericHedge hedge(String name);
 
     /**
-     * Returns a managed {@link Hedge} or creates a new one with the default Hedge
+     * Returns a managed {@link GenericHedge} or creates a new one with the default Hedge
      * configuration.
      * <p>
      * The {@code tags} passed will be appended to the tags already configured for the registry.
@@ -67,24 +71,22 @@ public interface HedgeRegistry extends GenericHedgeRegistry<Hedge, HedgeConfig> 
      *
      * @param name the name of the Hedge
      * @param tags tags added to the Hedge
-     * @return The {@link Hedge}
+     * @return The {@link GenericHedge}
      */
-    @Override
-    Hedge hedge(String name, Map<String, String> tags);
+    GenericHedge hedge(String name, Map<String, String> tags);
 
     /**
-     * Returns a managed {@link Hedge} or creates a new one with a custom Hedge
+     * Returns a managed {@link GenericHedge} or creates a new one with a custom Hedge
      * configuration.
      *
      * @param name        the name of the Hedge
      * @param hedgeConfig a custom Hedge configuration
-     * @return The {@link Hedge}
+     * @return The {@link GenericHedge}
      */
-    @Override
-    Hedge hedge(String name, HedgeConfig hedgeConfig);
+    GenericHedge hedge(String name, C hedgeConfig);
 
     /**
-     * Returns a managed {@link Hedge} or creates a new one with a custom Hedge
+     * Returns a managed {@link GenericHedge} or creates a new one with a custom Hedge
      * configuration.
      * <p>
      * The {@code tags} passed will be appended to the tags already configured for the registry.
@@ -94,25 +96,23 @@ public interface HedgeRegistry extends GenericHedgeRegistry<Hedge, HedgeConfig> 
      * @param name        the name of the Hedge
      * @param hedgeConfig a custom Hedge configuration
      * @param tags        tags added to the Hedge
-     * @return The {@link Hedge}
+     * @return The {@link GenericHedge}
      */
-    @Override
-    Hedge hedge(String name, HedgeConfig hedgeConfig,
+    GenericHedge hedge(String name, C hedgeConfig,
                 Map<String, String> tags);
 
     /**
-     * Returns a managed {@link HedgeConfig} or creates a new one with a custom
+     * Returns a managed {@link GenericHedge} or creates a new one with a custom
      * HedgeConfig configuration.
      *
      * @param name                the name of the HedgeConfig
      * @param hedgeConfigSupplier a supplier of a custom HedgeConfig configuration
      * @return The {@link HedgeConfig}
      */
-    @Override
-    Hedge hedge(String name, Supplier<HedgeConfig> hedgeConfigSupplier);
+    GenericHedge hedge(String name, Supplier<C> hedgeConfigSupplier);
 
     /**
-     * Returns a managed {@link Hedge} or creates a new one with a custom Hedge
+     * Returns a managed {@link GenericHedge} or creates a new one with a custom Hedge
      * configuration.
      * <p>
      * The {@code tags} passed will be appended to the tags already configured for the registry.
@@ -122,26 +122,24 @@ public interface HedgeRegistry extends GenericHedgeRegistry<Hedge, HedgeConfig> 
      * @param name                the name of the Hedge
      * @param hedgeConfigSupplier a supplier of a custom Hedge configuration
      * @param tags                tags added to the Hedge
-     * @return The {@link Hedge}
+     * @return The {@link GenericHedge}
      */
-    @Override
-    Hedge hedge(String name,
-                Supplier<HedgeConfig> hedgeConfigSupplier,
+    GenericHedge hedge(String name,
+                Supplier<C> hedgeConfigSupplier,
                 Map<String, String> tags);
 
     /**
-     * Returns a managed {@link Hedge} or creates a new one.
+     * Returns a managed {@link GenericHedge} or creates a new one.
      * The configuration must have been added upfront via {@link #addConfiguration(String, Object)}.
      *
      * @param name       the name of the Hedge
      * @param configName the name of the shared configuration
-     * @return The {@link Hedge}
+     * @return The {@link GenericHedge}
      */
-    @Override
-    Hedge hedge(String name, String configName);
+    GenericHedge hedge(String name, String configName);
 
     /**
-     * Returns a managed {@link Hedge} or creates a new one.
+     * Returns a managed {@link GenericHedge} or creates a new one.
      * The configuration must have been added upfront via {@link #addConfiguration(String, Object)}.
      * <p>
      * The {@code tags} passed will be appended to the tags already configured for the registry.
@@ -151,10 +149,9 @@ public interface HedgeRegistry extends GenericHedgeRegistry<Hedge, HedgeConfig> 
      * @param name       the name of the Hedge
      * @param configName the name of the shared configuration
      * @param tags       tags added to the Hedge
-     * @return The {@link Hedge}
+     * @return The {@link GenericHedge}
      */
-    @Override
-    Hedge hedge(String name, String configName,
+    GenericHedge hedge(String name, String configName,
                 Map<String, String> tags);
 
 }

--- a/resilience4j-hedge/src/main/java/io/github/resilience4j/hedge/Hedge.java
+++ b/resilience4j-hedge/src/main/java/io/github/resilience4j/hedge/Hedge.java
@@ -20,13 +20,10 @@ package io.github.resilience4j.hedge;
 
 import io.github.resilience4j.core.EventConsumer;
 import io.github.resilience4j.hedge.event.*;
-import io.github.resilience4j.hedge.internal.HedgeDurationSupplier;
 import io.github.resilience4j.hedge.internal.HedgeImpl;
 
 import java.time.Duration;
 import java.util.Map;
-import java.util.concurrent.*;
-import java.util.function.Supplier;
 
 /**
  * A Hedge executes extra requests if the main execution does not return in time. Hedges rely on a scheduled thread pool
@@ -39,7 +36,7 @@ import java.util.function.Supplier;
  * Good candidates for Hedged calls include side-effect-free calls, calls which may have a long response time tail. Do
  * not hedge non-idempotent inserts or other similar calls.
  */
-public interface Hedge {
+public interface Hedge extends GenericHedge {
 
     String DEFAULT_NAME = "UNDEFINED";
 
@@ -114,49 +111,11 @@ public interface Hedge {
     }
 
     /**
-     * Creates a CompletableFuture that is enhanced by a Hedge.
-     *
-     * @param callable        the callable to submit
-     * @param executorService the executor service to which you are submitting the callable and hedges.
-     * @param <T>             the type of results supplied by the supplier
-     * @return a CompletableFuture which is resolved by the Hedge
-     */
-    <T> CompletableFuture<T> submit(Callable<T> callable, ExecutorService executorService);
-
-    String getName();
-
-    /**
-     * Returns an unmodifiable map with tags assigned to this Hedge.
-     *
-     * @return the tags assigned to this Hedge in an unmodifiable map
-     */
-    Map<String, String> getTags();
-
-    /**
-     * Get the HedgeConfig of this Hedge decorator.
-     *
-     * @return the HedgeConfig of this Hedge decorator
-     */
-    HedgeConfig getHedgeConfig();
-
-    /**
-     * Creates a CompletionStage supplier which is enhanced by a Hedge
-     *
-     * @param <T>      the type of the returned CompletionStage's result
-     * @param <F>      the CompletionStage type supplied
-     * @param supplier the original CompletionStage supplier
-     * @return a CompletionStage supplier which is decorated by a Hedge
-     */
-    <T, F extends CompletionStage<T>> Supplier<CompletionStage<T>> decorateCompletionStage(
-        Supplier<F> supplier);
-
-    /**
      * Get the Metrics of this Hedge.
      *
      * @return the Metrics of this Hedge
      */
     Metrics getMetrics();
-
 
     interface Metrics {
 
@@ -173,63 +132,6 @@ public interface Hedge {
         long getSecondaryFailureCount();
         int getSecondaryPoolActiveCount();
     }
-
-    /**
-     * Returns an EventPublisher which can be used to register event consumers.
-     *
-     * @return an EventPublisher
-     */
-    EventPublisher getEventPublisher();
-
-    /**
-     * Returns HedgeDurationSupplier which are used to determine whether to hedge.
-     *
-     * @return current Hedge's Duration Supplier
-     */
-    HedgeDurationSupplier getDurationSupplier();
-
-    /**
-     * Returns the current duration that the next hedged call would be expected to wait before hedging.
-     *
-     * @return current Hedge's Duration
-     */
-    Duration getDuration();
-
-    /**
-     * Records a successful call.
-     * <p>
-     *
-     * @param duration the duration the primary took to succeed
-     *                 This method must be invoked when a call was successful.
-     */
-    void onPrimarySuccess(Duration duration);
-
-    /**
-     * Records a successful hedged call.
-     * <p>
-     *
-     * @param duration the duration the hedge took to succeed
-     *                 This method must be invoked when a hedged call was successful.
-     */
-    void onSecondarySuccess(Duration duration);
-
-    /**
-     * Records a failed call. This method must be invoked when a call failed.
-     *
-     * @param duration  the duration the primary took to fail
-     * @param throwable The throwable which must be recorded
-     */
-
-    //make configurable to include errors in calculations (same with hedged)
-    void onPrimaryFailure(Duration duration, Throwable throwable);
-
-    /**
-     * Records a failed hedged call. This method must be invoked when a hedged call failed.
-     *
-     * @param duration  the duration the hedge took to fail
-     * @param throwable The throwable which must be recorded
-     */
-    void onSecondaryFailure(Duration duration, Throwable throwable);
 
     /**
      * An EventPublisher which can be used to register event consumers.

--- a/resilience4j-hedge/src/main/java/io/github/resilience4j/hedge/HedgeConfig.java
+++ b/resilience4j-hedge/src/main/java/io/github/resilience4j/hedge/HedgeConfig.java
@@ -21,7 +21,6 @@ package io.github.resilience4j.hedge;
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.toList;
 
-import java.io.Serializable;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,28 +33,14 @@ import io.github.resilience4j.core.lang.Nullable;
 /**
  * HedgeConfig manages the configuration of Hedges
  */
-public class HedgeConfig implements Serializable {
+public class HedgeConfig extends SimpleHedgeConfig {
 
     private static final long serialVersionUID = 2203981592465761602L;
 
-    private static final String HEDGE_DURATION_MUST_NOT_BE_NULL = "HedgeDuration must not be null";
-    private final int concurrentHedges;
-    private final HedgeDurationSupplierType durationSupplierType;
-    private final boolean shouldUseFactorAsPercentage;
-    private final int hedgeTimeFactor;
-    private final boolean shouldMeasureErrors;
-    private final int windowSize;
-    private final Duration cutoff;
     private final transient ContextPropagator[] contextPropagators;
 
     private HedgeConfig(int concurrentHedges, HedgeDurationSupplierType durationSupplierType, boolean shouldUseFactorAsPercentage, int hedgeTimeFactor, boolean shouldMeasureErrors, int windowSize, Duration cutoff, ContextPropagator[] propagators) {
-        this.concurrentHedges = concurrentHedges;
-        this.durationSupplierType = durationSupplierType;
-        this.shouldUseFactorAsPercentage = shouldUseFactorAsPercentage;
-        this.hedgeTimeFactor = hedgeTimeFactor;
-        this.shouldMeasureErrors = shouldMeasureErrors;
-        this.windowSize = windowSize;
-        this.cutoff = cutoff;
+        super(concurrentHedges, durationSupplierType, shouldUseFactorAsPercentage, hedgeTimeFactor, shouldMeasureErrors, windowSize, cutoff);
         this.contextPropagators = propagators;
     }
 
@@ -85,10 +70,6 @@ public class HedgeConfig implements Serializable {
         return contextPropagators;
     }
 
-    public int getConcurrentHedges() {
-        return concurrentHedges;
-    }
-
     @Override
     public String toString() {
         return "HedgeConfig{" +
@@ -100,43 +81,12 @@ public class HedgeConfig implements Serializable {
             "}";
     }
 
-    public HedgeDurationSupplierType getDurationSupplier() {
-        return durationSupplierType;
-    }
-
-    public boolean isShouldUseFactorAsPercentage() {
-        return shouldUseFactorAsPercentage;
-    }
-
-    public int getHedgeTimeFactor() {
-        return hedgeTimeFactor;
-    }
-
-    public boolean isShouldMeasureErrors() {
-        return shouldMeasureErrors;
-    }
-
-    public int getWindowSize() {
-        return windowSize;
-    }
-
-    public Duration getCutoff() {
-        return cutoff;
-    }
-
     public enum HedgeDurationSupplierType {
         PRECONFIGURED, AVERAGE_PLUS
     }
 
-    public static class Builder {
+    public static class Builder extends SimpleHedgeConfig.Builder<Builder> {
 
-        private HedgeDurationSupplierType hedgeDurationSupplierType = HedgeDurationSupplierType.PRECONFIGURED;
-        private boolean shouldUseFactorAsPercentage = false;
-        private int hedgeTimeFactor = 0;
-        private boolean shouldMeasureErrors = true;
-        private int windowSize = 100;
-        private Duration cutoff;
-        private int concurrentHedges = 10;
         private Class<? extends ContextPropagator>[] contextPropagatorClasses = new Class[0];
         private List<? extends ContextPropagator> contextPropagators = new ArrayList<>();
 
@@ -144,12 +94,7 @@ public class HedgeConfig implements Serializable {
         }
 
         public Builder(HedgeConfig baseConfig) {
-            this.shouldUseFactorAsPercentage = baseConfig.shouldUseFactorAsPercentage;
-            this.hedgeTimeFactor = baseConfig.hedgeTimeFactor;
-            this.shouldMeasureErrors = baseConfig.shouldMeasureErrors;
-            this.windowSize = baseConfig.windowSize;
-            this.cutoff = baseConfig.cutoff;
-            this.concurrentHedges = baseConfig.concurrentHedges;
+            super(baseConfig);
         }
 
         public static Builder fromConfig(HedgeConfig baseConfig) {
@@ -161,6 +106,7 @@ public class HedgeConfig implements Serializable {
          *
          * @return the HedgeConfig
          */
+        @Override
         public HedgeConfig build() {
             final List<ContextPropagator> propagators = new ArrayList<>();
 
@@ -187,32 +133,6 @@ public class HedgeConfig implements Serializable {
             );
         }
 
-        public Builder averagePlusPercentageDuration(int percentageAsInteger, boolean shouldMeasureErrors) {
-            this.hedgeDurationSupplierType = HedgeDurationSupplierType.AVERAGE_PLUS;
-            this.shouldUseFactorAsPercentage = true;
-            this.hedgeTimeFactor = percentageAsInteger;
-            this.shouldMeasureErrors = shouldMeasureErrors;
-            return this;
-        }
-
-        public Builder averagePlusAmountDuration(int amount, boolean shouldMeasureErrors, int windowSize) {
-            this.hedgeDurationSupplierType = HedgeDurationSupplierType.AVERAGE_PLUS;
-            this.shouldUseFactorAsPercentage = false;
-            this.hedgeTimeFactor = amount;
-            this.shouldMeasureErrors = shouldMeasureErrors;
-            this.windowSize = windowSize;
-            return this;
-        }
-
-        public Builder preconfiguredDuration(Duration cutoff) {
-            if (cutoff == null) {
-                throw new NullPointerException(HEDGE_DURATION_MUST_NOT_BE_NULL);
-            }
-            this.hedgeDurationSupplierType = HedgeDurationSupplierType.PRECONFIGURED;
-            this.cutoff = cutoff;
-            return this;
-        }
-
         /**
          * Configures the context propagator classes.
          *
@@ -231,11 +151,6 @@ public class HedgeConfig implements Serializable {
             this.contextPropagators = contextPropagators != null ?
                 Arrays.stream(contextPropagators).collect(toList()) :
                 new ArrayList<>();
-            return this;
-        }
-
-        public Builder withMaxConcurrency(int concurrentHedges) {
-            this.concurrentHedges = concurrentHedges;
             return this;
         }
     }

--- a/resilience4j-hedge/src/main/java/io/github/resilience4j/hedge/SimpleHedgeConfig.java
+++ b/resilience4j-hedge/src/main/java/io/github/resilience4j/hedge/SimpleHedgeConfig.java
@@ -1,0 +1,231 @@
+package io.github.resilience4j.hedge;
+
+import io.github.resilience4j.hedge.HedgeConfig.HedgeDurationSupplierType;
+
+import java.io.Serializable;
+import java.time.Duration;
+
+/**
+ * Base Hedge configuration.
+ */
+public class SimpleHedgeConfig implements Serializable {
+    protected static final String HEDGE_DURATION_MUST_NOT_BE_NULL = "HedgeDuration must not be null";
+    protected final int concurrentHedges;
+    protected final HedgeDurationSupplierType durationSupplierType;
+    protected final boolean shouldUseFactorAsPercentage;
+    protected final int hedgeTimeFactor;
+    protected final boolean shouldMeasureErrors;
+    protected final int windowSize;
+    protected final Duration cutoff;
+
+    /**
+     * Constructor for SimpleHedgeConfig.
+     *
+     * @param concurrentHedges          the number of concurrent hedges allowed
+     * @param durationSupplierType      the type of duration supplier
+     * @param shouldUseFactorAsPercentage whether to use factor as percentage
+     * @param hedgeTimeFactor           the hedge time factor
+     * @param shouldMeasureErrors       whether to measure errors
+     * @param windowSize                the window size for error measurement
+     * @param cutoff                    the cutoff duration
+     */
+    public SimpleHedgeConfig(int concurrentHedges, HedgeDurationSupplierType durationSupplierType, boolean shouldUseFactorAsPercentage, int hedgeTimeFactor, boolean shouldMeasureErrors, int windowSize, Duration cutoff) {
+        this.concurrentHedges = concurrentHedges;
+        this.durationSupplierType = durationSupplierType;
+        this.shouldUseFactorAsPercentage = shouldUseFactorAsPercentage;
+        this.hedgeTimeFactor = hedgeTimeFactor;
+        this.shouldMeasureErrors = shouldMeasureErrors;
+        this.windowSize = windowSize;
+        this.cutoff = cutoff;
+    }
+
+    /**
+     * Creates a default SimpleHedge configuration.
+     *
+     * @return a default SimpleHedge configuration.
+     */
+    public static SimpleHedgeConfig ofDefaults() {
+        return new Builder<>().build();
+    }
+
+    /**
+     * Returns the maximum number of concurrent hedges.
+     *
+     * @return the maximum number of concurrent hedges.
+     */
+    public int getConcurrentHedges() {
+        return concurrentHedges;
+    }
+
+    /**
+     * Returns the type of duration supplier.
+     *
+     * @return the duration supplier type.
+     */
+    public HedgeDurationSupplierType getDurationSupplier() {
+        return durationSupplierType;
+    }
+
+    /**
+     * Returns true if the hedge time factor should be used as a percentage, false otherwise.
+     *
+     * @return true if the hedge time factor should be used as a percentage.
+     */
+    public boolean isShouldUseFactorAsPercentage() {
+        return shouldUseFactorAsPercentage;
+    }
+
+    /**
+     * Returns the hedge time factor.
+     *
+     * @return the hedge time factor.
+     */
+    public int getHedgeTimeFactor() {
+        return hedgeTimeFactor;
+    }
+
+    /**
+     * Returns true if errors should be measured, false otherwise.
+     *
+     * @return true if errors should be measured.
+     */
+    public boolean isShouldMeasureErrors() {
+        return shouldMeasureErrors;
+    }
+
+    /**
+     * Returns the window size for error measurement.
+     *
+     * @return the window size.
+     */
+    public int getWindowSize() {
+        return windowSize;
+    }
+
+    /**
+     * Returns the cutoff duration.
+     *
+     * @return the cutoff duration.
+     */
+    public Duration getCutoff() {
+        return cutoff;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends Builder<T>> {
+
+        protected HedgeDurationSupplierType hedgeDurationSupplierType = HedgeDurationSupplierType.PRECONFIGURED;
+        protected boolean shouldUseFactorAsPercentage = false;
+        protected int hedgeTimeFactor = 0;
+        protected boolean shouldMeasureErrors = true;
+        protected int windowSize = 100;
+        protected Duration cutoff;
+        protected int concurrentHedges = 10;
+
+        /**
+         * Creates a builder for a SimpleHedgeConfig.
+         */
+        public Builder() {
+        }
+
+        /**
+         * Creates a builder for a SimpleHedgeConfig from an existing SimpleHedgeConfig.
+         *
+         * @param baseConfig the base configuration to copy from.
+         */
+        public Builder(SimpleHedgeConfig baseConfig) {
+            this.shouldUseFactorAsPercentage = baseConfig.shouldUseFactorAsPercentage;
+            this.hedgeTimeFactor = baseConfig.hedgeTimeFactor;
+            this.shouldMeasureErrors = baseConfig.shouldMeasureErrors;
+            this.windowSize = baseConfig.windowSize;
+            this.cutoff = baseConfig.cutoff;
+            this.concurrentHedges = baseConfig.concurrentHedges;
+        }
+
+        /**
+         * Creates a builder for a SimpleHedgeConfig from an existing HedgeConfig.
+         *
+         * @param baseConfig the base configuration to copy from.
+         * @return a Builder
+         */
+        public static Builder fromConfig(HedgeConfig baseConfig) {
+            return new Builder(baseConfig);
+        }
+
+        /**
+         * Builds a SimpleHedgeConfig.
+         *
+         * @return the SimpleHedgeConfig.
+         */
+        public SimpleHedgeConfig build() {
+            return new SimpleHedgeConfig(
+                concurrentHedges,
+                hedgeDurationSupplierType,
+                shouldUseFactorAsPercentage,
+                hedgeTimeFactor,
+                shouldMeasureErrors,
+                windowSize,
+                cutoff
+            );
+        }
+
+        /**
+         * Configures the Hedge to use an average plus percentage duration.
+         *
+         * @param percentageAsInteger the percentage as an integer.
+         * @param shouldMeasureErrors whether to measure errors.
+         * @return the Builder.
+         */
+        public T averagePlusPercentageDuration(int percentageAsInteger, boolean shouldMeasureErrors) {
+            this.hedgeDurationSupplierType = HedgeDurationSupplierType.AVERAGE_PLUS;
+            this.shouldUseFactorAsPercentage = true;
+            this.hedgeTimeFactor = percentageAsInteger;
+            this.shouldMeasureErrors = shouldMeasureErrors;
+            return (T) this;
+        }
+
+        /**
+         * Configures the Hedge to use an average plus amount duration.
+         *
+         * @param amount            the amount to add to the average.
+         * @param shouldMeasureErrors whether to measure errors.
+         * @param windowSize        the window size for error measurement.
+         * @return the Builder.
+         */
+        public T averagePlusAmountDuration(int amount, boolean shouldMeasureErrors, int windowSize) {
+            this.hedgeDurationSupplierType = HedgeDurationSupplierType.AVERAGE_PLUS;
+            this.shouldUseFactorAsPercentage = false;
+            this.hedgeTimeFactor = amount;
+            this.shouldMeasureErrors = shouldMeasureErrors;
+            this.windowSize = windowSize;
+            return (T) this;
+        }
+
+        /**
+         * Configures the Hedge to use a preconfigured duration.
+         *
+         * @param cutoff the cutoff duration.
+         * @return the Builder.
+         * @throws NullPointerException if cutoff is null.
+         */
+        public T preconfiguredDuration(Duration cutoff) {
+            if (cutoff == null) {
+                throw new NullPointerException(HEDGE_DURATION_MUST_NOT_BE_NULL);
+            }
+            this.hedgeDurationSupplierType = HedgeDurationSupplierType.PRECONFIGURED;
+            this.cutoff = cutoff;
+            return (T) this;
+        }
+
+        /**
+         * Configures the maximum number of concurrent hedges.
+         *
+         * @param concurrentHedges the maximum number of concurrent hedges.
+         * @return the Builder.
+         */
+        public T withMaxConcurrency(int concurrentHedges) {
+            this.concurrentHedges = concurrentHedges;
+            return (T) this;
+        }
+    }
+}

--- a/resilience4j-hedge/src/main/java/io/github/resilience4j/hedge/internal/ExecutorServiceHedge.java
+++ b/resilience4j-hedge/src/main/java/io/github/resilience4j/hedge/internal/ExecutorServiceHedge.java
@@ -1,0 +1,188 @@
+package io.github.resilience4j.hedge.internal;
+
+import io.github.resilience4j.core.lang.NonNull;
+import io.github.resilience4j.hedge.GenericHedge;
+import io.github.resilience4j.hedge.Hedge;
+import io.github.resilience4j.hedge.SimpleHedgeConfig;
+import io.github.resilience4j.hedge.event.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.*;
+import java.util.function.Supplier;
+
+/**
+ * A GenericHedge implementation backed by an ExecutorService.
+ *
+ * @param <E> the type of ScheduledExecutorService
+ */
+public class ExecutorServiceHedge<E extends ScheduledExecutorService> implements GenericHedge {
+    private static final Logger LOG = LoggerFactory.getLogger(ExecutorServiceHedge.class);
+    protected final String name;
+    protected final Map<String, String> tags;
+    protected final SimpleHedgeConfig hedgeConfig;
+    protected final HedgeEventProcessor eventProcessor;
+    protected final HedgeDurationSupplier durationSupplier;
+
+    protected final E configuredHedgeExecutor;
+
+    /**
+     * Constructor for ExecutorServiceHedge.
+     *
+     * @param name                      the name of the Hedge
+     * @param tags                      the tags of the Hedge
+     * @param hedgeConfig               the configuration
+     * @param scheduledExecutorService  the ScheduledExecutorService to use
+     */
+    public ExecutorServiceHedge(String name, Map<String, String> tags, SimpleHedgeConfig hedgeConfig, @NonNull E scheduledExecutorService) {
+        this.name = name;
+        this.tags = Objects.requireNonNull(tags, "Tags must not be null");
+        this.hedgeConfig = hedgeConfig;
+        this.eventProcessor = new HedgeEventProcessor();
+        this.durationSupplier = HedgeDurationSupplier.fromConfig(hedgeConfig);
+        this.configuredHedgeExecutor = scheduledExecutorService;
+    }
+
+    private static <T> CompletableFuture<T> callableFuture(Callable<T> callable, ExecutorService executorService) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                return callable.call();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }, executorService);
+    }
+
+    @Override
+    public HedgeDurationSupplier getDurationSupplier() {
+        return durationSupplier;
+    }
+
+    @Override
+    public Duration getDuration() {
+        return durationSupplier.get();
+    }
+
+    @Override
+    public <T> CompletableFuture<T> submit(Callable<T> callable, ExecutorService primaryExecutor) {
+        return decorateCaller(() -> ExecutorServiceHedge.callableFuture(callable, primaryExecutor), () -> ExecutorServiceHedge.callableFuture(callable, configuredHedgeExecutor))
+                .get()
+                .toCompletableFuture();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T, F extends CompletionStage<T>> Supplier<CompletionStage<T>> decorateCompletionStage(Supplier<F> supplier) {
+        return decorateCaller(supplier, supplier);
+    }
+
+    private <T, F extends CompletionStage<T>> Supplier<CompletionStage<T>> decorateCaller(Supplier<F> primarySupplier, Supplier<F> hedgedSupplier) {
+        return () -> {
+            long start = System.nanoTime();
+            CompletableFuture<HedgeResult<T>> supplied = primarySupplier.get().toCompletableFuture()
+                    .handle((t, throwable) -> HedgeResult.of(t, true, Optional.ofNullable(throwable)));
+            CompletableFuture<T> timedCompletable = new CompletableFuture<>();
+            CompletableFuture<HedgeResult<T>> hedged = timedCompletable
+                    .thenCompose(t -> hedgedSupplier.get())
+                    .handle((t, throwable) -> HedgeResult.of(t, false, Optional.ofNullable(throwable)));
+            ScheduledFuture<Boolean> sf = configuredHedgeExecutor.schedule(() -> timedCompletable.complete(null), durationSupplier.get().toNanos(), TimeUnit.NANOSECONDS);
+            return CompletableFuture.anyOf(hedged, supplied)
+                    .thenApply(s -> {
+                        HedgeResult<T> t = (HedgeResult<T>) s;
+                        long duration = System.nanoTime() - start;
+                        if (t.fromPrimary) {
+                            sf.cancel(true);
+                            hedged.cancel(false);
+                            if (t.throwable.isPresent()) {
+                                onPrimaryFailure(Duration.ofNanos(duration), t.throwable.get());
+                                throw (RuntimeException) t.throwable.get();
+                            } else {
+                                onPrimarySuccess(Duration.ofNanos(duration));
+                            }
+                        } else {
+                            supplied.cancel(false);
+                            if (t.throwable.isPresent()) {
+                                onSecondaryFailure(Duration.ofNanos(duration), t.throwable.get());
+                                throw (RuntimeException) t.throwable.get();
+                            } else {
+                                onSecondarySuccess(Duration.ofNanos(duration));
+                            }
+                        }
+                        return t.value;
+                    });
+        };
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Map<String, String> getTags() {
+        return tags;
+    }
+
+    @Override
+    public SimpleHedgeConfig getHedgeConfig() {
+        return hedgeConfig;
+    }
+
+    @Override
+    public Hedge.EventPublisher getEventPublisher() {
+        return eventProcessor;
+    }
+
+    @Override
+    public void onPrimarySuccess(Duration duration) {
+        durationSupplier.accept(HedgeEvent.Type.PRIMARY_SUCCESS, duration);
+        if (eventProcessor.hasConsumers()) {
+            publishEvent(new HedgeOnPrimarySuccessEvent(name, duration));
+        }
+    }
+
+    @Override
+    public void onSecondarySuccess(Duration duration) {
+        durationSupplier.accept(HedgeEvent.Type.SECONDARY_SUCCESS, duration);
+        if (eventProcessor.hasConsumers()) {
+            publishEvent(new HedgeOnSecondarySuccessEvent(name, duration));
+        }
+    }
+
+    @Override
+    public void onPrimaryFailure(Duration duration, Throwable throwable) {
+        durationSupplier.accept(HedgeEvent.Type.PRIMARY_FAILURE, duration);
+        if (eventProcessor.hasConsumers()) {
+            publishEvent(new HedgeOnPrimaryFailureEvent(name, duration, throwable));
+        }
+    }
+
+    @Override
+    public void onSecondaryFailure(Duration duration, Throwable throwable) {
+        durationSupplier.accept(HedgeEvent.Type.SECONDARY_FAILURE, duration);
+        if (eventProcessor.hasConsumers()) {
+            publishEvent(new HedgeOnSecondaryFailureEvent(name, duration, throwable));
+        }
+    }
+
+    private void publishEvent(HedgeEvent event) {
+        try {
+            eventProcessor.consumeEvent(event);
+        } catch (RuntimeException e) {
+            LOG.warn("Failed to handle event {}", event.getEventType(), e);
+        }
+    }
+
+    /**
+     * Gets the configured hedge executor.
+     *
+     * @return the configured hedge executor
+     */
+    public E getConfiguredHedgeExecutor() {
+        return configuredHedgeExecutor;
+    }
+}

--- a/resilience4j-hedge/src/main/java/io/github/resilience4j/hedge/internal/HedgeDurationSupplier.java
+++ b/resilience4j-hedge/src/main/java/io/github/resilience4j/hedge/internal/HedgeDurationSupplier.java
@@ -19,6 +19,7 @@
 package io.github.resilience4j.hedge.internal;
 
 import io.github.resilience4j.hedge.HedgeConfig;
+import io.github.resilience4j.hedge.SimpleHedgeConfig;
 import io.github.resilience4j.hedge.event.HedgeEvent;
 
 import java.time.Duration;
@@ -35,7 +36,7 @@ public interface HedgeDurationSupplier extends Supplier<Duration>{
      * @param config - the given HedgeConfiguration
      * @return the configured HedgeDurationSupplier
      */
-    static HedgeDurationSupplier fromConfig(HedgeConfig config) {
+    static HedgeDurationSupplier fromConfig(SimpleHedgeConfig config) {
         if (config.getDurationSupplier() == HedgeConfig.HedgeDurationSupplierType.PRECONFIGURED) {
             return ofPreconfigured(config.getCutoff());
         } else {

--- a/resilience4j-hedge/src/main/java/io/github/resilience4j/hedge/internal/HedgeImpl.java
+++ b/resilience4j-hedge/src/main/java/io/github/resilience4j/hedge/internal/HedgeImpl.java
@@ -19,127 +19,58 @@
 package io.github.resilience4j.hedge.internal;
 
 import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
+import io.github.resilience4j.core.lang.NonNull;
 import io.github.resilience4j.hedge.Hedge;
 import io.github.resilience4j.hedge.HedgeConfig;
-import io.github.resilience4j.hedge.event.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Supplier;
 
 import static java.util.Collections.emptyMap;
 
-public class HedgeImpl implements Hedge {
+public class HedgeImpl extends ExecutorServiceHedge<ScheduledThreadPoolExecutor> implements Hedge {
 
-    private static final Logger LOG = LoggerFactory.getLogger(HedgeImpl.class);
-
-    private final String name;
-    private final Map<String, String> tags;
-    private final HedgeConfig hedgeConfig;
-    private final HedgeEventProcessor eventProcessor;
-    private final HedgeDurationSupplier durationSupplier;
     private final HedgeMetrics metrics;
-    private final ContextAwareScheduledThreadPoolExecutor configuredHedgeExecutor;
 
     public HedgeImpl(String name, HedgeConfig hedgeConfig) {
         this(name, hedgeConfig, emptyMap());
     }
 
+    /**
+     * Creates a new HedgeImpl with the given name, config, and tags.
+     *
+     * @param name                      the name of the Hedge
+     * @param hedgeConfig               the Hedge configuration
+     * @param tags                      the tags of the Hedge
+     * @param scheduledThreadPoolExecutor the ScheduledThreadPoolExecutor to use
+     */
+    public HedgeImpl(String name, HedgeConfig hedgeConfig,
+                     Map<String, String> tags,
+                     @NonNull ScheduledThreadPoolExecutor scheduledThreadPoolExecutor) {
+        super(name, tags, hedgeConfig, scheduledThreadPoolExecutor);
+        this.metrics = new HedgeMetrics();
+        eventProcessor.onPrimarySuccess(__ -> metrics.primarySuccess.incrementAndGet());
+        eventProcessor.onPrimaryFailure(__ -> metrics.primaryFailure.incrementAndGet());
+        eventProcessor.onSecondarySuccess(__ -> metrics.secondarySuccess.incrementAndGet());
+        eventProcessor.onSecondaryFailure(__ -> metrics.secondaryFailure.incrementAndGet());
+    }
+
+    /**
+     * Creates a new HedgeImpl with the given name, config, and tags using a default context-aware executor.
+     *
+     * @param name        the name of the Hedge
+     * @param hedgeConfig the Hedge configuration
+     * @param tags        the tags of the Hedge
+     */
     public HedgeImpl(String name, HedgeConfig hedgeConfig,
                      Map<String, String> tags) {
-        this.name = name;
-        this.tags = Objects.requireNonNull(tags, "Tags must not be null");
-        this.hedgeConfig = hedgeConfig;
-        this.eventProcessor = new HedgeEventProcessor();
-        this.durationSupplier = HedgeDurationSupplier.fromConfig(hedgeConfig);
-        this.metrics = new HedgeMetrics();
-        this.configuredHedgeExecutor =
-            ContextAwareScheduledThreadPoolExecutor
+        this(name, hedgeConfig, tags, ContextAwareScheduledThreadPoolExecutor
                 .newScheduledThreadPool()
                 .corePoolSize(hedgeConfig.getConcurrentHedges())
                 .contextPropagators(hedgeConfig.getContextPropagators())
-                .build();
-    }
-
-    @Override
-    public HedgeDurationSupplier getDurationSupplier() {
-        return durationSupplier;
-    }
-
-    @Override
-    public Duration getDuration() {
-        return durationSupplier.get();
-    }
-
-    private static <T> CompletableFuture<T> callableFuture(Callable<T> callable, ExecutorService executorService) {
-        return CompletableFuture.supplyAsync(() -> {
-            try {
-                return callable.call();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        }, executorService);
-    }
-
-    @Override
-    public <T> CompletableFuture<T> submit(Callable<T> callable, ExecutorService primaryExecutor) {
-        return decorateCaller(() -> callableFuture(callable, primaryExecutor), () -> callableFuture(callable, configuredHedgeExecutor))
-            .get()
-            .toCompletableFuture();
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public <T, F extends CompletionStage<T>> Supplier<CompletionStage<T>> decorateCompletionStage(Supplier<F> supplier) {
-        return decorateCaller(supplier, supplier);
-    }
-
-    private <T, F extends CompletionStage<T>> Supplier<CompletionStage<T>> decorateCaller(Supplier<F> primarySupplier, Supplier<F> hedgedSupplier) {
-        return () -> {
-            long start = System.nanoTime();
-            CompletableFuture<HedgeResult<T>> supplied = primarySupplier.get().toCompletableFuture()
-                .handle((t, throwable) -> HedgeResult.of(t, true, Optional.ofNullable(throwable)));
-            CompletableFuture<T> timedCompletable = new CompletableFuture<>();
-            CompletableFuture<HedgeResult<T>> hedged = timedCompletable
-                .thenCompose(t -> hedgedSupplier.get())
-                .handle((t, throwable) -> HedgeResult.of(t, false, Optional.ofNullable(throwable)));
-            ScheduledFuture<Boolean> sf = configuredHedgeExecutor.schedule(() -> timedCompletable.complete(null), durationSupplier.get().toNanos(), TimeUnit.NANOSECONDS);
-            return CompletableFuture.anyOf(hedged, supplied)
-                .thenApply(s -> {
-                    HedgeResult<T> t = (HedgeResult<T>) s;
-                    long duration = System.nanoTime() - start;
-                    if (t.fromPrimary) {
-                        sf.cancel(true);
-                        hedged.cancel(false);
-                        if (t.throwable.isPresent()) {
-                            onPrimaryFailure(Duration.ofNanos(duration), t.throwable.get());
-                            throw (RuntimeException) t.throwable.get();
-                        } else {
-                            onPrimarySuccess(Duration.ofNanos(duration));
-                        }
-                    } else {
-                        supplied.cancel(false);
-                        if (t.throwable.isPresent()) {
-                            onSecondaryFailure(Duration.ofNanos(duration), t.throwable.get());
-                            throw (RuntimeException) t.throwable.get();
-                        } else {
-                            onSecondarySuccess(Duration.ofNanos(duration));
-                        }
-                    }
-                    return t.value;
-                });
-        };
-    }
-
-    @Override
-    public String getName() {
-        return name;
+                .build());
     }
 
     @Override
@@ -181,66 +112,7 @@ public class HedgeImpl implements Hedge {
 
         @Override
         public int getSecondaryPoolActiveCount() {
-            return configuredHedgeExecutor.getActiveCount();
-        }
-    }
-
-    @Override
-    public Map<String, String> getTags() {
-        return tags;
-    }
-
-    @Override
-    public HedgeConfig getHedgeConfig() {
-        return hedgeConfig;
-    }
-
-    @Override
-    public EventPublisher getEventPublisher() {
-        return eventProcessor;
-    }
-
-    @Override
-    public void onPrimarySuccess(Duration duration) {
-        metrics.primarySuccess.incrementAndGet();
-        durationSupplier.accept(HedgeEvent.Type.PRIMARY_SUCCESS, duration);
-        if (eventProcessor.hasConsumers()) {
-            publishEvent(new HedgeOnPrimarySuccessEvent(name, duration));
-        }
-    }
-
-    @Override
-    public void onSecondarySuccess(Duration duration) {
-        metrics.secondarySuccess.incrementAndGet();
-        durationSupplier.accept(HedgeEvent.Type.SECONDARY_SUCCESS, duration);
-        if (eventProcessor.hasConsumers()) {
-            publishEvent(new HedgeOnSecondarySuccessEvent(name, duration));
-        }
-    }
-
-    @Override
-    public void onPrimaryFailure(Duration duration, Throwable throwable) {
-        metrics.primaryFailure.incrementAndGet();
-        durationSupplier.accept(HedgeEvent.Type.PRIMARY_FAILURE, duration);
-        if (eventProcessor.hasConsumers()) {
-            publishEvent(new HedgeOnPrimaryFailureEvent(name, duration, throwable));
-        }
-    }
-
-    @Override
-    public void onSecondaryFailure(Duration duration, Throwable throwable) {
-        metrics.secondaryFailure.incrementAndGet();
-        durationSupplier.accept(HedgeEvent.Type.SECONDARY_FAILURE, duration);
-        if (eventProcessor.hasConsumers()) {
-            publishEvent(new HedgeOnSecondaryFailureEvent(name, duration, throwable));
-        }
-    }
-
-    private void publishEvent(HedgeEvent event) {
-        try {
-            eventProcessor.consumeEvent(event);
-        } catch (RuntimeException e) {
-            LOG.warn("Failed to handle event {}", event.getEventType(), e);
+            return getConfiguredHedgeExecutor().getActiveCount();
         }
     }
 

--- a/resilience4j-hedge/src/main/java/io/github/resilience4j/hedge/internal/InMemoryGenericHedgeRegistry.java
+++ b/resilience4j-hedge/src/main/java/io/github/resilience4j/hedge/internal/InMemoryGenericHedgeRegistry.java
@@ -1,0 +1,212 @@
+/*
+ *
+ *  Copyright 2021: Matthew Sandoz
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.hedge.internal;
+
+import io.github.resilience4j.core.ConfigurationNotFoundException;
+import io.github.resilience4j.core.lang.NonNull;
+import io.github.resilience4j.core.registry.AbstractRegistry;
+import io.github.resilience4j.core.registry.RegistryEventConsumer;
+import io.github.resilience4j.hedge.*;
+
+import java.util.*;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptyMap;
+
+/**
+ * Backend Hedge manager. Constructs backend Hedges according to configuration values.
+ */
+public class InMemoryGenericHedgeRegistry extends
+    AbstractRegistry<GenericHedge, SimpleHedgeConfig> implements GenericHedgeRegistry<GenericHedge, SimpleHedgeConfig> {
+
+    private final Function<SimpleHedgeConfig, ScheduledExecutorService> executorFunction;
+    /**
+     * Constructor
+     *
+     * @param defaultConfig          the default config to use for new Hedges
+     * @param registryEventConsumers initialized consumers for hedges
+     * @param tags                   a map of tags for the registry
+     * @param executorFunction       function that provides an executor service based on config
+     */
+    public InMemoryGenericHedgeRegistry(SimpleHedgeConfig defaultConfig,
+                                        List<RegistryEventConsumer<GenericHedge>> registryEventConsumers,
+                                        Map<String, String> tags,
+                                        @NonNull Function<SimpleHedgeConfig, ScheduledExecutorService> executorFunction) {
+        super(defaultConfig, registryEventConsumers, tags);
+        this.executorFunction = executorFunction;
+    }
+
+    /**
+     * Builder for an InMemoryGenericHedgeRegistry.
+     */
+    public static class Builder {
+        private final Map<String, String> tags = new HashMap<>();
+        private final Map<String, SimpleHedgeConfig> configs = new HashMap<>();
+        private SimpleHedgeConfig defaultConfig = SimpleHedgeConfig.ofDefaults();
+        private final List<RegistryEventConsumer<GenericHedge>> consumers = new ArrayList<>();
+        private final Function<SimpleHedgeConfig, ScheduledExecutorService> executorServiceFunction;
+
+        /**
+         * Constructor for the Builder.
+         *
+         * @param executorFunction function to provide executor service
+         */
+        public Builder(@NonNull Function<SimpleHedgeConfig, ScheduledExecutorService> executorFunction) {
+            this.executorServiceFunction = executorFunction;
+        }
+
+        /**
+         * Adds tags to the registry.
+         *
+         * @param tags the tags
+         * @return the Builder
+         */
+        public Builder withTags(Map<String, String> tags) {
+            this.tags.putAll(tags);
+            return this;
+        }
+
+        /**
+         * Adds configurations to the registry.
+         *
+         * @param configs the configurations
+         * @return the Builder
+         */
+        public Builder withConfigs(Map<String, SimpleHedgeConfig> configs) {
+            this.configs.putAll(configs);
+            return this;
+        }
+
+        /**
+         * Sets the default configuration.
+         *
+         * @param config the default configuration
+         * @return the Builder
+         * @throws NullPointerException if the config is null
+         */
+        public Builder withDefaultConfig(SimpleHedgeConfig config) {
+            if (config == null) {
+                throw new NullPointerException(CONFIG_MUST_NOT_BE_NULL);
+            } else {
+                this.defaultConfig = config;
+                return this;
+            }
+        }
+
+        /**
+         * Adds consumers to the registry.
+         *
+         * @param registryEventConsumers the consumers
+         * @return the Builder
+         */
+        public Builder withConsumers(List<RegistryEventConsumer<GenericHedge>> registryEventConsumers) {
+            this.consumers.addAll(registryEventConsumers);
+            return this;
+        }
+
+        /**
+         * Adds a single consumer to the registry.
+         *
+         * @param registryEventConsumer the consumer
+         * @return the Builder
+         */
+        public Builder withConsumer(RegistryEventConsumer<GenericHedge> registryEventConsumer) {
+            this.consumers.add(registryEventConsumer);
+            return this;
+        }
+
+        /**
+         * Builds the registry.
+         *
+         * @return the newly constructed GenericHedgeRegistry
+         */
+        public GenericHedgeRegistry<? super GenericHedge, ? super SimpleHedgeConfig> build() {
+            configs.remove("default");
+            GenericHedgeRegistry<? super GenericHedge, ? super SimpleHedgeConfig> registry = new InMemoryGenericHedgeRegistry(defaultConfig, consumers, tags, executorServiceFunction);
+            configs.forEach(registry::addConfiguration);
+            return registry;
+        }
+    }
+
+    @Override
+    public Stream<GenericHedge> getAllHedges() {
+        return entryMap.values().stream();
+    }
+
+    @Override
+    public GenericHedge hedge(final String name) {
+        return hedge(name, getDefaultConfig(), emptyMap());
+    }
+
+    @Override
+    public GenericHedge hedge(String name,
+                       Map<String, String> tags) {
+        return hedge(name, getDefaultConfig(), tags);
+    }
+
+    @Override
+    public GenericHedge hedge(final String name, final SimpleHedgeConfig config) {
+        return hedge(name, config, emptyMap());
+    }
+
+    @Override
+    public GenericHedge hedge(String name,
+                       SimpleHedgeConfig hedgeConfig,
+                       Map<String, String> tags) {
+        return computeIfAbsent(name, () -> {
+            SimpleHedgeConfig simpleHedgeConfig = Objects.requireNonNull(hedgeConfig, CONFIG_MUST_NOT_BE_NULL);
+            return GenericHedge.of(name,
+                    simpleHedgeConfig, getAllTags(tags), executorFunction.apply(simpleHedgeConfig));
+        });
+    }
+
+    @Override
+    public GenericHedge hedge(final String name,
+                       final Supplier<SimpleHedgeConfig> hedgeConfigSupplier) {
+        return hedge(name, hedgeConfigSupplier, emptyMap());
+    }
+
+    @Override
+    public GenericHedge hedge(String name,
+                       Supplier<SimpleHedgeConfig> hedgeConfigSupplier,
+                       Map<String, String> tags) {
+        return computeIfAbsent(name, () -> {
+            SimpleHedgeConfig simpleHedgeConfig = Objects.requireNonNull(
+                    Objects.requireNonNull(hedgeConfigSupplier, SUPPLIER_MUST_NOT_BE_NULL).get(),
+                    CONFIG_MUST_NOT_BE_NULL);
+            return GenericHedge.of(name, simpleHedgeConfig, getAllTags(tags), executorFunction.apply(simpleHedgeConfig));
+        });
+    }
+
+    @Override
+    public GenericHedge hedge(String name, String configName) {
+        return hedge(name, configName, emptyMap());
+    }
+
+    @Override
+    public GenericHedge hedge(String name, String configName,
+                       Map<String, String> tags) {
+        SimpleHedgeConfig config = getConfiguration(configName)
+            .orElseThrow(() -> new ConfigurationNotFoundException(configName));
+        return hedge(name, config, tags);
+    }
+}


### PR DESCRIPTION
This introduces a "generic" Hedge to allow configuration of an external executor, mainly to allow configuration of one of the micrometer [ExecutorServices](https://github.com/micrometer-metrics/context-propagation/blob/main/context-propagation/src/main/java/io/micrometer/context/ContextScheduledExecutorService.java).

Most of the changes are to support `ExecutorServiceHedge` which is detached from any notion of `ContextPropagator`s. A lot of work is therefore only there to extract interfaces and superclasses without any reference to the ContextPropagator API.

This is the bare minimum to allow any motivated dev to have a hook in the library to inject their own.

Part of #2353 