### PR TITLE
Feature: Add GenericBulkhead and update dependents

### DIFF
--- a/resilience4j-all/src/main/java/io/github/resilience4j/decorators/Decorators.java
+++ b/resilience4j-all/src/main/java/io/github/resilience4j/decorators/Decorators.java
@@ -2,6 +2,7 @@ package io.github.resilience4j.decorators;
 
 import io.github.resilience4j.bulkhead.Bulkhead;
 import io.github.resilience4j.bulkhead.BulkheadFullException;
+import io.github.resilience4j.bulkhead.GenericBulkhead;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
 import io.github.resilience4j.cache.Cache;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
@@ -148,8 +149,12 @@ public interface Decorators {
             return Decorators.ofCompletionStage(getCompletionStageSupplier(threadPoolBulkhead));
         }
 
+        public DecorateCompletionStage<T> withBulkhead(GenericBulkhead genericBulkhead) {
+            return Decorators.ofCompletionStage(getCompletionStageSupplier(genericBulkhead));
+        }
+
         private Supplier<CompletionStage<T>> getCompletionStageSupplier(
-            ThreadPoolBulkhead threadPoolBulkhead) {
+            GenericBulkhead threadPoolBulkhead) {
             return () -> {
                 try {
                     return threadPoolBulkhead.executeSupplier(supplier);

--- a/resilience4j-all/src/test/java/io/github/resilience4j/decorators/DecoratorsTest.java
+++ b/resilience4j-all/src/test/java/io/github/resilience4j/decorators/DecoratorsTest.java
@@ -516,7 +516,7 @@ class DecoratorsTest {
         ThreadPoolBulkhead bulkhead = ThreadPoolBulkhead.ofDefaults("helloBackend");
         ThreadPoolBulkhead bulkheadMock = spy(bulkhead);
 
-        given(bulkheadMock.submit(any(Callable.class))).willThrow(BulkheadFullException.createBulkheadFullException(bulkhead));
+        willThrow(BulkheadFullException.createBulkheadFullException(bulkhead)).given(bulkheadMock).submit(any(Callable.class));
 
         CompletionStage<String> completionStage = Decorators
             .ofSupplier(() -> helloWorldService.returnHelloWorld())
@@ -534,7 +534,7 @@ class DecoratorsTest {
     void decorateCallableWithBulkheadFullExceptionFallback() throws Exception {
         ThreadPoolBulkhead bulkhead = ThreadPoolBulkhead.ofDefaults("helloBackend");
         ThreadPoolBulkhead bulkheadMock = spy(bulkhead);
-        given(bulkheadMock.submit(any(Callable.class))).willThrow(BulkheadFullException.createBulkheadFullException(bulkhead));
+        willThrow(BulkheadFullException.createBulkheadFullException(bulkhead)).given(bulkheadMock).submit(any(Callable.class));
 
         CompletionStage<String> completionStage = Decorators
             .ofCallable(() -> helloWorldService.returnHelloWorldWithException())
@@ -552,7 +552,7 @@ class DecoratorsTest {
     void decorateRunnableWithBulkheadFullExceptionFallback() throws Exception {
         ThreadPoolBulkhead bulkhead = ThreadPoolBulkhead.ofDefaults("helloBackend");
         ThreadPoolBulkhead bulkheadMock = spy(bulkhead);
-        given(bulkheadMock.submit(any(Callable.class))).willThrow(BulkheadFullException.createBulkheadFullException(bulkhead));
+        willThrow(BulkheadFullException.createBulkheadFullException(bulkhead)).given(bulkheadMock).submit(any(Callable.class));
 
         CompletionStage<Void> completionStage = Decorators
             .ofRunnable(() -> helloWorldService.sayHelloWorld())

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/BulkheadConfig.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/BulkheadConfig.java
@@ -19,14 +19,13 @@
 package io.github.resilience4j.bulkhead;
 
 import javax.annotation.concurrent.Immutable;
-import java.io.Serializable;
 import java.time.Duration;
 
 /**
  * A {@link BulkheadConfig} configures a {@link Bulkhead}
  */
 @Immutable
-public class BulkheadConfig implements Serializable {
+public class BulkheadConfig extends GenericBulkheadConfig {
 
     private static final long serialVersionUID = -9139631465007403460L;
 
@@ -37,7 +36,6 @@ public class BulkheadConfig implements Serializable {
 
     private final int maxConcurrentCalls;
     private final Duration maxWaitDuration;
-    private final boolean writableStackTraceEnabled;
     private final boolean fairCallHandlingEnabled;
 
     private BulkheadConfig(int maxConcurrentCalls, Duration maxWaitDuration,

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/BulkheadFullException.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/BulkheadFullException.java
@@ -30,6 +30,12 @@ public class BulkheadFullException extends RuntimeException {
         this.bulkheadName = bulkheadName;
     }
 
+    private BulkheadFullException(String bulkheadName, boolean writableStackTrace) {
+        super(String.format("Bulkhead '%s' is full and does not permit further calls", bulkheadName), null, false, writableStackTrace);
+
+        this.bulkheadName = bulkheadName;
+    }
+
     /**
      * Static method to construct a {@link BulkheadFullException} with a Bulkhead.
      *
@@ -41,17 +47,11 @@ public class BulkheadFullException extends RuntimeException {
 
         String bulkheadName = bulkhead.getName();
 
-        String message;
         if (Thread.currentThread().isInterrupted()) {
-            message = String
-                .format("Bulkhead '%s' is full and thread was interrupted during permission wait",
-                    bulkheadName);
+            return new BulkheadFullAndInterruptedException(bulkheadName, writableStackTraceEnabled);
         } else {
-            message = String.format("Bulkhead '%s' is full and does not permit further calls",
-                bulkheadName);
+            return new BulkheadFullException(bulkheadName, writableStackTraceEnabled);
         }
-
-        return new BulkheadFullException(bulkheadName, message, writableStackTraceEnabled);
     }
 
     /**
@@ -65,13 +65,29 @@ public class BulkheadFullException extends RuntimeException {
 
         String bulkheadName = bulkhead.getName();
 
-        String message = String
-            .format("Bulkhead '%s' is full and does not permit further calls", bulkheadName);
+        return new BulkheadFullException(bulkheadName, writableStackTraceEnabled);
+    }
 
-        return new BulkheadFullException(bulkheadName, message, writableStackTraceEnabled);
+    /**
+     * Static method to construct a {@link BulkheadFullException} with a Bulkhead.
+     *
+     * @param bulkheadName the name of the bulkhead
+     * @param enableWritableStackTrace whether to enable the writable stack trace.
+     */
+    public static BulkheadFullException createBulkheadFullException(String bulkheadName, boolean enableWritableStackTrace) {
+        return new BulkheadFullException(bulkheadName, enableWritableStackTrace);
     }
 
     public String getBulkheadName() {
         return bulkheadName;
+    }
+
+    /**
+     *  * A {@link BulkheadFullAndInterruptedException} signals that the bulkhead is full and the thread was interrupted during permission wait.
+     */
+    public static class BulkheadFullAndInterruptedException extends BulkheadFullException {
+        private BulkheadFullAndInterruptedException(String bulkheadName, boolean writableStackTrace) {
+            super(bulkheadName, String.format("Bulkhead '%s' is full and thread was interrupted during permission wait", bulkheadName), writableStackTrace);
+        }
     }
 }

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/GenericBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/GenericBulkhead.java
@@ -1,0 +1,198 @@
+package io.github.resilience4j.bulkhead;
+
+import io.github.resilience4j.bulkhead.internal.ExecutorServiceBulkhead;
+import io.github.resilience4j.core.lang.NonNull;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
+
+/**
+ * Generic Bulkhead contract and factory interface
+ */
+public interface GenericBulkhead extends AutoCloseable {
+
+    static GenericBulkhead of(String name,
+                              @NonNull ExecutorService executor,
+                              @NonNull GenericBulkheadConfig config) {
+        return new ExecutorServiceBulkhead(name, executor, config.isWritableStackTraceEnabled());
+    }
+
+    static GenericBulkhead of(String name,
+                              Map<String, String> tags,
+                              @NonNull ExecutorService executor,
+                              @NonNull GenericBulkheadConfig config) {
+        return new ExecutorServiceBulkhead(name, tags, executor, config.isWritableStackTraceEnabled());
+    }
+
+    /**
+     * Returns a supplier which submits a value-returning task for execution and
+     * returns a {@link CompletionStage} representing the pending results of the task.
+     *
+     * @param bulkhead the bulkhead
+     * @param callable the value-returning task to submit
+     * @param <T>      the result type of the callable
+     * @return a supplier which submits a value-returning task for execution and returns a CompletionStage representing the pending
+     * results of the task
+     * @throws BulkheadFullException if the task cannot be submitted because the Bulkhead is full
+     */
+    static <T> Supplier<CompletionStage<T>> decorateCallable(GenericBulkhead bulkhead,
+                                                             Callable<T> callable) {
+        return () -> bulkhead.submit(callable);
+    }
+
+    /**
+     * Returns a supplier which submits a value-returning task for execution
+     * and returns a {@link CompletionStage} representing the pending results of the task.
+     *
+     * @param bulkhead the bulkhead
+     * @param supplier the value-returning task to submit
+     * @param <T>      the result type of the supplier
+     * @return a supplier which submits a value-returning task for execution and returns a CompletionStage representing the pending
+     * results of the task
+     * @throws BulkheadFullException if the task cannot be submitted because the Bulkhead is full
+     */
+    static <T> Supplier<CompletionStage<T>> decorateSupplier(GenericBulkhead bulkhead,
+                                                             Supplier<T> supplier) {
+        return () -> bulkhead.submit(supplier::get);
+    }
+
+    /**
+     * Returns a supplier which submits a task for execution and returns a {@link CompletionStage} representing the state of the task.
+     *
+     * @param bulkhead the bulkhead
+     * @param runnable the to submit
+     * @return a supplier which submits a task for execution to the ThreadPoolBulkhead
+     * and returns a CompletionStage representing the state of the task
+     * @throws BulkheadFullException if the task cannot be submitted because the Bulkhead is full
+     */
+    static Supplier<CompletionStage<Void>> decorateRunnable(GenericBulkhead bulkhead, Runnable runnable) {
+        return () -> bulkhead.submit(runnable);
+    }
+
+    /**
+     * Submits a value-returning task for execution and returns a {@link CompletionStage} representing the
+     * asynchronous computation  of the task.
+     *
+     * @param task the value-returning task to submit
+     * @param <T> the type of the task's result
+     * @return CompletionStage representing the asynchronous computation of the task. The CompletionStage is completed exceptionally with a {@link BulkheadFullException}
+     * when the task could not be submitted, because the Bulkhead was full
+     * @throws BulkheadFullException if the task cannot be submitted, because the Bulkhead is full
+     */
+    <T> CompletionStage<T> submit(Callable<T> task);
+
+    /**
+     * Submits a task for execution to the ThreadPoolBulkhead and returns a {@link CompletionStage} representing the
+     * asynchronous computation  of the task.
+     *
+     *
+     * @param task the task to submit
+     * @return CompletionStage representing the asynchronous computation of the task.
+     * @throws BulkheadFullException if the task cannot be submitted, because the Bulkhead is full
+     */
+    CompletionStage<Void> submit(Runnable task);
+
+    /**
+     * Returns the name of this bulkhead.
+     *
+     * @return the name of this bulkhead
+     */
+    String getName();
+
+    /**
+     * Returns an unmodifiable map with tags assigned to this Retry.
+     *
+     * @return the tags assigned to this Retry in an unmodifiable map
+     */
+    Map<String, String> getTags();
+
+    /**
+     * Returns an EventPublisher which subscribes to the reactive stream of BulkheadEvent and can be
+     * used to register event consumers.
+     *
+     * @return an EventPublisher
+     */
+    ThreadPoolBulkhead.ThreadPoolBulkheadEventPublisher getEventPublisher();
+
+    /**
+     * Returns a supplier which submits a value-returning task for execution and
+     * returns a CompletionStage representing the asynchronous computation of the task.
+     *
+     * @param supplier the value-returning task to submit
+     * @param <T>      the result type of the callable
+     * @return a supplier which submits a value-returning task for execution and returns a CompletionStage representing
+     * the asynchronous computation of the task
+     * @throws BulkheadFullException if the task cannot be submitted because the Bulkhead is full
+     */
+    default <T> Supplier<CompletionStage<T>> decorateSupplier(Supplier<T> supplier) {
+        return decorateSupplier(this, supplier);
+    }
+
+    /**
+     * Returns a supplier which submits a value-returning task for execution and
+     * returns a CompletionStage representing the asynchronous computation of the task.
+     *
+     * @param callable the value-returning task to submit
+     * @param <T>      the result type of the callable
+     * @return a supplier which submits a value-returning task for execution and returns a CompletionStage representing
+     * the asynchronous computation of the task
+     * @throws BulkheadFullException if the task cannot be submitted because the Bulkhead is full
+     */
+    default <T> Supplier<CompletionStage<T>> decorateCallable(Callable<T> callable) {
+        return decorateCallable(this, callable);
+    }
+
+    /**
+     * Returns a supplier which submits a task for execution and returns a {@link CompletionStage} representing the
+     * asynchronous computation of the task.
+     *
+     * @param runnable the task to submit
+     * @return a supplier which submits a task for execution and returns a CompletionStage representing
+     * the asynchronous computation of the task
+     * @throws BulkheadFullException if the task cannot be submitted because the Bulkhead is full
+     */
+    default Supplier<CompletionStage<Void>> decorateRunnable(Runnable runnable) {
+        return decorateRunnable(this, runnable);
+    }
+
+    /**
+     * Submits a value-returning task for execution and returns a {@link CompletionStage} representing the
+     * asynchronous computation of the task.
+     *
+     * @param supplier the value-returning task to submit
+     * @param <T> the type of the task's result
+     * @return a CompletionStage representing the asynchronous computation of the task.
+     * @throws BulkheadFullException if the task cannot be submitted, because the Bulkhead is full
+     */
+    default <T> CompletionStage<T> executeSupplier(Supplier<T> supplier) {
+        return decorateSupplier(this, supplier).get();
+    }
+
+    /**
+     * Submits a value-returning task for execution and returns a {@link CompletionStage} representing the
+     * asynchronous computation  of the task.
+     *
+     * @param callable the value-returning task to submit
+     * @param <T>      the result type of the Callable
+     * @return a {@link CompletionStage} representing the asynchronous computation of the task.
+     * @throws BulkheadFullException if the task cannot be submitted, because the Bulkhead is full
+     */
+    default <T> CompletionStage<T> executeCallable(Callable<T> callable) {
+        return decorateCallable(this, callable).get();
+    }
+
+    /**
+     * Submits a task for execution and returns a {@link CompletionStage} representing the
+     * asynchronous computation  of the task.
+     *
+     * @param runnable the task to submit
+     * @return CompletionStage representing the asynchronous computation of the task.
+     * @throws BulkheadFullException if the task cannot be submitted, because the Bulkhead is full
+     */
+    default CompletionStage<Void> executeRunnable(Runnable runnable) {
+        return decorateRunnable(this, runnable).get();
+    }
+}

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/GenericBulkheadConfig.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/GenericBulkheadConfig.java
@@ -1,0 +1,32 @@
+package io.github.resilience4j.bulkhead;
+
+import javax.annotation.concurrent.Immutable;
+import java.io.Serializable;
+
+/**
+ * Base Bulkhead configuration.
+ */
+public class GenericBulkheadConfig implements Serializable {
+    public static final boolean DEFAULT_WRITABLE_STACK_TRACE_ENABLED = true;
+    private static final long serialVersionUID = 625685690021881900L;
+
+    protected boolean writableStackTraceEnabled = DEFAULT_WRITABLE_STACK_TRACE_ENABLED;
+
+    /**
+     * Creates a default GenericBulkhead configuration.
+     *
+     * @return a default GenericBulkhead configuration.
+     */
+    public static GenericBulkheadConfig ofDefaults() {
+        return new GenericBulkheadConfig();
+    }
+
+    /**
+     * Checks if writable stack trace is enabled.
+     *
+     * @return true if enabled, false otherwise.
+     */
+    public boolean isWritableStackTraceEnabled() {
+        return writableStackTraceEnabled;
+    }
+}

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/GenericBulkheadRegistry.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/GenericBulkheadRegistry.java
@@ -1,0 +1,420 @@
+/*
+ *
+ *  Copyright 2017 Robert Winkler, Lucas Lech, Mahmoud Romeh
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.bulkhead;
+
+
+import io.github.resilience4j.bulkhead.internal.InMemoryGenericBulkheadRegistry;
+import io.github.resilience4j.bulkhead.internal.InMemoryThreadPoolBulkheadRegistry;
+import io.github.resilience4j.core.Registry;
+import io.github.resilience4j.core.RegistryStore;
+import io.github.resilience4j.core.lang.NonNull;
+import io.github.resilience4j.core.registry.RegistryEventConsumer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static java.util.Collections.emptyMap;
+
+/**
+ * The {@link GenericBulkheadRegistry} is a factory to create ThreadPoolBulkhead instances which
+ * stores all bulkhead instances in a registry.
+ */
+public interface GenericBulkheadRegistry extends
+    Registry<GenericBulkhead, GenericBulkheadConfig>, AutoCloseable {
+
+    /**
+     * Creates a BulkheadRegistry with a custom Bulkhead configuration.
+     *
+     * @param bulkheadConfig a custom ThreadPoolBulkhead configuration
+     * @param executorFunction function that provides an executor service
+     * @return a ThreadPoolBulkheadRegistry instance backed by a custom ThreadPoolBulkhead
+     * configuration
+     */
+    static GenericBulkheadRegistry of(GenericBulkheadConfig bulkheadConfig, Function<GenericBulkheadConfig, ScheduledExecutorService> executorFunction) {
+        return new InMemoryGenericBulkheadRegistry(bulkheadConfig, executorFunction);
+    }
+
+    /**
+     * Creates a ThreadPoolBulkheadRegistry with a custom default ThreadPoolBulkhead configuration
+     * and a ThreadPoolBulkhead registry event consumer.
+     *
+     * @param bulkheadConfig        a custom default ThreadPoolBulkhead configuration.
+     * @param registryEventConsumer a ThreadPoolBulkhead registry event consumer.
+     * @param executorFunction function that provides an executor service
+     * @return a ThreadPoolBulkheadRegistry with a custom ThreadPoolBulkhead configuration and a
+     * ThreadPoolBulkhead registry event consumer.
+     */
+    static GenericBulkheadRegistry of(GenericBulkheadConfig bulkheadConfig,
+                                      RegistryEventConsumer<GenericBulkhead> registryEventConsumer, Function<GenericBulkheadConfig, ScheduledExecutorService> executorFunction) {
+        return new InMemoryGenericBulkheadRegistry(bulkheadConfig, registryEventConsumer, executorFunction);
+    }
+
+    /**
+     * Creates a ThreadPoolBulkheadRegistry with a custom default ThreadPoolBulkhead configuration
+     * and a list of ThreadPoolBulkhead registry event consumers.
+     *
+     * @param bulkheadConfig         a custom default ThreadPoolBulkhead configuration.
+     * @param registryEventConsumers a list of ThreadPoolBulkhead registry event consumers.
+     * @param executorFunction function that provides an executor service
+     * @return a ThreadPoolBulkheadRegistry with a custom ThreadPoolBulkhead configuration and a
+     * list of ThreadPoolBulkhead registry event consumers.
+     */
+    static GenericBulkheadRegistry of(GenericBulkheadConfig bulkheadConfig,
+                                      List<RegistryEventConsumer<GenericBulkhead>> registryEventConsumers,
+                                      Function<GenericBulkheadConfig, ScheduledExecutorService> executorFunction) {
+        return new InMemoryGenericBulkheadRegistry(bulkheadConfig, registryEventConsumers, executorFunction);
+    }
+
+    /**
+     * Creates a ThreadPoolBulkheadRegistry with a default ThreadPoolBulkhead configuration
+     *
+     * @param executorFunction function that provides an executor service
+     * @return a ThreadPoolBulkheadRegistry instance backed by a default ThreadPoolBulkhead
+     * configuration
+     */
+    static GenericBulkheadRegistry ofDefaults(Function<GenericBulkheadConfig, ScheduledExecutorService> executorFunction) {
+        return ofDefaults(emptyMap(), executorFunction);
+    }
+
+    /**
+     * Creates a ThreadPoolBulkheadRegistry with a default ThreadPoolBulkhead configuration
+     * <p>
+     * Tags added to the registry will be added to every instance created by this registry.
+     *
+     * @param tags default tags to add to the registry
+     * @param executorFunction function that provides an executor service
+     * @return a ThreadPoolBulkheadRegistry instance backed by a default ThreadPoolBulkhead
+     * configuration
+     */
+    static GenericBulkheadRegistry ofDefaults(Map<String, String> tags,
+                                              Function<GenericBulkheadConfig, ScheduledExecutorService> executorFunction) {
+        return new InMemoryGenericBulkheadRegistry(GenericBulkheadConfig.ofDefaults(), tags, executorFunction);
+    }
+
+    /**
+     * Creates a ThreadPoolBulkheadRegistry with a Map of shared ThreadPoolBulkhead configurations.
+     *
+     * @param configs a Map of shared Bulkhead configurations
+     * @param executorFunction function that provides an executor service
+     * @return a ThreadPoolBulkheadRegistry with a Map of shared ThreadPoolBulkhead configurations.
+     */
+    static GenericBulkheadRegistry of(Map<String, GenericBulkheadConfig> configs, Function<GenericBulkheadConfig, ScheduledExecutorService> executorFunction) {
+        return of(configs, emptyMap(), executorFunction);
+    }
+
+    /**
+     * Creates a ThreadPoolBulkheadRegistry with a Map of shared ThreadPoolBulkhead configurations.
+     * <p>
+     * Tags added to the registry will be added to every instance created by this registry.
+     *
+     * @param configs a Map of shared Bulkhead configurations
+     * @param tags    default tags to add to the registry
+     * @param executorFunction function that provides an executor service
+     * @return a ThreadPoolBulkheadRegistry with a Map of shared ThreadPoolBulkhead configurations.
+     */
+    static GenericBulkheadRegistry of(Map<String, GenericBulkheadConfig> configs, Map<String, String> tags,
+                                      Function<GenericBulkheadConfig, ScheduledExecutorService> executorFunction) {
+        return new InMemoryGenericBulkheadRegistry(configs, tags, executorFunction);
+    }
+
+    /**
+     * Creates a ThreadPoolBulkheadRegistry with a Map of shared ThreadPoolBulkhead configurations
+     * and a ThreadPoolBulkhead registry event consumer.
+     *
+     * @param configs               a Map of shared ThreadPoolBulkhead configurations.
+     * @param registryEventConsumer a ThreadPoolBulkhead registry event consumer.
+     * @param executorFunction function that provides an executor service
+     * @return a ThreadPoolBulkheadRegistry with a Map of shared ThreadPoolBulkhead configurations
+     * and a ThreadPoolBulkhead registry event consumer.
+     */
+    static GenericBulkheadRegistry of(Map<String, GenericBulkheadConfig> configs,
+                                      RegistryEventConsumer<GenericBulkhead> registryEventConsumer,
+                                      Function<GenericBulkheadConfig, ScheduledExecutorService> executorFunction) {
+        return of(configs, registryEventConsumer, emptyMap(), executorFunction);
+    }
+
+    /**
+     * Creates a ThreadPoolBulkheadRegistry with a Map of shared ThreadPoolBulkhead configurations
+     * and a ThreadPoolBulkhead registry event consumer.
+     * <p>
+     * Tags added to the registry will be added to every instance created by this registry.
+     *
+     * @param configs               a Map of shared ThreadPoolBulkhead configurations.
+     * @param registryEventConsumer a ThreadPoolBulkhead registry event consumer.
+     * @param tags                  default tags to add to the registry
+     * @param executorFunction function that provides an executor service
+     * @return a ThreadPoolBulkheadRegistry with a Map of shared ThreadPoolBulkhead configurations
+     * and a ThreadPoolBulkhead registry event consumer.
+     */
+    static GenericBulkheadRegistry of(Map<String, GenericBulkheadConfig> configs,
+                                      RegistryEventConsumer<GenericBulkhead> registryEventConsumer, Map<String, String> tags,
+                                      Function<GenericBulkheadConfig, ScheduledExecutorService> executorFunction) {
+        return new InMemoryGenericBulkheadRegistry(configs, registryEventConsumer, tags, executorFunction);
+    }
+
+    /**
+     * Creates a ThreadPoolBulkheadRegistry with a Map of shared ThreadPoolBulkhead configurations
+     * and a list of ThreadPoolBulkhead registry event consumers.
+     *
+     * @param configs                a Map of shared ThreadPoolBulkhead configurations.
+     * @param registryEventConsumers a list of ThreadPoolBulkhead registry event consumers.
+     * @param executorFunction function that provides an executor service
+     * @return a ThreadPoolBulkheadRegistry with a Map of shared ThreadPoolBulkhead configurations
+     * and a list of ThreadPoolBulkhead registry event consumers.
+     */
+    static GenericBulkheadRegistry of(Map<String, GenericBulkheadConfig> configs,
+                                      List<RegistryEventConsumer<GenericBulkhead>> registryEventConsumers,
+                                      Function<GenericBulkheadConfig, ScheduledExecutorService> executorFunction) {
+        return of(configs, registryEventConsumers, emptyMap(), executorFunction);
+    }
+
+    /**
+     * Creates a ThreadPoolBulkheadRegistry with a Map of shared ThreadPoolBulkhead configurations
+     * and a list of ThreadPoolBulkhead registry event consumers.
+     * <p>
+     * Tags added to the registry will be added to every instance created by this registry.
+     *
+     * @param configs                a Map of shared ThreadPoolBulkhead configurations.
+     * @param registryEventConsumers a list of ThreadPoolBulkhead registry event consumers.
+     * @param tags                   Tags to add to the ThreadPoolBulkhead
+     * @param executorFunction function that provides an executor service
+     * @return a ThreadPoolBulkheadRegistry with a Map of shared ThreadPoolBulkhead configurations
+     * and a list of ThreadPoolBulkhead registry event consumers.
+     */
+    static GenericBulkheadRegistry of(Map<String, GenericBulkheadConfig> configs,
+                                      List<RegistryEventConsumer<GenericBulkhead>> registryEventConsumers, Map<String, String> tags,
+                                      Function<GenericBulkheadConfig, ScheduledExecutorService> executorFunction) {
+        return new InMemoryGenericBulkheadRegistry(configs, registryEventConsumers, tags, executorFunction);
+    }
+
+    /**
+     * Returns all managed {@link GenericBulkhead} instances.
+     *
+     * @return all managed {@link GenericBulkhead} instances.
+     */
+    Set<GenericBulkhead> getAllBulkheads();
+
+    /**
+     * Returns a managed {@link GenericBulkhead} or creates a new one with default
+     * configuration.
+     *
+     * @param name the name of the ThreadPoolBulkhead
+     * @return The {@link GenericBulkhead}
+     */
+    GenericBulkhead bulkhead(String name);
+
+    /**
+     * Returns a managed {@link GenericBulkhead} or creates a new one with default
+     * configuration.
+     *
+     * @param name the name of the ThreadPoolBulkhead
+     * @param tags Tags to add to the ThreadPoolBulkhead
+     * @return The {@link GenericBulkhead}
+     */
+    GenericBulkhead bulkhead(String name, Map<String, String> tags);
+
+    /**
+     * Returns a managed {@link GenericBulkhead} or creates a new one with a custom
+     * ThreadPoolBulkhead configuration.
+     *
+     * @param name   the name of the ThreadPoolBulkhead
+     * @param config a custom ThreadPoolBulkheadConfig configuration
+     * @return The {@link GenericBulkhead}
+     */
+    GenericBulkhead bulkhead(String name, GenericBulkheadConfig config);
+
+    /**
+     * Returns a managed {@link GenericBulkhead} or creates a new one with a custom
+     * ThreadPoolBulkhead configuration.
+     * <p>
+     * The {@code tags} passed will be appended to the tags already configured for the registry.
+     * When tags (keys) of the two collide the tags passed with this method will override the tags
+     * of the registry.
+     *
+     * @param name   the name of the ThreadPoolBulkhead
+     * @param config a custom ThreadPoolBulkheadConfig configuration
+     * @param tags   tags to add to the ThreadPoolBulkhead
+     * @return The {@link GenericBulkhead}
+     */
+    GenericBulkhead bulkhead(String name, GenericBulkheadConfig config, Map<String, String> tags);
+
+    /**
+     * Returns a managed {@link GenericBulkhead} or creates a new one with a custom
+     * ThreadPoolBulkhead configuration.
+     *
+     * @param name                   the name of the ThreadPoolBulkhead
+     * @param bulkheadConfigSupplier a custom ThreadPoolBulkhead configuration supplier
+     * @return The {@link GenericBulkhead}
+     */
+    GenericBulkhead bulkhead(String name,
+        Supplier<GenericBulkheadConfig> bulkheadConfigSupplier);
+
+    /**
+     * Returns a managed {@link GenericBulkhead} or creates a new one with a custom
+     * ThreadPoolBulkhead configuration.
+     * <p>
+     * The {@code tags} passed will be appended to the tags already configured for the registry.
+     * When tags (keys) of the two collide the tags passed with this method will override the tags
+     * of the registry.
+     *
+     * @param name                   the name of the ThreadPoolBulkhead
+     * @param bulkheadConfigSupplier a custom ThreadPoolBulkhead configuration supplier
+     * @param tags                   tags to add to the ThreadPoolBulkhead
+     * @return The {@link GenericBulkhead}
+     */
+    GenericBulkhead bulkhead(String name,
+        Supplier<GenericBulkheadConfig> bulkheadConfigSupplier, Map<String, String> tags);
+
+    /**
+     * Returns a managed {@link GenericBulkhead} or creates a new one.
+     * The configuration must have been added upfront via {@link #addConfiguration(String, Object)}.
+     *
+     * @param name       the name of the ThreadPoolBulkhead
+     * @param configName the name of the shared configuration
+     * @return The {@link GenericBulkhead}
+     */
+    GenericBulkhead bulkhead(String name, String configName);
+
+    /**
+     * Returns a managed {@link GenericBulkhead} or creates a new one.
+     * The configuration must have been added upfront via {@link #addConfiguration(String, Object)}.
+     * <p>
+     * The {@code tags} passed will be appended to the tags already configured for the registry.
+     * When tags (keys) of the two collide the tags passed with this method will override the tags
+     * of the registry.
+     *
+     * @param name       the name of the ThreadPoolBulkhead
+     * @param configName the name of the shared configuration
+     * @param tags       tags to add to the ThreadPoolBulkhead
+     * @return The {@link GenericBulkhead}
+     */
+    GenericBulkhead bulkhead(String name, String configName, Map<String, String> tags);
+
+    /**
+     * Returns a builder to create a custom ThreadPoolBulkheadRegistry.
+     *
+     * @param executorFunction function that provides an executor service
+     * @return a {@link GenericBulkheadRegistry.Builder}
+     */
+    static Builder custom(Function<GenericBulkheadConfig, ScheduledExecutorService> executorFunction) {
+        return new Builder(executorFunction);
+    }
+
+    /**
+     * Builder to create a custom GenericBulkheadRegistry.
+     */
+    class Builder {
+
+        private static final String DEFAULT_CONFIG = "default";
+        private RegistryStore<GenericBulkhead> registryStore;
+        private Map<String, GenericBulkheadConfig> threadPoolBulkheadConfigsMap;
+        private List<RegistryEventConsumer<GenericBulkhead>> registryEventConsumers;
+        private Map<String, String> tags;
+        private Function<GenericBulkheadConfig, ScheduledExecutorService> executorServiceFunction;
+
+        /**
+         * Constructor for the Builder.
+         *
+         * @param executorServiceFunction function to provide an executor service
+         */
+        public Builder(@NonNull Function<GenericBulkheadConfig, ScheduledExecutorService> executorServiceFunction) {
+            this.threadPoolBulkheadConfigsMap = new java.util.HashMap<>();
+            this.registryEventConsumers = new ArrayList<>();
+            this.executorServiceFunction = executorServiceFunction;
+        }
+
+        /**
+         * Sets the registry store.
+         *
+         * @param registryStore the registry store
+         * @return the Builder
+         */
+        public Builder withRegistryStore(RegistryStore<GenericBulkhead> registryStore) {
+            this.registryStore = registryStore;
+            return this;
+        }
+
+        /**
+         * Configures a ThreadPoolBulkheadRegistry with a custom default ThreadPoolBulkhead configuration.
+         *
+         * @param threadPoolBulkheadConfig a custom default ThreadPoolBulkhead configuration
+         * @return a {@link GenericBulkheadRegistry.Builder}
+         */
+        public Builder withThreadPoolBulkheadConfig(GenericBulkheadConfig threadPoolBulkheadConfig) {
+            threadPoolBulkheadConfigsMap.put(DEFAULT_CONFIG, threadPoolBulkheadConfig);
+            return this;
+        }
+
+        /**
+         * Configures a ThreadPoolBulkheadRegistry with a custom ThreadPoolBulkhead configuration.
+         *
+         * @param configName configName for a custom shared ThreadPoolBulkhead configuration
+         * @param configuration a custom shared ThreadPoolBulkhead configuration
+         * @return a {@link GenericBulkheadRegistry.Builder}
+         * @throws IllegalArgumentException if {@code configName.equals("default")}
+         */
+        public Builder addThreadPoolBulkheadConfig(String configName, ThreadPoolBulkheadConfig configuration) {
+            if (configName.equals(DEFAULT_CONFIG)) {
+                throw new IllegalArgumentException(
+                    "You cannot add another configuration with name 'default' as it is preserved for default configuration");
+            }
+            threadPoolBulkheadConfigsMap.put(configName, configuration);
+            return this;
+        }
+
+        /**
+         * Configures a ThreadPoolBulkheadRegistry with a ThreadPoolBulkhead registry event consumer.
+         *
+         * @param registryEventConsumer a ThreadPoolBulkhead registry event consumer.
+         * @return a {@link GenericBulkheadRegistry.Builder}
+         */
+        public Builder addRegistryEventConsumer(RegistryEventConsumer<GenericBulkhead> registryEventConsumer) {
+            this.registryEventConsumers.add(registryEventConsumer);
+            return this;
+        }
+
+        /**
+         * Configures a ThreadPoolBulkheadRegistry with Tags.
+         * <p>
+         * Tags added to the registry will be added to every instance created by this registry.
+         *
+         * @param tags default tags to add to the registry.
+         * @return a {@link GenericBulkheadRegistry.Builder}
+         */
+        public Builder withTags(Map<String, String> tags) {
+            this.tags = tags;
+            return this;
+        }
+
+        /**
+         * Builds a ThreadPoolBulkheadRegistry
+         *
+         * @return the ThreadPoolBulkheadRegistry
+         */
+        public GenericBulkheadRegistry build() {
+            return new InMemoryGenericBulkheadRegistry(threadPoolBulkheadConfigsMap, registryEventConsumers, tags,
+                registryStore, executorServiceFunction);
+        }
+    }
+}

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkhead.java
@@ -33,7 +33,7 @@ import java.util.function.Supplier;
 /**
  * A Bulkhead instance is thread-safe can be used to decorate multiple requests.
  */
-public interface ThreadPoolBulkhead extends AutoCloseable {
+public interface ThreadPoolBulkhead extends GenericBulkhead {
 
     /**
      * Returns a supplier which submits a value-returning task for execution and
@@ -45,10 +45,12 @@ public interface ThreadPoolBulkhead extends AutoCloseable {
      * @return a supplier which submits a value-returning task for execution and returns a CompletionStage representing the pending
      * results of the task
      * @throws BulkheadFullException if the task cannot be submitted because the Bulkhead is full
+     * @deprecated use {@link GenericBulkhead#decorateCallable(Callable)} instead.
      */
+    @Deprecated
     static <T> Supplier<CompletionStage<T>> decorateCallable(ThreadPoolBulkhead bulkhead,
-        Callable<T> callable) {
-        return () -> bulkhead.submit(callable);
+                                                             Callable<T> callable) {
+        return GenericBulkhead.decorateCallable(bulkhead, callable);
     }
 
     /**
@@ -61,10 +63,12 @@ public interface ThreadPoolBulkhead extends AutoCloseable {
      * @return a supplier which submits a value-returning task for execution and returns a CompletionStage representing the pending
      * results of the task
      * @throws BulkheadFullException if the task cannot be submitted because the Bulkhead is full
+     * @deprecated use {@link GenericBulkhead#decorateSupplier(Supplier)} instead.
      */
+    @Deprecated
     static <T> Supplier<CompletionStage<T>> decorateSupplier(ThreadPoolBulkhead bulkhead,
         Supplier<T> supplier) {
-        return () -> bulkhead.submit(supplier::get);
+        return GenericBulkhead.decorateSupplier(bulkhead, supplier);
     }
 
     /**
@@ -75,9 +79,11 @@ public interface ThreadPoolBulkhead extends AutoCloseable {
      * @return a supplier which submits a task for execution to the ThreadPoolBulkhead
      * and returns a CompletionStage representing the state of the task
      * @throws BulkheadFullException if the task cannot be submitted because the Bulkhead is full
+     * @deprecated use {@link GenericBulkhead#decorateRunnable(Runnable)} instead.
      */
+    @Deprecated
     static Supplier<CompletionStage<Void>> decorateRunnable(ThreadPoolBulkhead bulkhead, Runnable runnable) {
-        return () -> bulkhead.submit(runnable);
+        return GenericBulkhead.decorateRunnable(bulkhead, runnable);
     }
 
     /**
@@ -125,36 +131,6 @@ public interface ThreadPoolBulkhead extends AutoCloseable {
     }
 
     /**
-     * Submits a value-returning task for execution and returns a {@link CompletionStage} representing the
-     * asynchronous computation  of the task.
-     *
-     * @param task the value-returning task to submit
-     * @param <T> the type of the task's result
-     * @return CompletionStage representing the asynchronous computation of the task. The CompletionStage is completed exceptionally with a {@link BulkheadFullException}
-     * when the task could not be submitted, because the Bulkhead was full
-     * @throws BulkheadFullException if the task cannot be submitted, because the Bulkhead is full
-     */
-    <T> CompletionStage<T> submit(Callable<T> task);
-
-    /**
-     * Submits a task for execution to the ThreadPoolBulkhead and returns a {@link CompletionStage} representing the
-     * asynchronous computation  of the task.
-     *
-     *
-     * @param task the task to submit
-     * @return CompletionStage representing the asynchronous computation of the task.
-     * @throws BulkheadFullException if the task cannot be submitted, because the Bulkhead is full
-     */
-    CompletionStage<Void> submit(Runnable task);
-
-    /**
-     * Returns the name of this bulkhead.
-     *
-     * @return the name of this bulkhead
-     */
-    String getName();
-
-    /**
      * Returns the ThreadPoolBulkheadConfig of this Bulkhead.
      *
      * @return bulkhead config
@@ -167,100 +143,6 @@ public interface ThreadPoolBulkhead extends AutoCloseable {
      * @return the Metrics of this Bulkhead
      */
     Metrics getMetrics();
-
-    /**
-     * Returns an unmodifiable map with tags assigned to this Retry.
-     *
-     * @return the tags assigned to this Retry in an unmodifiable map
-     */
-    Map<String, String> getTags();
-
-    /**
-     * Returns an EventPublisher which subscribes to the reactive stream of BulkheadEvent and can be
-     * used to register event consumers.
-     *
-     * @return an EventPublisher
-     */
-    ThreadPoolBulkheadEventPublisher getEventPublisher();
-
-    /**
-     * Returns a supplier which submits a value-returning task for execution and
-     * returns a CompletionStage representing the asynchronous computation of the task.
-     *
-     * @param supplier the value-returning task to submit
-     * @param <T>      the result type of the callable
-     * @return a supplier which submits a value-returning task for execution and returns a CompletionStage representing
-     * the asynchronous computation of the task
-     * @throws BulkheadFullException if the task cannot be submitted because the Bulkhead is full
-     */
-    default <T> Supplier<CompletionStage<T>> decorateSupplier(Supplier<T> supplier) {
-        return decorateSupplier(this, supplier);
-    }
-
-    /**
-     * Returns a supplier which submits a value-returning task for execution and
-     * returns a CompletionStage representing the asynchronous computation of the task.
-     *
-     * @param callable the value-returning task to submit
-     * @param <T>      the result type of the callable
-     * @return a supplier which submits a value-returning task for execution and returns a CompletionStage representing
-     * the asynchronous computation of the task
-     * @throws BulkheadFullException if the task cannot be submitted because the Bulkhead is full
-     */
-    default <T> Supplier<CompletionStage<T>> decorateCallable(Callable<T> callable) {
-        return decorateCallable(this, callable);
-    }
-
-    /**
-     * Returns a supplier which submits a task for execution and returns a {@link CompletionStage} representing the
-     * asynchronous computation of the task.
-     *
-     * @param runnable the task to submit
-     * @return a supplier which submits a task for execution and returns a CompletionStage representing
-     * the asynchronous computation of the task
-     * @throws BulkheadFullException if the task cannot be submitted because the Bulkhead is full
-     */
-    default Supplier<CompletionStage<Void>> decorateRunnable(Runnable runnable) {
-        return decorateRunnable(this, runnable);
-    }
-
-    /**
-     * Submits a value-returning task for execution and returns a {@link CompletionStage} representing the
-     * asynchronous computation of the task.
-     *
-     * @param supplier the value-returning task to submit
-     * @param <T> the type of the task's result
-     * @return a CompletionStage representing the asynchronous computation of the task.
-     * @throws BulkheadFullException if the task cannot be submitted, because the Bulkhead is full
-     */
-    default <T> CompletionStage<T> executeSupplier(Supplier<T> supplier) {
-        return decorateSupplier(this, supplier).get();
-    }
-
-    /**
-     * Submits a value-returning task for execution and returns a {@link CompletionStage} representing the
-     * asynchronous computation  of the task.
-     *
-     * @param callable the value-returning task to submit
-     * @param <T>      the result type of the Callable
-     * @return a {@link CompletionStage} representing the asynchronous computation of the task.
-     * @throws BulkheadFullException if the task cannot be submitted, because the Bulkhead is full
-     */
-    default <T> CompletionStage<T> executeCallable(Callable<T> callable) {
-        return decorateCallable(this, callable).get();
-    }
-
-    /**
-     * Submits a task for execution and returns a {@link CompletionStage} representing the
-     * asynchronous computation  of the task.
-     *
-     * @param runnable the task to submit
-     * @return CompletionStage representing the asynchronous computation of the task.
-     * @throws BulkheadFullException if the task cannot be submitted, because the Bulkhead is full
-     */
-    default CompletionStage<Void> executeRunnable(Runnable runnable) {
-        return decorateRunnable(this, runnable).get();
-    }
 
     interface Metrics {
 

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfig.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfig.java
@@ -38,7 +38,8 @@ import static java.util.stream.Collectors.toList;
 /**
  * A {@link ThreadPoolBulkheadConfig} configures a {@link Bulkhead}
  */
-public class ThreadPoolBulkheadConfig {
+public class ThreadPoolBulkheadConfig extends GenericBulkheadConfig {
+    private static final long serialVersionUID = -3296453918126573034L;
 
     public static final int DEFAULT_QUEUE_CAPACITY = 100;
     public static final Duration DEFAULT_KEEP_ALIVE_DURATION = Duration.ofMillis(20);
@@ -47,13 +48,11 @@ public class ThreadPoolBulkheadConfig {
             - 1 : 1;
     public static final int DEFAULT_MAX_THREAD_POOL_SIZE = Runtime.getRuntime()
         .availableProcessors();
-    public static final boolean DEFAULT_WRITABLE_STACK_TRACE_ENABLED = true;
 
     private int maxThreadPoolSize = DEFAULT_MAX_THREAD_POOL_SIZE;
     private int coreThreadPoolSize = DEFAULT_CORE_THREAD_POOL_SIZE;
     private int queueCapacity = DEFAULT_QUEUE_CAPACITY;
     private Duration keepAliveDuration = DEFAULT_KEEP_ALIVE_DURATION;
-    private boolean writableStackTraceEnabled = DEFAULT_WRITABLE_STACK_TRACE_ENABLED;    
     private List<ContextPropagator> contextPropagators = new ArrayList<>();
     private RejectedExecutionHandler rejectedExecutionHandler = new ThreadPoolExecutor.AbortPolicy();
 
@@ -100,10 +99,6 @@ public class ThreadPoolBulkheadConfig {
     }
 
     public int getCoreThreadPoolSize() { return coreThreadPoolSize; }
-
-    public boolean isWritableStackTraceEnabled() {
-        return writableStackTraceEnabled;
-    }
 
     public List<ContextPropagator> getContextPropagator() {
         return contextPropagators;

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/AbstractExecutorServiceBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/AbstractExecutorServiceBulkhead.java
@@ -1,0 +1,167 @@
+package io.github.resilience4j.bulkhead.internal;
+
+import io.github.resilience4j.bulkhead.BulkheadFullException;
+import io.github.resilience4j.bulkhead.GenericBulkhead;
+import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
+import io.github.resilience4j.bulkhead.event.BulkheadEvent;
+import io.github.resilience4j.bulkhead.event.BulkheadOnCallFinishedEvent;
+import io.github.resilience4j.bulkhead.event.BulkheadOnCallPermittedEvent;
+import io.github.resilience4j.bulkhead.event.BulkheadOnCallRejectedEvent;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+import java.util.concurrent.*;
+import java.util.function.Supplier;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * An ExecutorService-based Bulkhead implementation.
+ */
+public abstract class AbstractExecutorServiceBulkhead<T extends ExecutorService> implements GenericBulkhead {
+
+    private static final String TAGS_MUST_NOT_BE_NULL = "Tags must not be null";
+
+    protected final T executorService;
+    protected final Map<String, String> tags;
+    private final BulkheadEventProcessor eventProcessor;
+    protected final String name;
+
+    public AbstractExecutorServiceBulkhead(T executorService, String name, Map<String, String> tags) {
+        this.executorService = executorService;
+        this.eventProcessor = new BulkheadEventProcessor();
+        this.name = name;
+        this.tags = requireNonNull(tags, TAGS_MUST_NOT_BE_NULL);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T2> CompletableFuture<T2> submit(Callable<T2> callable) {
+        final CompletableFuture<T2> promise = new CompletableFuture<>();
+        try {
+            CompletableFuture.supplyAsync(decorate(() -> {
+                try {
+                    publishBulkheadEvent(() -> new BulkheadOnCallPermittedEvent(name));
+                    return callable.call();
+                } catch (CompletionException e) {
+                    throw e;
+                } catch (Exception e) {
+                    throw new CompletionException(e);
+                }
+            }), executorService).whenComplete((result, throwable) -> {
+                publishBulkheadEvent(() -> new BulkheadOnCallFinishedEvent(name));
+                if (throwable != null) {
+                    promise.completeExceptionally(throwable);
+                } else {
+                    promise.complete(result);
+                }
+            });
+        } catch (RejectedExecutionException rejected) {
+            publishBulkheadEvent(() -> new BulkheadOnCallRejectedEvent(name));
+            throw BulkheadFullException.createBulkheadFullException(name, isWritableStackTraceEnabled());
+        }
+        return promise;
+    }
+
+    protected <R> @Nonnull Supplier<R> decorate(Supplier<R> supplier) {
+        return supplier;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<Void> submit(Runnable runnable) {
+        final CompletableFuture<Void> promise = new CompletableFuture<>();
+        try {
+            CompletableFuture.runAsync(decorate(() -> {
+                try {
+                    publishBulkheadEvent(() -> new BulkheadOnCallPermittedEvent(name));
+                    runnable.run();
+                } catch (Exception e) {
+                    throw new CompletionException(e);
+                }
+            }), executorService).whenComplete((result, throwable) -> {
+                publishBulkheadEvent(() -> new BulkheadOnCallFinishedEvent(name));
+                if (throwable != null) {
+                    promise.completeExceptionally(throwable);
+                } else {
+                    promise.complete(result);
+                }
+            });
+        } catch (RejectedExecutionException rejected) {
+            publishBulkheadEvent(() -> new BulkheadOnCallRejectedEvent(name));
+            throw BulkheadFullException.createBulkheadFullException(name, isWritableStackTraceEnabled());
+        }
+        return promise;
+    }
+
+    /**
+     * Decorates the runnable, if necessary.
+     *
+     * @param runnable the runnable to decorate
+     * @return the decorated runnable
+     */
+    protected Runnable decorate(Runnable runnable) {
+        return runnable;
+    }
+
+    /**
+     * Indicates if writable stack traces should be enabled on thrown exceptions.
+     *
+     * @return true if writable stack traces should be enabled on thrown exceptions
+     */
+    protected abstract boolean isWritableStackTraceEnabled();
+
+    /**
+     * Publishes a bulkhead event to an internal processor.
+     *
+     * @param eventSupplier the event supplier
+     */
+    protected void publishBulkheadEvent(Supplier<BulkheadEvent> eventSupplier) {
+        if (eventProcessor.hasConsumers()) {
+            eventProcessor.consumeEvent(eventSupplier.get());
+        }
+    }
+
+    @Override
+    public void close() {
+        executorService.shutdown();
+        try {
+            if (!executorService.awaitTermination(5, TimeUnit.SECONDS)) {
+                executorService.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            if (!executorService.isTerminated()) {
+                executorService.shutdownNow();
+            }
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ThreadPoolBulkhead.ThreadPoolBulkheadEventPublisher getEventPublisher() {
+        return eventProcessor;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<String, String> getTags() {
+        return tags;
+    }
+}

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/BulkheadEventProcessor.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/BulkheadEventProcessor.java
@@ -1,0 +1,42 @@
+package io.github.resilience4j.bulkhead.internal;
+
+import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
+import io.github.resilience4j.bulkhead.event.BulkheadEvent;
+import io.github.resilience4j.bulkhead.event.BulkheadOnCallFinishedEvent;
+import io.github.resilience4j.bulkhead.event.BulkheadOnCallPermittedEvent;
+import io.github.resilience4j.bulkhead.event.BulkheadOnCallRejectedEvent;
+import io.github.resilience4j.core.EventConsumer;
+import io.github.resilience4j.core.EventProcessor;
+
+class BulkheadEventProcessor extends EventProcessor<BulkheadEvent> implements
+        ThreadPoolBulkhead.ThreadPoolBulkheadEventPublisher, EventConsumer<BulkheadEvent> {
+
+    @Override
+    public ThreadPoolBulkhead.ThreadPoolBulkheadEventPublisher onCallPermitted(
+            EventConsumer<BulkheadOnCallPermittedEvent> onCallPermittedEventConsumer) {
+        registerConsumer(BulkheadOnCallPermittedEvent.class.getName(),
+                onCallPermittedEventConsumer);
+        return this;
+    }
+
+    @Override
+    public ThreadPoolBulkhead.ThreadPoolBulkheadEventPublisher onCallRejected(
+            EventConsumer<BulkheadOnCallRejectedEvent> onCallRejectedEventConsumer) {
+        registerConsumer(BulkheadOnCallRejectedEvent.class.getName(),
+                onCallRejectedEventConsumer);
+        return this;
+    }
+
+    @Override
+    public ThreadPoolBulkhead.ThreadPoolBulkheadEventPublisher onCallFinished(
+            EventConsumer<BulkheadOnCallFinishedEvent> onCallFinishedEventConsumer) {
+        registerConsumer(BulkheadOnCallFinishedEvent.class.getName(),
+                onCallFinishedEventConsumer);
+        return this;
+    }
+
+    @Override
+    public void consumeEvent(BulkheadEvent event) {
+        super.processEvent(event);
+    }
+}

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/ExecutorServiceBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/ExecutorServiceBulkhead.java
@@ -1,0 +1,75 @@
+/*
+ *
+ *  Copyright 2019 Robert Winkler, Mahmoud Romeh
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.bulkhead.internal;
+
+
+import io.github.resilience4j.bulkhead.GenericBulkhead;
+import io.github.resilience4j.core.lang.NonNull;
+
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+
+import static java.util.Collections.emptyMap;
+
+/**
+ * A Bulkhead implementation delegating to an injected ExecutorService.
+ */
+public class ExecutorServiceBulkhead extends AbstractExecutorServiceBulkhead<ExecutorService> implements GenericBulkhead {
+
+    private final boolean writableStackTraceEnabled;
+
+    /**
+     * Creates a bulkhead using given executor service
+     *
+     * @param name                     the name of this bulkhead
+     * @param executor                 the executor service
+     * @param enableWritableStackTrace whether to enable writable stack trace
+     */
+    public ExecutorServiceBulkhead(String name,
+                                   @NonNull ExecutorService executor,
+                                   boolean enableWritableStackTrace) {
+        this(name, emptyMap(), executor, enableWritableStackTrace);
+    }
+
+    /**
+     * Creates a bulkhead using given executor service
+     *
+     * @param name                     the name of this bulkhead
+     * @param tags                     tags to add to the Bulkhead
+     * @param executor                 the executor service
+     * @param enableWritableStackTrace whether to enable writable stack trace
+     */
+    public ExecutorServiceBulkhead(String name,
+                                   Map<String, String> tags,
+                                   @NonNull ExecutorService executor,
+                                   boolean enableWritableStackTrace) {
+        super(executor, name, tags);
+        this.writableStackTraceEnabled = enableWritableStackTrace;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("ExecutorServiceBulkhead '%s'", this.name);
+    }
+
+    @Override
+    public boolean isWritableStackTraceEnabled() {
+        return writableStackTraceEnabled;
+    }
+}

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/FixedThreadPoolBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/FixedThreadPoolBulkhead.java
@@ -19,26 +19,19 @@
 package io.github.resilience4j.bulkhead.internal;
 
 
-import io.github.resilience4j.bulkhead.BulkheadFullException;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkheadConfig;
-import io.github.resilience4j.bulkhead.event.BulkheadEvent;
-import io.github.resilience4j.bulkhead.event.BulkheadOnCallFinishedEvent;
-import io.github.resilience4j.bulkhead.event.BulkheadOnCallPermittedEvent;
-import io.github.resilience4j.bulkhead.event.BulkheadOnCallRejectedEvent;
 import io.github.resilience4j.core.ContextPropagator;
-import io.github.resilience4j.core.EventConsumer;
-import io.github.resilience4j.core.EventProcessor;
-import io.github.resilience4j.core.lang.Nullable;
+import io.github.resilience4j.core.lang.NonNull;
 import io.github.resilience4j.core.ExecutorServiceFactory;
 import io.github.resilience4j.core.ThreadType;
 
+import javax.annotation.Nonnull;
 import java.util.Map;
 import java.util.concurrent.*;
 import java.util.function.Supplier;
 
 import static java.util.Collections.emptyMap;
-import static java.util.Objects.requireNonNull;
 
 /**
  * A Bulkhead implementation based on a fixed ThreadPoolExecutor. which is based into the thread
@@ -46,17 +39,10 @@ import static java.util.Objects.requireNonNull;
  * free thread from the thread pool or the queue is not yet full , it will be permitted 3- otherwise
  * the thread pool will throw RejectedExecutionException which mean is not permitted
  */
-public class FixedThreadPoolBulkhead implements ThreadPoolBulkhead {
+public class FixedThreadPoolBulkhead extends AbstractExecutorServiceBulkhead<ThreadPoolExecutor> implements ThreadPoolBulkhead {
 
-    private static final String CONFIG_MUST_NOT_BE_NULL = "Config must not be null";
-    private static final String TAGS_MUST_NOTE_BE_NULL = "Tags must not be null";
-
-    private final String name;
-    private final ThreadPoolExecutor executorService;
     private final FixedThreadPoolBulkhead.BulkheadMetrics metrics;
-    private final FixedThreadPoolBulkhead.BulkheadEventProcessor eventProcessor;
     private final ThreadPoolBulkheadConfig config;
-    private final Map<String, String> tags;
 
     /**
      * Creates a bulkhead using a configuration supplied
@@ -64,7 +50,7 @@ public class FixedThreadPoolBulkhead implements ThreadPoolBulkhead {
      * @param name           the name of this bulkhead
      * @param bulkheadConfig custom bulkhead configuration
      */
-    public FixedThreadPoolBulkhead(String name, @Nullable ThreadPoolBulkheadConfig bulkheadConfig) {
+    public FixedThreadPoolBulkhead(String name, ThreadPoolBulkheadConfig bulkheadConfig) {
         this(name, bulkheadConfig, emptyMap());
     }
 
@@ -75,25 +61,22 @@ public class FixedThreadPoolBulkhead implements ThreadPoolBulkhead {
      * @param bulkheadConfig custom bulkhead configuration
      * @param tags           tags to add to the Bulkhead
      */
-    public FixedThreadPoolBulkhead(String name, @Nullable ThreadPoolBulkheadConfig bulkheadConfig,
+    public FixedThreadPoolBulkhead(String name, @NonNull ThreadPoolBulkheadConfig bulkheadConfig,
         Map<String, String> tags) {
-        this.name = name;
-        this.config = requireNonNull(bulkheadConfig, CONFIG_MUST_NOT_BE_NULL);
-        this.tags = requireNonNull(tags, TAGS_MUST_NOTE_BE_NULL);
+        super(new ThreadPoolExecutor(bulkheadConfig.getCoreThreadPoolSize(),
+                bulkheadConfig.getMaxThreadPoolSize(),
+                bulkheadConfig.getKeepAliveDuration().toMillis(), TimeUnit.MILLISECONDS,
+                bulkheadConfig.getQueueCapacity() == 0 ? new SynchronousQueue<>() : new ArrayBlockingQueue<>(bulkheadConfig.getQueueCapacity()),
+                ExecutorServiceFactory.getThreadType() == ThreadType.VIRTUAL
+                        ? Thread.ofVirtual().name(String.join("-", "bulkhead", name, "v-"), 0).factory()
+                        : new BulkheadNamingThreadFactory(name),
+                bulkheadConfig.getRejectedExecutionHandler()),
+            name,
+            tags);
+        this.config = bulkheadConfig;
         // init thread pool executor
-        ThreadFactory threadFactory = ExecutorServiceFactory.getThreadType() == ThreadType.VIRTUAL
-            ? Thread.ofVirtual().name(String.join("-", "bulkhead", name, "v-"), 0).factory()
-            : new BulkheadNamingThreadFactory(name);
-
-        this.executorService = new ThreadPoolExecutor(config.getCoreThreadPoolSize(),
-            config.getMaxThreadPoolSize(),
-            config.getKeepAliveDuration().toMillis(), TimeUnit.MILLISECONDS,
-            config.getQueueCapacity() == 0 ? new SynchronousQueue<>() : new ArrayBlockingQueue<>(config.getQueueCapacity()),
-            threadFactory,
-            config.getRejectedExecutionHandler());
         // adding prover jvm executor shutdown
         this.metrics = new FixedThreadPoolBulkhead.BulkheadMetrics();
-        this.eventProcessor = new FixedThreadPoolBulkhead.BulkheadEventProcessor();
     }
 
     /**
@@ -135,72 +118,19 @@ public class FixedThreadPoolBulkhead implements ThreadPoolBulkhead {
         this(name, configSupplier.get(), tags);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public <T> CompletableFuture<T> submit(Callable<T> callable) {
-        final CompletableFuture<T> promise = new CompletableFuture<>();
-        try {
-            CompletableFuture.supplyAsync(ContextPropagator.decorateSupplier(config.getContextPropagator(),() -> {
-                try {
-                    publishBulkheadEvent(() -> new BulkheadOnCallPermittedEvent(name));
-                    return callable.call();
-                } catch (CompletionException e) {
-                    throw e;
-                } catch (Exception e){
-                    throw new CompletionException(e);
-                }
-            }), executorService).whenComplete((result, throwable) -> {
-                publishBulkheadEvent(() -> new BulkheadOnCallFinishedEvent(name));
-                if (throwable != null) {
-                    promise.completeExceptionally(throwable);
-                } else {
-                    promise.complete(result);
-                }
-            });
-        } catch (RejectedExecutionException rejected) {
-            publishBulkheadEvent(() -> new BulkheadOnCallRejectedEvent(name));
-            throw BulkheadFullException.createBulkheadFullException(this);
-        }
-        return promise;
+    protected <T> @Nonnull Supplier<T> decorate(Supplier<T> supplier) {
+        return ContextPropagator.decorateSupplier(config.getContextPropagator(), supplier);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public CompletableFuture<Void> submit(Runnable runnable) {
-        final CompletableFuture<Void> promise = new CompletableFuture<>();
-        try {
-            CompletableFuture.runAsync(ContextPropagator.decorateRunnable(config.getContextPropagator(),() -> {
-                try {
-                    publishBulkheadEvent(() -> new BulkheadOnCallPermittedEvent(name));
-                    runnable.run();
-                } catch (Exception e) {
-                    throw new CompletionException(e);
-                }
-            }), executorService).whenComplete((result, throwable) -> {
-                publishBulkheadEvent(() -> new BulkheadOnCallFinishedEvent(name));
-                if (throwable != null) {
-                    promise.completeExceptionally(throwable);
-                } else {
-                    promise.complete(result);
-                }
-            });
-        } catch (RejectedExecutionException rejected) {
-            publishBulkheadEvent(() -> new BulkheadOnCallRejectedEvent(name));
-            throw BulkheadFullException.createBulkheadFullException(this);
-        }
-        return promise;
+    protected boolean isWritableStackTraceEnabled() {
+        return config.isWritableStackTraceEnabled();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public String getName() {
-        return this.name;
+    public Runnable decorate(Runnable runnable) {
+        return ContextPropagator.decorateRunnable(config.getContextPropagator(), runnable);
     }
 
     /**
@@ -219,79 +149,9 @@ public class FixedThreadPoolBulkhead implements ThreadPoolBulkhead {
         return metrics;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Map<String, String> getTags() {
-        return tags;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public ThreadPoolBulkheadEventPublisher getEventPublisher() {
-        return eventProcessor;
-    }
-
-    private void publishBulkheadEvent(Supplier<BulkheadEvent> eventSupplier) {
-        if (eventProcessor.hasConsumers()) {
-            eventProcessor.consumeEvent(eventSupplier.get());
-        }
-    }
-
     @Override
     public String toString() {
         return String.format("FixedThreadPoolBulkhead '%s'", this.name);
-    }
-
-    @Override
-    public void close() {
-        executorService.shutdown();
-        try {
-            if (!executorService.awaitTermination(5, TimeUnit.SECONDS)) {
-                executorService.shutdownNow();
-            }
-        } catch (InterruptedException e) {
-            if (!executorService.isTerminated()) {
-                executorService.shutdownNow();
-            }
-            Thread.currentThread().interrupt();
-        }
-    }
-
-    private class BulkheadEventProcessor extends EventProcessor<BulkheadEvent> implements
-        ThreadPoolBulkheadEventPublisher, EventConsumer<BulkheadEvent> {
-
-        @Override
-        public ThreadPoolBulkheadEventPublisher onCallPermitted(
-            EventConsumer<BulkheadOnCallPermittedEvent> onCallPermittedEventConsumer) {
-            registerConsumer(BulkheadOnCallPermittedEvent.class.getName(),
-                onCallPermittedEventConsumer);
-            return this;
-        }
-
-        @Override
-        public ThreadPoolBulkheadEventPublisher onCallRejected(
-            EventConsumer<BulkheadOnCallRejectedEvent> onCallRejectedEventConsumer) {
-            registerConsumer(BulkheadOnCallRejectedEvent.class.getName(),
-                onCallRejectedEventConsumer);
-            return this;
-        }
-
-        @Override
-        public ThreadPoolBulkheadEventPublisher onCallFinished(
-            EventConsumer<BulkheadOnCallFinishedEvent> onCallFinishedEventConsumer) {
-            registerConsumer(BulkheadOnCallFinishedEvent.class.getName(),
-                onCallFinishedEventConsumer);
-            return this;
-        }
-
-        @Override
-        public void consumeEvent(BulkheadEvent event) {
-            super.processEvent(event);
-        }
     }
 
     /**

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/InMemoryGenericBulkheadRegistry.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/InMemoryGenericBulkheadRegistry.java
@@ -1,0 +1,333 @@
+/*
+ *
+ *  Copyright 2017 Robert Winkler, Lucas Lech, Mahmoud Romeh
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.bulkhead.internal;
+
+import io.github.resilience4j.bulkhead.*;
+import io.github.resilience4j.core.ConfigurationNotFoundException;
+import io.github.resilience4j.core.RegistryStore;
+import io.github.resilience4j.core.registry.AbstractRegistry;
+import io.github.resilience4j.core.registry.InMemoryRegistryStore;
+import io.github.resilience4j.core.registry.RegistryEventConsumer;
+
+import java.util.*;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static java.util.Collections.emptyMap;
+
+/**
+ * Thread pool Bulkhead instance manager; Constructs/returns thread pool bulkhead instances.
+ */
+public final class InMemoryGenericBulkheadRegistry extends
+    AbstractRegistry<GenericBulkhead, GenericBulkheadConfig> implements
+    GenericBulkheadRegistry {
+
+    private final Function<GenericBulkheadConfig, ScheduledExecutorService> scheduledExecutorService;
+
+    /**
+     * The constructor with default configuration.
+     *
+     * @param scheduledExecutorService function to create the scheduled executor service
+     */
+    public InMemoryGenericBulkheadRegistry(Function<GenericBulkheadConfig, ScheduledExecutorService> scheduledExecutorService) {
+        this(emptyMap(), scheduledExecutorService);
+    }
+
+    /**
+     * The constructor with a map of configurations.
+     *
+     * @param configs a map of configurations
+     * @param scheduledExecutorService function to create the scheduled executor service
+     */
+    public InMemoryGenericBulkheadRegistry(Map<String, GenericBulkheadConfig> configs, Function<GenericBulkheadConfig, ScheduledExecutorService> scheduledExecutorService) {
+        this(configs, emptyMap(), scheduledExecutorService);
+    }
+
+    /**
+     * The constructor with a map of configurations and a map of tags.
+     *
+     * @param configs a map of configurations
+     * @param tags a map of tags
+     * @param scheduledExecutorService function to create the scheduled executor service
+     */
+    public InMemoryGenericBulkheadRegistry(Map<String, GenericBulkheadConfig> configs, Map<String, String> tags, Function<GenericBulkheadConfig, ScheduledExecutorService> scheduledExecutorService) {
+        this(configs.getOrDefault(DEFAULT_CONFIG, GenericBulkheadConfig.ofDefaults()), tags, scheduledExecutorService);
+        this.configurations.putAll(configs);
+    }
+
+    /**
+     * The constructor with a map of configurations and a registry event consumer.
+     *
+     * @param configs a map of configurations
+     * @param registryEventConsumer a registry event consumer
+     * @param scheduledExecutorService function to create the scheduled executor service
+     */
+    public InMemoryGenericBulkheadRegistry(
+        Map<String, GenericBulkheadConfig> configs,
+        RegistryEventConsumer<GenericBulkhead> registryEventConsumer, Function<GenericBulkheadConfig, ScheduledExecutorService> scheduledExecutorService) {
+        this(configs, registryEventConsumer, emptyMap(), scheduledExecutorService);
+    }
+
+    /**
+     * The constructor with a map of configurations, a registry event consumer, and a map of tags.
+     *
+     * @param configs a map of configurations
+     * @param registryEventConsumer a registry event consumer
+     * @param tags a map of tags
+     * @param scheduledExecutorService function to create the scheduled executor service
+     */
+    public InMemoryGenericBulkheadRegistry(
+        Map<String, GenericBulkheadConfig> configs,
+        RegistryEventConsumer<GenericBulkhead> registryEventConsumer, Map<String, String> tags,
+        Function<GenericBulkheadConfig, ScheduledExecutorService> scheduledExecutorService) {
+        this(configs.getOrDefault(DEFAULT_CONFIG, GenericBulkheadConfig.ofDefaults()),
+            registryEventConsumer, tags, scheduledExecutorService);
+        this.configurations.putAll(configs);
+    }
+
+    /**
+     * The constructor with a map of configurations and a list of registry event consumers.
+     *
+     * @param configs a map of configurations
+     * @param registryEventConsumers a list of registry event consumers
+     * @param scheduledExecutorService function to create the scheduled executor service
+     */
+    public InMemoryGenericBulkheadRegistry(
+        Map<String, GenericBulkheadConfig> configs,
+        List<RegistryEventConsumer<GenericBulkhead>> registryEventConsumers,
+        Function<GenericBulkheadConfig, ScheduledExecutorService> scheduledExecutorService) {
+        this(configs, registryEventConsumers, emptyMap(), scheduledExecutorService);
+    }
+
+    /**
+     * The constructor with a map of configurations, a list of registry event consumers, and a map of tags.
+     *
+     * @param configs a map of configurations
+     * @param registryEventConsumers a list of registry event consumers
+     * @param tags a map of tags
+     * @param scheduledExecutorService function to create the scheduled executor service
+     */
+    public InMemoryGenericBulkheadRegistry(
+        Map<String, GenericBulkheadConfig> configs,
+        List<RegistryEventConsumer<GenericBulkhead>> registryEventConsumers, Map<String, String> tags,
+        Function<GenericBulkheadConfig, ScheduledExecutorService> scheduledExecutorService) {
+        this(configs.getOrDefault(DEFAULT_CONFIG, GenericBulkheadConfig.ofDefaults()),
+            registryEventConsumers, tags, scheduledExecutorService);
+        this.configurations.putAll(configs);
+    }
+
+    /**
+     * The constructor with custom default config.
+     *
+     * @param defaultConfig The default config.
+     * @param scheduledExecutorService function to create the scheduled executor service
+     */
+    public InMemoryGenericBulkheadRegistry(GenericBulkheadConfig defaultConfig, Function<GenericBulkheadConfig, ScheduledExecutorService> scheduledExecutorService) {
+        super(defaultConfig);
+        this.scheduledExecutorService = scheduledExecutorService;
+    }
+
+    /**
+     * The constructor with a default configuration and a map of tags.
+     *
+     * @param defaultConfig the default configuration
+     * @param tags a map of tags
+     * @param scheduledExecutorService function to create the scheduled executor service
+     */
+    public InMemoryGenericBulkheadRegistry(GenericBulkheadConfig defaultConfig, Map<String, String> tags, Function<GenericBulkheadConfig, ScheduledExecutorService> scheduledExecutorService) {
+        super(defaultConfig, tags);
+        this.scheduledExecutorService = scheduledExecutorService;
+    }
+
+    /**
+     * The constructor with a default configuration and a registry event consumer.
+     *
+     * @param defaultConfig the default configuration
+     * @param registryEventConsumer a registry event consumer
+     * @param scheduledExecutorService function to create the scheduled executor service
+     */
+    public InMemoryGenericBulkheadRegistry(
+            GenericBulkheadConfig defaultConfig,
+        RegistryEventConsumer<GenericBulkhead> registryEventConsumer, Function<GenericBulkheadConfig, ScheduledExecutorService> scheduledExecutorService) {
+        super(defaultConfig, registryEventConsumer);
+        this.scheduledExecutorService = scheduledExecutorService;
+    }
+
+    /**
+     * The constructor with a default configuration, a registry event consumer, and a map of tags.
+     *
+     * @param defaultConfig the default configuration
+     * @param registryEventConsumer a registry event consumer
+     * @param tags a map of tags
+     * @param scheduledExecutorService function to create the scheduled executor service
+     */
+    public InMemoryGenericBulkheadRegistry(
+        GenericBulkheadConfig defaultConfig,
+        RegistryEventConsumer<GenericBulkhead> registryEventConsumer, Map<String, String> tags,
+        Function<GenericBulkheadConfig, ScheduledExecutorService> scheduledExecutorService) {
+        super(defaultConfig, registryEventConsumer, tags);
+        this.scheduledExecutorService = scheduledExecutorService;
+    }
+
+    /**
+     * The constructor with a default configuration and a list of registry event consumers.
+     *
+     * @param defaultConfig the default configuration
+     * @param registryEventConsumers a list of registry event consumers
+     * @param scheduledExecutorService function to create the scheduled executor service
+     */
+    public InMemoryGenericBulkheadRegistry(
+        GenericBulkheadConfig defaultConfig,
+        List<RegistryEventConsumer<GenericBulkhead>> registryEventConsumers,
+        Function<GenericBulkheadConfig, ScheduledExecutorService> scheduledExecutorService) {
+        super(defaultConfig, registryEventConsumers);
+        this.scheduledExecutorService = scheduledExecutorService;
+    }
+
+    /**
+     * The constructor with a default configuration, a list of registry event consumers, and a map of tags.
+     *
+     * @param defaultConfig the default configuration
+     * @param registryEventConsumers a list of registry event consumers
+     * @param tags a map of tags
+     * @param scheduledExecutorService function to create the scheduled executor service
+     */
+    public InMemoryGenericBulkheadRegistry(
+        GenericBulkheadConfig defaultConfig,
+        List<RegistryEventConsumer<GenericBulkhead>> registryEventConsumers, Map<String, String> tags,
+        Function<GenericBulkheadConfig, ScheduledExecutorService> scheduledExecutorService) {
+        super(defaultConfig, registryEventConsumers, tags);
+        this.scheduledExecutorService = scheduledExecutorService;
+    }
+
+    /**
+     * The constructor with a map of configurations, a list of registry event consumers, a map of tags, a registry store, and an executor service function.
+     *
+     * @param configs a map of configurations
+     * @param registryEventConsumers a list of registry event consumers
+     * @param tags a map of tags
+     * @param registryStore the registry store
+     * @param scheduledExecutorService function to create the scheduled executor service
+     */
+    public InMemoryGenericBulkheadRegistry(Map<String, GenericBulkheadConfig> configs,
+                                           List<RegistryEventConsumer<GenericBulkhead>> registryEventConsumers,
+                                           Map<String, String> tags, RegistryStore<GenericBulkhead> registryStore,
+                                           Function<GenericBulkheadConfig, ScheduledExecutorService> scheduledExecutorService) {
+        super(configs.getOrDefault(DEFAULT_CONFIG, ThreadPoolBulkheadConfig.ofDefaults()),
+            registryEventConsumers, Optional.ofNullable(tags).orElse(emptyMap()),
+            Optional.ofNullable(registryStore).orElse(new InMemoryRegistryStore<>()));
+        this.configurations.putAll(configs);
+        this.scheduledExecutorService = scheduledExecutorService;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<GenericBulkhead> getAllBulkheads() {
+        return new HashSet<>(entryMap.values());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GenericBulkhead bulkhead(String name) {
+        return bulkhead(name, emptyMap());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GenericBulkhead bulkhead(String name, Map<String, String> tags) {
+        return bulkhead(name, getDefaultConfig(), tags);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GenericBulkhead bulkhead(String name, GenericBulkheadConfig config) {
+        return bulkhead(name, config, emptyMap());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GenericBulkhead bulkhead(String name, GenericBulkheadConfig config, Map<String, String> tags) {
+        return computeIfAbsent(name, () -> {
+            GenericBulkheadConfig bulkheadConfig = Objects.requireNonNull(config, CONFIG_MUST_NOT_BE_NULL);
+            return GenericBulkhead
+                .of(name, getAllTags(tags), scheduledExecutorService.apply(bulkheadConfig), bulkheadConfig);
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GenericBulkhead bulkhead(String name,
+        Supplier<GenericBulkheadConfig> bulkheadConfigSupplier) {
+        return bulkhead(name, bulkheadConfigSupplier, emptyMap());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GenericBulkhead bulkhead(String name,
+        Supplier<GenericBulkheadConfig> bulkheadConfigSupplier, Map<String, String> tags) {
+        return computeIfAbsent(name, () -> {
+            GenericBulkheadConfig bulkheadConfig = Objects.requireNonNull(
+                    Objects.requireNonNull(bulkheadConfigSupplier, SUPPLIER_MUST_NOT_BE_NULL).get(),
+                    CONFIG_MUST_NOT_BE_NULL);
+            return GenericBulkhead.of(name, getAllTags(tags), scheduledExecutorService.apply(bulkheadConfig), bulkheadConfig);
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GenericBulkhead bulkhead(String name, String configName) {
+        return bulkhead(name, configName, emptyMap());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GenericBulkhead bulkhead(String name, String configName, Map<String, String> tags) {
+        return computeIfAbsent(name, () -> {
+            GenericBulkheadConfig bulkheadConfig = getConfiguration(configName)
+                    .orElseThrow(() -> new ConfigurationNotFoundException(configName));
+            return GenericBulkhead.of(name, getAllTags(tags), scheduledExecutorService.apply(bulkheadConfig), bulkheadConfig);
+        });
+    }
+
+    @Override
+    public void close() throws Exception {
+        for (GenericBulkhead bulkhead : getAllBulkheads()) {
+            bulkhead.close();
+        }
+    }
+}

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadTest.java
@@ -217,13 +217,6 @@ public class ThreadPoolBulkheadTest extends ThreadModeTestBase {
     }
 
     @Test
-    public void testCreateWithNullConfig() {
-        assertThatThrownBy(() -> ThreadPoolBulkhead.of("test", (ThreadPoolBulkheadConfig) null))
-            .isInstanceOf(NullPointerException.class)
-            .hasMessage("Config must not be null");
-    }
-
-    @Test
     public void testCreateThreadsUsingNameForPrefix()
         throws ExecutionException, InterruptedException {
         LOG.info("Running testCreateThreadsUsingNameForPrefix in {}", getThreadModeDescription());

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/internal/FixedThreadPoolBulkheadTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/internal/FixedThreadPoolBulkheadTest.java
@@ -19,6 +19,7 @@
 package io.github.resilience4j.bulkhead.internal;
 
 
+import io.github.resilience4j.bulkhead.GenericBulkhead;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkheadConfig;
 import io.github.resilience4j.core.registry.*;

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedThreadPoolBulkheadMetricsPublisherTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedThreadPoolBulkheadMetricsPublisherTest.java
@@ -16,6 +16,7 @@
 
 package io.github.resilience4j.micrometer.tagged;
 
+import io.github.resilience4j.bulkhead.GenericBulkhead;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkheadConfig;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkheadRegistry;


### PR DESCRIPTION
This introduces a "generic" BulkHead to allow configuration of an external executor, mainly to allow configuration of one of the micrometer [ExecutorServices](https://github.com/micrometer-metrics/context-propagation/blob/main/context-propagation/src/main/java/io/micrometer/context/ContextScheduledExecutorService.java).

Most of the changes are to support `AbstractExecutorServiceBulkhead` which is detached from any notion of `ContextPropagator`s. A lot of work is therefore only there to extract interfaces and superclasses without any reference to the ContextPropagator API.

This is the bare minimum to allow any motivated dev to have a hook in the library to inject their own.

Part of https://github.com/resilience4j/resilience4j/issues/2353