### PR TITLE
resilience4j-reactor: JUnit 4 → JUnit 6 migration

### DIFF
--- a/resilience4j-reactor/build.gradle
+++ b/resilience4j-reactor/build.gradle
@@ -8,9 +8,6 @@ dependencies {
     implementation(project(":resilience4j-retry"))
     implementation(project(":resilience4j-timelimiter"))
 
-    testRuntimeOnly(libs.junit.vintage.engine)
-
-    testImplementation(libs.junit)
     testImplementation(project(":resilience4j-micrometer").sourceSets.test.output)
     testImplementation(project(":resilience4j-test"))
     testImplementation(libs.blockhound)

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/ReactorOperatorFallbackDecorator.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/ReactorOperatorFallbackDecorator.java
@@ -26,7 +26,6 @@ public class ReactorOperatorFallbackDecorator<T> implements UnaryOperator<Publis
 
     private final Map<Class<? extends Throwable>, Publisher<T>> FALLBACK_PUBLISHER_CACHE = new HashMap<>();
 
-
     private ReactorOperatorFallbackDecorator(Class<? extends Throwable> throwableType, Publisher<T> fallback) {
         FALLBACK_PUBLISHER_CACHE.put(throwableType, fallback);
     }
@@ -100,7 +99,6 @@ public class ReactorOperatorFallbackDecorator<T> implements UnaryOperator<Publis
     public Function<Publisher<T>, Publisher<T>> decorate(UnaryOperator<Publisher<T>> operator) {
         return compose(operator);
     }
-
 
     /**
      * a convenience method that initializes a default retry fallback behavior (after {@link MaxRetriesExceededException} is thrown

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/adapter/ReactorAdapter.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/adapter/ReactorAdapter.java
@@ -15,7 +15,6 @@
  */
 package io.github.resilience4j.reactor.adapter;
 
-
 import io.github.resilience4j.core.EventPublisher;
 import reactor.core.publisher.DirectProcessor;
 import reactor.core.publisher.Flux;

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/ratelimiter/operator/RateLimiterOperator.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/ratelimiter/operator/RateLimiterOperator.java
@@ -24,7 +24,6 @@ import reactor.core.publisher.Mono;
 
 import java.util.function.UnaryOperator;
 
-
 /**
  * A RateLimiter operator which checks if a downstream subscriber/observer can acquire a permission
  * to subscribe to an upstream Publisher. Otherwise emits a {@link RequestNotPermitted} if the rate

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/CombinedOperatorsTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/CombinedOperatorsTest.java
@@ -13,7 +13,7 @@ import io.github.resilience4j.reactor.ratelimiter.operator.RateLimiterOperator;
 import io.github.resilience4j.reactor.retry.RetryOperator;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 
-public class CombinedOperatorsTest {
+class CombinedOperatorsTest {
 
     private final RateLimiter rateLimiter = RateLimiter.of("test",
         RateLimiterConfig.custom().limitForPeriod(5).timeoutDuration(Duration.ZERO)
@@ -42,7 +42,7 @@ public class CombinedOperatorsTest {
             BulkheadConfig.custom().maxConcurrentCalls(1).maxWaitDuration(Duration.ZERO).build());
 
     @Test
-    public void shouldEmitEvents() {
+    void shouldEmitEvents() {
         StepVerifier.create(
             Flux.just("Event 1", "Event 2")
                 .transformDeferred(BulkheadOperator.of(bulkhead))
@@ -54,7 +54,7 @@ public class CombinedOperatorsTest {
     }
 
     @Test
-    public void shouldEmitEventsWithRetry() {
+    void shouldEmitEventsWithRetry() {
         StepVerifier.create(
             Flux.just("Event 1", "Event 2")
                 .transformDeferred(retryOperator)
@@ -67,7 +67,7 @@ public class CombinedOperatorsTest {
     }
 
     @Test
-    public void shouldEmitEvent() {
+    void shouldEmitEvent() {
         StepVerifier.create(
             Mono.just("Event 1")
                 .transformDeferred(BulkheadOperator.of(bulkhead))
@@ -78,7 +78,7 @@ public class CombinedOperatorsTest {
     }
 
     @Test
-    public void shouldEmitEventWithRetry() {
+    void shouldEmitEventWithRetry() {
         StepVerifier.create(
             Mono.just("Event 1")
                 .transformDeferred(retryOperator)
@@ -90,7 +90,7 @@ public class CombinedOperatorsTest {
     }
 
     @Test
-    public void shouldPropagateError() {
+    void shouldPropagateError() {
         StepVerifier.create(
             Flux.error(new IOException("BAM!"))
                 .transformDeferred(BulkheadOperator.of(bulkhead))
@@ -101,7 +101,7 @@ public class CombinedOperatorsTest {
     }
 
     @Test
-    public void shouldEmitErrorWithCircuitBreakerOpenExceptionEvenWhenErrorDuringSubscribe() {
+    void shouldEmitErrorWithCircuitBreakerOpenExceptionEvenWhenErrorDuringSubscribe() {
         circuitBreaker.transitionToOpenState();
         StepVerifier.create(
             Flux.error(new IOException("BAM!"))
@@ -113,7 +113,7 @@ public class CombinedOperatorsTest {
     }
 
     @Test
-    public void shouldEmitErrorWithCircuitBreakerOpenExceptionEvenWhenErrorNotOnSubscribe() {
+    void shouldEmitErrorWithCircuitBreakerOpenExceptionEvenWhenErrorNotOnSubscribe() {
         circuitBreaker.transitionToOpenState();
         StepVerifier.create(
             Flux.error(new IOException("BAM!"), true)

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/ReactorOperatorFallbackDecoratorTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/ReactorOperatorFallbackDecoratorTest.java
@@ -10,9 +10,9 @@ import io.github.resilience4j.test.HelloWorldException;
 import io.github.resilience4j.test.HelloWorldService;
 import io.github.resilience4j.timelimiter.TimeLimiter;
 import io.github.resilience4j.timelimiter.TimeLimiterConfig;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -30,8 +30,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.*;
 
-
-public class ReactorOperatorFallbackDecoratorTest {
+class ReactorOperatorFallbackDecoratorTest {
 
     private HelloWorldService helloWorldService;
 
@@ -39,15 +38,15 @@ public class ReactorOperatorFallbackDecoratorTest {
 
     private final TimeLimiter timeLimiter = mock(TimeLimiter.class);
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         helloWorldService = mock(HelloWorldService.class);
         circuitBreaker = mock(CircuitBreaker.class, RETURNS_DEEP_STUBS);
     }
 
     @Test
-    @Ignore("when mono completes with onError, onComplete is not triggered and no MaxRetriesExceededException is thrown so this test fails")
-    public void shouldFallbackOnRetriesExceededUsingMono() {
+    @Disabled("when mono completes with onError, onComplete is not triggered and no MaxRetriesExceededException is thrown so this test fails")
+    void shouldFallbackOnRetriesExceededUsingMono() {
         RetryConfig config = RetryConfig.custom()
             .waitDuration(Duration.ofMillis(10))
             .failAfterMaxAttempts(true)
@@ -84,7 +83,7 @@ public class ReactorOperatorFallbackDecoratorTest {
     }
 
     @Test
-    public void shouldFallbackOnRetriesExceededUsingFlux() {
+    void shouldFallbackOnRetriesExceededUsingFlux() {
         RetryConfig config = RetryConfig.<String>custom()
             .retryOnResult("retry"::equals)
             .waitDuration(Duration.ofMillis(10))
@@ -108,7 +107,7 @@ public class ReactorOperatorFallbackDecoratorTest {
     }
 
     @Test
-    public void shouldFallbackOntimeoutUsingMono() {
+    void shouldFallbackOntimeoutUsingMono() {
         given(timeLimiter.getTimeLimiterConfig())
             .willReturn(TimeLimiterConfig.custom()
                 .timeoutDuration(Duration.ofMillis(1))
@@ -128,7 +127,7 @@ public class ReactorOperatorFallbackDecoratorTest {
     }
 
     @Test
-    public void shouldFallbackOnTimeoutUsingFlux() {
+    void shouldFallbackOnTimeoutUsingFlux() {
         given(timeLimiter.getTimeLimiterConfig())
             .willReturn(TimeLimiterConfig.custom()
                 .timeoutDuration(Duration.ofMillis(1))
@@ -148,7 +147,7 @@ public class ReactorOperatorFallbackDecoratorTest {
     }
 
     @Test
-    public void shouldFallbackOnCircuitOpen() {
+    void shouldFallbackOnCircuitOpen() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(false);
 
         StepVerifier.create(
@@ -163,6 +162,5 @@ public class ReactorOperatorFallbackDecoratorTest {
 
         verify(circuitBreaker, never()).onResult(anyLong(), any(TimeUnit.class), any());
     }
-
 
 }

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/BulkheadSubscriberWhiteboxVerification.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/BulkheadSubscriberWhiteboxVerification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Julien Hoarau
+ * Copyright 2026 Julien Hoarau
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import org.reactivestreams.tck.SubscriberWhiteboxVerification;
 import org.reactivestreams.tck.TestEnvironment;
 import reactor.core.publisher.MonoProcessor;
 
-public class BulkheadSubscriberWhiteboxVerification extends
+class BulkheadSubscriberWhiteboxVerification extends
     SubscriberWhiteboxVerification<Integer> {
 
     public BulkheadSubscriberWhiteboxVerification() {

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/FluxBulkheadTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/FluxBulkheadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Julien Hoarau
+ * Copyright 2026 Julien Hoarau
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ package io.github.resilience4j.reactor.bulkhead.operator;
 
 import io.github.resilience4j.bulkhead.Bulkhead;
 import io.github.resilience4j.bulkhead.BulkheadFullException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
@@ -28,18 +28,17 @@ import java.time.Duration;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
-public class FluxBulkheadTest {
-
+class FluxBulkheadTest {
 
     private Bulkhead bulkhead;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         bulkhead = mock(Bulkhead.class, RETURNS_DEEP_STUBS);
     }
 
     @Test
-    public void shouldEmitEvent() {
+    void shouldEmitEvent() {
         given(bulkhead.tryAcquirePermission()).willReturn(true);
 
         StepVerifier.create(
@@ -53,7 +52,7 @@ public class FluxBulkheadTest {
     }
 
     @Test
-    public void shouldPropagateError() {
+    void shouldPropagateError() {
         given(bulkhead.tryAcquirePermission()).willReturn(true);
 
         StepVerifier.create(
@@ -67,7 +66,7 @@ public class FluxBulkheadTest {
     }
 
     @Test
-    public void shouldEmitErrorWithBulkheadFullException() {
+    void shouldEmitErrorWithBulkheadFullException() {
         given(bulkhead.tryAcquirePermission()).willReturn(false);
         bulkhead.tryAcquirePermission();
 
@@ -82,7 +81,7 @@ public class FluxBulkheadTest {
     }
 
     @Test
-    public void shouldEmitBulkheadFullExceptionEvenWhenErrorDuringSubscribe() {
+    void shouldEmitBulkheadFullExceptionEvenWhenErrorDuringSubscribe() {
         given(bulkhead.tryAcquirePermission()).willReturn(false);
 
         StepVerifier.create(
@@ -96,7 +95,7 @@ public class FluxBulkheadTest {
     }
 
     @Test
-    public void shouldEmitBulkheadFullExceptionEvenWhenErrorNotOnSubscribe() {
+    void shouldEmitBulkheadFullExceptionEvenWhenErrorNotOnSubscribe() {
         given(bulkhead.tryAcquirePermission()).willReturn(false);
 
         StepVerifier.create(
@@ -110,7 +109,7 @@ public class FluxBulkheadTest {
     }
 
     @Test
-    public void shouldReleaseBulkheadSemaphoreOnCancel() {
+    void shouldReleaseBulkheadSemaphoreOnCancel() {
         given(bulkhead.tryAcquirePermission()).willReturn(true);
 
         StepVerifier.create(
@@ -125,7 +124,7 @@ public class FluxBulkheadTest {
     }
 
     @Test
-    public void shouldInvokeOnCompleteOnCancelWhenEventWasEmitted() {
+    void shouldInvokeOnCompleteOnCancelWhenEventWasEmitted() {
         given(bulkhead.tryAcquirePermission()).willReturn(true);
 
         StepVerifier.create(
@@ -141,7 +140,7 @@ public class FluxBulkheadTest {
     }
 
     @Test
-    public void shouldOnceEmitCompleteWhenErrorInCompleteEvent() {
+    void shouldOnceEmitCompleteWhenErrorInCompleteEvent() {
         given(bulkhead.tryAcquirePermission()).willReturn(true);
         doThrow(new RuntimeException("BAM!")).when(bulkhead).onComplete();
 

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/MonoBulkheadTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/MonoBulkheadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Julien Hoarau
+ * Copyright 2026 Julien Hoarau
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ package io.github.resilience4j.reactor.bulkhead.operator;
 
 import io.github.resilience4j.bulkhead.Bulkhead;
 import io.github.resilience4j.bulkhead.BulkheadFullException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -28,17 +28,17 @@ import java.time.Duration;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
-public class MonoBulkheadTest {
+class MonoBulkheadTest {
 
     private Bulkhead bulkhead;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         bulkhead = mock(Bulkhead.class, RETURNS_DEEP_STUBS);
     }
 
     @Test
-    public void shouldEmitEvent() {
+    void shouldEmitEvent() {
         given(bulkhead.tryAcquirePermission()).willReturn(true);
 
         StepVerifier.create(
@@ -51,7 +51,7 @@ public class MonoBulkheadTest {
     }
 
     @Test
-    public void shouldPropagateError() {
+    void shouldPropagateError() {
         given(bulkhead.tryAcquirePermission()).willReturn(true);
 
         StepVerifier.create(
@@ -65,7 +65,7 @@ public class MonoBulkheadTest {
     }
 
     @Test
-    public void shouldEmitErrorWithBulkheadFullException() {
+    void shouldEmitErrorWithBulkheadFullException() {
         given(bulkhead.tryAcquirePermission()).willReturn(false);
 
         StepVerifier.create(
@@ -79,7 +79,7 @@ public class MonoBulkheadTest {
     }
 
     @Test
-    public void shouldEmitBulkheadFullExceptionEvenWhenErrorDuringSubscribe() {
+    void shouldEmitBulkheadFullExceptionEvenWhenErrorDuringSubscribe() {
         given(bulkhead.tryAcquirePermission()).willReturn(false);
 
         StepVerifier.create(
@@ -91,7 +91,7 @@ public class MonoBulkheadTest {
     }
 
     @Test
-    public void shouldReleaseBulkheadSemaphoreOnCancel() {
+    void shouldReleaseBulkheadSemaphoreOnCancel() {
         given(bulkhead.tryAcquirePermission()).willReturn(true);
 
         StepVerifier.create(
@@ -106,7 +106,7 @@ public class MonoBulkheadTest {
     }
 
     @Test
-    public void shouldOnceEmitCompleteWhenErrorInCompleteEvent() {
+    void shouldOnceEmitCompleteWhenErrorInCompleteEvent() {
         given(bulkhead.tryAcquirePermission()).willReturn(true);
         doThrow(new RuntimeException("BAM!")).when(bulkhead).onComplete();
 

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/CircuitBreakerSubscriberWhiteboxVerification.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/CircuitBreakerSubscriberWhiteboxVerification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Julien Hoarau
+ * Copyright 2026 Julien Hoarau
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import org.reactivestreams.tck.SubscriberWhiteboxVerification;
 import org.reactivestreams.tck.TestEnvironment;
 import reactor.core.publisher.MonoProcessor;
 
-public class CircuitBreakerSubscriberWhiteboxVerification extends
+class CircuitBreakerSubscriberWhiteboxVerification extends
     SubscriberWhiteboxVerification<Integer> {
 
     public CircuitBreakerSubscriberWhiteboxVerification() {

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/FluxCircuitBreakerTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/FluxCircuitBreakerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Julien Hoarau
+ * Copyright 2026 Julien Hoarau
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ package io.github.resilience4j.reactor.circuitbreaker.operator;
 
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -30,17 +30,17 @@ import java.util.concurrent.TimeUnit;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
-public class FluxCircuitBreakerTest {
+class FluxCircuitBreakerTest {
 
     private CircuitBreaker circuitBreaker;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         circuitBreaker = mock(CircuitBreaker.class, RETURNS_DEEP_STUBS);
     }
 
     @Test
-    public void shouldSubscribeToFluxJust() {
+    void shouldSubscribeToFluxJust() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
         given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
         given(circuitBreaker.getTimestampUnit()).willReturn(TimeUnit.NANOSECONDS);
@@ -58,7 +58,7 @@ public class FluxCircuitBreakerTest {
     }
 
     @Test
-    public void shouldPropagateError() {
+    void shouldPropagateError() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
         given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
         given(circuitBreaker.getTimestampUnit()).willReturn(TimeUnit.NANOSECONDS);
@@ -75,7 +75,7 @@ public class FluxCircuitBreakerTest {
     }
 
     @Test
-    public void shouldPropagateErrorWhenErrorNotOnSubscribe() {
+    void shouldPropagateErrorWhenErrorNotOnSubscribe() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
         given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
         given(circuitBreaker.getTimestampUnit()).willReturn(TimeUnit.NANOSECONDS);
@@ -92,7 +92,7 @@ public class FluxCircuitBreakerTest {
     }
 
     @Test
-    public void shouldSubscribeToMonoJustTwice() {
+    void shouldSubscribeToMonoJustTwice() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
         given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
         given(circuitBreaker.getTimestampUnit()).willReturn(TimeUnit.NANOSECONDS);
@@ -110,7 +110,7 @@ public class FluxCircuitBreakerTest {
     }
 
     @Test
-    public void shouldEmitErrorWithCircuitBreakerOpenException() {
+    void shouldEmitErrorWithCircuitBreakerOpenException() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(false);
 
         StepVerifier.create(
@@ -125,7 +125,7 @@ public class FluxCircuitBreakerTest {
     }
 
     @Test
-    public void shouldEmitCircuitBreakerOpenExceptionEvenWhenErrorNotOnSubscribe() {
+    void shouldEmitCircuitBreakerOpenExceptionEvenWhenErrorNotOnSubscribe() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(false);
 
         StepVerifier.create(
@@ -140,7 +140,7 @@ public class FluxCircuitBreakerTest {
     }
 
     @Test
-    public void shouldEmitCircuitBreakerOpenExceptionEvenWhenErrorDuringSubscribe() {
+    void shouldEmitCircuitBreakerOpenExceptionEvenWhenErrorDuringSubscribe() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(false);
 
         StepVerifier.create(
@@ -155,7 +155,7 @@ public class FluxCircuitBreakerTest {
     }
 
     @Test
-    public void shouldReleasePermissionOnCancel() {
+    void shouldReleasePermissionOnCancel() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
 
         StepVerifier.create(
@@ -173,7 +173,7 @@ public class FluxCircuitBreakerTest {
     }
 
     @Test
-    public void shouldInvokeOnSuccessOnCancelWhenEventWasEmitted() {
+    void shouldInvokeOnSuccessOnCancelWhenEventWasEmitted() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
         given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
         given(circuitBreaker.getTimestampUnit()).willReturn(TimeUnit.NANOSECONDS);

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/MonoCircuitBreakerTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/circuitbreaker/operator/MonoCircuitBreakerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Julien Hoarau
+ * Copyright 2026 Julien Hoarau
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ package io.github.resilience4j.reactor.circuitbreaker.operator;
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.test.HelloWorldService;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -28,26 +28,26 @@ import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.*;
 
-public class MonoCircuitBreakerTest {
+class MonoCircuitBreakerTest {
 
     private CircuitBreaker circuitBreaker;
     private HelloWorldService helloWorldService;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         circuitBreaker = mock(CircuitBreaker.class, RETURNS_DEEP_STUBS);
         helloWorldService = mock(HelloWorldService.class);
     }
 
     @Test
-    public void shouldSubscribeToMonoJust() {
+    void shouldSubscribeToMonoJust() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
         given(helloWorldService.returnHelloWorld()).willReturn("Hello World");
         given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
@@ -66,7 +66,7 @@ public class MonoCircuitBreakerTest {
     }
 
     @Test
-    public void shouldSubscribeToMonoFromCallable() {
+    void shouldSubscribeToMonoFromCallable() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
         given(helloWorldService.returnHelloWorld()).willReturn("Hello World");
         given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
@@ -85,7 +85,7 @@ public class MonoCircuitBreakerTest {
     }
 
     @Test
-    public void shouldSubscribeToMonoFromCallableMultipleTimes() {
+    void shouldSubscribeToMonoFromCallableMultipleTimes() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
         given(helloWorldService.returnHelloWorld()).willReturn("Hello World");
         given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
@@ -107,7 +107,7 @@ public class MonoCircuitBreakerTest {
     }
 
     @Test
-    public void emptyMonoShouldBeSuccessful() {
+    void emptyMonoShouldBeSuccessful() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
         given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
         given(circuitBreaker.getTimestampUnit()).willReturn(TimeUnit.NANOSECONDS);
@@ -123,7 +123,7 @@ public class MonoCircuitBreakerTest {
     }
 
     @Test
-    public void shouldPropagateError() {
+    void shouldPropagateError() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
         given(circuitBreaker.getCurrentTimestamp()).willReturn(System.nanoTime());
         given(circuitBreaker.getTimestampUnit()).willReturn(TimeUnit.NANOSECONDS);
@@ -140,7 +140,7 @@ public class MonoCircuitBreakerTest {
     }
 
     @Test
-    public void shouldEmitCallNotPermittedExceptionEvenWhenErrorDuringSubscribe() {
+    void shouldEmitCallNotPermittedExceptionEvenWhenErrorDuringSubscribe() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(false);
 
         StepVerifier.create(
@@ -155,7 +155,7 @@ public class MonoCircuitBreakerTest {
     }
 
     @Test
-    public void shouldEmitErrorWithCircuitBreakerOpenException() {
+    void shouldEmitErrorWithCircuitBreakerOpenException() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(false);
 
         StepVerifier.create(
@@ -170,7 +170,7 @@ public class MonoCircuitBreakerTest {
     }
 
     @Test
-    public void shouldReleasePermissionOnCancel() {
+    void shouldReleasePermissionOnCancel() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
 
         StepVerifier.create(
@@ -188,7 +188,7 @@ public class MonoCircuitBreakerTest {
     }
 
     @Test
-    public void shouldNotSubscribeToMonoFromCallable() {
+    void shouldNotSubscribeToMonoFromCallable() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(false);
         given(helloWorldService.returnHelloWorld()).willReturn("Hello World");
 
@@ -206,7 +206,7 @@ public class MonoCircuitBreakerTest {
     }
 
     @Test
-    public void shouldRecordSuccessWhenUsingToFuture() {
+    void shouldRecordSuccessWhenUsingToFuture() {
         given(circuitBreaker.tryAcquirePermission()).willReturn(true);
 
         try {
@@ -216,7 +216,7 @@ public class MonoCircuitBreakerTest {
                 .get();
 
         } catch (InterruptedException | ExecutionException e) {
-            fail();
+            fail("Unexpected exception: " + e);
         }
     }
 }

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/micrometer/operator/FluxTimerTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/micrometer/operator/FluxTimerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Mariusz Kopylec
+ * Copyright 2026 Mariusz Kopylec
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import io.github.resilience4j.micrometer.Timer;
 import io.github.resilience4j.micrometer.TimerConfig;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 
 import java.util.List;
@@ -30,10 +30,10 @@ import static java.time.Duration.ofSeconds;
 import static org.assertj.core.api.BDDAssertions.failBecauseExceptionWasNotThrown;
 import static org.assertj.core.api.BDDAssertions.then;
 
-public class FluxTimerTest {
+class FluxTimerTest {
 
     @Test
-    public void shouldTimeSuccessfulFlux() {
+    void shouldTimeSuccessfulFlux() {
         List<String> messages = List.of("Hello 1", "Hello 2", "Hello 3");
         MeterRegistry registry = new SimpleMeterRegistry();
         Timer timer = Timer.of("timer 1", registry);
@@ -47,7 +47,7 @@ public class FluxTimerTest {
     }
 
     @Test
-    public void shouldTimeFailedFlux() {
+    void shouldTimeFailedFlux() {
         IllegalStateException exception = new IllegalStateException();
         MeterRegistry registry = new SimpleMeterRegistry();
         TimerConfig config = TimerConfig.custom()

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/micrometer/operator/MonoTimerTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/micrometer/operator/MonoTimerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Mariusz Kopylec
+ * Copyright 2026 Mariusz Kopylec
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import io.github.resilience4j.micrometer.Timer;
 import io.github.resilience4j.micrometer.TimerConfig;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
 import static io.github.resilience4j.micrometer.TimerAssertions.thenFailureTimed;
@@ -28,10 +28,10 @@ import static java.time.Duration.ofSeconds;
 import static org.assertj.core.api.BDDAssertions.failBecauseExceptionWasNotThrown;
 import static org.assertj.core.api.BDDAssertions.then;
 
-public class MonoTimerTest {
+class MonoTimerTest {
 
     @Test
-    public void shouldTimeSuccessfulMono() {
+    void shouldTimeSuccessfulMono() {
         String message = "Hello!";
         MeterRegistry registry = new SimpleMeterRegistry();
         Timer timer = Timer.of("timer 1", registry);
@@ -44,7 +44,7 @@ public class MonoTimerTest {
     }
 
     @Test
-    public void shouldTimeFailedMono() {
+    void shouldTimeFailedMono() {
         IllegalStateException exception = new IllegalStateException();
         MeterRegistry registry = new SimpleMeterRegistry();
         TimerConfig config = TimerConfig.custom()

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/ratelimiter/operator/FluxRateLimiterTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/ratelimiter/operator/FluxRateLimiterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Julien Hoarau
+ * Copyright 2026 Julien Hoarau
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@ import io.github.resilience4j.ratelimiter.RateLimiterConfig;
 import io.github.resilience4j.ratelimiter.RequestNotPermitted;
 import io.github.resilience4j.reactor.ratelimiter.operator.OverloadException.SpecificOverloadException;
 import io.github.resilience4j.reactor.ratelimiter.operator.ResponseWithPotentialOverload.SpecificResponseWithPotentialOverload;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
@@ -36,17 +36,17 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 
-public class FluxRateLimiterTest {
+class FluxRateLimiterTest {
 
     private RateLimiter rateLimiter;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         rateLimiter = mock(RateLimiter.class, RETURNS_DEEP_STUBS);
     }
 
     @Test
-    public void shouldEmitEvent() {
+    void shouldEmitEvent() {
         given(rateLimiter.reservePermission(1)).willReturn(Duration.ofSeconds(0).toNanos());
 
         StepVerifier.create(
@@ -58,7 +58,7 @@ public class FluxRateLimiterTest {
     }
 
     @Test
-    public void shouldReservePermissionWithCustomPermits() {
+    void shouldReservePermissionWithCustomPermits() {
         given(rateLimiter.reservePermission(10)).willReturn(Duration.ofSeconds(0).toNanos());
 
         StepVerifier.create(
@@ -72,7 +72,7 @@ public class FluxRateLimiterTest {
     }
 
     @Test
-    public void shouldDelaySubscription() {
+    void shouldDelaySubscription() {
         given(rateLimiter.reservePermission(1)).willReturn(Duration.ofMillis(50).toNanos());
 
         StepVerifier.create(
@@ -84,7 +84,7 @@ public class FluxRateLimiterTest {
     }
 
     @Test
-    public void shouldPropagateError() {
+    void shouldPropagateError() {
         given(rateLimiter.reservePermission(1)).willReturn(Duration.ofSeconds(0).toNanos());
 
         StepVerifier.create(
@@ -97,7 +97,7 @@ public class FluxRateLimiterTest {
     }
 
     @Test
-    public void shouldEmitRequestNotPermittedException() {
+    void shouldEmitRequestNotPermittedException() {
         given(rateLimiter.reservePermission(1)).willReturn(-1L);
 
         StepVerifier.create(
@@ -109,7 +109,7 @@ public class FluxRateLimiterTest {
     }
 
     @Test
-    public void shouldEmitRequestNotPermittedExceptionEvenWhenErrorDuringSubscribe() {
+    void shouldEmitRequestNotPermittedExceptionEvenWhenErrorDuringSubscribe() {
         given(rateLimiter.reservePermission(1)).willReturn(-1L);
 
         StepVerifier.create(
@@ -121,7 +121,7 @@ public class FluxRateLimiterTest {
     }
 
     @Test
-    public void shouldDrainRateLimiterInConditionMetOnFailedCall() {
+    void shouldDrainRateLimiterInConditionMetOnFailedCall() {
         RateLimiter rateLimiter = RateLimiter.of("someLimiter", RateLimiterConfig.custom()
             .limitForPeriod(5)
             .limitRefreshPeriod(Duration.ofHours(1))
@@ -139,7 +139,7 @@ public class FluxRateLimiterTest {
     }
 
     @Test
-    public void shouldDrainRateLimiterInConditionMetOnSuccessfulCall() {
+    void shouldDrainRateLimiterInConditionMetOnSuccessfulCall() {
         RateLimiter rateLimiter = RateLimiter.of("someLimiter", RateLimiterConfig.custom()
             .limitForPeriod(5)
             .limitRefreshPeriod(Duration.ofHours(1))
@@ -161,7 +161,7 @@ public class FluxRateLimiterTest {
     }
 
     @Test
-    public void shouldNotDrainRateLimiterInConditionNotMetOnSuccessfulCall() {
+    void shouldNotDrainRateLimiterInConditionNotMetOnSuccessfulCall() {
         RateLimiter rateLimiter = RateLimiter.of("someLimiter", RateLimiterConfig.custom()
             .limitForPeriod(5)
             .limitRefreshPeriod(Duration.ofHours(1))

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/ratelimiter/operator/MonoRateLimiterTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/ratelimiter/operator/MonoRateLimiterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Julien Hoarau
+ * Copyright 2026 Julien Hoarau
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
 import io.github.resilience4j.ratelimiter.RequestNotPermitted;
 import io.github.resilience4j.reactor.ratelimiter.operator.ResponseWithPotentialOverload.SpecificResponseWithPotentialOverload;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -35,10 +35,10 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 
-public class MonoRateLimiterTest {
+class MonoRateLimiterTest {
 
     @Test
-    public void shouldEmitEvent() {
+    void shouldEmitEvent() {
         RateLimiter rateLimiter = mock(RateLimiter.class, RETURNS_DEEP_STUBS);
         given(rateLimiter.reservePermission(1)).willReturn(Duration.ofSeconds(0).toNanos());
 
@@ -50,7 +50,7 @@ public class MonoRateLimiterTest {
     }
 
     @Test
-    public void shouldPropagateError() {
+    void shouldPropagateError() {
         RateLimiter rateLimiter = mock(RateLimiter.class, RETURNS_DEEP_STUBS);
         given(rateLimiter.reservePermission(1)).willReturn(Duration.ofSeconds(0).toNanos());
 
@@ -63,7 +63,7 @@ public class MonoRateLimiterTest {
     }
 
     @Test
-    public void shouldReservePermissionWithCustomPermits() {
+    void shouldReservePermissionWithCustomPermits() {
         RateLimiter rateLimiter = mock(RateLimiter.class, RETURNS_DEEP_STUBS);
         given(rateLimiter.reservePermission(10)).willReturn(Duration.ofSeconds(0).toNanos());
 
@@ -77,7 +77,7 @@ public class MonoRateLimiterTest {
     }
 
     @Test
-    public void shouldDelaySubscription() {
+    void shouldDelaySubscription() {
         RateLimiter rateLimiter = mock(RateLimiter.class, RETURNS_DEEP_STUBS);
         given(rateLimiter.reservePermission(1)).willReturn(Duration.ofMillis(50).toNanos());
 
@@ -89,9 +89,8 @@ public class MonoRateLimiterTest {
             .verify(Duration.ofMillis(150));
     }
 
-
     @Test
-    public void shouldEmitErrorWithBulkheadFullException() {
+    void shouldEmitErrorWithBulkheadFullException() {
         RateLimiter rateLimiter = mock(RateLimiter.class, RETURNS_DEEP_STUBS);
         given(rateLimiter.reservePermission(1)).willReturn(-1L);
 
@@ -104,7 +103,7 @@ public class MonoRateLimiterTest {
     }
 
     @Test
-    public void shouldEmitRequestNotPermittedExceptionEvenWhenErrorDuringSubscribe() {
+    void shouldEmitRequestNotPermittedExceptionEvenWhenErrorDuringSubscribe() {
         RateLimiter rateLimiter = mock(RateLimiter.class, RETURNS_DEEP_STUBS);
         given(rateLimiter.reservePermission(1)).willReturn(-1L);
 
@@ -116,7 +115,7 @@ public class MonoRateLimiterTest {
     }
 
     @Test
-    public void shouldDrainRateLimiterInConditionMetOnFailedCall() {
+    void shouldDrainRateLimiterInConditionMetOnFailedCall() {
         RateLimiter rateLimiter = RateLimiter.of("someLimiter", RateLimiterConfig.custom()
             .limitForPeriod(5)
             .limitRefreshPeriod(Duration.ofHours(1))
@@ -134,7 +133,7 @@ public class MonoRateLimiterTest {
     }
 
     @Test
-    public void shouldDrainRateLimiterInConditionMetOnSuccessfulCall() {
+    void shouldDrainRateLimiterInConditionMetOnSuccessfulCall() {
         RateLimiter rateLimiter = RateLimiter.of("someLimiter", RateLimiterConfig.custom()
             .limitForPeriod(5)
             .limitRefreshPeriod(Duration.ofHours(1))
@@ -156,7 +155,7 @@ public class MonoRateLimiterTest {
     }
 
     @Test
-    public void shouldNotDrainRateLimiterInConditionNotMetOnSuccessfulCall() {
+    void shouldNotDrainRateLimiterInConditionNotMetOnSuccessfulCall() {
         RateLimiter rateLimiter = RateLimiter.of("someLimiter", RateLimiterConfig.custom()
             .limitForPeriod(5)
             .limitRefreshPeriod(Duration.ofHours(1))

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/ratelimiter/operator/RateLimiterSubscriberWhiteboxVerification.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/ratelimiter/operator/RateLimiterSubscriberWhiteboxVerification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Julien Hoarau
+ * Copyright 2026 Julien Hoarau
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import org.reactivestreams.tck.SubscriberWhiteboxVerification;
 import org.reactivestreams.tck.TestEnvironment;
 import reactor.core.publisher.MonoProcessor;
 
-public class RateLimiterSubscriberWhiteboxVerification extends
+class RateLimiterSubscriberWhiteboxVerification extends
     SubscriberWhiteboxVerification<Integer> {
 
     public RateLimiterSubscriberWhiteboxVerification() {

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/retry/RetryOperatorTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/retry/RetryOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Dan Maas
+ * Copyright 2026 Dan Maas
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,9 @@ import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.test.HelloWorldException;
 import io.github.resilience4j.test.HelloWorldService;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -32,27 +32,28 @@ import java.io.IOException;
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 
-public class RetryOperatorTest {
+class RetryOperatorTest {
 
     private HelloWorldService helloWorldService;
 
-    @BeforeClass
-    public static void beforeClass() {
+    @BeforeAll
+    static void beforeClass() {
         //BlockHound.install(new ReactorIntegration());
     }
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         helloWorldService = mock(HelloWorldService.class);
     }
 
     @Test
-    public void returnOnCompleteUsingMono() {
+    void returnOnCompleteUsingMono() {
         RetryConfig config = retryConfig();
         Retry retry = Retry.of("testName", config);
         RetryOperator<String> retryOperator = RetryOperator.of(retry);
@@ -81,24 +82,25 @@ public class RetryOperatorTest {
         assertThat(metrics.getNumberOfFailedCallsWithoutRetryAttempt()).isZero();
     }
 
-
-    @Test(expected = StackOverflowError.class)
-    public void shouldNotRetryUsingMonoStackOverFlow() {
+    @Test
+    void shouldNotRetryUsingMonoStackOverFlow() {
         RetryConfig config = retryConfig();
         Retry retry = Retry.of("testName", config);
         RetryOperator<String> retryOperator = RetryOperator.of(retry);
         given(helloWorldService.returnHelloWorld())
             .willThrow(new StackOverflowError("BAM!"));
 
-        StepVerifier.create(Mono.fromCallable(helloWorldService::returnHelloWorld)
-            .transformDeferred(retryOperator))
-            .expectSubscription()
-            .expectError(StackOverflowError.class)
-            .verify(Duration.ofSeconds(1));
+        assertThatThrownBy(() ->
+            StepVerifier.create(Mono.fromCallable(helloWorldService::returnHelloWorld)
+                .transformDeferred(retryOperator))
+                .expectSubscription()
+                .expectError(StackOverflowError.class)
+                .verify(Duration.ofSeconds(1)))
+            .isInstanceOf(StackOverflowError.class);
     }
 
     @Test
-    public void shouldNotRetryWhenItThrowErrorMono() {
+    void shouldNotRetryWhenItThrowErrorMono() {
         RetryConfig config = retryConfig();
         Retry retry = Retry.of("testName", config);
         RetryOperator<String> retryOperator = RetryOperator.of(retry);
@@ -117,9 +119,8 @@ public class RetryOperatorTest {
         assertThat(metrics.getNumberOfFailedCallsWithoutRetryAttempt()).isZero();
     }
 
-
     @Test
-    public void returnOnErrorUsingMono() {
+    void returnOnErrorUsingMono() {
         RetryConfig config = retryConfig();
         Retry retry = Retry.of("testName", config);
         RetryOperator<String> retryOperator = RetryOperator.of(retry);
@@ -145,7 +146,7 @@ public class RetryOperatorTest {
     }
 
     @Test
-    public void doNotRetryFromPredicateUsingMono() {
+    void doNotRetryFromPredicateUsingMono() {
         RetryConfig config = RetryConfig.custom()
             .retryOnException(t -> t instanceof IOException)
             .waitDuration(Duration.ofMillis(50))
@@ -167,7 +168,7 @@ public class RetryOperatorTest {
     }
 
     @Test
-    public void retryOnResultUsingMono() {
+    void retryOnResultUsingMono() {
         RetryConfig config = RetryConfig.<String>custom()
             .retryOnResult("retry"::equals)
             .waitDuration(Duration.ofMillis(10))
@@ -191,7 +192,7 @@ public class RetryOperatorTest {
     }
 
     @Test
-    public void retryOnResultFailAfterMaxAttemptsUsingMono() {
+    void retryOnResultFailAfterMaxAttemptsUsingMono() {
         RetryConfig config = RetryConfig.<String>custom()
             .retryOnResult("retry"::equals)
             .waitDuration(Duration.ofMillis(10))
@@ -211,7 +212,7 @@ public class RetryOperatorTest {
     }
 
     @Test
-    public void retryOnResultFailAfterMaxAttemptsWithExceptionUsingMono() {
+    void retryOnResultFailAfterMaxAttemptsWithExceptionUsingMono() {
         RetryConfig config = RetryConfig.<String>custom()
             .retryOnResult("retry"::equals)
             .waitDuration(Duration.ofMillis(10))
@@ -232,7 +233,7 @@ public class RetryOperatorTest {
     }
 
     @Test
-    public void shouldFailWithExceptionFlux() {
+    void shouldFailWithExceptionFlux() {
         RetryConfig config = retryConfig();
         Retry retry = Retry.of("testName", config);
         RetryOperator<Object> retryOperator = RetryOperator.of(retry);
@@ -251,7 +252,7 @@ public class RetryOperatorTest {
     }
 
     @Test
-    public void retryOnResultUsingFlux() {
+    void retryOnResultUsingFlux() {
         RetryConfig config = RetryConfig.<String>custom()
             .retryOnResult("retry"::equals)
             .waitDuration(Duration.ofMillis(10))
@@ -272,7 +273,7 @@ public class RetryOperatorTest {
     }
 
     @Test
-    public void retryOnResultFailAfterMaxAttemptsUsingFlux() {
+    void retryOnResultFailAfterMaxAttemptsUsingFlux() {
         RetryConfig config = RetryConfig.<String>custom()
             .retryOnResult("retry"::equals)
             .waitDuration(Duration.ofMillis(10))
@@ -292,7 +293,7 @@ public class RetryOperatorTest {
     }
 
     @Test
-    public void retryOnResultFailAfterMaxAttemptsWithExceptionUsingFlux() {
+    void retryOnResultFailAfterMaxAttemptsWithExceptionUsingFlux() {
         RetryConfig config = RetryConfig.<String>custom()
             .retryOnResult("retry"::equals)
             .waitDuration(Duration.ofMillis(10))

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/timelimiter/TimeLimiterOperatorTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/timelimiter/TimeLimiterOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 authors
+ * Copyright 2026 authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package io.github.resilience4j.reactor.timelimiter;
 import io.github.resilience4j.test.HelloWorldService;
 import io.github.resilience4j.timelimiter.TimeLimiter;
 import io.github.resilience4j.timelimiter.TimeLimiterConfig;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -34,14 +34,13 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 
-
-public class TimeLimiterOperatorTest {
+class TimeLimiterOperatorTest {
 
     private final TimeLimiter timeLimiter = mock(TimeLimiter.class);
     private final HelloWorldService helloWorldService = mock(HelloWorldService.class);
 
     @Test
-    public void doNotTimeoutUsingMono() {
+    void doNotTimeoutUsingMono() {
         given(timeLimiter.getTimeLimiterConfig())
             .willReturn(toConfig(Duration.ofMinutes(1)));
         given(helloWorldService.returnHelloWorld())
@@ -58,7 +57,7 @@ public class TimeLimiterOperatorTest {
     }
 
     @Test
-    public void timeoutUsingMono() {
+    void timeoutUsingMono() {
         given(timeLimiter.getTimeLimiterConfig())
             .willReturn(toConfig(Duration.ofMillis(1)));
 
@@ -73,7 +72,7 @@ public class TimeLimiterOperatorTest {
     }
 
     @Test
-    public void timeoutNeverUsingMono() {
+    void timeoutNeverUsingMono() {
         given(timeLimiter.getTimeLimiterConfig())
             .willReturn(toConfig(Duration.ofMillis(1)));
 
@@ -88,7 +87,7 @@ public class TimeLimiterOperatorTest {
     }
 
     @Test
-    public void otherErrorUsingMono() {
+    void otherErrorUsingMono() {
         given(timeLimiter.getTimeLimiterConfig())
             .willReturn(toConfig(Duration.ofMinutes(1)));
         given(helloWorldService.returnHelloWorld())
@@ -105,7 +104,7 @@ public class TimeLimiterOperatorTest {
     }
 
     @Test
-    public void doNotTimeoutUsingFlux() {
+    void doNotTimeoutUsingFlux() {
         given(timeLimiter.getTimeLimiterConfig())
             .willReturn(toConfig(Duration.ofMinutes(1)));
 
@@ -121,7 +120,7 @@ public class TimeLimiterOperatorTest {
     }
 
     @Test
-    public void timeoutUsingFlux() {
+    void timeoutUsingFlux() {
         given(timeLimiter.getTimeLimiterConfig())
             .willReturn(toConfig(Duration.ofMillis(1)));
 
@@ -136,7 +135,7 @@ public class TimeLimiterOperatorTest {
     }
 
     @Test
-    public void timeoutNeverUsingFlux() {
+    void timeoutNeverUsingFlux() {
         given(timeLimiter.getTimeLimiterConfig())
             .willReturn(toConfig(Duration.ofMillis(1)));
 
@@ -151,7 +150,7 @@ public class TimeLimiterOperatorTest {
     }
 
     @Test
-    public void otherErrorUsingFlux() {
+    void otherErrorUsingFlux() {
         given(timeLimiter.getTimeLimiterConfig())
             .willReturn(toConfig(Duration.ofMinutes(1)));
 


### PR DESCRIPTION
## Changes

* Migrated JUnit 4.13 annotations to Junit Jupiter equivalents
* Replaced `@Ignore` with `@Disabled`
* Replaced `@BeforeClass` with `@BeforeAll`
* Converted `@Test(expected=...)` to `assertThatThrownBy`
* Applied OpenRewrite recipes
    * [JUnit 6 best practices](https://docs.openrewrite.org/recipes/java/testing/junit/junit6bestpractices)
    * [Mockito best practices](https://docs.openrewrite.org/recipes/java/testing/mockito/mockitobestpractices)
    * [Migrate JUnit asserts to AssertJ](https://docs.openrewrite.org/recipes/java/testing/assertj/junittoassertj)
    * [AssertJ best practices](https://docs.openrewrite.org/recipes/java/testing/assertj/assertj-best-practices)
* Removed `public` modifiers
* Updated Copyright to 2026

## Coverage

| Metric      | Before | After |
|-------------|--------|-------|
| Instruction | 93.5%  | 93.5% |
| Line        | 93.6%  | 93.6% |
| Branch      | 77.8%  | 77.8% |

## Test runtime

| Metric | Before | After |
|--------|--------|-------|
| Tests  | 86     | 86    |
| Time   | 2.1s   | 2.0s  |
