### PR TITLE
#issue 2450: Enhance virtual thread support in RetryAspect and TimeLimiterAspect by using ExecutorServiceFactory for fallback schedulers

### DIFF
--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/retry/configure/RetryAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/retry/configure/RetryAspect.java
@@ -16,12 +16,13 @@
 package io.github.resilience4j.spring6.retry.configure;
 
 import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
+import io.github.resilience4j.core.ExecutorServiceFactory;
 import io.github.resilience4j.core.functions.CheckedSupplier;
 import io.github.resilience4j.core.lang.Nullable;
-import io.github.resilience4j.spring6.fallback.FallbackExecutor;
 import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.retry.RetryRegistry;
 import io.github.resilience4j.retry.annotation.Retry;
+import io.github.resilience4j.spring6.fallback.FallbackExecutor;
 import io.github.resilience4j.spring6.spelresolver.SpelResolver;
 import io.github.resilience4j.spring6.utils.AnnotationExtractor;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -37,7 +38,10 @@ import org.springframework.core.Ordered;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.List;
-import java.util.concurrent.*;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 /**
  * This Spring AOP aspect intercepts all methods which are annotated with a {@link Retry}
@@ -93,7 +97,9 @@ public class RetryAspect implements Ordered, AutoCloseable {
         this.spelResolver = spelResolver;
         this.retryExecutorService = contextAwareScheduledThreadPoolExecutor != null ?
             contextAwareScheduledThreadPoolExecutor :
-            Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
+            ExecutorServiceFactory.newScheduledThreadPool(
+                Runtime.getRuntime().availableProcessors(),
+                "RetryAspect");
     }
 
     @Pointcut(value = "@within(retry) || @annotation(retry)", argNames = "retry")

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterAspect.java
@@ -17,14 +17,15 @@
 package io.github.resilience4j.spring6.timelimiter.configure;
 
 import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
+import io.github.resilience4j.core.ExecutorServiceFactory;
 import io.github.resilience4j.core.functions.CheckedSupplier;
 import io.github.resilience4j.core.lang.Nullable;
 import io.github.resilience4j.spring6.fallback.FallbackExecutor;
 import io.github.resilience4j.spring6.spelresolver.SpelResolver;
+import io.github.resilience4j.spring6.utils.AnnotationExtractor;
 import io.github.resilience4j.timelimiter.TimeLimiterConfig;
 import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
 import io.github.resilience4j.timelimiter.annotation.TimeLimiter;
-import io.github.resilience4j.spring6.utils.AnnotationExtractor;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -37,7 +38,10 @@ import org.springframework.core.Ordered;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.List;
-import java.util.concurrent.*;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 @Aspect
 public class TimeLimiterAspect implements Ordered, AutoCloseable {
@@ -64,7 +68,9 @@ public class TimeLimiterAspect implements Ordered, AutoCloseable {
         this.spelResolver = spelResolver;
         this.timeLimiterExecutorService = contextAwareScheduledThreadPoolExecutor != null ?
             contextAwareScheduledThreadPoolExecutor :
-            Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
+            ExecutorServiceFactory.newScheduledThreadPool(
+                Runtime.getRuntime().availableProcessors(),
+                "TimeLimiterAspect");
     }
 
     @Pointcut(value = "@within(timeLimiter) || @annotation(timeLimiter)", argNames = "timeLimiter")

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/retry/configure/RetryAspectVirtualThreadTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/retry/configure/RetryAspectVirtualThreadTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.spring6.retry.configure;
+
+import io.github.resilience4j.core.ThreadType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@link RetryAspect}'s fallback scheduler honors the
+ * {@code resilience4j.thread.type} system property when no
+ * {@code ContextAwareScheduledThreadPoolExecutor} bean is provided.
+ */
+@RunWith(Parameterized.class)
+public class RetryAspectVirtualThreadTest {
+
+    private static final String SYS_PROP_KEY = "resilience4j.thread.type";
+    private static final String EXPECTED_POOL_NAME = "RetryAspect";
+
+    private final ThreadType threadType;
+    private String originalProperty;
+    private RetryAspect aspect;
+
+    public RetryAspectVirtualThreadTest(ThreadType threadType) {
+        this.threadType = threadType;
+    }
+
+    @Parameterized.Parameters(name = "threadMode={0}")
+    public static Collection<Object[]> threadModes() {
+        return Arrays.asList(new Object[][]{
+            {ThreadType.PLATFORM},
+            {ThreadType.VIRTUAL}
+        });
+    }
+
+    @Before
+    public void setUp() {
+        originalProperty = System.getProperty(SYS_PROP_KEY);
+        if (threadType == ThreadType.VIRTUAL) {
+            System.setProperty(SYS_PROP_KEY, threadType.toString());
+        } else {
+            System.clearProperty(SYS_PROP_KEY);
+        }
+        // Pass null for contextAwareScheduledThreadPoolExecutor to force the
+        // ExecutorServiceFactory fallback path under test.
+        aspect = new RetryAspect(null, null, null, null, null, null);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (aspect != null) {
+            aspect.close();
+        }
+        if (originalProperty != null) {
+            System.setProperty(SYS_PROP_KEY, originalProperty);
+        } else {
+            System.clearProperty(SYS_PROP_KEY);
+        }
+    }
+
+    @Test
+    public void fallbackSchedulerShouldUseConfiguredThreadType() throws Exception {
+        ScheduledExecutorService executor = extractExecutorService(aspect);
+
+        boolean ranOnVirtual = executor
+            .submit(() -> Thread.currentThread().isVirtual())
+            .get(5, TimeUnit.SECONDS);
+
+        assertThat(ranOnVirtual)
+            .as("RetryAspect fallback scheduler must respect resilience4j.thread.type=%s",
+                threadType)
+            .isEqualTo(threadType == ThreadType.VIRTUAL);
+    }
+
+    @Test
+    public void fallbackSchedulerShouldHaveAspectScopedThreadName() throws Exception {
+        ScheduledExecutorService executor = extractExecutorService(aspect);
+
+        String threadName = executor
+            .submit(() -> Thread.currentThread().getName())
+            .get(5, TimeUnit.SECONDS);
+
+        assertThat(threadName).contains(EXPECTED_POOL_NAME);
+        if (threadType == ThreadType.VIRTUAL) {
+            assertThat(threadName).contains("-vthread-");
+        } else {
+            assertThat(threadName).contains("-thread-");
+        }
+    }
+
+    private static ScheduledExecutorService extractExecutorService(RetryAspect aspect)
+        throws Exception {
+        Field field = RetryAspect.class.getDeclaredField("retryExecutorService");
+        field.setAccessible(true);
+        return (ScheduledExecutorService) field.get(aspect);
+    }
+}

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/retry/configure/RetryAspectVirtualThreadTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/retry/configure/RetryAspectVirtualThreadTest.java
@@ -16,17 +16,14 @@
 package io.github.resilience4j.spring6.retry.configure;
 
 import io.github.resilience4j.core.ThreadType;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.lang.reflect.Field;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -35,43 +32,28 @@ import static org.assertj.core.api.Assertions.assertThat;
  * {@code resilience4j.thread.type} system property when no
  * {@code ContextAwareScheduledThreadPoolExecutor} bean is provided.
  */
