### PR TITLE
resilience4j-micrometer: JUnit 4 → JUnit 6 migration

### DIFF
--- a/resilience4j-micrometer/build.gradle
+++ b/resilience4j-micrometer/build.gradle
@@ -8,10 +8,6 @@ dependencies {
     implementation(project(":resilience4j-retry"))
     implementation(project(":resilience4j-timelimiter"))
 
-    testRuntimeOnly(libs.junit.vintage.engine)
-
-    testImplementation(libs.junit)
-    testImplementation(libs.awaitility.old)
     testImplementation(libs.vavr)
     testImplementation(project(":resilience4j-test"))
     testImplementation(libs.micrometer.observation.test)

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/ObservationsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/ObservationsTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2017: Robert Winkler
+ *  Copyright 2026: Robert Winkler
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@
  */
 package io.github.resilience4j.micrometer;
 
-import com.jayway.awaitility.Awaitility;
 import io.github.resilience4j.core.functions.CheckedFunction;
 import io.github.resilience4j.core.functions.CheckedRunnable;
 import io.github.resilience4j.core.functions.CheckedSupplier;
@@ -27,24 +26,25 @@ import io.github.resilience4j.test.HelloWorldService;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.tck.TestObservationRegistry;
 import io.vavr.control.Try;
-import org.junit.Before;
-import org.junit.Test;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.*;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import static com.jayway.awaitility.Awaitility.await;
 import static io.micrometer.observation.tck.TestObservationRegistryAssert.assertThat;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 
-public class ObservationsTest {
+class ObservationsTest {
 
     private HelloWorldService helloWorldService;
 
@@ -52,15 +52,15 @@ public class ObservationsTest {
 
     private Observation observation;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         observationRegistry = TestObservationRegistry.create();
         observation = Observations.ofObservationRegistry(ObservationsTest.class.getName(), observationRegistry);
         helloWorldService = mock(HelloWorldService.class);
     }
 
     @Test
-    public void shouldDecorateCheckedSupplier() throws Throwable {
+    void shouldDecorateCheckedSupplier() throws Throwable {
         given(helloWorldService.returnHelloWorldWithException()).willReturn("Hello world");
         CheckedSupplier<String> timedSupplier = Observations
             .decorateCheckedSupplier(observation, helloWorldService::returnHelloWorldWithException);
@@ -73,7 +73,7 @@ public class ObservationsTest {
     }
 
     @Test
-    public void shouldDecorateCallable() throws Throwable {
+    void shouldDecorateCallable() throws Throwable {
         given(helloWorldService.returnHelloWorldWithException()).willReturn("Hello world");
         Callable<String> timedSupplier = Observations
             .decorateCallable(observation, helloWorldService::returnHelloWorldWithException);
@@ -86,7 +86,7 @@ public class ObservationsTest {
     }
 
     @Test
-    public void shouldExecuteCallable() throws Throwable {
+    void shouldExecuteCallable() throws Throwable {
         given(helloWorldService.returnHelloWorldWithException()).willReturn("Hello world");
 
         String value = Observations
@@ -97,9 +97,8 @@ public class ObservationsTest {
         then(helloWorldService).should(times(1)).returnHelloWorldWithException();
     }
 
-
     @Test
-    public void shouldDecorateRunnable() throws Throwable {
+    void shouldDecorateRunnable() {
         Runnable timedRunnable = Observations.decorateRunnable(observation, helloWorldService::sayHelloWorld);
 
         timedRunnable.run();
@@ -109,7 +108,7 @@ public class ObservationsTest {
     }
 
     @Test
-    public void shouldExecuteRunnable() throws Throwable {
+    void shouldExecuteRunnable() {
         Observations.executeRunnable(observation, helloWorldService::sayHelloWorld);
 
         assertThatObservationWasStartedAndFinishedWithoutErrors();
@@ -117,7 +116,7 @@ public class ObservationsTest {
     }
 
     @Test
-    public void shouldExecuteCompletionStageSupplier() throws Throwable {
+    void shouldExecuteCompletionStageSupplier() throws Throwable {
         given(helloWorldService.returnHelloWorld()).willReturn("Hello world");
         Supplier<CompletionStage<String>> completionStageSupplier =
             () -> CompletableFuture.supplyAsync(helloWorldService::returnHelloWorld);
@@ -127,14 +126,12 @@ public class ObservationsTest {
         String value = stringCompletionStage.toCompletableFuture().get();
         assertThat(value).isEqualTo("Hello world");
         await().atMost(1, SECONDS)
-            .until(() -> {
-                assertThatObservationWasStartedAndFinishedWithoutErrors();
-            });
+            .untilAsserted(this::assertThatObservationWasStartedAndFinishedWithoutErrors);
         then(helloWorldService).should(times(1)).returnHelloWorld();
     }
 
     @Test
-    public void shouldExecuteCompletionStageAndReturnWithExceptionAtSyncStage() throws Throwable {
+    void shouldExecuteCompletionStageAndReturnWithExceptionAtSyncStage() {
         Supplier<CompletionStage<String>> completionStageSupplier = () -> {
             throw new HelloWorldException();
         };
@@ -151,9 +148,8 @@ public class ObservationsTest {
             .isInstanceOf(HelloWorldException.class);
     }
 
-
     @Test
-    public void shouldExecuteCompletionStageAndReturnWithExceptionAtASyncStage() throws Throwable {
+    void shouldExecuteCompletionStageAndReturnWithExceptionAtASyncStage() {
         given(helloWorldService.returnHelloWorld()).willThrow(new HelloWorldException());
         Supplier<CompletionStage<String>> completionStageSupplier =
             () -> CompletableFuture.supplyAsync(helloWorldService::returnHelloWorld);
@@ -164,7 +160,7 @@ public class ObservationsTest {
             .isInstanceOf(ExecutionException.class).hasCause(new HelloWorldException());
 
         Awaitility.await()
-            .until(() -> assertThat(observationRegistry)
+            .untilAsserted(() -> assertThat(observationRegistry)
                 .hasSingleObservationThat()
                 .hasNameEqualTo(ObservationsTest.class.getName())
                 .hasBeenStarted()
@@ -174,9 +170,8 @@ public class ObservationsTest {
         then(helloWorldService).should().returnHelloWorld();
     }
 
-
     @Test
-    public void shouldDecorateCheckedRunnableAndReturnWithSuccess() throws Throwable {
+    void shouldDecorateCheckedRunnableAndReturnWithSuccess() throws Throwable {
         CheckedRunnable timedRunnable = Observations
             .decorateCheckedRunnable(observation, helloWorldService::sayHelloWorldWithException);
 
@@ -187,7 +182,7 @@ public class ObservationsTest {
     }
 
     @Test
-    public void shouldDecorateSupplierAndReturnWithException() throws Throwable {
+    void shouldDecorateSupplierAndReturnWithException() {
         given(helloWorldService.returnHelloWorld()).willThrow(new RuntimeException("BAM!"));
         Supplier<String> supplier = Observations
             .decorateSupplier(observation, helloWorldService::returnHelloWorld);
@@ -208,7 +203,7 @@ public class ObservationsTest {
     }
 
     @Test
-    public void shouldDecorateSupplier() throws Throwable {
+    void shouldDecorateSupplier() {
         given(helloWorldService.returnHelloWorld()).willReturn("Hello world");
         Supplier<String> timedSupplier = Observations
             .decorateSupplier(observation, helloWorldService::returnHelloWorld);
@@ -220,7 +215,7 @@ public class ObservationsTest {
     }
 
     @Test
-    public void shouldExecuteSupplier() throws Throwable {
+    void shouldExecuteSupplier() {
         given(helloWorldService.returnHelloWorld()).willReturn("Hello world")
             .willThrow(new IllegalArgumentException("BAM!"));
 
@@ -234,9 +229,8 @@ public class ObservationsTest {
         then(helloWorldService).should().returnHelloWorld();
     }
 
-
     @Test
-    public void shouldDecorateFunctionAndReturnWithSuccess() throws Throwable {
+    void shouldDecorateFunctionAndReturnWithSuccess() {
         given(helloWorldService.returnHelloWorldWithName("Tom")).willReturn("Hello world Tom");
         Function<String, String> function = Observations
             .decorateFunction(observation, helloWorldService::returnHelloWorldWithName);
@@ -249,7 +243,7 @@ public class ObservationsTest {
     }
 
     @Test
-    public void shouldDecorateCheckedFunctionAndReturnWithSuccess() throws Throwable {
+    void shouldDecorateCheckedFunctionAndReturnWithSuccess() throws Throwable {
         given(helloWorldService.returnHelloWorldWithNameWithException("Tom"))
             .willReturn("Hello world Tom");
         CheckedFunction<String, String> function = Observations.decorateCheckedFunction(observation,

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/TimerAssertions.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/TimerAssertions.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2023 Mariusz Kopylec
+ *  Copyright 2026 Mariusz Kopylec
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/TimerConfigTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/TimerConfigTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2023 Mariusz Kopylec
+ *  Copyright 2026 Mariusz Kopylec
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,14 +15,14 @@
  */
 package io.github.resilience4j.micrometer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
-public class TimerConfigTest {
+class TimerConfigTest {
 
     @Test
-    public void shouldCreateDefaultTimerConfig() {
+    void shouldCreateDefaultTimerConfig() {
         TimerConfig config = TimerConfig.ofDefaults();
 
         then(config.getMetricNames()).isEqualTo("resilience4j.timer.calls");
@@ -30,7 +30,7 @@ public class TimerConfigTest {
     }
 
     @Test
-    public void shouldCreateCustomTimerConfig() {
+    void shouldCreateCustomTimerConfig() {
         TimerConfig config = TimerConfig.custom()
                 .metricNames("resilience4j.timer.operations")
                 .onFailureTagResolver(throwable -> throwable.getClass().getName())
@@ -41,7 +41,7 @@ public class TimerConfigTest {
     }
 
     @Test
-    public void shouldCreateTimerConfigFromPrototype() {
+    void shouldCreateTimerConfigFromPrototype() {
         TimerConfig prototype = TimerConfig.custom()
                 .onFailureTagResolver(throwable -> throwable.getClass().getName())
                 .build();

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/TimerEventPublisherTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/TimerEventPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2023 Mariusz Kopylec
+ *  Copyright 2026 Mariusz Kopylec
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -19,25 +19,18 @@ import io.github.resilience4j.micrometer.event.TimerOnFailureEvent;
 import io.github.resilience4j.micrometer.event.TimerOnStartEvent;
 import io.github.resilience4j.micrometer.event.TimerOnSuccessEvent;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
-import java.time.ZonedDateTime;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static io.github.resilience4j.micrometer.event.TimerEvent.Type.*;
-import static java.time.ZonedDateTime.now;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.junit.rules.ExpectedException.none;
 
-public class TimerEventPublisherTest {
-
-    @Rule
-    public ExpectedException expectedException = none();
+class TimerEventPublisherTest {
 
     @Test
-    public void shouldHandleOnStartEvent() {
+    void shouldHandleOnStartEvent() {
         AtomicReference<TimerOnStartEvent> consumedEvent = new AtomicReference<>();
         Timer timer = Timer.of("some operation", new SimpleMeterRegistry());
         timer.getEventPublisher().onStart(consumedEvent::set);
@@ -48,7 +41,7 @@ public class TimerEventPublisherTest {
     }
 
     @Test
-    public void shouldHandleOnSuccessEvent() {
+    void shouldHandleOnSuccessEvent() {
         AtomicReference<TimerOnSuccessEvent> consumedEvent = new AtomicReference<>();
         Timer timer = Timer.of("some operation", new SimpleMeterRegistry());
         timer.getEventPublisher().onSuccess(consumedEvent::set);
@@ -66,15 +59,14 @@ public class TimerEventPublisherTest {
     }
 
     @Test
-    public void shouldHandleOnFailureEvent() {
-        expectedException.expect(RuntimeException.class);
-
+    void shouldHandleOnFailureEvent() {
         AtomicReference<TimerOnFailureEvent> consumedEvent = new AtomicReference<>();
         Timer timer = Timer.of("some operation", new SimpleMeterRegistry());
         timer.getEventPublisher().onFailure(consumedEvent::set);
-        timer.executeSupplier(() -> {
+
+        assertThatThrownBy(() -> timer.executeSupplier(() -> {
             throw new RuntimeException();
-        });
+        })).isInstanceOf(RuntimeException.class);
 
         then(consumedEvent.get().getTimerName()).isEqualTo("some operation");
         then(consumedEvent.get().getEventType()).isEqualTo(FAILURE);

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/TimerRegistryTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/TimerRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2023 Mariusz Kopylec
+ *  Copyright 2026 Mariusz Kopylec
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import io.github.resilience4j.core.registry.EntryRemovedEvent;
 import io.github.resilience4j.core.registry.EntryReplacedEvent;
 import io.github.resilience4j.core.registry.RegistryEventConsumer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -34,10 +34,10 @@ import static io.github.resilience4j.micrometer.TimerRegistry.ofDefaults;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.BDDAssertions.then;
 
-public class TimerRegistryTest {
+class TimerRegistryTest {
 
     @Test
-    public void shouldCreateDefaultTimerRegistry() {
+    void shouldCreateDefaultTimerRegistry() {
         TimerRegistry registry = ofDefaults(new SimpleMeterRegistry());
 
         then(registry.getDefaultConfig().getMetricNames()).isEqualTo(TimerConfig.ofDefaults().getMetricNames());
@@ -47,7 +47,7 @@ public class TimerRegistryTest {
     }
 
     @Test
-    public void shouldCreateCustomTimerRegistry() {
+    void shouldCreateCustomTimerRegistry() {
         TimerConfig defaultConfig = TimerConfig.custom()
                 .metricNames("resilience4j.timer.operations")
                 .build();
@@ -63,7 +63,7 @@ public class TimerRegistryTest {
     }
 
     @Test
-    public void shouldCreateTimersFromRegistry() {
+    void shouldCreateTimersFromRegistry() {
         TimerConfig defaultConfig = TimerConfig.custom()
                 .metricNames("resilience4j.timer.operations")
                 .build();
@@ -83,7 +83,7 @@ public class TimerRegistryTest {
     }
 
     @Test
-    public void shouldCreateTimerWithCustomTagsFromRegistry() {
+    void shouldCreateTimerWithCustomTagsFromRegistry() {
         TimerRegistry registry = of(TimerConfig.ofDefaults(), emptyMap(), Collections.emptyList(), Map.of("tag1", "ignored value"), new SimpleMeterRegistry());
 
         Timer timer = registry.timer("some operation", Map.of("tag1", "primary value", "tag2", "value2"));
@@ -91,7 +91,7 @@ public class TimerRegistryTest {
     }
 
     @Test
-    public void shouldCreateTimerWithCustomConfigFromRegistry() {
+    void shouldCreateTimerWithCustomConfigFromRegistry() {
         TimerConfig config = TimerConfig.custom()
                 .metricNames("resilience4j.timer.operations")
                 .build();
@@ -102,7 +102,7 @@ public class TimerRegistryTest {
     }
 
     @Test
-    public void shouldAddEventConsumerToRegistry() {
+    void shouldAddEventConsumerToRegistry() {
         TimerRegistry registry = of(TimerConfig.ofDefaults(), emptyMap(), List.of(new NoOpTimerEventConsumer()), emptyMap(), new SimpleMeterRegistry());
 
         then(getEventProcessor(registry.getEventPublisher())).hasValueSatisfying(processor ->
@@ -111,7 +111,7 @@ public class TimerRegistryTest {
     }
 
     @Test
-    public void shouldAddTimerConfigToRegistry() {
+    void shouldAddTimerConfigToRegistry() {
         TimerConfig config = TimerConfig.custom()
                 .metricNames("resilience4j.timer.operations")
                 .build();

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/TimerTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/TimerTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2023 Mariusz Kopylec
+ *  Copyright 2026 Mariusz Kopylec
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package io.github.resilience4j.micrometer;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -29,10 +29,10 @@ import static java.util.concurrent.CompletableFuture.completedStage;
 import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.assertj.core.api.BDDAssertions.then;
 
-public class TimerTest {
+class TimerTest {
 
     @Test
-    public void shouldCreateDefaultTimer() {
+    void shouldCreateDefaultTimer() {
         MeterRegistry registry = new SimpleMeterRegistry();
         Timer timer = of("timer 1", registry);
 
@@ -45,7 +45,7 @@ public class TimerTest {
     }
 
     @Test
-    public void shouldCreateCustomTimer() {
+    void shouldCreateCustomTimer() {
         MeterRegistry registry = new SimpleMeterRegistry();
         TimerConfig config = TimerConfig.custom()
                 .metricNames("resilience4j.timer.operations")
@@ -63,7 +63,7 @@ public class TimerTest {
     }
 
     @Test
-    public void shouldTimeSuccessfulOperationUsingDefaultTimer() throws Throwable {
+    void shouldTimeSuccessfulOperationUsingDefaultTimer() throws Throwable {
         MeterRegistry registry = new SimpleMeterRegistry();
         Timer timer = of("timer 1", registry);
 
@@ -109,7 +109,7 @@ public class TimerTest {
     }
 
     @Test
-    public void shouldTimeSuccessfulOperationUsingCustomTimer() throws Throwable {
+    void shouldTimeSuccessfulOperationUsingCustomTimer() throws Throwable {
         MeterRegistry registry = new SimpleMeterRegistry();
         TimerConfig config = TimerConfig.custom()
                 .metricNames("resilience4j.timer.operations")
@@ -159,7 +159,7 @@ public class TimerTest {
     }
 
     @Test
-    public void shouldTimeFailedOperationUsingDefaultTimer() throws Throwable {
+    void shouldTimeFailedOperationUsingDefaultTimer() throws Throwable {
         MeterRegistry registry = new SimpleMeterRegistry();
         Timer timer = of("timer 1", registry);
 
@@ -243,7 +243,7 @@ public class TimerTest {
     }
 
     @Test
-    public void shouldTimeFailedOperationUsingCustomTimer() throws Throwable {
+    void shouldTimeFailedOperationUsingCustomTimer() throws Throwable {
         MeterRegistry registry = new SimpleMeterRegistry();
         TimerConfig config = TimerConfig.custom()
                 .metricNames("resilience4j.timer.operations")

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/MetricsTestHelper.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/MetricsTestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Yevhenii Voievodin
+ * Copyright 2026 Yevhenii Voievodin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedBulkheadMetricsPublisherTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedBulkheadMetricsPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Ingyu Hwang
+ * Copyright 2026 Ingyu Hwang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,8 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -34,15 +34,15 @@ import static io.github.resilience4j.micrometer.tagged.BulkheadMetricNames.DEFAU
 import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByNamesTag;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TaggedBulkheadMetricsPublisherTest {
+class TaggedBulkheadMetricsPublisherTest {
 
     private MeterRegistry meterRegistry;
     private Bulkhead bulkhead;
     private BulkheadRegistry bulkheadRegistry;
     private TaggedBulkheadMetricsPublisher taggedBulkheadMetricsPublisher;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         meterRegistry = new SimpleMeterRegistry();
         taggedBulkheadMetricsPublisher = new TaggedBulkheadMetricsPublisher(meterRegistry);
         bulkheadRegistry = BulkheadRegistry
@@ -56,7 +56,7 @@ public class TaggedBulkheadMetricsPublisherTest {
     }
 
     @Test
-    public void shouldAddMetricsForANewlyCreatedRetry() {
+    void shouldAddMetricsForANewlyCreatedRetry() {
         Bulkhead newBulkhead = bulkheadRegistry.bulkhead("backendB");
 
         assertThat(taggedBulkheadMetricsPublisher.meterIdMap).containsKeys("backendA", "backendB");
@@ -76,7 +76,7 @@ public class TaggedBulkheadMetricsPublisherTest {
     }
 
     @Test
-    public void shouldRemovedMetricsForRemovedRetry() {
+    void shouldRemovedMetricsForRemovedRetry() {
         List<Meter> meters = meterRegistry.getMeters();
         assertThat(meters).hasSize(2);
 
@@ -90,7 +90,7 @@ public class TaggedBulkheadMetricsPublisherTest {
     }
 
     @Test
-    public void shouldReplaceMetrics() {
+    void shouldReplaceMetrics() {
         Collection<Gauge> gauges = meterRegistry
             .get(DEFAULT_BULKHEAD_MAX_ALLOWED_CONCURRENT_CALLS_METRIC_NAME).gauges();
 
@@ -115,7 +115,7 @@ public class TaggedBulkheadMetricsPublisherTest {
     }
 
     @Test
-    public void availableConcurrentCallsGaugeIsRegistered() {
+    void availableConcurrentCallsGaugeIsRegistered() {
         Gauge available = meterRegistry.get(DEFAULT_BULKHEAD_AVAILABLE_CONCURRENT_CALLS_METRIC_NAME)
             .gauge();
 
@@ -125,7 +125,7 @@ public class TaggedBulkheadMetricsPublisherTest {
     }
 
     @Test
-    public void maxAllowedConcurrentCallsGaugeIsRegistered() {
+    void maxAllowedConcurrentCallsGaugeIsRegistered() {
         Gauge maxAllowed = meterRegistry
             .get(DEFAULT_BULKHEAD_MAX_ALLOWED_CONCURRENT_CALLS_METRIC_NAME).gauge();
 
@@ -136,7 +136,7 @@ public class TaggedBulkheadMetricsPublisherTest {
     }
 
     @Test
-    public void customMetricNamesGetApplied() {
+    void customMetricNamesGetApplied() {
         MeterRegistry meterRegistry = new SimpleMeterRegistry();
         TaggedBulkheadMetricsPublisher taggedBulkheadMetricsPublisher = new TaggedBulkheadMetricsPublisher(
             BulkheadMetricNames.custom()
@@ -161,7 +161,7 @@ public class TaggedBulkheadMetricsPublisherTest {
     }
 
     @Test
-    public void testReplaceNewMeter(){
+    void testReplaceNewMeter(){
         Bulkhead oldOne = Bulkhead.of("backendC", BulkheadConfig.ofDefaults());
         // add meters of old
         taggedBulkheadMetricsPublisher.addMetrics(meterRegistry, oldOne);

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedBulkheadMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedBulkheadMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Yevhenii Voievodin, ,Mahmoud Romeh
+ * Copyright 2026 Yevhenii Voievodin, ,Mahmoud Romeh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,8 @@ import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.search.RequiredSearch;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -34,15 +34,15 @@ import static io.github.resilience4j.micrometer.tagged.BulkheadMetricNames.DEFAU
 import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByNamesTag;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TaggedBulkheadMetricsTest {
+class TaggedBulkheadMetricsTest {
 
     private MeterRegistry meterRegistry;
     private Bulkhead bulkhead;
     private BulkheadRegistry bulkheadRegistry;
     private TaggedBulkheadMetrics taggedBulkheadMetrics;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         meterRegistry = new SimpleMeterRegistry();
         bulkheadRegistry = BulkheadRegistry.ofDefaults();
         bulkhead = bulkheadRegistry.bulkhead("backendA");
@@ -56,7 +56,7 @@ public class TaggedBulkheadMetricsTest {
     }
 
     @Test
-    public void shouldAddMetricsForANewlyCreatedRetry() {
+    void shouldAddMetricsForANewlyCreatedRetry() {
         Bulkhead newBulkhead = bulkheadRegistry.bulkhead("backendB");
 
         assertThat(taggedBulkheadMetrics.meterIdMap).containsKeys("backendA", "backendB");
@@ -76,7 +76,7 @@ public class TaggedBulkheadMetricsTest {
     }
 
     @Test
-    public void shouldRemovedMetricsForRemovedRetry() {
+    void shouldRemovedMetricsForRemovedRetry() {
         List<Meter> meters = meterRegistry.getMeters();
         assertThat(meters).hasSize(2);
 
@@ -90,7 +90,7 @@ public class TaggedBulkheadMetricsTest {
     }
 
     @Test
-    public void shouldReplaceMetrics() {
+    void shouldReplaceMetrics() {
         Collection<Gauge> gauges = meterRegistry
             .get(DEFAULT_BULKHEAD_MAX_ALLOWED_CONCURRENT_CALLS_METRIC_NAME).gauges();
 
@@ -115,7 +115,7 @@ public class TaggedBulkheadMetricsTest {
     }
 
     @Test
-    public void availableConcurrentCallsGaugeIsRegistered() {
+    void availableConcurrentCallsGaugeIsRegistered() {
         Gauge available = meterRegistry.get(DEFAULT_BULKHEAD_AVAILABLE_CONCURRENT_CALLS_METRIC_NAME)
             .gauge();
 
@@ -125,7 +125,7 @@ public class TaggedBulkheadMetricsTest {
     }
 
     @Test
-    public void maxAllowedConcurrentCallsGaugeIsRegistered() {
+    void maxAllowedConcurrentCallsGaugeIsRegistered() {
         Gauge maxAllowed = meterRegistry
             .get(DEFAULT_BULKHEAD_MAX_ALLOWED_CONCURRENT_CALLS_METRIC_NAME).gauge();
 
@@ -136,7 +136,7 @@ public class TaggedBulkheadMetricsTest {
     }
 
     @Test
-    public void customTagsShouldBeAdded() {
+    void customTagsShouldBeAdded() {
         Bulkhead bulkheadC = bulkheadRegistry.bulkhead("backendC", Map.of("key1", "value1"));
         // record some basic stats
         bulkheadC.tryAcquirePermission();
@@ -149,7 +149,7 @@ public class TaggedBulkheadMetricsTest {
     }
 
     @Test
-    public void customMetricNamesGetApplied() {
+    void customMetricNamesGetApplied() {
         MeterRegistry meterRegistry = new SimpleMeterRegistry();
         BulkheadRegistry bulkheadRegistry = BulkheadRegistry.ofDefaults();
         bulkhead = bulkheadRegistry.bulkhead("backendA");

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetricsPublisherTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetricsPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Ingyu Hwang
+ * Copyright 2026 Ingyu Hwang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,8 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.*;
@@ -36,15 +36,15 @@ import static io.github.resilience4j.micrometer.tagged.CircuitBreakerMetricNames
 import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByKindAndNameTags;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TaggedCircuitBreakerMetricsPublisherTest {
+class TaggedCircuitBreakerMetricsPublisherTest {
 
     private MeterRegistry meterRegistry;
     private CircuitBreaker circuitBreaker;
     private CircuitBreakerRegistry circuitBreakerRegistry;
     private TaggedCircuitBreakerMetricsPublisher taggedCircuitBreakerMetricsPublisher;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         meterRegistry = new SimpleMeterRegistry();
         taggedCircuitBreakerMetricsPublisher =
             new TaggedCircuitBreakerMetricsPublisher(meterRegistry);
@@ -66,7 +66,7 @@ public class TaggedCircuitBreakerMetricsPublisherTest {
     }
 
     @Test
-    public void shouldAddMetricsForANewlyCreatedCircuitBreaker() {
+    void shouldAddMetricsForANewlyCreatedCircuitBreaker() {
         CircuitBreaker newCircuitBreaker = circuitBreakerRegistry.circuitBreaker("backendB");
         newCircuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
 
@@ -89,7 +89,7 @@ public class TaggedCircuitBreakerMetricsPublisherTest {
     }
 
     @Test
-    public void shouldRemovedMetricsForRemovedRetry() {
+    void shouldRemovedMetricsForRemovedRetry() {
         List<Meter> meters = meterRegistry.getMeters();
         assertThat(meters).hasSize(16);
 
@@ -103,7 +103,7 @@ public class TaggedCircuitBreakerMetricsPublisherTest {
     }
 
     @Test
-    public void notPermittedCallsCounterReportsCorrespondingValue() {
+    void notPermittedCallsCounterReportsCorrespondingValue() {
         List<Meter> meters = meterRegistry.getMeters();
         assertThat(meters).hasSize(16);
 
@@ -117,7 +117,7 @@ public class TaggedCircuitBreakerMetricsPublisherTest {
     }
 
     @Test
-    public void failedCallsGaugeReportsCorrespondingValue() {
+    void failedCallsGaugeReportsCorrespondingValue() {
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS)
             .gauges();
 
@@ -129,7 +129,7 @@ public class TaggedCircuitBreakerMetricsPublisherTest {
     }
 
     @Test
-    public void successfulCallsGaugeReportsCorrespondingValue() {
+    void successfulCallsGaugeReportsCorrespondingValue() {
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS)
             .gauges();
 
@@ -142,7 +142,7 @@ public class TaggedCircuitBreakerMetricsPublisherTest {
     }
 
     @Test
-    public void slowSuccessFulCallsGaugeReportsCorrespondingValue() {
+    void slowSuccessFulCallsGaugeReportsCorrespondingValue() {
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_SLOW_CALLS).gauges();
 
         Optional<Gauge> slow = MetricsTestHelper.findMeterByKindAndNameTags(gauges, "successful",
@@ -153,7 +153,7 @@ public class TaggedCircuitBreakerMetricsPublisherTest {
     }
 
     @Test
-    public void slowFailedCallsGaugeReportsCorrespondingValue() {
+    void slowFailedCallsGaugeReportsCorrespondingValue() {
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_SLOW_CALLS).gauges();
 
         Optional<Gauge> slow = MetricsTestHelper.findMeterByKindAndNameTags(gauges, "failed",
@@ -164,7 +164,7 @@ public class TaggedCircuitBreakerMetricsPublisherTest {
     }
 
     @Test
-    public void failureRateGaugeReportsCorrespondingValue() {
+    void failureRateGaugeReportsCorrespondingValue() {
         Gauge failureRate = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_FAILURE_RATE).gauge();
 
         assertThat(failureRate).isNotNull();
@@ -173,7 +173,7 @@ public class TaggedCircuitBreakerMetricsPublisherTest {
     }
 
     @Test
-    public void slowCallRateGaugeReportsCorrespondingValue() {
+    void slowCallRateGaugeReportsCorrespondingValue() {
         Gauge slowCallRate = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_SLOW_CALL_RATE).gauge();
 
         assertThat(slowCallRate).isNotNull();
@@ -182,7 +182,7 @@ public class TaggedCircuitBreakerMetricsPublisherTest {
     }
 
     @Test
-    public void stateGaugeReportsCorrespondingValue() {
+    void stateGaugeReportsCorrespondingValue() {
         Gauge state = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_STATE).gauge();
 
         assertThat(state.value()).isEqualTo(circuitBreaker.getState().getOrder());
@@ -190,7 +190,7 @@ public class TaggedCircuitBreakerMetricsPublisherTest {
     }
 
     @Test
-    public void metricsAreRegisteredWithCustomName() {
+    void metricsAreRegisteredWithCustomName() {
         MeterRegistry meterRegistry = new SimpleMeterRegistry();
         TaggedCircuitBreakerMetricsPublisher taggedCircuitBreakerMetricsPublisher = new TaggedCircuitBreakerMetricsPublisher(
             CircuitBreakerMetricNames.custom()
@@ -225,7 +225,7 @@ public class TaggedCircuitBreakerMetricsPublisherTest {
     }
 
     @Test
-    public void testReplaceNewMeter(){
+    void testReplaceNewMeter(){
         CircuitBreaker oldOne = CircuitBreaker.of("backendC", CircuitBreakerConfig.ofDefaults());
         // add meters of old
         taggedCircuitBreakerMetricsPublisher.addMetrics(meterRegistry, oldOne);
@@ -256,6 +256,5 @@ public class TaggedCircuitBreakerMetricsPublisherTest {
         assertThat(successful).isPresent();
         assertThat(successful.get().value())
             .isEqualTo(newOne.getMetrics().getNumberOfSuccessfulCalls());
-
     }
 }

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedCircuitBreakerMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Yevhenii Voievodin,Mahmoud Romeh
+ * Copyright 2026 Yevhenii Voievodin,Mahmoud Romeh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,8 @@ import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.search.RequiredSearch;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.*;
@@ -36,15 +36,15 @@ import static io.github.resilience4j.micrometer.tagged.CircuitBreakerMetricNames
 import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByKindAndNameTags;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TaggedCircuitBreakerMetricsTest {
+class TaggedCircuitBreakerMetricsTest {
 
     private MeterRegistry meterRegistry;
     private CircuitBreaker circuitBreaker;
     private CircuitBreakerRegistry circuitBreakerRegistry;
     private TaggedCircuitBreakerMetrics taggedCircuitBreakerMetrics;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         meterRegistry = new SimpleMeterRegistry();
         circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
         CircuitBreakerConfig configWithSlowCallThreshold = CircuitBreakerConfig.custom()
@@ -65,7 +65,7 @@ public class TaggedCircuitBreakerMetricsTest {
     }
 
     @Test
-    public void shouldAddMetricsForANewlyCreatedCircuitBreaker() {
+    void shouldAddMetricsForANewlyCreatedCircuitBreaker() {
         CircuitBreaker newCircuitBreaker = circuitBreakerRegistry.circuitBreaker("backendB");
         newCircuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
 
@@ -88,7 +88,7 @@ public class TaggedCircuitBreakerMetricsTest {
     }
 
     @Test
-    public void shouldAddCustomTags() {
+    void shouldAddCustomTags() {
         CircuitBreaker circuitBreakerF = circuitBreakerRegistry.circuitBreaker("backendF", Map.of("key1", "value1"));
         circuitBreakerF.onSuccess(0, TimeUnit.NANOSECONDS);
         assertThat(taggedCircuitBreakerMetrics.meterIdMap).containsKeys("backendA", "backendF");
@@ -100,7 +100,7 @@ public class TaggedCircuitBreakerMetricsTest {
     }
 
     @Test
-    public void shouldRemovedMetricsForRemovedRetry() {
+    void shouldRemovedMetricsForRemovedRetry() {
         List<Meter> meters = meterRegistry.getMeters();
         assertThat(meters).hasSize(16);
 
@@ -114,7 +114,7 @@ public class TaggedCircuitBreakerMetricsTest {
     }
 
     @Test
-    public void notPermittedCallsCounterReportsCorrespondingValue() {
+    void notPermittedCallsCounterReportsCorrespondingValue() {
         List<Meter> meters = meterRegistry.getMeters();
         assertThat(meters).hasSize(16);
 
@@ -128,7 +128,7 @@ public class TaggedCircuitBreakerMetricsTest {
     }
 
     @Test
-    public void failedCallsGaugeReportsCorrespondingValue() {
+    void failedCallsGaugeReportsCorrespondingValue() {
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS)
             .gauges();
 
@@ -140,7 +140,7 @@ public class TaggedCircuitBreakerMetricsTest {
     }
 
     @Test
-    public void successfulCallsGaugeReportsCorrespondingValue() {
+    void successfulCallsGaugeReportsCorrespondingValue() {
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_BUFFERED_CALLS)
             .gauges();
 
@@ -154,7 +154,7 @@ public class TaggedCircuitBreakerMetricsTest {
     }
 
     @Test
-    public void slowSuccessfulGaugeReportsCorrespondingValue() {
+    void slowSuccessfulGaugeReportsCorrespondingValue() {
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_SLOW_CALLS).gauges();
 
         Optional<Gauge> slow = MetricsTestHelper.findMeterByKindAndNameTags(gauges, "successful",
@@ -166,7 +166,7 @@ public class TaggedCircuitBreakerMetricsTest {
     }
 
     @Test
-    public void slowFailedCallsGaugeReportsCorrespondingValue() {
+    void slowFailedCallsGaugeReportsCorrespondingValue() {
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_SLOW_CALLS).gauges();
 
         Optional<Gauge> slow = MetricsTestHelper.findMeterByKindAndNameTags(gauges, "failed",
@@ -177,7 +177,7 @@ public class TaggedCircuitBreakerMetricsTest {
     }
 
     @Test
-    public void failureRateGaugeReportsCorrespondingValue() {
+    void failureRateGaugeReportsCorrespondingValue() {
         Gauge failureRate = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_FAILURE_RATE).gauge();
 
         assertThat(failureRate).isNotNull();
@@ -186,7 +186,7 @@ public class TaggedCircuitBreakerMetricsTest {
     }
 
     @Test
-    public void slowCallRateGaugeReportsCorrespondingValue() {
+    void slowCallRateGaugeReportsCorrespondingValue() {
         Gauge slowCallRate = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_SLOW_CALL_RATE).gauge();
 
         assertThat(slowCallRate).isNotNull();
@@ -195,7 +195,7 @@ public class TaggedCircuitBreakerMetricsTest {
     }
 
     @Test
-    public void stateGaugeReportsCorrespondingValue() {
+    void stateGaugeReportsCorrespondingValue() {
         Gauge state = meterRegistry.get(DEFAULT_CIRCUIT_BREAKER_STATE).gauge();
 
         assertThat(state.value()).isEqualTo(circuitBreaker.getState().getOrder());
@@ -203,7 +203,7 @@ public class TaggedCircuitBreakerMetricsTest {
     }
 
     @Test
-    public void metricsAreRegisteredWithCustomName() {
+    void metricsAreRegisteredWithCustomName() {
         MeterRegistry meterRegistry = new SimpleMeterRegistry();
         CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
         circuitBreakerRegistry.circuitBreaker("backendA");

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRateLimiterMetricsPublisherTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRateLimiterMetricsPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Ingyu Hwang
+ * Copyright 2026 Ingyu Hwang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,26 +23,26 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByNamesTag;
 import static io.github.resilience4j.micrometer.tagged.RateLimiterMetricNames.DEFAULT_AVAILABLE_PERMISSIONS_METRIC_NAME;
 import static io.github.resilience4j.micrometer.tagged.RateLimiterMetricNames.DEFAULT_WAITING_THREADS_METRIC_NAME;
-import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByNamesTag;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TaggedRateLimiterMetricsPublisherTest {
+class TaggedRateLimiterMetricsPublisherTest {
 
     private MeterRegistry meterRegistry;
     private RateLimiter rateLimiter;
     private RateLimiterRegistry rateLimiterRegistry;
     private TaggedRateLimiterMetricsPublisher taggedRateLimiterMetricsPublisher;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         meterRegistry = new SimpleMeterRegistry();
         taggedRateLimiterMetricsPublisher = new TaggedRateLimiterMetricsPublisher(meterRegistry);
         rateLimiterRegistry = RateLimiterRegistry
@@ -52,7 +52,7 @@ public class TaggedRateLimiterMetricsPublisherTest {
     }
 
     @Test
-    public void shouldAddMetricsForANewlyCreatedRateLimiter() {
+    void shouldAddMetricsForANewlyCreatedRateLimiter() {
         RateLimiter newRateLimiter = rateLimiterRegistry.rateLimiter("backendB");
 
         assertThat(taggedRateLimiterMetricsPublisher.meterIdMap)
@@ -73,7 +73,7 @@ public class TaggedRateLimiterMetricsPublisherTest {
     }
 
     @Test
-    public void shouldRemovedMetricsForRemovedRetry() {
+    void shouldRemovedMetricsForRemovedRetry() {
         List<Meter> meters = meterRegistry.getMeters();
         assertThat(meters).hasSize(2);
 
@@ -87,7 +87,7 @@ public class TaggedRateLimiterMetricsPublisherTest {
     }
 
     @Test
-    public void shouldReplaceMetrics() {
+    void shouldReplaceMetrics() {
         Gauge availablePermissions = meterRegistry.get(DEFAULT_AVAILABLE_PERMISSIONS_METRIC_NAME)
             .gauge();
 
@@ -112,7 +112,7 @@ public class TaggedRateLimiterMetricsPublisherTest {
     }
 
     @Test
-    public void availablePermissionsGaugeIsRegistered() {
+    void availablePermissionsGaugeIsRegistered() {
         Gauge availablePermissions = meterRegistry.get(DEFAULT_AVAILABLE_PERMISSIONS_METRIC_NAME)
             .gauge();
 
@@ -124,7 +124,7 @@ public class TaggedRateLimiterMetricsPublisherTest {
     }
 
     @Test
-    public void waitingThreadsGaugeIsRegistered() {
+    void waitingThreadsGaugeIsRegistered() {
         Gauge waitingThreads = meterRegistry.get(DEFAULT_WAITING_THREADS_METRIC_NAME).gauge();
 
         assertThat(waitingThreads).isNotNull();
@@ -134,7 +134,7 @@ public class TaggedRateLimiterMetricsPublisherTest {
     }
 
     @Test
-    public void customMetricNamesGetApplied() {
+    void customMetricNamesGetApplied() {
         MeterRegistry meterRegistry = new SimpleMeterRegistry();
         TaggedRateLimiterMetricsPublisher taggedRateLimiterMetricsPublisher = new TaggedRateLimiterMetricsPublisher(
             RateLimiterMetricNames.custom()
@@ -159,7 +159,7 @@ public class TaggedRateLimiterMetricsPublisherTest {
     }
 
     @Test
-    public void testReplaceNewMeter() {
+    void testReplaceNewMeter() {
         RateLimiter oldOne = RateLimiter.of("backendC", RateLimiterConfig.ofDefaults());
         // add meters of old
         taggedRateLimiterMetricsPublisher.addMetrics(meterRegistry, oldOne);

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRateLimiterMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRateLimiterMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Yevhenii Voievodin, Mahmoud Romeh
+ * Copyright 2026 Yevhenii Voievodin, Mahmoud Romeh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -33,15 +33,15 @@ import static io.github.resilience4j.micrometer.tagged.RateLimiterMetricNames.DE
 import static io.github.resilience4j.micrometer.tagged.RateLimiterMetricNames.DEFAULT_WAITING_THREADS_METRIC_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TaggedRateLimiterMetricsTest {
+class TaggedRateLimiterMetricsTest {
 
     private MeterRegistry meterRegistry;
     private RateLimiter rateLimiter;
     private RateLimiterRegistry rateLimiterRegistry;
     private TaggedRateLimiterMetrics taggedRateLimiterMetrics;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         meterRegistry = new SimpleMeterRegistry();
         rateLimiterRegistry = RateLimiterRegistry.ofDefaults();
 
@@ -52,7 +52,7 @@ public class TaggedRateLimiterMetricsTest {
     }
 
     @Test
-    public void shouldAddMetricsForANewlyCreatedRateLimiter() {
+    void shouldAddMetricsForANewlyCreatedRateLimiter() {
         RateLimiter newRateLimiter = rateLimiterRegistry.rateLimiter("backendB");
 
         assertThat(taggedRateLimiterMetrics.meterIdMap).containsKeys("backendA", "backendB");
@@ -72,7 +72,7 @@ public class TaggedRateLimiterMetricsTest {
     }
 
     @Test
-    public void shouldAddCustomTags() {
+    void shouldAddCustomTags() {
         RateLimiter newRateLimiter = rateLimiterRegistry.rateLimiter("backendF", Map.of("key1", "value1"));
         assertThat(taggedRateLimiterMetrics.meterIdMap).containsKeys("backendA", "backendF");
         assertThat(taggedRateLimiterMetrics.meterIdMap.get("backendA")).hasSize(2);
@@ -83,7 +83,7 @@ public class TaggedRateLimiterMetricsTest {
     }
 
     @Test
-    public void shouldRemovedMetricsForRemovedRetry() {
+    void shouldRemovedMetricsForRemovedRetry() {
         List<Meter> meters = meterRegistry.getMeters();
         assertThat(meters).hasSize(2);
 
@@ -97,7 +97,7 @@ public class TaggedRateLimiterMetricsTest {
     }
 
     @Test
-    public void shouldReplaceMetrics() {
+    void shouldReplaceMetrics() {
         Gauge availablePermissions = meterRegistry.get(DEFAULT_AVAILABLE_PERMISSIONS_METRIC_NAME)
             .gauge();
 
@@ -122,7 +122,7 @@ public class TaggedRateLimiterMetricsTest {
     }
 
     @Test
-    public void availablePermissionsGaugeIsRegistered() {
+    void availablePermissionsGaugeIsRegistered() {
         Gauge availablePermissions = meterRegistry.get(DEFAULT_AVAILABLE_PERMISSIONS_METRIC_NAME)
             .gauge();
 
@@ -134,7 +134,7 @@ public class TaggedRateLimiterMetricsTest {
     }
 
     @Test
-    public void waitingThreadsGaugeIsRegistered() {
+    void waitingThreadsGaugeIsRegistered() {
         Gauge waitingThreads = meterRegistry.get(DEFAULT_WAITING_THREADS_METRIC_NAME).gauge();
 
         assertThat(waitingThreads).isNotNull();
@@ -144,7 +144,7 @@ public class TaggedRateLimiterMetricsTest {
     }
 
     @Test
-    public void customMetricNamesGetApplied() {
+    void customMetricNamesGetApplied() {
         MeterRegistry meterRegistry = new SimpleMeterRegistry();
         RateLimiterRegistry rateLimiterRegistry = RateLimiterRegistry.ofDefaults();
         rateLimiterRegistry.rateLimiter("backendA");

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRetryMetricsPublisherTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRetryMetricsPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Ingyu Hwang
+ * Copyright 2026 Ingyu Hwang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,25 +23,25 @@ import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static io.github.resilience4j.micrometer.tagged.RetryMetricNames.DEFAULT_RETRY_CALLS;
 import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByKindAndNameTags;
+import static io.github.resilience4j.micrometer.tagged.RetryMetricNames.DEFAULT_RETRY_CALLS;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TaggedRetryMetricsPublisherTest {
+class TaggedRetryMetricsPublisherTest {
 
     private MeterRegistry meterRegistry;
     private Retry retry;
     private RetryRegistry retryRegistry;
     private TaggedRetryMetricsPublisher taggedRetryMetricsPublisher;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         meterRegistry = new SimpleMeterRegistry();
         taggedRetryMetricsPublisher = new TaggedRetryMetricsPublisher(meterRegistry);
         retryRegistry = RetryRegistry.of(RetryConfig.ofDefaults(), taggedRetryMetricsPublisher);
@@ -53,7 +53,7 @@ public class TaggedRetryMetricsPublisherTest {
     }
 
     @Test
-    public void shouldAddMetricsForANewlyCreatedRetry() {
+    void shouldAddMetricsForANewlyCreatedRetry() {
         Retry newRetry = retryRegistry.retry("backendB");
 
         assertThat(taggedRetryMetricsPublisher.meterIdMap).containsKeys("backendA", "backendB");
@@ -74,7 +74,7 @@ public class TaggedRetryMetricsPublisherTest {
     }
 
     @Test
-    public void shouldRemovedMetricsForRemovedRetry() {
+    void shouldRemovedMetricsForRemovedRetry() {
         List<Meter> meters = meterRegistry.getMeters();
         assertThat(meters).hasSize(4);
 
@@ -88,7 +88,7 @@ public class TaggedRetryMetricsPublisherTest {
     }
 
     @Test
-    public void shouldReplaceMetrics() {
+    void shouldReplaceMetrics() {
         Collection<FunctionCounter> counters = meterRegistry.get(DEFAULT_RETRY_CALLS).functionCounters();
         Optional<FunctionCounter> successfulWithoutRetry = MetricsTestHelper.findMeterByKindAndNameTags(counters,
             "successful_without_retry", retry.getName());
@@ -110,7 +110,7 @@ public class TaggedRetryMetricsPublisherTest {
     }
 
     @Test
-    public void successfulWithoutRetryCallsGaugeReportsCorrespondingValue() {
+    void successfulWithoutRetryCallsGaugeReportsCorrespondingValue() {
         Collection<FunctionCounter> counters = meterRegistry.get(DEFAULT_RETRY_CALLS)
             .functionCounters();
 
@@ -122,7 +122,7 @@ public class TaggedRetryMetricsPublisherTest {
     }
 
     @Test
-    public void successfulWithRetryCallsGaugeReportsCorrespondingValue() {
+    void successfulWithRetryCallsGaugeReportsCorrespondingValue() {
         Collection<FunctionCounter> counters = meterRegistry.get(DEFAULT_RETRY_CALLS)
             .functionCounters();
 
@@ -134,7 +134,7 @@ public class TaggedRetryMetricsPublisherTest {
     }
 
     @Test
-    public void failedWithoutRetryCallsGaugeReportsCorrespondingValue() {
+    void failedWithoutRetryCallsGaugeReportsCorrespondingValue() {
         Collection<FunctionCounter> counters = meterRegistry.get(DEFAULT_RETRY_CALLS)
             .functionCounters();
 
@@ -146,7 +146,7 @@ public class TaggedRetryMetricsPublisherTest {
     }
 
     @Test
-    public void failedWithRetryCallsGaugeReportsCorrespondingValue() {
+    void failedWithRetryCallsGaugeReportsCorrespondingValue() {
         Collection<FunctionCounter> counters = meterRegistry.get(DEFAULT_RETRY_CALLS).
             functionCounters();
 
@@ -159,7 +159,7 @@ public class TaggedRetryMetricsPublisherTest {
     }
 
     @Test
-    public void metricsAreRegisteredWithCustomNames() {
+    void metricsAreRegisteredWithCustomNames() {
         MeterRegistry meterRegistry = new SimpleMeterRegistry();
         TaggedRetryMetricsPublisher taggedRetryMetricsPublisher = new TaggedRetryMetricsPublisher(
             RetryMetricNames.custom()
@@ -179,7 +179,7 @@ public class TaggedRetryMetricsPublisherTest {
     }
 
     @Test
-    public void testReplaceNewMeter() {
+    void testReplaceNewMeter() {
         Retry oldOne = Retry.of("backendC", RetryConfig.ofDefaults());
         // add meters of old
         taggedRetryMetricsPublisher.addMetrics(meterRegistry, oldOne);
@@ -195,7 +195,6 @@ public class TaggedRetryMetricsPublisherTest {
         assertThat(successfulWithoutRetry).isPresent();
         assertThat(successfulWithoutRetry.get().count())
             .isEqualTo(oldOne.getMetrics().getNumberOfSuccessfulCallsWithoutRetryAttempt());
-
 
         Retry newOne = Retry.of("backendC", RetryConfig.ofDefaults());
         // add meters of old

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRetryMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedRetryMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Yevhenii Voievodin
+ * Copyright 2026 Yevhenii Voievodin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@ import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -32,15 +32,15 @@ import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMet
 import static io.github.resilience4j.micrometer.tagged.RetryMetricNames.DEFAULT_RETRY_CALLS;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TaggedRetryMetricsTest {
+class TaggedRetryMetricsTest {
 
     private MeterRegistry meterRegistry;
     private Retry retry;
     private RetryRegistry retryRegistry;
     private TaggedRetryMetrics taggedRetryMetrics;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         meterRegistry = new SimpleMeterRegistry();
         retryRegistry = RetryRegistry.ofDefaults();
 
@@ -54,7 +54,7 @@ public class TaggedRetryMetricsTest {
     }
 
     @Test
-    public void shouldAddMetricsForANewlyCreatedRetry() {
+    void shouldAddMetricsForANewlyCreatedRetry() {
         Retry newRetry = retryRegistry.retry("backendB");
 
         assertThat(taggedRetryMetrics.meterIdMap).containsKeys("backendA", "backendB");
@@ -75,7 +75,7 @@ public class TaggedRetryMetricsTest {
     }
 
     @Test
-    public void shouldAddCustomTags() {
+    void shouldAddCustomTags() {
         retryRegistry.retry("backendF", Map.of("key1", "value1"));
         assertThat(taggedRetryMetrics.meterIdMap).containsKeys("backendA", "backendF");
         assertThat(taggedRetryMetrics.meterIdMap.get("backendA")).hasSize(4);
@@ -87,7 +87,7 @@ public class TaggedRetryMetricsTest {
     }
 
     @Test
-    public void shouldRemovedMetricsForRemovedRetry() {
+    void shouldRemovedMetricsForRemovedRetry() {
         List<Meter> meters = meterRegistry.getMeters();
         assertThat(meters).hasSize(4);
 
@@ -101,7 +101,7 @@ public class TaggedRetryMetricsTest {
     }
 
     @Test
-    public void shouldReplaceMetrics() {
+    void shouldReplaceMetrics() {
         Collection<FunctionCounter> counters = meterRegistry.get(DEFAULT_RETRY_CALLS)
             .functionCounters();
         Optional<FunctionCounter> successfulWithoutRetry = findMeterByKindAndNameTags(counters,
@@ -123,7 +123,7 @@ public class TaggedRetryMetricsTest {
     }
 
     @Test
-    public void successfulWithoutRetryCallsGaugeReportsCorrespondingValue() {
+    void successfulWithoutRetryCallsGaugeReportsCorrespondingValue() {
         Collection<FunctionCounter> counters = meterRegistry.get(DEFAULT_RETRY_CALLS)
             .functionCounters();
 
@@ -135,7 +135,7 @@ public class TaggedRetryMetricsTest {
     }
 
     @Test
-    public void successfulWithRetryCallsGaugeReportsCorrespondingValue() {
+    void successfulWithRetryCallsGaugeReportsCorrespondingValue() {
         Collection<FunctionCounter> counters = meterRegistry.get(DEFAULT_RETRY_CALLS)
             .functionCounters();
 
@@ -147,7 +147,7 @@ public class TaggedRetryMetricsTest {
     }
 
     @Test
-    public void failedWithoutRetryCallsGaugeReportsCorrespondingValue() {
+    void failedWithoutRetryCallsGaugeReportsCorrespondingValue() {
         Collection<FunctionCounter> counters = meterRegistry.get(DEFAULT_RETRY_CALLS)
             .functionCounters();
 
@@ -159,7 +159,7 @@ public class TaggedRetryMetricsTest {
     }
 
     @Test
-    public void failedWithRetryCallsGaugeReportsCorrespondingValue() {
+    void failedWithRetryCallsGaugeReportsCorrespondingValue() {
         Collection<FunctionCounter> counters = meterRegistry.get(DEFAULT_RETRY_CALLS)
             .functionCounters();
 
@@ -171,7 +171,7 @@ public class TaggedRetryMetricsTest {
     }
 
     @Test
-    public void metricsAreRegisteredWithCustomNames() {
+    void metricsAreRegisteredWithCustomNames() {
         MeterRegistry meterRegistry = new SimpleMeterRegistry();
         RetryRegistry retryRegistry = RetryRegistry.ofDefaults();
         retryRegistry.retry("backendA");

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedThreadPoolBulkheadMetricsPublisherTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedThreadPoolBulkheadMetricsPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Ingyu Hwang
+ * Copyright 2026 Ingyu Hwang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,19 +23,19 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static org.awaitility.Awaitility.await;
 import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMeterByNamesTag;
 import static io.github.resilience4j.micrometer.tagged.ThreadPoolBulkheadMetricNames.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
-public class TaggedThreadPoolBulkheadMetricsPublisherTest {
+class TaggedThreadPoolBulkheadMetricsPublisherTest {
 
     private static final List<String> EXPECTED_METERS = Arrays.asList(
         "custom.max.thread.pool.size",
@@ -52,8 +52,8 @@ public class TaggedThreadPoolBulkheadMetricsPublisherTest {
     private ThreadPoolBulkheadRegistry bulkheadRegistry;
     private TaggedThreadPoolBulkheadMetricsPublisher taggedBulkheadMetricsPublisher;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         meterRegistry = new SimpleMeterRegistry();
         taggedBulkheadMetricsPublisher = new TaggedThreadPoolBulkheadMetricsPublisher(
             meterRegistry);
@@ -68,7 +68,7 @@ public class TaggedThreadPoolBulkheadMetricsPublisherTest {
     }
 
     @Test
-    public void shouldAddMetricsForANewlyCreatedRetry() {
+    void shouldAddMetricsForANewlyCreatedRetry() {
         ThreadPoolBulkhead newBulkhead = bulkheadRegistry.bulkhead("backendB");
 
         assertThat(taggedBulkheadMetricsPublisher.meterIdMap).containsKeys("backendA", "backendB");
@@ -88,7 +88,7 @@ public class TaggedThreadPoolBulkheadMetricsPublisherTest {
     }
 
     @Test
-    public void shouldRemovedMetricsForRemovedRetry() {
+    void shouldRemovedMetricsForRemovedRetry() {
         List<Meter> meters = meterRegistry.getMeters();
         assertThat(meters).hasSize(EXPECTED_METER_COUNT);
 
@@ -102,7 +102,7 @@ public class TaggedThreadPoolBulkheadMetricsPublisherTest {
     }
 
     @Test
-    public void shouldReplaceMetrics() {
+    void shouldReplaceMetrics() {
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_MAX_THREAD_POOL_SIZE_METRIC_NAME)
             .gauges();
 
@@ -125,9 +125,8 @@ public class TaggedThreadPoolBulkheadMetricsPublisherTest {
             .isEqualTo(newBulkhead.getMetrics().getMaximumThreadPoolSize());
     }
 
-
     @Test
-    public void maxThreadPoolSizeGaugeIsRegistered() {
+    void maxThreadPoolSizeGaugeIsRegistered() {
         Gauge available = meterRegistry.get(DEFAULT_MAX_THREAD_POOL_SIZE_METRIC_NAME).gauge();
 
         assertThat(available).isNotNull();
@@ -135,7 +134,7 @@ public class TaggedThreadPoolBulkheadMetricsPublisherTest {
     }
 
     @Test
-    public void coreThreadPoolSizeGaugeIsRegistered() {
+    void coreThreadPoolSizeGaugeIsRegistered() {
         Gauge maxAllowed = meterRegistry.get(DEFAULT_CORE_THREAD_POOL_SIZE_METRIC_NAME).gauge();
 
         assertThat(maxAllowed).isNotNull();
@@ -144,7 +143,7 @@ public class TaggedThreadPoolBulkheadMetricsPublisherTest {
     }
 
     @Test
-    public void queueCapacityGaugeIsRegistered() {
+    void queueCapacityGaugeIsRegistered() {
         Gauge maxAllowed = meterRegistry.get(DEFAULT_BULKHEAD_QUEUE_CAPACITY_METRIC_NAME).gauge();
 
         assertThat(maxAllowed).isNotNull();
@@ -153,7 +152,7 @@ public class TaggedThreadPoolBulkheadMetricsPublisherTest {
     }
 
     @Test
-    public void queueDepthGaugeIsRegistered() {
+    void queueDepthGaugeIsRegistered() {
         Gauge maxAllowed = meterRegistry.get(DEFAULT_BULKHEAD_QUEUE_DEPTH_METRIC_NAME).gauge();
 
         assertThat(maxAllowed).isNotNull();
@@ -162,7 +161,7 @@ public class TaggedThreadPoolBulkheadMetricsPublisherTest {
     }
 
     @Test
-    public void threadPoolSizeIsRegistered() {
+    void threadPoolSizeIsRegistered() {
         Gauge maxAllowed = meterRegistry.get(DEFAULT_THREAD_POOL_SIZE_METRIC_NAME).gauge();
 
         assertThat(maxAllowed).isNotNull();
@@ -171,7 +170,7 @@ public class TaggedThreadPoolBulkheadMetricsPublisherTest {
     }
 
     @Test
-    public void activeThreadCountIsRegistered() {
+    void activeThreadCountIsRegistered() {
         Gauge activeCount = meterRegistry.get(DEFAULT_BULKHEAD_ACTIVE_THREAD_COUNT_METRIC_NAME).gauge();
 
         assertThat(activeCount).isNotNull();
@@ -187,7 +186,7 @@ public class TaggedThreadPoolBulkheadMetricsPublisherTest {
     }
 
     @Test
-    public void availableThreadCountIsRegistered() {
+    void availableThreadCountIsRegistered() {
         Gauge availableThreadCount = meterRegistry.get(DEFAULT_BULKHEAD_AVAILABLE_THREAD_COUNT_METRIC_NAME).gauge();
 
         assertThat(availableThreadCount).isNotNull();
@@ -203,7 +202,7 @@ public class TaggedThreadPoolBulkheadMetricsPublisherTest {
     }
 
     @Test
-    public void customMetricNamesGetApplied() {
+    void customMetricNamesGetApplied() {
         MeterRegistry meterRegistry = new SimpleMeterRegistry();
         TaggedThreadPoolBulkheadMetricsPublisher taggedBulkheadMetricsPublisher =
             new TaggedThreadPoolBulkheadMetricsPublisher(
@@ -226,7 +225,7 @@ public class TaggedThreadPoolBulkheadMetricsPublisherTest {
     }
 
     @Test
-    public void testReplaceNewMeter(){
+    void testReplaceNewMeter(){
         ThreadPoolBulkhead oldOne = ThreadPoolBulkhead.of("backendC", ThreadPoolBulkheadConfig.ofDefaults());
         // add meters of old
         taggedBulkheadMetricsPublisher.addMetrics(meterRegistry, oldOne);

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedThreadPoolBulkheadMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedThreadPoolBulkheadMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Robert Winkler, Mahmoud Romeh
+ * Copyright 2026 Robert Winkler, Mahmoud Romeh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -32,7 +32,7 @@ import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMet
 import static io.github.resilience4j.micrometer.tagged.ThreadPoolBulkheadMetricNames.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TaggedThreadPoolBulkheadMetricsTest {
+class TaggedThreadPoolBulkheadMetricsTest {
 
     private static final List<String> EXPECTED_METERS = Arrays.asList(
         "custom.max.thread.pool.size",
@@ -49,8 +49,8 @@ public class TaggedThreadPoolBulkheadMetricsTest {
     private ThreadPoolBulkheadRegistry bulkheadRegistry;
     private TaggedThreadPoolBulkheadMetrics taggedBulkheadMetrics;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         meterRegistry = new SimpleMeterRegistry();
         bulkheadRegistry = ThreadPoolBulkheadRegistry.ofDefaults();
         bulkhead = bulkheadRegistry.bulkhead("backendA");
@@ -65,7 +65,7 @@ public class TaggedThreadPoolBulkheadMetricsTest {
     }
 
     @Test
-    public void shouldAddMetricsForANewlyCreatedRetry() {
+    void shouldAddMetricsForANewlyCreatedRetry() {
         ThreadPoolBulkhead newBulkhead = bulkheadRegistry.bulkhead("backendB");
 
         assertThat(taggedBulkheadMetrics.meterIdMap).containsKeys("backendA", "backendB");
@@ -85,7 +85,7 @@ public class TaggedThreadPoolBulkheadMetricsTest {
     }
 
     @Test
-    public void shouldAddCustomTags() {
+    void shouldAddCustomTags() {
         bulkheadRegistry.bulkhead("backendF", Map.of("key1", "value1"));
         assertThat(taggedBulkheadMetrics.meterIdMap).containsKeys("backendA", "backendF");
         assertThat(taggedBulkheadMetrics.meterIdMap.get("backendA")).hasSize(EXPECTED_METER_COUNT);
@@ -97,7 +97,7 @@ public class TaggedThreadPoolBulkheadMetricsTest {
     }
 
     @Test
-    public void shouldRemovedMetricsForRemovedRetry() {
+    void shouldRemovedMetricsForRemovedRetry() {
         List<Meter> meters = meterRegistry.getMeters();
         assertThat(meters).hasSize(EXPECTED_METER_COUNT);
 
@@ -111,7 +111,7 @@ public class TaggedThreadPoolBulkheadMetricsTest {
     }
 
     @Test
-    public void shouldReplaceMetrics() {
+    void shouldReplaceMetrics() {
         Collection<Gauge> gauges = meterRegistry.get(DEFAULT_MAX_THREAD_POOL_SIZE_METRIC_NAME)
             .gauges();
 
@@ -135,9 +135,8 @@ public class TaggedThreadPoolBulkheadMetricsTest {
             .isEqualTo(newBulkhead.getMetrics().getMaximumThreadPoolSize());
     }
 
-
     @Test
-    public void maxThreadPoolSizeGaugeIsRegistered() {
+    void maxThreadPoolSizeGaugeIsRegistered() {
         Gauge available = meterRegistry.get(DEFAULT_MAX_THREAD_POOL_SIZE_METRIC_NAME).gauge();
 
         assertThat(available).isNotNull();
@@ -145,7 +144,7 @@ public class TaggedThreadPoolBulkheadMetricsTest {
     }
 
     @Test
-    public void coreThreadPoolSizeGaugeIsRegistered() {
+    void coreThreadPoolSizeGaugeIsRegistered() {
         Gauge maxAllowed = meterRegistry.get(DEFAULT_CORE_THREAD_POOL_SIZE_METRIC_NAME).gauge();
 
         assertThat(maxAllowed).isNotNull();
@@ -154,7 +153,7 @@ public class TaggedThreadPoolBulkheadMetricsTest {
     }
 
     @Test
-    public void queueCapacityGaugeIsRegistered() {
+    void queueCapacityGaugeIsRegistered() {
         Gauge maxAllowed = meterRegistry.get(DEFAULT_BULKHEAD_QUEUE_CAPACITY_METRIC_NAME).gauge();
 
         assertThat(maxAllowed).isNotNull();
@@ -163,7 +162,7 @@ public class TaggedThreadPoolBulkheadMetricsTest {
     }
 
     @Test
-    public void queueDepthGaugeIsRegistered() {
+    void queueDepthGaugeIsRegistered() {
         Gauge maxAllowed = meterRegistry.get(DEFAULT_BULKHEAD_QUEUE_DEPTH_METRIC_NAME).gauge();
 
         assertThat(maxAllowed).isNotNull();
@@ -172,7 +171,7 @@ public class TaggedThreadPoolBulkheadMetricsTest {
     }
 
     @Test
-    public void threadPoolSizeIsRegistered() {
+    void threadPoolSizeIsRegistered() {
         Gauge maxAllowed = meterRegistry.get(DEFAULT_THREAD_POOL_SIZE_METRIC_NAME).gauge();
 
         assertThat(maxAllowed).isNotNull();
@@ -181,7 +180,7 @@ public class TaggedThreadPoolBulkheadMetricsTest {
     }
 
     @Test
-    public void availableThreadCountIsRegistered() {
+    void availableThreadCountIsRegistered() {
         Gauge availableThreadCount = meterRegistry.get(DEFAULT_BULKHEAD_AVAILABLE_THREAD_COUNT_METRIC_NAME).gauge();
 
         assertThat(availableThreadCount).isNotNull();
@@ -190,7 +189,7 @@ public class TaggedThreadPoolBulkheadMetricsTest {
     }
 
     @Test
-    public void customMetricNamesGetApplied() {
+    void customMetricNamesGetApplied() {
         MeterRegistry meterRegistry = new SimpleMeterRegistry();
         ThreadPoolBulkheadRegistry bulkheadRegistry = ThreadPoolBulkheadRegistry.ofDefaults();
         bulkhead = bulkheadRegistry.bulkhead("backendA");

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedTimeLimiterMetricsPublisherTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedTimeLimiterMetricsPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Ingyu Hwang
+ * Copyright 2026 Ingyu Hwang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,8 @@ import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.search.RequiredSearch;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.*;
 import java.util.concurrent.TimeoutException;
@@ -35,15 +35,15 @@ import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMet
 import static io.github.resilience4j.micrometer.tagged.TimeLimiterMetricNames.DEFAULT_TIME_LIMITER_CALLS;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TaggedTimeLimiterMetricsPublisherTest {
+class TaggedTimeLimiterMetricsPublisherTest {
 
     private MeterRegistry meterRegistry;
     private TimeLimiter timeLimiter;
     private TimeLimiterRegistry timeLimiterRegistry;
     private TaggedTimeLimiterMetricsPublisher taggedTimeLimiterMetricsPublisher;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         meterRegistry = new SimpleMeterRegistry();
         taggedTimeLimiterMetricsPublisher = new TaggedTimeLimiterMetricsPublisher(meterRegistry);
         timeLimiterRegistry = TimeLimiterRegistry
@@ -53,7 +53,7 @@ public class TaggedTimeLimiterMetricsPublisherTest {
     }
 
     @Test
-    public void shouldAddMetricsForANewlyCreatedTimeLimiter() {
+    void shouldAddMetricsForANewlyCreatedTimeLimiter() {
         TimeLimiter newTimeLimiter = timeLimiterRegistry.timeLimiter("backendB");
         newTimeLimiter.onSuccess();
 
@@ -72,7 +72,7 @@ public class TaggedTimeLimiterMetricsPublisherTest {
     }
 
     @Test
-    public void shouldAddCustomTags() {
+    void shouldAddCustomTags() {
         TimeLimiter timeLimiterF = timeLimiterRegistry.timeLimiter("backendF", Map.of("key1", "value1"));
         timeLimiterF.onSuccess();
         assertThat(taggedTimeLimiterMetricsPublisher.meterIdMap).containsKeys("backendA", "backendF");
@@ -84,7 +84,7 @@ public class TaggedTimeLimiterMetricsPublisherTest {
     }
 
     @Test
-    public void shouldRemovedMetricsForRemovedRetry() {
+    void shouldRemovedMetricsForRemovedRetry() {
         assertThat(meterRegistry.getMeters()).hasSize(3);
 
         assertThat(taggedTimeLimiterMetricsPublisher.meterIdMap).containsKeys("backendA");
@@ -96,7 +96,7 @@ public class TaggedTimeLimiterMetricsPublisherTest {
     }
 
     @Test
-    public void shouldReplaceMetrics() {
+    void shouldReplaceMetrics() {
         Counter before = meterRegistry.get(DEFAULT_TIME_LIMITER_CALLS).counter();
         assertThat(before).isNotNull();
         assertThat(before.count()).isZero();
@@ -112,7 +112,7 @@ public class TaggedTimeLimiterMetricsPublisherTest {
     }
 
     @Test
-    public void successfulCounterIsRegistered() {
+    void successfulCounterIsRegistered() {
         Collection<Counter> counters = meterRegistry.get(DEFAULT_TIME_LIMITER_CALLS).counters();
         timeLimiter.onSuccess();
 
@@ -122,7 +122,7 @@ public class TaggedTimeLimiterMetricsPublisherTest {
     }
 
     @Test
-    public void failedCounterIsRegistered() {
+    void failedCounterIsRegistered() {
         Collection<Counter> counters = meterRegistry.get(DEFAULT_TIME_LIMITER_CALLS).counters();
         timeLimiter.onError(new RuntimeException());
 
@@ -132,7 +132,7 @@ public class TaggedTimeLimiterMetricsPublisherTest {
     }
 
     @Test
-    public void timoutCounterIsRegistered() {
+    void timoutCounterIsRegistered() {
         Collection<Counter> counters = meterRegistry.get(DEFAULT_TIME_LIMITER_CALLS).counters();
         timeLimiter.onError(new TimeoutException());
 
@@ -142,7 +142,7 @@ public class TaggedTimeLimiterMetricsPublisherTest {
     }
 
     @Test
-    public void customMetricNamesGetApplied() {
+    void customMetricNamesGetApplied() {
         MeterRegistry meterRegistry = new SimpleMeterRegistry();
         TaggedTimeLimiterMetricsPublisher taggedTimeLimiterMetricsPublisher = new TaggedTimeLimiterMetricsPublisher(
             TimeLimiterMetricNames.custom()
@@ -165,7 +165,7 @@ public class TaggedTimeLimiterMetricsPublisherTest {
     }
 
     @Test
-    public void testReplaceNewMeter(){
+    void testReplaceNewMeter(){
         TimeLimiter oldOne = TimeLimiter.of("backendC", TimeLimiterConfig.ofDefaults());
         // add meters of old
         taggedTimeLimiterMetricsPublisher.addMetrics(meterRegistry, oldOne);

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedTimeLimiterMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/TaggedTimeLimiterMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 authors
+ * Copyright 2026 authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,8 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -35,15 +35,15 @@ import static io.github.resilience4j.micrometer.tagged.MetricsTestHelper.findMet
 import static io.github.resilience4j.micrometer.tagged.TimeLimiterMetricNames.DEFAULT_TIME_LIMITER_CALLS;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TaggedTimeLimiterMetricsTest {
+class TaggedTimeLimiterMetricsTest {
 
     private MeterRegistry meterRegistry;
     private TimeLimiter timeLimiter;
     private TimeLimiterRegistry timeLimiterRegistry;
     private TaggedTimeLimiterMetrics taggedTimeLimiterMetrics;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         meterRegistry = new SimpleMeterRegistry();
         timeLimiterRegistry = TimeLimiterRegistry.ofDefaults();
 
@@ -54,7 +54,7 @@ public class TaggedTimeLimiterMetricsTest {
     }
 
     @Test
-    public void shouldAddMetricsForANewlyCreatedTimeLimiter() {
+    void shouldAddMetricsForANewlyCreatedTimeLimiter() {
         TimeLimiter newTimeLimiter = timeLimiterRegistry.timeLimiter("backendB");
         newTimeLimiter.onSuccess();
 
@@ -72,7 +72,7 @@ public class TaggedTimeLimiterMetricsTest {
     }
 
     @Test
-    public void shouldRemovedMetricsForRemovedRetry() {
+    void shouldRemovedMetricsForRemovedRetry() {
         assertThat(meterRegistry.getMeters()).hasSize(3);
 
         assertThat(taggedTimeLimiterMetrics.meterIdMap).containsKeys("backendA");
@@ -84,7 +84,7 @@ public class TaggedTimeLimiterMetricsTest {
     }
 
     @Test
-    public void shouldReplaceMetrics() {
+    void shouldReplaceMetrics() {
         Counter before = meterRegistry.get(DEFAULT_TIME_LIMITER_CALLS).counter();
         assertThat(before).isNotNull();
         assertThat(before.count()).isZero();
@@ -100,7 +100,7 @@ public class TaggedTimeLimiterMetricsTest {
     }
 
     @Test
-    public void successfulCounterIsRegistered() {
+    void successfulCounterIsRegistered() {
         Collection<Counter> counters = meterRegistry.get(DEFAULT_TIME_LIMITER_CALLS).counters();
         timeLimiter.onSuccess();
 
@@ -110,7 +110,7 @@ public class TaggedTimeLimiterMetricsTest {
     }
 
     @Test
-    public void failedCounterIsRegistered() {
+    void failedCounterIsRegistered() {
         Collection<Counter> counters = meterRegistry.get(DEFAULT_TIME_LIMITER_CALLS).counters();
         timeLimiter.onError(new RuntimeException());
 
@@ -120,7 +120,7 @@ public class TaggedTimeLimiterMetricsTest {
     }
 
     @Test
-    public void timoutCounterIsRegistered() {
+    void timoutCounterIsRegistered() {
         Collection<Counter> counters = meterRegistry.get(DEFAULT_TIME_LIMITER_CALLS).counters();
         timeLimiter.onError(new TimeoutException());
 
@@ -130,7 +130,7 @@ public class TaggedTimeLimiterMetricsTest {
     }
 
     @Test
-    public void customMetricNamesGetApplied() {
+    void customMetricNamesGetApplied() {
         MeterRegistry meterRegistry = new SimpleMeterRegistry();
         TimeLimiterRegistry timeLimiterRegistry = TimeLimiterRegistry.ofDefaults();
         timeLimiterRegistry.timeLimiter("backendA");

--- a/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/ThreadMetricsTest.java
+++ b/resilience4j-micrometer/src/test/java/io/github/resilience4j/micrometer/tagged/ThreadMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025
+ * Copyright 2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,71 +17,70 @@ package io.github.resilience4j.micrometer.tagged;
 
 import io.github.resilience4j.core.ThreadType;
 import io.micrometer.core.instrument.Gauge;
-import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link ThreadMetrics}.
- * 
+ *
  * @author kanghyun.yang
  * @since 3.0.0
  */
-public class ThreadMetricsTest {
+class ThreadMetricsTest {
 
     private MeterRegistry meterRegistry;
     private static final String SYSTEM_PROPERTY_KEY = "resilience4j.thread.type";
-    
-    @Before
-    public void setUp() {
+
+    @BeforeEach
+    void setUp() {
         meterRegistry = new SimpleMeterRegistry();
     }
-    
-    @After
-    public void tearDown() {
+
+    @AfterEach
+    void tearDown() {
         System.clearProperty(SYSTEM_PROPERTY_KEY);
     }
-    
+
     @Test
-    public void shouldRegisterMetrics() {
+    void shouldRegisterMetrics() {
         ThreadMetrics threadMetrics = ThreadMetrics.ofMeterRegistry(meterRegistry);
-        
+
         assertThat(meterRegistry.find(ThreadMetrics.DEFAULT_PREFIX + ".virtual_thread_enabled").gauge())
             .isNotNull();
     }
-    
+
     @Test
-    public void shouldReportVirtualThreadsDisabled() {
+    void shouldReportVirtualThreadsDisabled() {
         System.clearProperty(SYSTEM_PROPERTY_KEY);
-        
+
         ThreadMetrics.ofMeterRegistry(meterRegistry);
-        
+
         Gauge gauge = meterRegistry.find(ThreadMetrics.DEFAULT_PREFIX + ".virtual_thread_enabled").gauge();
         assertThat(gauge).isNotNull();
         assertThat(gauge.value()).isZero();
     }
-    
+
     @Test
-    public void shouldReportVirtualThreadsEnabled() {
+    void shouldReportVirtualThreadsEnabled() {
         System.setProperty(SYSTEM_PROPERTY_KEY, ThreadType.VIRTUAL.toString());
-        
+
         ThreadMetrics.ofMeterRegistry(meterRegistry);
-        
+
         Gauge gauge = meterRegistry.find(ThreadMetrics.DEFAULT_PREFIX + ".virtual_thread_enabled").gauge();
         assertThat(gauge).isNotNull();
         assertThat(gauge.value()).isEqualTo(1.0);
     }
-    
+
     @Test
-    public void shouldUseCustomPrefix() {
+    void shouldUseCustomPrefix() {
         String customPrefix = "custom.prefix";
         ThreadMetrics.ofMeterRegistry(customPrefix, meterRegistry);
-        
+
         assertThat(meterRegistry.find(customPrefix + ".virtual_thread_enabled").gauge())
             .isNotNull();
     }


### PR DESCRIPTION
## Changes

* Migrated JUnit 4.13 annotations to Junit Jupiter equivalents
* Replaced `@Rule ExpectedException` with `assertThatThrownBy`
* Migrated to awaitility 4.x
* Applied OpenRewrite recipes
    * [JUnit 6 best practices](https://docs.openrewrite.org/recipes/java/testing/junit/junit6bestpractices)
    * [Mockito best practices](https://docs.openrewrite.org/recipes/java/testing/mockito/mockitobestpractices)
    * [Migrate JUnit asserts to AssertJ](https://docs.openrewrite.org/recipes/java/testing/assertj/junittoassertj)
    * [AssertJ best practices](https://docs.openrewrite.org/recipes/java/testing/assertj/assertj-best-practices)
* Removed `public` modifiers
* Updated Copyright to 2026

## Coverage

| Metric      | Before | After |
|-------------|--------|-------|
| Instruction | 93.4%  | 93.4% |
| Line        | 94.8%  | 94.8% |
| Branch      | 90.6%  | 90.6% |

## Test runtime

| Metric | Before | After |
|--------|--------|-------|
| Tests  | 146    | 146   |
| Time   | 1.5s   | 1.7s  |
