### PR TITLE
resilience4j-ratelimiter: JUnit 4 → JUnit 6 migration

### DIFF
--- a/resilience4j-ratelimiter/build.gradle
+++ b/resilience4j-ratelimiter/build.gradle
@@ -1,10 +1,6 @@
 dependencies {
     api(project(":resilience4j-core"))
 
-    testRuntimeOnly(libs.junit.vintage.engine)
-
-    testImplementation(libs.junit)
-    testImplementation(libs.awaitility.old)
     testImplementation(libs.vavr)
     testImplementation(project(":resilience4j-core").sourceSets.test.output)
 }

--- a/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/RateLimiterConfigTest.java
+++ b/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/RateLimiterConfigTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2016 Robert Winkler and Bohdan Storozhuk
+ *  Copyright 2026 Robert Winkler and Bohdan Storozhuk
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -19,19 +19,15 @@
 package io.github.resilience4j.ratelimiter;
 
 import io.github.resilience4j.core.functions.Either;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.internal.matchers.ThrowableCauseMatcher;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.function.Predicate;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.hamcrest.CoreMatchers.isA;
 
-
-public class RateLimiterConfigTest {
+class RateLimiterConfigTest {
 
     private static final int LIMIT = 50;
     private static final Duration TIMEOUT = Duration.ofSeconds(5);
@@ -39,14 +35,10 @@ public class RateLimiterConfigTest {
     private static final Predicate<Either<? extends Throwable, ?>> DRAIN_CONDITION_CHECKER = result -> false;
     private static final String TIMEOUT_DURATION_MUST_NOT_BE_NULL = "TimeoutDuration must not be null";
     private static final String TIMEOUT_DURATION_MUST_NOT_BE_NEGATIVE = "TimeoutDuration must not be negative";
-    private static final String REFRESH_PERIOD_MUST_NOT_BE_NULL = "RefreshPeriod must not be null";
-
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
+    private static final String REFRESH_PERIOD_MUST_NOT_BE_NULL = "LimitRefreshPeriod must not be null";
 
     @Test
-    public void builderPositive() throws Exception {
+    void builderPositive() {
         RateLimiterConfig config = RateLimiterConfig.custom()
             .timeoutDuration(TIMEOUT)
             .limitRefreshPeriod(REFRESH_PERIOD)
@@ -61,70 +53,68 @@ public class RateLimiterConfigTest {
     }
 
     @Test
-    public void builderTimeoutIsNull() throws Exception {
-        exception.expect(NullPointerException.class);
-        exception.expectMessage(TIMEOUT_DURATION_MUST_NOT_BE_NULL);
-        RateLimiterConfig.custom()
-            .timeoutDuration(null);
+    void builderTimeoutIsNull() {
+        assertThatThrownBy(() -> RateLimiterConfig.custom().timeoutDuration(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage(TIMEOUT_DURATION_MUST_NOT_BE_NULL);
     }
 
     @Test
-    public void builderTimeoutIsNegative() throws Exception {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(TIMEOUT_DURATION_MUST_NOT_BE_NEGATIVE);
-        RateLimiterConfig.custom()
-            .timeoutDuration(Duration.ofNanos(-1));
+    void builderTimeoutIsNegative() {
+        assertThatThrownBy(() -> RateLimiterConfig.custom().timeoutDuration(Duration.ofNanos(-1)))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage(TIMEOUT_DURATION_MUST_NOT_BE_NEGATIVE);
     }
 
     @Test
-    public void builderRefreshPeriodIsNull() throws Exception {
-        exception.expect(NullPointerException.class);
-        exception.expectMessage(REFRESH_PERIOD_MUST_NOT_BE_NULL);
-        RateLimiterConfig.custom()
-            .limitRefreshPeriod(null);
+    void builderRefreshPeriodIsNull() {
+        assertThatThrownBy(() -> RateLimiterConfig.custom().limitRefreshPeriod(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage(REFRESH_PERIOD_MUST_NOT_BE_NULL);
     }
 
     @Test
-    public void builderRefreshPeriodTooShort() throws Exception {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("RefreshPeriod is too short");
-        RateLimiterConfig.custom()
+    void builderRefreshPeriodTooShort() {
+        assertThatThrownBy(() -> RateLimiterConfig.custom()
             .timeoutDuration(TIMEOUT)
             .limitRefreshPeriod(Duration.ZERO)
             .limitForPeriod(LIMIT)
-            .build();
+            .build())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("RefreshPeriod is too short");
     }
+
     @Test
-    public void builderRefreshPeriodNegative() throws Exception {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("RefreshPeriod is too short");
-        RateLimiterConfig.custom()
+    void builderRefreshPeriodNegative() {
+        assertThatThrownBy(() -> RateLimiterConfig.custom()
             .timeoutDuration(TIMEOUT)
             .limitRefreshPeriod(Duration.ofNanos(-1))
             .limitForPeriod(LIMIT)
-            .build();
+            .build())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("RefreshPeriod is too short");
     }
 
     @Test
-    public void builderLimitIsLessThanOne() throws Exception {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("LimitForPeriod should be greater than 0");
-        RateLimiterConfig.custom()
-            .limitForPeriod(0);
-    }
-    @Test
-    public void buildTimeoutDurationIsNotWithinLimits() {
-        exception.expect(ThrowableCauseMatcher.hasCause(isA(ArithmeticException.class)));
-        exception.expectMessage("TimeoutDuration too large");
-        RateLimiterConfig.custom()
-            .timeoutDuration(Duration.ofSeconds(Long.MAX_VALUE));
+    void builderLimitIsLessThanOne() {
+        assertThatThrownBy(() -> RateLimiterConfig.custom().limitForPeriod(0))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("LimitForPeriod should be greater than 0");
     }
 
     @Test
-    public void buildLimitRefreshPeriodIsNotWithinLimits() {
-        exception.expect(ThrowableCauseMatcher.hasCause(isA(ArithmeticException.class)));
-        exception.expectMessage("LimitRefreshPeriod too large");
-        RateLimiterConfig.custom()
-            .limitRefreshPeriod(Duration.ofSeconds(Long.MAX_VALUE));
+    void buildTimeoutDurationIsNotWithinLimits() {
+        assertThatThrownBy(() -> RateLimiterConfig.custom()
+            .timeoutDuration(Duration.ofSeconds(Long.MAX_VALUE)))
+            .hasMessageContaining("TimeoutDuration too large")
+            .hasCauseInstanceOf(ArithmeticException.class);
+    }
+
+    @Test
+    void buildLimitRefreshPeriodIsNotWithinLimits() {
+        assertThatThrownBy(() -> RateLimiterConfig.custom()
+            .limitRefreshPeriod(Duration.ofSeconds(Long.MAX_VALUE)))
+            .hasMessageContaining("LimitRefreshPeriod too large")
+            .hasCauseInstanceOf(ArithmeticException.class);
     }
 }

--- a/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/RateLimiterEventPublisherTest.java
+++ b/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/RateLimiterEventPublisherTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2016 Robert Winkler and Bohdan Storozhuk
+ *  Copyright 2026 Robert Winkler and Bohdan Storozhuk
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@
 package io.github.resilience4j.ratelimiter;
 
 import io.vavr.control.Try;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 
 import java.time.Duration;
@@ -30,7 +30,7 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 
-public class RateLimiterEventPublisherTest {
+class RateLimiterEventPublisherTest {
 
     private static final int LIMIT = 1;
     private static final Duration TIMEOUT = Duration.ZERO;
@@ -39,8 +39,8 @@ public class RateLimiterEventPublisherTest {
     private RateLimiter rateLimiter;
     private Logger logger;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         RateLimiterConfig config = RateLimiterConfig.custom()
             .timeoutDuration(TIMEOUT)
             .limitRefreshPeriod(REFRESH_PERIOD)
@@ -51,7 +51,7 @@ public class RateLimiterEventPublisherTest {
     }
 
     @Test
-    public void shouldReturnTheSameConsumer() {
+    void shouldReturnTheSameConsumer() {
         RateLimiter.EventPublisher eventPublisher = rateLimiter.getEventPublisher();
         RateLimiter.EventPublisher eventPublisher2 = rateLimiter.getEventPublisher();
 
@@ -60,7 +60,7 @@ public class RateLimiterEventPublisherTest {
 
 
     @Test
-    public void shouldConsumeOnSuccessEvent() throws Throwable {
+    void shouldConsumeOnSuccessEvent() {
         rateLimiter.getEventPublisher().onSuccess(
             event -> logger.info(event.getEventType().toString()));
 
@@ -71,7 +71,7 @@ public class RateLimiterEventPublisherTest {
     }
 
     @Test
-    public void shouldConsumeOnFailureEvent() throws Throwable {
+    void shouldConsumeOnFailureEvent() {
         rateLimiter.getEventPublisher().onFailure(
             event -> logger.info(event.getEventType().toString()));
         rateLimiter.executeSupplier(() -> "Hello world");

--- a/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/RateLimiterRegistryTest.java
+++ b/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/RateLimiterRegistryTest.java
@@ -4,7 +4,7 @@ import io.github.resilience4j.core.ConfigurationNotFoundException;
 import io.github.resilience4j.core.EventProcessor;
 import io.github.resilience4j.core.Registry;
 import io.github.resilience4j.core.registry.*;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.*;
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
-public class RateLimiterRegistryTest {
+class RateLimiterRegistryTest {
 
     private static Optional<EventProcessor<?>> getEventProcessor(
         Registry.EventPublisher<RateLimiter> eventPublisher) {
@@ -25,7 +25,7 @@ public class RateLimiterRegistryTest {
     }
 
     @Test
-    public void shouldInitRegistryTags() {
+    void shouldInitRegistryTags() {
         Map<String, RateLimiterConfig> configs = new HashMap<>();
         configs.put("custom", RateLimiterConfig.ofDefaults());
         RateLimiterRegistry registry = RateLimiterRegistry.of(configs, Map.of("Tag1Key","Tag1Value"));
@@ -34,7 +34,7 @@ public class RateLimiterRegistryTest {
     }
 
     @Test
-    public void testCreateWithConfigurationMap() {
+    void testCreateWithConfigurationMap() {
         Map<String, RateLimiterConfig> configs = new HashMap<>();
         configs.put("default", RateLimiterConfig.ofDefaults());
         configs.put("custom", RateLimiterConfig.ofDefaults());
@@ -46,7 +46,7 @@ public class RateLimiterRegistryTest {
     }
 
     @Test
-    public void testCreateWithConfigurationMapWithoutDefaultConfig() {
+    void testCreateWithConfigurationMapWithoutDefaultConfig() {
         Map<String, RateLimiterConfig> configs = new HashMap<>();
         configs.put("custom", RateLimiterConfig.ofDefaults());
 
@@ -57,7 +57,7 @@ public class RateLimiterRegistryTest {
     }
 
     @Test
-    public void testCreateWithCustomConfig() {
+    void testCreateWithCustomConfig() {
         RateLimiterConfig config = RateLimiterConfig.custom()
             .limitForPeriod(10)
             .timeoutDuration(Duration.ofMillis(50))
@@ -70,7 +70,7 @@ public class RateLimiterRegistryTest {
     }
 
     @Test
-    public void testCreateWithSingleRegistryEventConsumer() {
+    void testCreateWithSingleRegistryEventConsumer() {
         RateLimiterRegistry rateLimiterRegistry = RateLimiterRegistry
             .of(RateLimiterConfig.ofDefaults(), new NoOpRateLimiterEventConsumer());
 
@@ -79,7 +79,7 @@ public class RateLimiterRegistryTest {
     }
 
     @Test
-    public void testCreateWithMultipleRegistryEventConsumer() {
+    void testCreateWithMultipleRegistryEventConsumer() {
         List<RegistryEventConsumer<RateLimiter>> registryEventConsumers = new ArrayList<>();
         registryEventConsumers.add(new NoOpRateLimiterEventConsumer());
         registryEventConsumers.add(new NoOpRateLimiterEventConsumer());
@@ -92,7 +92,7 @@ public class RateLimiterRegistryTest {
     }
 
     @Test
-    public void testCreateWithConfigurationMapWithSingleRegistryEventConsumer() {
+    void testCreateWithConfigurationMapWithSingleRegistryEventConsumer() {
         Map<String, RateLimiterConfig> configs = new HashMap<>();
         configs.put("custom", RateLimiterConfig.ofDefaults());
 
@@ -104,7 +104,7 @@ public class RateLimiterRegistryTest {
     }
 
     @Test
-    public void testCreateWithConfigurationMapWithMultiRegistryEventConsumer() {
+    void testCreateWithConfigurationMapWithMultiRegistryEventConsumer() {
         Map<String, RateLimiterConfig> configs = new HashMap<>();
         configs.put("custom", RateLimiterConfig.ofDefaults());
 
@@ -120,7 +120,7 @@ public class RateLimiterRegistryTest {
     }
 
     @Test
-    public void testAddConfiguration() {
+    void testAddConfiguration() {
         RateLimiterRegistry rateLimiterRegistry = RateLimiterRegistry.ofDefaults();
         rateLimiterRegistry.addConfiguration("custom", RateLimiterConfig.custom().build());
 
@@ -129,7 +129,7 @@ public class RateLimiterRegistryTest {
     }
 
     @Test
-    public void testWithNotExistingConfig() {
+    void testWithNotExistingConfig() {
         RateLimiterRegistry rateLimiterRegistry = RateLimiterRegistry.ofDefaults();
 
         assertThatThrownBy(() -> rateLimiterRegistry.rateLimiter("test", "doesNotExist"))
@@ -137,13 +137,13 @@ public class RateLimiterRegistryTest {
     }
 
     @Test
-    public void noTagsByDefault() {
+    void noTagsByDefault() {
         RateLimiter rateLimiter = RateLimiterRegistry.ofDefaults().rateLimiter("testName");
         assertThat(rateLimiter.getTags()).isEmpty();
     }
 
     @Test
-    public void tagsOfRegistryAddedToInstance() {
+    void tagsOfRegistryAddedToInstance() {
         RateLimiterConfig rateLimiterConfig = RateLimiterConfig.ofDefaults();
         Map<String, RateLimiterConfig> ratelimiterConfigs = Collections
             .singletonMap("default", rateLimiterConfig);
@@ -156,7 +156,7 @@ public class RateLimiterRegistryTest {
     }
 
     @Test
-    public void tagsAddedToInstance() {
+    void tagsAddedToInstance() {
         RateLimiterRegistry rateLimiterRegistry = RateLimiterRegistry.ofDefaults();
         Map<String, String> retryTags = Map.of("key1", "value1", "key2", "value2");
         RateLimiter rateLimiter = rateLimiterRegistry.rateLimiter("testName", retryTags);
@@ -165,7 +165,7 @@ public class RateLimiterRegistryTest {
     }
 
     @Test
-    public void tagsOfRetriesShouldNotBeMixed() {
+    void tagsOfRetriesShouldNotBeMixed() {
         RateLimiterRegistry rateLimiterRegistry = RateLimiterRegistry.ofDefaults();
         RateLimiterConfig rateLimiterConfig = RateLimiterConfig.ofDefaults();
         Map<String, String> rateLimiterTags = Map.of("key1", "value1", "key2", "value2");
@@ -180,7 +180,7 @@ public class RateLimiterRegistryTest {
     }
 
     @Test
-    public void tagsOfInstanceTagsShouldOverrideRegistryTags() {
+    void tagsOfInstanceTagsShouldOverrideRegistryTags() {
         RateLimiterConfig rateLimiterConfig = RateLimiterConfig.ofDefaults();
         Map<String, RateLimiterConfig> rateLimiterConfigs = Collections
             .singletonMap("default", rateLimiterConfig);
@@ -212,7 +212,7 @@ public class RateLimiterRegistryTest {
     }
 
     @Test
-    public void testCreateUsingBuilderWithDefaultConfig() {
+    void testCreateUsingBuilderWithDefaultConfig() {
         RateLimiterRegistry rateLimiterRegistry =
             RateLimiterRegistry.custom().withRateLimiterConfig(RateLimiterConfig.ofDefaults()).build();
         RateLimiter rateLimiter = rateLimiterRegistry.rateLimiter("testName");
@@ -223,7 +223,7 @@ public class RateLimiterRegistryTest {
     }
 
     @Test
-    public void testCreateUsingBuilderWithCustomConfig() {
+    void testCreateUsingBuilderWithCustomConfig() {
         int limitForPeriod = 10;
         RateLimiterConfig rateLimiterConfig = RateLimiterConfig.custom()
             .limitForPeriod(10).build();
@@ -237,7 +237,7 @@ public class RateLimiterRegistryTest {
     }
 
     @Test
-    public void testCreateUsingBuilderWithoutDefaultConfig() {
+    void testCreateUsingBuilderWithoutDefaultConfig() {
         int limitForPeriod = 10;
         RateLimiterConfig rateLimiterConfig = RateLimiterConfig.custom()
             .limitForPeriod(limitForPeriod).build();
@@ -258,15 +258,16 @@ public class RateLimiterRegistryTest {
             .isEqualTo(limitForPeriod);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testAddMultipleDefaultConfigUsingBuilderShouldThrowException() {
+    @Test
+    void testAddMultipleDefaultConfigUsingBuilderShouldThrowException() {
         RateLimiterConfig rateLimiterConfig = RateLimiterConfig.custom()
             .limitForPeriod(10).build();
-        RateLimiterRegistry.custom().addRateLimiterConfig("default", rateLimiterConfig).build();
+        assertThatThrownBy(() -> RateLimiterRegistry.custom().addRateLimiterConfig("default", rateLimiterConfig).build())
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void testCreateUsingBuilderWithDefaultAndCustomConfig() {
+    void testCreateUsingBuilderWithDefaultAndCustomConfig() {
         RateLimiterConfig rateLimiterConfig = RateLimiterConfig.custom()
             .limitForPeriod(10).build();
         RateLimiterConfig customRateLimiterConfig = RateLimiterConfig.custom()
@@ -284,14 +285,14 @@ public class RateLimiterRegistryTest {
     }
 
     @Test
-    public void testCreateUsingBuilderWithNullConfig() {
+    void testCreateUsingBuilderWithNullConfig() {
         assertThatThrownBy(
             () -> RateLimiterRegistry.custom().withRateLimiterConfig(null).build())
             .isInstanceOf(NullPointerException.class).hasMessage("Config must not be null");
     }
 
     @Test
-    public void testCreateUsingBuilderWithMultipleRegistryEventConsumer() {
+    void testCreateUsingBuilderWithMultipleRegistryEventConsumer() {
         RateLimiterRegistry rateLimiterRegistry = RateLimiterRegistry.custom()
             .withRateLimiterConfig(RateLimiterConfig.ofDefaults())
             .addRegistryEventConsumer(new NoOpRateLimiterEventConsumer())
@@ -303,7 +304,7 @@ public class RateLimiterRegistryTest {
     }
 
     @Test
-    public void testCreateUsingBuilderWithRegistryTags() {
+    void testCreateUsingBuilderWithRegistryTags() {
         Map<String, String> rateLimiterTags = Map.of("key1", "value1", "key2", "value2");
         RateLimiterRegistry rateLimiterRegistry = RateLimiterRegistry.custom()
             .withRateLimiterConfig(RateLimiterConfig.ofDefaults())
@@ -315,7 +316,7 @@ public class RateLimiterRegistryTest {
     }
 
     @Test
-    public void testCreateUsingBuilderWithRegistryStore() {
+    void testCreateUsingBuilderWithRegistryStore() {
         RateLimiterRegistry rateLimiterRegistry = RateLimiterRegistry.custom()
             .withRateLimiterConfig(RateLimiterConfig.ofDefaults())
             .withRegistryStore(new InMemoryRegistryStore<>())

--- a/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/RateLimiterTest.java
+++ b/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/RateLimiterTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2016 Robert Winkler and Bohdan Storozhuk
+ *  Copyright 2026 Robert Winkler and Bohdan Storozhuk
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -22,11 +22,10 @@ import io.github.resilience4j.core.functions.CheckedFunction;
 import io.github.resilience4j.core.functions.CheckedRunnable;
 import io.github.resilience4j.core.functions.CheckedSupplier;
 import io.vavr.control.Try;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
-import java.util.concurrent.Future;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -35,12 +34,10 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import static com.jayway.awaitility.Awaitility.await;
-import static io.vavr.API.*;
-import static io.vavr.Predicates.instanceOf;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -48,7 +45,7 @@ import static org.mockito.Mockito.*;
 
 
 @SuppressWarnings("unchecked")
-public class RateLimiterTest {
+class RateLimiterTest {
 
     private static final int LIMIT = 50;
     private static final Duration TIMEOUT = Duration.ofSeconds(5);
@@ -57,8 +54,8 @@ public class RateLimiterTest {
     private RateLimiterConfig config;
     private RateLimiter limit;
 
-    @Before
-    public void init() {
+    @BeforeEach
+    void init() {
         config = RateLimiterConfig.custom()
             .timeoutDuration(TIMEOUT)
             .limitRefreshPeriod(REFRESH_PERIOD)
@@ -69,7 +66,7 @@ public class RateLimiterTest {
     }
 
     @Test
-    public void decorateCheckedSupplier() throws Throwable {
+    void decorateCheckedSupplier() throws Throwable {
         CheckedSupplier supplier = mock(CheckedSupplier.class);
         CheckedSupplier decorated = RateLimiter.decorateCheckedSupplier(limit, supplier);
         given(limit.acquirePermission(1)).willReturn(false);
@@ -86,7 +83,7 @@ public class RateLimiterTest {
     }
 
     @Test
-    public void decorateCheckedRunnable() throws Throwable {
+    void decorateCheckedRunnable() throws Throwable {
         CheckedRunnable runnable = mock(CheckedRunnable.class);
         CheckedRunnable decorated = RateLimiter.decorateCheckedRunnable(limit, runnable);
         given(limit.acquirePermission(1)).willReturn(false);
@@ -103,7 +100,7 @@ public class RateLimiterTest {
     }
 
     @Test
-    public void decorateCheckedFunction() throws Throwable {
+    void decorateCheckedFunction() throws Throwable {
         CheckedFunction<Integer, String> function = mock(CheckedFunction.class);
         CheckedFunction<Integer, String> decorated = RateLimiter
             .decorateCheckedFunction(limit, function);
@@ -121,7 +118,7 @@ public class RateLimiterTest {
     }
 
     @Test
-    public void decorateSupplier() {
+    void decorateSupplier() {
         Supplier supplier = mock(Supplier.class);
         Supplier decorated = RateLimiter.decorateSupplier(limit, supplier);
         given(limit.acquirePermission(1)).willReturn(false);
@@ -138,7 +135,7 @@ public class RateLimiterTest {
     }
 
     @Test
-    public void decorateConsumer() {
+    void decorateConsumer() {
         Consumer<Integer> consumer = mock(Consumer.class);
         Consumer<Integer> decorated = RateLimiter.decorateConsumer(limit, consumer);
         given(limit.acquirePermission(1)).willReturn(false);
@@ -155,7 +152,7 @@ public class RateLimiterTest {
     }
 
     @Test
-    public void decorateRunnable() {
+    void decorateRunnable() {
         Runnable runnable = mock(Runnable.class);
         Runnable decorated = RateLimiter.decorateRunnable(limit, runnable);
         given(limit.acquirePermission(1)).willReturn(false);
@@ -172,7 +169,7 @@ public class RateLimiterTest {
     }
 
     @Test
-    public void decorateFunction() {
+    void decorateFunction() {
         Function<Integer, String> function = mock(Function.class);
         Function<Integer, String> decorated = RateLimiter.decorateFunction(limit, function);
         given(limit.acquirePermission(1)).willReturn(false);
@@ -189,7 +186,7 @@ public class RateLimiterTest {
     }
 
     @Test
-    public void decorateCompletionStage() {
+    void decorateCompletionStage() throws Exception {
         Supplier supplier = mock(Supplier.class);
         given(supplier.get()).willReturn("Resource");
         Supplier<CompletionStage<String>> completionStage = () -> supplyAsync(supplier);
@@ -201,10 +198,7 @@ public class RateLimiterTest {
             .whenComplete((v, e) -> error.set(e))
             .toCompletableFuture();
 
-        Try<String> errorResult = Try.of(notPermittedFuture::get);
-
-        assertTrue(errorResult.isFailure());
-        assertThat(errorResult.getCause()).isInstanceOf(ExecutionException.class);
+        assertThatThrownBy(notPermittedFuture::get).isInstanceOf(ExecutionException.class);
         assertThat(notPermittedFuture.isCompletedExceptionally()).isTrue();
         assertThat(error.get()).isExactlyInstanceOf(RequestNotPermitted.class);
         then(supplier).should(never()).get();
@@ -215,29 +209,26 @@ public class RateLimiterTest {
             .whenComplete((v, e) -> error.set(e))
             .toCompletableFuture();
 
-        Try<String> successResult = Try.of(success::get);
-
-        assertThat(successResult.isSuccess()).isTrue();
+        assertThat(success.get()).isNotNull();
         assertThat(success.isCompletedExceptionally()).isFalse();
         assertThat(shouldBeEmpty.get()).isNull();
         then(supplier).should().get();
     }
 
-    @Test(expected = RequestNotPermitted.class)
-    public void decorateFutureFailure()
-            throws InterruptedException, ExecutionException, TimeoutException {
-
+    @Test
+    void decorateFutureFailure() {
         Supplier<String> supplier = mock(Supplier.class);
         given(supplier.get()).willReturn("Resource");
         Supplier<Future<String>> decoratedFuture =
             RateLimiter.decorateFuture(limit, () -> supplyAsync(supplier));
         given(limit.acquirePermission(1)).willReturn(false);
 
-        decoratedFuture.get().get(2, TimeUnit.SECONDS);
+        assertThatThrownBy(() -> decoratedFuture.get().get(2, TimeUnit.SECONDS))
+            .isInstanceOf(RequestNotPermitted.class);
     }
 
     @Test
-    public void decorateFutureSuccess()
+    void decorateFutureSuccess()
             throws ExecutionException, InterruptedException, TimeoutException {
         Supplier<String> supplier = mock(Supplier.class);
         given(supplier.get()).willReturn("Resource");
@@ -252,7 +243,7 @@ public class RateLimiterTest {
     }
 
     @Test
-    public void waitForPermissionWithOne() {
+    void waitForPermissionWithOne() {
         given(limit.acquirePermission(1)).willReturn(true);
 
         RateLimiter.waitForPermission(limit);
@@ -260,17 +251,18 @@ public class RateLimiterTest {
         then(limit).should().acquirePermission(1);
     }
 
-    @Test(expected = RequestNotPermitted.class)
-    public void waitForPermissionWithoutOne() {
+    @Test
+    void waitForPermissionWithoutOne() {
         given(limit.acquirePermission(1)).willReturn(false);
 
-        RateLimiter.waitForPermission(limit);
+        assertThatThrownBy(() -> RateLimiter.waitForPermission(limit))
+            .isInstanceOf(RequestNotPermitted.class);
 
         then(limit).should().acquirePermission(1);
     }
 
     @Test
-    public void waitForPermissionWithInterruption() {
+    void waitForPermissionWithInterruption() {
         when(limit.acquirePermission(1))
             .then(invocation -> {
                 LockSupport.parkNanos(5_000_000_000L);
@@ -279,13 +271,11 @@ public class RateLimiterTest {
         AtomicBoolean wasInterrupted = new AtomicBoolean(true);
         Thread thread = new Thread(() -> {
             wasInterrupted.set(false);
-            Throwable cause = Try.run(() -> RateLimiter.waitForPermission(limit))
-                .getCause();
-            Boolean interrupted = Match(cause).of(
-                Case($(instanceOf(IllegalStateException.class)), true)
-            );
-            interrupted = interrupted && Thread.currentThread().isInterrupted();
-            wasInterrupted.set(interrupted);
+            try {
+                RateLimiter.waitForPermission(limit);
+            } catch (IllegalStateException e) {
+                wasInterrupted.set(Thread.currentThread().isInterrupted());
+            }
         });
         thread.setDaemon(true);
         thread.start();
@@ -300,7 +290,7 @@ public class RateLimiterTest {
     }
 
     @Test
-    public void construction() {
+    void construction() {
         RateLimiter rateLimiter = RateLimiter.of("test", () -> config);
         assertThat(rateLimiter).isNotNull();
     }

--- a/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/RateLimiterWithConditionalDrainIntegrationTest.java
+++ b/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/RateLimiterWithConditionalDrainIntegrationTest.java
@@ -1,6 +1,6 @@
 package io.github.resilience4j.ratelimiter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.function.Supplier;
@@ -10,10 +10,10 @@ import static io.github.resilience4j.core.ResultUtils.isSuccessfulAndReturned;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
-public class RateLimiterWithConditionalDrainIntegrationTest {
+class RateLimiterWithConditionalDrainIntegrationTest {
 
     @Test
-    public void shouldDrainRateLimiterInConditionMetOnFailedCall() {
+    void shouldDrainRateLimiterInConditionMetOnFailedCall() {
         RateLimiter limiter = RateLimiter.of("someLimiter", RateLimiterConfig.custom()
             .limitForPeriod(5)
             .limitRefreshPeriod(Duration.ofHours(1))
@@ -32,7 +32,7 @@ public class RateLimiterWithConditionalDrainIntegrationTest {
     }
 
     @Test
-    public void shouldDrainRateLimiterInConditionMetOnSuccessfulCall() {
+    void shouldDrainRateLimiterInConditionMetOnSuccessfulCall() {
         RateLimiter limiter = RateLimiter.of("someLimiter", RateLimiterConfig.custom()
             .limitForPeriod(5)
             .limitRefreshPeriod(Duration.ofHours(1))
@@ -52,7 +52,7 @@ public class RateLimiterWithConditionalDrainIntegrationTest {
     }
 
     @Test
-    public void shouldNotDrainRateLimiterInConditionNotMetOnSuccessfulCall() {
+    void shouldNotDrainRateLimiterInConditionNotMetOnSuccessfulCall() {
         RateLimiter limiter = RateLimiter.of("someLimiter", RateLimiterConfig.custom()
             .limitForPeriod(5)
             .limitRefreshPeriod(Duration.ofHours(1))

--- a/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/RateLimiterWithConditionalDrainTest.java
+++ b/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/RateLimiterWithConditionalDrainTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2016 Robert Winkler and Bohdan Storozhuk
+ *  Copyright 2026 Robert Winkler and Bohdan Storozhuk
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@ import io.github.resilience4j.core.functions.CheckedSupplier;
 import io.github.resilience4j.core.functions.Either;
 import io.github.resilience4j.ratelimiter.internal.AtomicRateLimiter;
 import io.vavr.control.Try;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.function.Predicate;
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.*;
 
 
 @SuppressWarnings("unchecked")
-public class RateLimiterWithConditionalDrainTest {
+class RateLimiterWithConditionalDrainTest {
 
     private static final int LIMIT = 50;
     private static final Duration TIMEOUT = Duration.ofSeconds(5);
@@ -44,8 +44,8 @@ public class RateLimiterWithConditionalDrainTest {
     private Predicate<Either<? extends Throwable, ?>> drainConditionChecker;
     private RateLimiter limit;
 
-    @Before
-    public void init() {
+    @BeforeEach
+    void init() {
         drainConditionChecker = mock(Predicate.class);
         RateLimiterConfig config = RateLimiterConfig.custom()
             .timeoutDuration(TIMEOUT)
@@ -59,7 +59,7 @@ public class RateLimiterWithConditionalDrainTest {
     }
 
     @Test
-    public void decorateCheckedSupplierAndApplyWithDrainConditionNotMet() throws Throwable {
+    void decorateCheckedSupplierAndApplyWithDrainConditionNotMet() {
         CheckedSupplier<?> supplier = mock(CheckedSupplier.class);
         CheckedSupplier<?> decorated = RateLimiter.decorateCheckedSupplier(limit, supplier);
         given(limit.acquirePermission(1)).willReturn(true);
@@ -73,7 +73,7 @@ public class RateLimiterWithConditionalDrainTest {
     }
 
     @Test
-    public void decorateFailingCheckedSupplierAndApplyWithDrainConditionNotMet() throws Throwable {
+    void decorateFailingCheckedSupplierAndApplyWithDrainConditionNotMet() throws Throwable {
         CheckedSupplier<?> supplier = mock(CheckedSupplier.class);
         when(supplier.get()).thenThrow(RuntimeException.class);
         CheckedSupplier<?> decorated = RateLimiter.decorateCheckedSupplier(limit, supplier);
@@ -88,7 +88,7 @@ public class RateLimiterWithConditionalDrainTest {
     }
 
     @Test
-    public void decorateCheckedSupplierAndApplyWithDrainConditionMet() throws Throwable {
+    void decorateCheckedSupplierAndApplyWithDrainConditionMet() {
         CheckedSupplier<?> supplier = mock(CheckedSupplier.class);
         CheckedSupplier<?> decorated = RateLimiter.decorateCheckedSupplier(limit, supplier);
         given(limit.acquirePermission(1)).willReturn(true);

--- a/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/RequestNotPermittedExceptionTest.java
+++ b/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/RequestNotPermittedExceptionTest.java
@@ -1,14 +1,14 @@
 package io.github.resilience4j.ratelimiter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.github.resilience4j.ratelimiter.RequestNotPermitted.createRequestNotPermitted;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class RequestNotPermittedExceptionTest {
+class RequestNotPermittedExceptionTest {
 
     @Test
-    public void shouldReturnCorrectMessageWhenStateIsOpen() {
+    void shouldReturnCorrectMessageWhenStateIsOpen() {
         RateLimiter rateLimiter = RateLimiter.ofDefaults("testName");
         final RequestNotPermitted requestNotPermitted = createRequestNotPermitted(rateLimiter);
         assertThat(requestNotPermitted.getMessage())

--- a/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/AtomicRateLimiterTest.java
+++ b/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/AtomicRateLimiterTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2016 Robert Winkler and Bohdan Storozhuk
+ *  Copyright 2026 Robert Winkler and Bohdan Storozhuk
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -18,12 +18,10 @@
  */
 package io.github.resilience4j.ratelimiter.internal;
 
-import com.jayway.awaitility.core.ConditionFactory;
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.awaitility.core.ConditionFactory;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -31,15 +29,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static com.jayway.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.BDDAssertions.then;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
-@RunWith(MockitoJUnitRunner.class)
-public class AtomicRateLimiterTest {
+class AtomicRateLimiterTest {
 
     private static final String LIMITER_NAME = "test";
     private static final long CYCLE_IN_NANOS = 250_000_000L;
@@ -54,18 +51,17 @@ public class AtomicRateLimiterTest {
             .pollInterval(POLL_INTERVAL_IN_NANOS, TimeUnit.NANOSECONDS);
     }
 
-
-    private void setTimeOnNanos(long nanoTime) throws Exception {
+    private void setTimeOnNanos(long nanoTime) {
         doReturn(nanoTime)
             .when(rateLimiter)
             .currentNanoTime();
     }
 
-    public void setup(Duration timeoutDuration) {
+    void setup(Duration timeoutDuration) {
         setup(Duration.ofNanos(CYCLE_IN_NANOS), timeoutDuration, PERMISSIONS_RER_CYCLE);
     }
 
-    public void setup(Duration cycleDuration, Duration timeoutDuration, int permissionPerCycle) {
+    void setup(Duration cycleDuration, Duration timeoutDuration, int permissionPerCycle) {
         RateLimiterConfig rateLimiterConfig = RateLimiterConfig.custom()
             .limitForPeriod(permissionPerCycle)
             .limitRefreshPeriod(cycleDuration)
@@ -76,7 +72,7 @@ public class AtomicRateLimiterTest {
     }
 
     @Test
-    public void notSpyRawTest() {
+    void notSpyRawTest() {
         RateLimiterConfig rateLimiterConfig = RateLimiterConfig.custom()
             .limitForPeriod(PERMISSIONS_RER_CYCLE)
             .limitRefreshPeriod(Duration.ofNanos(CYCLE_IN_NANOS))
@@ -87,13 +83,14 @@ public class AtomicRateLimiterTest {
         AtomicRateLimiter.AtomicRateLimiterMetrics rawDetailedMetrics = rawLimiter
             .getDetailedMetrics();
 
-        long firstCycle = waitForCurrentCycleToPass(rawDetailedMetrics);
+        long firstCycle = rawDetailedMetrics.getCycle();
+        await().atMost(1, SECONDS).until(() -> rawDetailedMetrics.getCycle() != firstCycle);
 
         boolean firstPermission = rawLimiter.acquirePermission();
 
         then(firstPermission).isTrue();
 
-        waitForPermissionRenewal(rawDetailedMetrics);
+        await().atMost(1, SECONDS).until(() -> rawDetailedMetrics.getNanosToWait() == 0);
 
         boolean secondPermission = rawLimiter.acquirePermission();
         then(secondPermission).isTrue();
@@ -103,7 +100,7 @@ public class AtomicRateLimiterTest {
         long secondCycle = rawDetailedMetrics.getCycle();
 
         rawLimiter.changeLimitForPeriod(PERMISSIONS_RER_CYCLE * 2);
-        waitForPermissionRenewal(rawDetailedMetrics);
+        await().atMost(1, SECONDS).until(() -> rawDetailedMetrics.getNanosToWait() == 0);
         boolean thirdPermission = rawLimiter.acquirePermission();
         then(thirdPermission).isTrue();
 
@@ -119,7 +116,7 @@ public class AtomicRateLimiterTest {
     }
 
     @Test
-    public void firstIterationAtomicRateLimitNanoTime() {
+    void firstIterationAtomicRateLimitNanoTime() {
         RateLimiterConfig rateLimiterConfig = RateLimiterConfig.custom()
             .limitForPeriod(PERMISSIONS_RER_CYCLE)
             .limitRefreshPeriod(Duration.ofNanos(CYCLE_IN_NANOS))
@@ -142,7 +139,7 @@ public class AtomicRateLimiterTest {
     }
 
     @Test
-    public void notSpyRawNonBlockingTest() {
+    void notSpyRawNonBlockingTest() {
         RateLimiterConfig rateLimiterConfig = RateLimiterConfig.custom()
             .limitForPeriod(PERMISSIONS_RER_CYCLE)
             .limitRefreshPeriod(Duration.ofNanos(CYCLE_IN_NANOS))
@@ -153,17 +150,18 @@ public class AtomicRateLimiterTest {
         AtomicRateLimiter.AtomicRateLimiterMetrics rawDetailedMetrics = rawLimiter
             .getDetailedMetrics();
 
-        long firstCycle = waitForCurrentCycleToPass(rawDetailedMetrics);
+        long firstCycle = rawDetailedMetrics.getCycle();
+        await().atMost(1, SECONDS).until(() -> rawDetailedMetrics.getCycle() != firstCycle);
 
         long firstPermission = rawLimiter.reservePermission();
-        waitForPermissionRenewal(rawDetailedMetrics);
+        await().atMost(1, SECONDS).until(() -> rawDetailedMetrics.getNanosToWait() == 0);
 
         long secondPermission = rawLimiter.reservePermission();
         long firstNoPermission = rawLimiter.reservePermission();
         long secondCycle = rawDetailedMetrics.getCycle();
 
         rawLimiter.changeLimitForPeriod(PERMISSIONS_RER_CYCLE * 2);
-        waitForPermissionRenewal(rawDetailedMetrics);
+        await().atMost(1, SECONDS).until(() -> rawDetailedMetrics.getNanosToWait() == 0);
         long thirdPermission = rawLimiter.reservePermission();
         long fourthPermission = rawLimiter.reservePermission();
         long secondNoPermission = rawLimiter.reservePermission();
@@ -182,7 +180,7 @@ public class AtomicRateLimiterTest {
     }
 
     @Test
-    public void permissionsInFirstCycle() throws Exception {
+    void permissionsInFirstCycle() throws Exception {
         setup(Duration.ZERO);
 
         setTimeOnNanos(CYCLE_IN_NANOS - 10);
@@ -192,7 +190,7 @@ public class AtomicRateLimiterTest {
     }
 
     @Test
-    public void acquireAndRefreshWithEventPublishing() throws Exception {
+    void acquireAndRefreshWithEventPublishing() throws Exception {
         setup(Duration.ZERO);
 
         setTimeOnNanos(CYCLE_IN_NANOS);
@@ -217,7 +215,7 @@ public class AtomicRateLimiterTest {
     }
 
     @Test
-    public void reserveAndRefresh() throws Exception {
+    void reserveAndRefresh() throws Exception {
         setup(Duration.ofNanos(CYCLE_IN_NANOS));
 
         setTimeOnNanos(CYCLE_IN_NANOS);
@@ -249,7 +247,7 @@ public class AtomicRateLimiterTest {
     }
 
     @Test
-    public void reserveFewThenSkipCyclesBeforeRefreshNonBlocking() throws Exception {
+    void reserveFewThenSkipCyclesBeforeRefreshNonBlocking() throws Exception {
         setup(Duration.ofNanos(CYCLE_IN_NANOS));
 
         setTimeOnNanos(CYCLE_IN_NANOS);
@@ -279,7 +277,7 @@ public class AtomicRateLimiterTest {
     }
 
     @Test
-    public void reserveFewThenSkipCyclesBeforeRefresh() throws Exception {
+    void reserveFewThenSkipCyclesBeforeRefresh() throws Exception {
         setup(Duration.ofNanos(CYCLE_IN_NANOS));
 
         setTimeOnNanos(CYCLE_IN_NANOS);
@@ -327,7 +325,7 @@ public class AtomicRateLimiterTest {
     }
 
     @Test
-    public void reserveManyCyclesIfWegithgreaterThenLimitPerPeriod() throws Exception {
+    void reserveManyCyclesIfWegithgreaterThenLimitPerPeriod() throws Exception {
         setup(Duration.ofNanos(CYCLE_IN_NANOS * 5));
         setTimeOnNanos(CYCLE_IN_NANOS);
         long nanosToWait = rateLimiter.reservePermission(PERMISSIONS_RER_CYCLE * 3);
@@ -335,7 +333,7 @@ public class AtomicRateLimiterTest {
     }
 
     @Test
-    public void rejectedByTimeoutNonBlocking() throws Exception {
+    void rejectedByTimeoutNonBlocking() throws Exception {
         setup(Duration.ZERO);
 
         setTimeOnNanos(CYCLE_IN_NANOS);
@@ -358,7 +356,7 @@ public class AtomicRateLimiterTest {
     }
 
     @Test
-    public void waitingThreadIsInterrupted() throws Exception {
+    void waitingThreadIsInterrupted() throws Exception {
         setup(Duration.ofNanos(CYCLE_IN_NANOS));
 
         setTimeOnNanos(CYCLE_IN_NANOS);
@@ -397,7 +395,7 @@ public class AtomicRateLimiterTest {
     }
 
     @Test
-    public void changePermissionsLimitBetweenCycles() throws Exception {
+    void changePermissionsLimitBetweenCycles() throws Exception {
         setup(Duration.ofNanos(CYCLE_IN_NANOS));
 
         setTimeOnNanos(CYCLE_IN_NANOS);
@@ -436,7 +434,7 @@ public class AtomicRateLimiterTest {
     }
 
     @Test
-    public void reservePermissionsUpfront() throws Exception {
+    void reservePermissionsUpfront() throws Exception {
         final int limitForPeriod = 3;
         final int tasksNum = 9;
         Duration limitRefreshPeriod = Duration.ofMillis(10);
@@ -460,7 +458,7 @@ public class AtomicRateLimiterTest {
     }
 
     @Test
-    public void changeDefaultTimeoutDuration() throws Exception {
+    void changeDefaultTimeoutDuration() {
         setup(Duration.ZERO);
 
         RateLimiterConfig rateLimiterConfig = rateLimiter.getRateLimiterConfig();
@@ -477,7 +475,7 @@ public class AtomicRateLimiterTest {
     }
 
     @Test
-    public void changeLimitForPeriod() throws Exception {
+    void changeLimitForPeriod() {
         setup(Duration.ZERO);
 
         RateLimiterConfig rateLimiterConfig = rateLimiter.getRateLimiterConfig();
@@ -494,7 +492,7 @@ public class AtomicRateLimiterTest {
     }
 
     @Test
-    public void metricsTest() {
+    void metricsTest() {
         RateLimiterConfig rateLimiterConfig = RateLimiterConfig.custom()
             .limitForPeriod(PERMISSIONS_RER_CYCLE)
             .limitRefreshPeriod(Duration.ofNanos(CYCLE_IN_NANOS))
@@ -512,7 +510,7 @@ public class AtomicRateLimiterTest {
         then(detailedMetrics.getAvailablePermissions()).isEqualTo(1);
         then(detailedMetrics.getNanosToWait()).isZero();
         boolean firstPermission = rawLimiter.acquirePermission();
-        waitForPermissionRenewal(detailedMetrics);
+        await().atMost(1, SECONDS).until(() -> detailedMetrics.getNanosToWait() == 0);
 
         boolean secondPermission = rawLimiter.acquirePermission();
         boolean firstNoPermission = rawLimiter.acquirePermission();
@@ -522,32 +520,15 @@ public class AtomicRateLimiterTest {
     }
 
     @Test
-    public void namePropagation() {
+    void namePropagation() {
         setup(Duration.ZERO);
         then(rateLimiter.getName()).isEqualTo(LIMITER_NAME);
     }
 
     @Test
-    public void metrics() {
+    void metrics() {
         setup(Duration.ZERO);
         then(rateLimiter.getMetrics().getNumberOfWaitingThreads()).isZero();
     }
 
-    private long waitForCurrentCycleToPass(
-        AtomicRateLimiter.AtomicRateLimiterMetrics rawDetailedMetrics) {
-        long cycle = rawDetailedMetrics.getCycle();
-        while (cycle == rawDetailedMetrics.getCycle()) {
-            // spin until the current cycle rolls over
-        }
-        return cycle;
-    }
-
-    private void waitForPermissionRenewal(
-        AtomicRateLimiter.AtomicRateLimiterMetrics rawDetailedMetrics) {
-        long nanosToWait = rawDetailedMetrics.getNanosToWait();
-        long startTime = System.nanoTime();
-        while (System.nanoTime() - startTime < nanosToWait) {
-            // spin until the next cycle begins
-        }
-    }
 }

--- a/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/InMemoryRateLimiterRegistryTest.java
+++ b/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/InMemoryRateLimiterRegistryTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2016 Robert Winkler and Bohdan Storozhuk
+ *  Copyright 2026 Robert Winkler and Bohdan Storozhuk
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -23,10 +23,8 @@ import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
 import org.assertj.core.api.AssertionsForClassTypes;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -36,23 +34,21 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.mockito.Mockito.*;
 
-public class InMemoryRateLimiterRegistryTest {
+class InMemoryRateLimiterRegistryTest {
 
     private static final int LIMIT = 50;
     private static final Duration TIMEOUT = Duration.ofSeconds(5);
     private static final Duration REFRESH_PERIOD = Duration.ofNanos(500);
     private static final String CONFIG_MUST_NOT_BE_NULL = "Config must not be null";
     private static final String NAME_MUST_NOT_BE_NULL = "Name must not be null";
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
     private RateLimiterConfig config;
 
-
-    @Before
-    public void init() {
+    @BeforeEach
+    void init() {
         config = RateLimiterConfig.custom()
             .timeoutDuration(TIMEOUT)
             .limitRefreshPeriod(REFRESH_PERIOD)
@@ -61,7 +57,7 @@ public class InMemoryRateLimiterRegistryTest {
     }
 
     @Test
-    public void rateLimiterPositive() throws Exception {
+    void rateLimiterPositive() {
         RateLimiterRegistry registry = RateLimiterRegistry.of(config);
         RateLimiter firstRateLimiter = registry.rateLimiter("test");
         RateLimiter anotherLimit = registry.rateLimiter("test1");
@@ -73,7 +69,7 @@ public class InMemoryRateLimiterRegistryTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void rateLimiterPositiveWithSupplier() throws Exception {
+    void rateLimiterPositiveWithSupplier() {
         RateLimiterRegistry registry = new InMemoryRateLimiterRegistry(config);
         Supplier<RateLimiterConfig> rateLimiterConfigSupplier = mock(Supplier.class);
         when(rateLimiterConfigSupplier.get())
@@ -91,56 +87,54 @@ public class InMemoryRateLimiterRegistryTest {
     }
 
     @Test
-    public void rateLimiterConfigIsNull() throws Exception {
-        exception.expect(NullPointerException.class);
-        exception.expectMessage(CONFIG_MUST_NOT_BE_NULL);
-        new InMemoryRateLimiterRegistry((RateLimiterConfig) null);
+    void rateLimiterConfigIsNull() {
+        assertThatThrownBy(() -> new InMemoryRateLimiterRegistry((RateLimiterConfig) null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage(CONFIG_MUST_NOT_BE_NULL);
     }
 
     @Test
-    public void rateLimiterNewWithNullName() throws Exception {
-        exception.expect(NullPointerException.class);
-        exception.expectMessage(NAME_MUST_NOT_BE_NULL);
+    void rateLimiterNewWithNullName() {
         RateLimiterRegistry registry = new InMemoryRateLimiterRegistry(config);
-        registry.rateLimiter(null);
+        assertThatThrownBy(() -> registry.rateLimiter(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage(NAME_MUST_NOT_BE_NULL);
     }
 
     @Test
-    public void rateLimiterNewWithNullNonDefaultConfig() throws Exception {
-        exception.expect(NullPointerException.class);
-        exception.expectMessage(CONFIG_MUST_NOT_BE_NULL);
+    void rateLimiterNewWithNullNonDefaultConfig() {
         RateLimiterRegistry registry = new InMemoryRateLimiterRegistry(config);
-        RateLimiterConfig rateLimiterConfig = null;
-        registry.rateLimiter("name", rateLimiterConfig);
+        assertThatThrownBy(() -> registry.rateLimiter("name", (RateLimiterConfig) null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage(CONFIG_MUST_NOT_BE_NULL);
     }
 
     @Test
-    public void rateLimiterNewWithNullNameAndNonDefaultConfig() throws Exception {
-        exception.expect(NullPointerException.class);
-        exception.expectMessage(NAME_MUST_NOT_BE_NULL);
+    void rateLimiterNewWithNullNameAndNonDefaultConfig() {
         RateLimiterRegistry registry = new InMemoryRateLimiterRegistry(config);
-        registry.rateLimiter(null, config);
+        assertThatThrownBy(() -> registry.rateLimiter(null, config))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage(NAME_MUST_NOT_BE_NULL);
     }
 
     @Test
-    public void rateLimiterNewWithNullNameAndConfigSupplier() throws Exception {
-        exception.expect(NullPointerException.class);
-        exception.expectMessage(NAME_MUST_NOT_BE_NULL);
+    void rateLimiterNewWithNullNameAndConfigSupplier() {
         RateLimiterRegistry registry = new InMemoryRateLimiterRegistry(config);
-        registry.rateLimiter(null, () -> config);
+        assertThatThrownBy(() -> registry.rateLimiter(null, () -> config))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage(NAME_MUST_NOT_BE_NULL);
     }
 
     @Test
-    public void rateLimiterNewWithNullConfigSupplier() throws Exception {
-        exception.expect(NullPointerException.class);
-        exception.expectMessage("Supplier must not be null");
+    void rateLimiterNewWithNullConfigSupplier() {
         RateLimiterRegistry registry = new InMemoryRateLimiterRegistry(config);
-        Supplier<RateLimiterConfig> rateLimiterConfigSupplier = null;
-        registry.rateLimiter("name", rateLimiterConfigSupplier);
+        assertThatThrownBy(() -> registry.rateLimiter("name", (Supplier<RateLimiterConfig>) null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("Supplier must not be null");
     }
 
     @Test
-    public void rateLimiterGetAllRateLimiters() {
+    void rateLimiterGetAllRateLimiters() {
         RateLimiterRegistry registry = new InMemoryRateLimiterRegistry(config);
         final RateLimiter rateLimiter = registry.rateLimiter("foo");
 
@@ -149,7 +143,7 @@ public class InMemoryRateLimiterRegistryTest {
     }
 
     @Test
-    public void shouldCreateRateLimiterRegistryWithRegistryStore() {
+    void shouldCreateRateLimiterRegistryWithRegistryStore() {
         RegistryEventConsumer<RateLimiter> registryEventConsumer = getNoOpsRegistryEventConsumer();
         List<RegistryEventConsumer<RateLimiter>> registryEventConsumers = new ArrayList<>();
         registryEventConsumers.add(registryEventConsumer);

--- a/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/RateLimitersImplementationTest.java
+++ b/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/RateLimitersImplementationTest.java
@@ -1,33 +1,31 @@
 package io.github.resilience4j.ratelimiter.internal;
 
-import io.github.resilience4j.core.ThreadModeTestBase;
+import io.github.resilience4j.core.ThreadModeExtension;
 import io.github.resilience4j.core.ThreadType;
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
 import io.github.resilience4j.ratelimiter.event.RateLimiterOnDrainedEvent;
-import org.junit.Test;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static com.jayway.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.BDDAssertions.then;
+import static org.awaitility.Awaitility.await;
 
 /**
  * Tests for functions that are common in all implementations should go here.
  * Now supports both platform and virtual thread testing modes.
  */
-public abstract class RateLimitersImplementationTest extends ThreadModeTestBase {
-
-    public RateLimitersImplementationTest(ThreadType threadType) {
-        super(threadType);
-    }
+@ExtendWith(ThreadModeExtension.class)
+abstract class RateLimitersImplementationTest {
 
     protected abstract RateLimiter buildRateLimiter(RateLimiterConfig config);
 
-    @Test
-    public void acquireBigNumberOfPermitsAtStartOfCycleTest() {
+    @TestTemplate
+    void acquireBigNumberOfPermitsAtStartOfCycleTest(ThreadType threadType) {
         RateLimiterConfig config = RateLimiterConfig.custom()
             .limitForPeriod(10)
             .limitRefreshPeriod(Duration.ofNanos(500_000_000L))
@@ -39,20 +37,20 @@ public abstract class RateLimitersImplementationTest extends ThreadModeTestBase 
         waitForRefresh(metrics, config);
 
         boolean firstPermission = limiter.acquirePermission(5);
-        then(firstPermission).describedAs("First permission acquisition in " + getThreadModeDescription()).isTrue();
+        then(firstPermission).describedAs("First permission acquisition in " + threadType).isTrue();
         boolean secondPermission = limiter.acquirePermission(5);
-        then(secondPermission).describedAs("Second permission acquisition in " + getThreadModeDescription()).isTrue();
+        then(secondPermission).describedAs("Second permission acquisition in " + threadType).isTrue();
         boolean firstNoPermission = limiter.acquirePermission(1);
-        then(firstNoPermission).describedAs("Should reject additional permission in " + getThreadModeDescription()).isFalse();
+        then(firstNoPermission).describedAs("Should reject additional permission in " + threadType).isFalse();
 
         waitForRefresh(metrics, config);
 
         boolean retryInNewCyclePermission = limiter.acquirePermission(1);
-        then(retryInNewCyclePermission).describedAs("Retry after refresh in " + getThreadModeDescription()).isTrue();
+        then(retryInNewCyclePermission).describedAs("Retry after refresh in " + threadType).isTrue();
     }
 
-    @Test
-    public void tryToAcquireBigNumberOfPermitsAtEndOfCycleTest() {
+    @TestTemplate
+    void tryToAcquireBigNumberOfPermitsAtEndOfCycleTest(ThreadType threadType) {
         RateLimiterConfig config = RateLimiterConfig.custom()
             .limitForPeriod(10)
             .limitRefreshPeriod(Duration.ofNanos(250_000_000L))
@@ -64,20 +62,20 @@ public abstract class RateLimitersImplementationTest extends ThreadModeTestBase 
         waitForRefresh(metrics, config);
 
         boolean firstPermission = limiter.acquirePermission(1);
-        then(firstPermission).describedAs("First permission (1 permit) in " + getThreadModeDescription()).isTrue();
+        then(firstPermission).describedAs("First permission (1 permit) in " + threadType).isTrue();
         boolean secondPermission = limiter.acquirePermission(5);
-        then(secondPermission).describedAs("Second permission (5 permits) in " + getThreadModeDescription()).isTrue();
+        then(secondPermission).describedAs("Second permission (5 permits) in " + threadType).isTrue();
         boolean firstNoPermission = limiter.acquirePermission(5);
-        then(firstNoPermission).describedAs("Should reject 5 more permits (only 4 left) in " + getThreadModeDescription()).isFalse();
+        then(firstNoPermission).describedAs("Should reject 5 more permits (only 4 left) in " + threadType).isFalse();
 
         waitForRefresh(metrics, config);
 
         boolean retryInSecondCyclePermission = limiter.acquirePermission(5);
-        then(retryInSecondCyclePermission).describedAs("Should acquire 5 permits after refresh in " + getThreadModeDescription()).isTrue();
+        then(retryInSecondCyclePermission).describedAs("Should acquire 5 permits after refresh in " + threadType).isTrue();
     }
 
-    @Test
-    public void tryToAcquirePermitsAfterDrainBeforeCycleEndsTest() {
+    @TestTemplate
+    void tryToAcquirePermitsAfterDrainBeforeCycleEndsTest(ThreadType threadType) {
         RateLimiterConfig config = RateLimiterConfig.custom()
             .limitForPeriod(10)
             .limitRefreshPeriod(Duration.ofNanos(250_000_000L))
@@ -91,16 +89,16 @@ public abstract class RateLimitersImplementationTest extends ThreadModeTestBase 
         limiter.drainPermissions();
 
         boolean firstNoPermission = limiter.acquirePermission();
-        then(firstNoPermission).describedAs("Should not acquire permission after draining in " + getThreadModeDescription()).isFalse();
+        then(firstNoPermission).describedAs("Should not acquire permission after draining in " + threadType).isFalse();
 
         ensureNextCycleStarted(metrics, config);
 
         boolean retryInSecondCyclePermission = limiter.acquirePermission();
-        then(retryInSecondCyclePermission).describedAs("Should acquire permission after cycle refresh in " + getThreadModeDescription()).isTrue();
+        then(retryInSecondCyclePermission).describedAs("Should acquire permission after cycle refresh in " + threadType).isTrue();
     }
 
-    @Test
-    public void drainCycleWhichAlreadyHashNoPremitsLeftTest() {
+    @TestTemplate
+    void drainCycleWhichAlreadyHashNoPremitsLeftTest(ThreadType threadType) {
         RateLimiterConfig config = RateLimiterConfig.custom()
             .limitForPeriod(10)
             .limitRefreshPeriod(Duration.ofNanos(250_000_000L))
@@ -113,14 +111,14 @@ public abstract class RateLimitersImplementationTest extends ThreadModeTestBase 
 
         limiter.drainPermissions();
         boolean firstPermission = limiter.acquirePermission(10);
-        then(firstPermission).describedAs("Should not acquire permissions after draining in " + getThreadModeDescription()).isFalse();
+        then(firstPermission).describedAs("Should not acquire permissions after draining in " + threadType).isFalse();
 
         AtomicReference<Object> eventAfterDrainCatcher = new AtomicReference<>();
         limiter.getEventPublisher().onEvent(event -> eventAfterDrainCatcher.set(event));
         limiter.drainPermissions();
         Object event = eventAfterDrainCatcher.get();
-        then(event).describedAs("Event should be RateLimiterOnDrainedEvent in " + getThreadModeDescription()).isInstanceOf(RateLimiterOnDrainedEvent.class);
-        then(((RateLimiterOnDrainedEvent) event).getNumberOfPermits()).describedAs("Drained permits should be zero in " + getThreadModeDescription()).isZero();
+        then(event).describedAs("Event should be RateLimiterOnDrainedEvent in " + threadType).isInstanceOf(RateLimiterOnDrainedEvent.class);
+        then(((RateLimiterOnDrainedEvent) event).getNumberOfPermits()).describedAs("Drained permits should be zero in " + threadType).isZero();
     }
 
     protected void waitForRefresh(RateLimiter.Metrics metrics, RateLimiterConfig config) {

--- a/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/SemaphoreBasedRateLimiterImplTest.java
+++ b/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/SemaphoreBasedRateLimiterImplTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2016 Robert Winkler and Bohdan Storozhuk
+ *  Copyright 2026 Robert Winkler and Bohdan Storozhuk
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -18,16 +18,11 @@
  */
 package io.github.resilience4j.ratelimiter.internal;
 
-import com.jayway.awaitility.core.ConditionFactory;
-import io.github.resilience4j.core.ThreadType;
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.awaitility.core.ConditionFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,23 +31,19 @@ import java.time.Duration;
 import java.util.concurrent.*;
 import java.util.function.Function;
 
-import static com.jayway.awaitility.Awaitility.await;
 import static io.vavr.control.Try.run;
 import static java.lang.Thread.State.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.BDDAssertions.then;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
-@RunWith(Parameterized.class)
-public class SemaphoreBasedRateLimiterImplTest extends RateLimitersImplementationTest {
+class SemaphoreBasedRateLimiterImplTest extends RateLimitersImplementationTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(SemaphoreBasedRateLimiterImplTest.class);
-
-    public SemaphoreBasedRateLimiterImplTest(ThreadType threadType) {
-        super(threadType);
-    }
 
     private static final int LIMIT = 2;
     private static final Duration TIMEOUT = Duration.ofMillis(100);
@@ -60,8 +51,7 @@ public class SemaphoreBasedRateLimiterImplTest extends RateLimitersImplementatio
     private static final String CONFIG_MUST_NOT_BE_NULL = "Config must not be null";
     private static final String NAME_MUST_NOT_BE_NULL = "Name must not be null";
     private static final Object O = new Object();
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
+
     private RateLimiterConfig config;
 
     private static ConditionFactory awaitImpatiently() {
@@ -75,8 +65,8 @@ public class SemaphoreBasedRateLimiterImplTest extends RateLimitersImplementatio
         return new SemaphoreBasedRateLimiter("test", config, Executors.newScheduledThreadPool(1));
     }
 
-    @Before
-    public void init() {
+    @BeforeEach
+    void init() {
         config = RateLimiterConfig.custom()
             .timeoutDuration(TIMEOUT)
             .limitRefreshPeriod(REFRESH_PERIOD)
@@ -85,9 +75,7 @@ public class SemaphoreBasedRateLimiterImplTest extends RateLimitersImplementatio
     }
 
     @Test
-    public void rateLimiterCreationWithProvidedScheduler() throws Exception {
-        LOG.info("Running rateLimiterCreationWithProvidedScheduler in {}", getThreadModeDescription());
-        
+    void rateLimiterCreationWithProvidedScheduler() throws Exception {
         ScheduledExecutorService scheduledExecutorService = mock(ScheduledExecutorService.class);
         RateLimiterConfig configSpy = spy(config);
         SemaphoreBasedRateLimiter limit = new SemaphoreBasedRateLimiter("test", configSpy,
@@ -119,12 +107,10 @@ public class SemaphoreBasedRateLimiterImplTest extends RateLimitersImplementatio
         then(limit.acquirePermission()).isTrue();
         then(limit.acquirePermission()).isTrue();
         then(limit.acquirePermission()).isFalse();
-
     }
 
     @Test
-    public void acquirePermissionAndMetrics() throws Exception {
-
+    void acquirePermissionAndMetrics() throws Exception {
         ScheduledExecutorService scheduledExecutorService = mock(ScheduledExecutorService.class);
         RateLimiterConfig configSpy = spy(config);
         SemaphoreBasedRateLimiter limit = new SemaphoreBasedRateLimiter("test", configSpy,
@@ -167,7 +153,7 @@ public class SemaphoreBasedRateLimiterImplTest extends RateLimitersImplementatio
     }
 
     @Test
-    public void changeDefaultTimeoutDuration() {
+    void changeDefaultTimeoutDuration() {
         ScheduledExecutorService scheduledExecutorService = mock(ScheduledExecutorService.class);
         RateLimiter rateLimiter = new SemaphoreBasedRateLimiter("some", config,
             scheduledExecutorService);
@@ -185,7 +171,7 @@ public class SemaphoreBasedRateLimiterImplTest extends RateLimitersImplementatio
     }
 
     @Test
-    public void changeLimitForPeriod() {
+    void changeLimitForPeriod() {
         ScheduledExecutorService scheduledExecutorService = mock(ScheduledExecutorService.class);
         RateLimiter rateLimiter = new SemaphoreBasedRateLimiter("some", config,
             scheduledExecutorService);
@@ -203,7 +189,7 @@ public class SemaphoreBasedRateLimiterImplTest extends RateLimitersImplementatio
     }
 
     @Test
-    public void acquirePermissionInterruption() {
+    void acquirePermissionInterruption() {
         ScheduledExecutorService scheduledExecutorService = mock(ScheduledExecutorService.class);
         RateLimiterConfig configSpy = spy(config);
         SemaphoreBasedRateLimiter limit = new SemaphoreBasedRateLimiter("test", configSpy,
@@ -233,14 +219,14 @@ public class SemaphoreBasedRateLimiterImplTest extends RateLimitersImplementatio
     }
 
     @Test
-    public void getName() {
+    void getName() {
         ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
         SemaphoreBasedRateLimiter limit = new SemaphoreBasedRateLimiter("test", config, scheduler);
         then(limit.getName()).isEqualTo("test");
     }
 
     @Test
-    public void getMetrics() {
+    void getMetrics() {
         ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
         SemaphoreBasedRateLimiter limit = new SemaphoreBasedRateLimiter("test", config, scheduler);
         RateLimiter.Metrics metrics = limit.getMetrics();
@@ -248,14 +234,14 @@ public class SemaphoreBasedRateLimiterImplTest extends RateLimitersImplementatio
     }
 
     @Test
-    public void getRateLimiterConfig() {
+    void getRateLimiterConfig() {
         ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
         SemaphoreBasedRateLimiter limit = new SemaphoreBasedRateLimiter("test", config, scheduler);
         then(limit.getRateLimiterConfig()).isEqualTo(config);
     }
 
     @Test
-    public void isUpperLimitedForPermissions() {
+    void isUpperLimitedForPermissions() {
         ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
         SemaphoreBasedRateLimiter limit = new SemaphoreBasedRateLimiter("test", config, scheduler);
         RateLimiter.Metrics metrics = limit.getMetrics();
@@ -265,7 +251,7 @@ public class SemaphoreBasedRateLimiterImplTest extends RateLimitersImplementatio
     }
 
     @Test
-    public void getDetailedMetrics() {
+    void getDetailedMetrics() {
         ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
         SemaphoreBasedRateLimiter limit = new SemaphoreBasedRateLimiter("test", config, scheduler);
         RateLimiter.Metrics metrics = limit.getMetrics();
@@ -274,28 +260,29 @@ public class SemaphoreBasedRateLimiterImplTest extends RateLimitersImplementatio
     }
 
     @Test
-    public void constructionWithNullName() {
-        exception.expect(NullPointerException.class);
-        exception.expectMessage(NAME_MUST_NOT_BE_NULL);
-        new SemaphoreBasedRateLimiter(null, config, (ScheduledExecutorService) null);
+    void constructionWithNullName() {
+        assertThatThrownBy(() -> new SemaphoreBasedRateLimiter(null, config, (ScheduledExecutorService) null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage(NAME_MUST_NOT_BE_NULL);
     }
 
     @Test
-    public void constructionWithNullConfig() {
-        exception.expect(NullPointerException.class);
-        exception.expectMessage(CONFIG_MUST_NOT_BE_NULL);
-        new SemaphoreBasedRateLimiter("test", null, (ScheduledExecutorService) null);
+    void constructionWithNullConfig() {
+        assertThatThrownBy(() -> new SemaphoreBasedRateLimiter("test", null, (ScheduledExecutorService) null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage(CONFIG_MUST_NOT_BE_NULL);
     }
 
     @Test
-    public void shutdownRateLimiter() throws InterruptedException {
+    @SuppressWarnings("unchecked")
+    void shutdownRateLimiter() throws InterruptedException {
         ScheduledExecutorService scheduledExecutorService = mock(ScheduledExecutorService.class);
         RateLimiterConfig configSpy = spy(config);
 
         ScheduledFuture<?> future = mock(ScheduledFuture.class);
 
-        doReturn(future).when(scheduledExecutorService).scheduleAtFixedRate(any(Runnable.class), any(Long.class), any(Long.class),
-            any(TimeUnit.class));
+        doReturn(future).when(scheduledExecutorService).scheduleAtFixedRate(
+            any(Runnable.class), any(Long.class), any(Long.class), any(TimeUnit.class));
 
         SemaphoreBasedRateLimiter limit = new SemaphoreBasedRateLimiter("test", configSpy,
             scheduledExecutorService);

--- a/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/SemaphoreBasedRateLimiterParameterizedTest.java
+++ b/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/SemaphoreBasedRateLimiterParameterizedTest.java
@@ -1,42 +1,28 @@
 package io.github.resilience4j.ratelimiter.internal;
 
-import io.github.resilience4j.core.ThreadType;
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
-import org.junit.After;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
 
 import java.util.concurrent.ScheduledExecutorService;
 
 /**
- * Parameterized test class that runs all common RateLimiter implementation tests
+ * Test class that runs all common RateLimiter implementation tests
  * in both platform thread and virtual thread modes to ensure comprehensive coverage
  * and behavioral consistency across thread types.
- * 
- * @author kanghyun.yang
- * @since 3.0.0
  */
-@RunWith(Parameterized.class)
-public class SemaphoreBasedRateLimiterParameterizedTest extends RateLimitersImplementationTest {
-
-    public SemaphoreBasedRateLimiterParameterizedTest(ThreadType threadType) {
-        super(threadType);
-    }
+class SemaphoreBasedRateLimiterParameterizedTest extends RateLimitersImplementationTest {
 
     private SemaphoreBasedRateLimiter testLimiter;
 
     @Override
     protected RateLimiter buildRateLimiter(RateLimiterConfig config) {
-        // Create limiter with null scheduler to use default scheduler
-        // Thread mode is already configured by ThreadModeTestBase
         testLimiter = new SemaphoreBasedRateLimiter("parameterized-test", config, (ScheduledExecutorService) null);
         return testLimiter;
     }
 
-    @After
-    public void shutdownLimiter() {
-        // Ensure proper cleanup of the limiter
+    @AfterEach
+    void shutdownLimiter() {
         if (testLimiter != null) {
             testLimiter.shutdown();
         }


### PR DESCRIPTION
## Changes

* Migrated JUnit 4.13 annotations to Junit Jupiter equivalents
* Migrated `ThreadModeTestBase` parameterized tests to `@TestTemplate` + `@ExtendWith(ThreadModeExtension.class)`
* Replaced `@Rule ExpectedException` with `assertThatThrownBy`
* Converted `@Test(expected=...)` to `assertThatThrownBy`
* Migrated to awaitility 4.x
* Applied OpenRewrite recipes
    * [JUnit 6 best practices](https://docs.openrewrite.org/recipes/java/testing/junit/junit6bestpractices)
    * [Mockito best practices](https://docs.openrewrite.org/recipes/java/testing/mockito/mockitobestpractices)
    * [Migrate JUnit asserts to AssertJ](https://docs.openrewrite.org/recipes/java/testing/assertj/junittoassertj)
    * [AssertJ best practices](https://docs.openrewrite.org/recipes/java/testing/assertj/assertj-best-practices)
* Removed `public` modifiers
* Updated Copyright to 2026

## Coverage

| Metric      | Before | After |
|-------------|--------|-------|
| Instruction | 83.4%  | 83.4% |
| Line        | 84.7%  | 84.7% |
| Branch      | 87.5%  | 87.5% |

## Test runtime

> [!NOTE]
> Test count decreased because vavr-based assertions (`Try.ofCallable`) were replaced with direct assertions, consolidating some test paths and using `@TestTemplace` for thread mode based test (counted as 1 test).

| Metric | Before | After |
|--------|--------|-------|
| Tests  | 127    | 114   |
| Time   | 10.3s  | 9.5s  |