-@RunWith(Parameterized.class)
-public class RetryAspectVirtualThreadTest {
+class RetryAspectVirtualThreadTest {
 
     private static final String SYS_PROP_KEY = "resilience4j.thread.type";
     private static final String EXPECTED_POOL_NAME = "RetryAspect";
 
-    private final ThreadType threadType;
     private String originalProperty;
     private RetryAspect aspect;
 
-    public RetryAspectVirtualThreadTest(ThreadType threadType) {
-        this.threadType = threadType;
+    private static Stream<ThreadType> threadModes() {
+        return Stream.of(ThreadType.PLATFORM, ThreadType.VIRTUAL);
     }
 
-    @Parameterized.Parameters(name = "threadMode={0}")
-    public static Collection<Object[]> threadModes() {
-        return Arrays.asList(new Object[][]{
-            {ThreadType.PLATFORM},
-            {ThreadType.VIRTUAL}
-        });
-    }
-
-    @Before
-    public void setUp() {
+    private void setUp(ThreadType threadType) {
         originalProperty = System.getProperty(SYS_PROP_KEY);
-        if (threadType == ThreadType.VIRTUAL) {
-            System.setProperty(SYS_PROP_KEY, threadType.toString());
-        } else {
-            System.clearProperty(SYS_PROP_KEY);
-        }
+        System.setProperty(SYS_PROP_KEY, threadType.toString());
         // Pass null for contextAwareScheduledThreadPoolExecutor to force the
         // ExecutorServiceFactory fallback path under test.
         aspect = new RetryAspect(null, null, null, null, null, null);
     }
 
-    @After
-    public void tearDown() throws Exception {
+    @AfterEach
+    void tearDown() throws Exception {
         if (aspect != null) {
             aspect.close();
         }
@@ -82,8 +64,10 @@ public class RetryAspectVirtualThreadTest {
         }
     }
 
-    @Test
-    public void fallbackSchedulerShouldUseConfiguredThreadType() throws Exception {
+    @ParameterizedTest(name = "threadMode={0}")
+    @MethodSource("threadModes")
+    void fallbackSchedulerShouldUseConfiguredThreadType(ThreadType threadType) throws Exception {
+        setUp(threadType);
         ScheduledExecutorService executor = extractExecutorService(aspect);
 
         boolean ranOnVirtual = executor
@@ -96,8 +80,10 @@ public class RetryAspectVirtualThreadTest {
             .isEqualTo(threadType == ThreadType.VIRTUAL);
     }
 
-    @Test
-    public void fallbackSchedulerShouldHaveAspectScopedThreadName() throws Exception {
+    @ParameterizedTest(name = "threadMode={0}")
+    @MethodSource("threadModes")
+    void fallbackSchedulerShouldHaveAspectScopedThreadName(ThreadType threadType) throws Exception {
+        setUp(threadType);
         ScheduledExecutorService executor = extractExecutorService(aspect);
 
         String threadName = executor

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterAspectVirtualThreadTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterAspectVirtualThreadTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.spring6.timelimiter.configure;
+
+import io.github.resilience4j.core.ThreadType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@link TimeLimiterAspect}'s fallback scheduler honors the
+ * {@code resilience4j.thread.type} system property when no
+ * {@code ContextAwareScheduledThreadPoolExecutor} bean is provided.
+ */
+@RunWith(Parameterized.class)
+public class TimeLimiterAspectVirtualThreadTest {
+
+    private static final String SYS_PROP_KEY = "resilience4j.thread.type";
+    private static final String EXPECTED_POOL_NAME = "TimeLimiterAspect";
+
+    private final ThreadType threadType;
+    private String originalProperty;
+    private TimeLimiterAspect aspect;
+
+    public TimeLimiterAspectVirtualThreadTest(ThreadType threadType) {
+        this.threadType = threadType;
+    }
+
+    @Parameterized.Parameters(name = "threadMode={0}")
+    public static Collection<Object[]> threadModes() {
+        return Arrays.asList(new Object[][]{
+            {ThreadType.PLATFORM},
+            {ThreadType.VIRTUAL}
+        });
+    }
+
+    @Before
+    public void setUp() {
+        originalProperty = System.getProperty(SYS_PROP_KEY);
+        if (threadType == ThreadType.VIRTUAL) {
+            System.setProperty(SYS_PROP_KEY, threadType.toString());
+        } else {
+            System.clearProperty(SYS_PROP_KEY);
+        }
+        // Pass null for contextAwareScheduledThreadPoolExecutor to force the
+        // ExecutorServiceFactory fallback path under test.
+        aspect = new TimeLimiterAspect(null, null, null, null, null, null);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (aspect != null) {
+            aspect.close();
+        }
+        if (originalProperty != null) {
+            System.setProperty(SYS_PROP_KEY, originalProperty);
+        } else {
+            System.clearProperty(SYS_PROP_KEY);
+        }
+    }
+
+    @Test
+    public void fallbackSchedulerShouldUseConfiguredThreadType() throws Exception {
+        ScheduledExecutorService executor = extractExecutorService(aspect);
+
+        boolean ranOnVirtual = executor
+            .submit(() -> Thread.currentThread().isVirtual())
+            .get(5, TimeUnit.SECONDS);
+
+        assertThat(ranOnVirtual)
+            .as("TimeLimiterAspect fallback scheduler must respect resilience4j.thread.type=%s",
+                threadType)
+            .isEqualTo(threadType == ThreadType.VIRTUAL);
+    }
+
+    @Test
+    public void fallbackSchedulerShouldHaveAspectScopedThreadName() throws Exception {
+        ScheduledExecutorService executor = extractExecutorService(aspect);
+
+        String threadName = executor
+            .submit(() -> Thread.currentThread().getName())
+            .get(5, TimeUnit.SECONDS);
+
+        assertThat(threadName).contains(EXPECTED_POOL_NAME);
+        if (threadType == ThreadType.VIRTUAL) {
+            assertThat(threadName).contains("-vthread-");
+        } else {
+            assertThat(threadName).contains("-thread-");
+        }
+    }
+
+    private static ScheduledExecutorService extractExecutorService(TimeLimiterAspect aspect)
+        throws Exception {
+        Field field = TimeLimiterAspect.class.getDeclaredField("timeLimiterExecutorService");
+        field.setAccessible(true);
+        return (ScheduledExecutorService) field.get(aspect);
+    }
+}

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterAspectVirtualThreadTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterAspectVirtualThreadTest.java
@@ -16,17 +16,14 @@
 package io.github.resilience4j.spring6.timelimiter.configure;
 
 import io.github.resilience4j.core.ThreadType;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.lang.reflect.Field;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -35,43 +32,28 @@ import static org.assertj.core.api.Assertions.assertThat;
  * {@code resilience4j.thread.type} system property when no
  * {@code ContextAwareScheduledThreadPoolExecutor} bean is provided.
  */
-@RunWith(Parameterized.class)
-public class TimeLimiterAspectVirtualThreadTest {
+class TimeLimiterAspectVirtualThreadTest {
 
     private static final String SYS_PROP_KEY = "resilience4j.thread.type";
     private static final String EXPECTED_POOL_NAME = "TimeLimiterAspect";
 
-    private final ThreadType threadType;
     private String originalProperty;
     private TimeLimiterAspect aspect;
 
-    public TimeLimiterAspectVirtualThreadTest(ThreadType threadType) {
-        this.threadType = threadType;
+    private static Stream<ThreadType> threadModes() {
+        return Stream.of(ThreadType.PLATFORM, ThreadType.VIRTUAL);
     }
 
-    @Parameterized.Parameters(name = "threadMode={0}")
-    public static Collection<Object[]> threadModes() {
-        return Arrays.asList(new Object[][]{
-            {ThreadType.PLATFORM},
-            {ThreadType.VIRTUAL}
-        });
-    }
-
-    @Before
-    public void setUp() {
+    private void setUp(ThreadType threadType) {
         originalProperty = System.getProperty(SYS_PROP_KEY);
-        if (threadType == ThreadType.VIRTUAL) {
-            System.setProperty(SYS_PROP_KEY, threadType.toString());
-        } else {
-            System.clearProperty(SYS_PROP_KEY);
-        }
+        System.setProperty(SYS_PROP_KEY, threadType.toString());
         // Pass null for contextAwareScheduledThreadPoolExecutor to force the
         // ExecutorServiceFactory fallback path under test.
         aspect = new TimeLimiterAspect(null, null, null, null, null, null);
     }
 
-    @After
-    public void tearDown() throws Exception {
+    @AfterEach
+    void tearDown() throws Exception {
         if (aspect != null) {
             aspect.close();
         }
@@ -82,8 +64,10 @@ public class TimeLimiterAspectVirtualThreadTest {
         }
     }
 
-    @Test
-    public void fallbackSchedulerShouldUseConfiguredThreadType() throws Exception {
+    @ParameterizedTest(name = "threadMode={0}")
+    @MethodSource("threadModes")
+    void fallbackSchedulerShouldUseConfiguredThreadType(ThreadType threadType) throws Exception {
+        setUp(threadType);
         ScheduledExecutorService executor = extractExecutorService(aspect);
 
         boolean ranOnVirtual = executor
@@ -96,8 +80,10 @@ public class TimeLimiterAspectVirtualThreadTest {
             .isEqualTo(threadType == ThreadType.VIRTUAL);
     }
 
-    @Test
-    public void fallbackSchedulerShouldHaveAspectScopedThreadName() throws Exception {
+    @ParameterizedTest(name = "threadMode={0}")
+    @MethodSource("threadModes")
+    void fallbackSchedulerShouldHaveAspectScopedThreadName(ThreadType threadType) throws Exception {
+        setUp(threadType);
         ScheduledExecutorService executor = extractExecutorService(aspect);
 
         String threadName = executor


### PR DESCRIPTION
Closes #2450

## Summary

Spring AOP aspects for `Retry` and `TimeLimiter` silently bypassed the `resilience4j.thread.type` configuration whenever the optional `ContextAwareScheduledThreadPoolExecutor` bean was absent. Their fallback path called `java.util.concurrent.Executors.newScheduledThreadPool(...)` directly, which uses the default `ThreadFactory` and therefore **always produces platform threads** — even when the user enabled virtual threads via system property, environment variable, or Spring Boot YAML.

This PR routes those fallback constructions through `ExecutorServiceFactory.newScheduledThreadPool(size, poolName)` so the documented `resilience4j.thread.type` switch is honored end-to-end. Two parameterized JUnit 5 tests (`RetryAspectVirtualThreadTest`, `TimeLimiterAspectVirtualThreadTest`) lock the contract in place against both `platform` and `virtual` modes.

## Motivation

`README.adoc` and `CLAUDE.md` advertise a single switch — `resilience4j.thread.type=virtual` — that flips Resilience4j's internal schedulers onto Java 21+ virtual threads:

```yaml
resilience4j:
  thread:
    type: virtual
```

That switch is read by `ExecutorServiceFactory` (in `resilience4j-core`) and is the single entry point that decides between platform and virtual `ThreadFactory` instances. Every internal scheduler is supposed to go through this factory.

The Spring (legacy) and Spring 6 aspects, however, contained a fallback branch that constructed a scheduler **without consulting the factory**:

```java
this.xxxExecutorService = contextAwareScheduledThreadPoolExecutor != null ?
    contextAwareScheduledThreadPoolExecutor :
    Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
```

When the autoconfigured `ContextAwareScheduledThreadPoolExecutor` bean is present, the configured behavior holds. But in any "bare" wiring — a custom `@Configuration` that defines the aspect manually, or any environment that has the aspect bean but not the optional context-aware executor — the user's `virtual` setting was silently ignored. The aspect kept running on platform threads while the rest of the library obeyed the switch.

This is a **configuration-contract defect**, not a performance discussion. Operators who turn on virtual mode and size their services around its concurrency assumptions deserve all internal schedulers to actually be virtual — including the ones owned by the Spring aspects.

## Changes

### Modified

Both files in `resilience4j-spring6` (Spring Boot 3 / Spring Framework 6):

- `resilience4j-spring6/.../spring6/timelimiter/configure/TimeLimiterAspect.java`
- `resilience4j-spring6/.../spring6/retry/configure/RetryAspect.java`

Each constructor now calls:

```java
ExecutorServiceFactory.newScheduledThreadPool(
    Runtime.getRuntime().availableProcessors(),
    "<AspectName>");
```

Pool names: `"TimeLimiterAspect"` and `"RetryAspect"` — visible in thread dumps and JFR (`TimeLimiterAspect-vthread-N` or `TimeLimiterAspect-thread-N`, depending on mode), giving clear ownership for any thread that originated from the aspect's fallback path.

The `import java.util.concurrent.*;` wildcard was also expanded to explicit imports (`CompletionException`, `CompletionStage`, `ScheduledExecutorService`, `TimeUnit`) in the two Spring 6 files; the only outwardly observable side effect is that `Executors` is no longer imported, since it is no longer referenced.

The legacy `resilience4j-spring` module contains the same defect pattern, but that module is no longer included in `settings.gradle` (removed in commit `ab7dca4b` together with the Spring Boot 2 line). It is therefore not part of any build artifact and is intentionally not touched here.

## Backwards compatibility

| Change | Impact | Notes |
|---|---|---|
| `resilience4j.thread.type=virtual` is now honored in the Spring 6 aspect fallback path | Behavioral fix, matches documented contract | Users who relied on the broken behavior to keep aspects on platform threads despite enabling virtual mode globally would see a change. There is no documented or supported way that intent is expressed today. |
| Fallback scheduler threads are now **daemon** (in platform mode) | Minor behavior shift | The previous `Executors.newScheduledThreadPool(...)` produced non-daemon platform threads via the default `ThreadFactory`. `ExecutorServiceFactory.newPlatformThreadFactory(...)` produces daemon platform threads. For an internal aspect-owned scheduler this is the safer default — it cannot delay JVM shutdown. The aspect already implements `AutoCloseable.close()` for clean shutdown, so the daemon flag is a defense-in-depth improvement, not the primary lifecycle mechanism. |
| Thread names changed from generic `pool-N-thread-M` to `TimeLimiterAspect-(v)thread-N` / `RetryAspect-(v)thread-N` | Observability improvement | Any monitoring grep that pinned to `pool-N-thread-M` would need to widen its pattern; the new names provide aspect-scoped attribution that the old names lacked. |
| Pool size, scheduler interface (`ScheduledExecutorService`), `close()` semantics | Unchanged | `Runtime.availableProcessors()` worker count and `AutoCloseable.close()` graceful-shutdown sequence are preserved exactly. |