### PR TITLE
resilience4j-timelimiter: JUnit 4 → JUnit 6 migration

### DIFF
--- a/resilience4j-timelimiter/build.gradle
+++ b/resilience4j-timelimiter/build.gradle
@@ -1,10 +1,6 @@
 dependencies {
     api(project(":resilience4j-core"))
 
-    testRuntimeOnly(libs.junit.vintage.engine)
-
-    testImplementation(libs.junit)
-    testImplementation(libs.vavr)
     testImplementation(project(":resilience4j-core").sourceSets.test.output)
 }
 ext.moduleName = "io.github.resilience4j.timelimiter"

--- a/resilience4j-timelimiter/src/test/java/io/github/resilience4j/timelimiter/TimeLimiterConfigTest.java
+++ b/resilience4j-timelimiter/src/test/java/io/github/resilience4j/timelimiter/TimeLimiterConfigTest.java
@@ -1,26 +1,21 @@
 package io.github.resilience4j.timelimiter;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.BDDAssertions.then;
 
-public class TimeLimiterConfigTest {
+class TimeLimiterConfigTest {
 
     private static final Duration TIMEOUT = Duration.ofSeconds(5);
     private static final boolean SHOULD_CANCEL = false;
     private static final String TIMEOUT_DURATION_MUST_NOT_BE_NULL = "TimeoutDuration must not be null";
     private static final String TIMEOUT_TO_STRING = "TimeLimiterConfig{timeoutDuration=PT1ScancelRunningFuture=true}";
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
-
     @Test
-    public void builderPositive() {
+    void builderPositive() {
         TimeLimiterConfig config = TimeLimiterConfig.custom()
             .timeoutDuration(TIMEOUT)
             .cancelRunningFuture(SHOULD_CANCEL)
@@ -31,39 +26,36 @@ public class TimeLimiterConfigTest {
     }
 
     @Test
-    public void defaultConstruction() {
+    void defaultConstruction() {
         TimeLimiterConfig config = TimeLimiterConfig.ofDefaults();
         then(config.getTimeoutDuration()).isEqualTo(Duration.ofSeconds(1));
         then(config.shouldCancelRunningFuture()).isTrue();
     }
 
     @Test
-    public void builderTimeoutIsNull() {
-        exception.expect(NullPointerException.class);
-        exception.expectMessage(TIMEOUT_DURATION_MUST_NOT_BE_NULL);
-
-        TimeLimiterConfig.custom()
-            .timeoutDuration(null);
+    void builderTimeoutIsNull() {
+        assertThatThrownBy(() -> TimeLimiterConfig.custom().timeoutDuration(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage(TIMEOUT_DURATION_MUST_NOT_BE_NULL);
     }
 
     @Test
-    public void configToString() {
+    void configToString() {
         then(TimeLimiterConfig.ofDefaults().toString()).isEqualTo(TIMEOUT_TO_STRING);
     }
 
     @Test
-    public void shouldUseBaseConfigAndOverwriteProperties() {
+    void shouldUseBaseConfigAndOverwriteProperties() {
         TimeLimiterConfig baseConfig = TimeLimiterConfig.custom()
-                .timeoutDuration(Duration.ofSeconds(5))
-                .cancelRunningFuture(false)
-                .build();
+            .timeoutDuration(Duration.ofSeconds(5))
+            .cancelRunningFuture(false)
+            .build();
 
         TimeLimiterConfig extendedConfig = TimeLimiterConfig.from(baseConfig)
-                .timeoutDuration(Duration.ofSeconds(20))
-                .build();
+            .timeoutDuration(Duration.ofSeconds(20))
+            .build();
 
         then(extendedConfig.getTimeoutDuration()).isEqualTo(Duration.ofSeconds(20));
         then(extendedConfig.shouldCancelRunningFuture()).isFalse();
     }
-
 }

--- a/resilience4j-timelimiter/src/test/java/io/github/resilience4j/timelimiter/TimeLimiterEventPublisherTest.java
+++ b/resilience4j-timelimiter/src/test/java/io/github/resilience4j/timelimiter/TimeLimiterEventPublisherTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2019 authors
+ *  Copyright 2026 authors
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -18,8 +18,7 @@
  */
 package io.github.resilience4j.timelimiter;
 
-import io.vavr.control.Try;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 
 import java.time.Duration;
@@ -30,15 +29,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 
-
-public class TimeLimiterEventPublisherTest {
+class TimeLimiterEventPublisherTest {
 
     private static final Duration NEVER = Duration.ZERO;
 
     private Logger logger = mock(Logger.class);
 
     @Test
-    public void shouldReturnTheSameConsumer() {
+    void shouldReturnTheSameConsumer() {
         TimeLimiter timeLimiter = TimeLimiter.of(NEVER);
 
         TimeLimiter.EventPublisher eventPublisher = timeLimiter.getEventPublisher();
@@ -48,7 +46,7 @@ public class TimeLimiterEventPublisherTest {
     }
 
     @Test
-    public void shouldConsumeOnSuccessEvent() throws Exception {
+    void shouldConsumeOnSuccessEvent() throws Exception {
         TimeLimiter timeLimiter = TimeLimiter.of(NEVER);
         timeLimiter.getEventPublisher()
             .onSuccess(event -> logger.info(event.getEventType().toString()));
@@ -62,20 +60,23 @@ public class TimeLimiterEventPublisherTest {
     }
 
     @Test
-    public void shouldConsumeOnTimeoutEvent() {
+    void shouldConsumeOnTimeoutEvent() {
         TimeLimiter timeLimiter = TimeLimiter.of(NEVER);
         timeLimiter.getEventPublisher()
             .onTimeout(event -> logger.info(event.getEventType().toString()));
         Supplier<CompletableFuture<String>> futureSupplier = () ->
             CompletableFuture.supplyAsync(this::timeout);
 
-        Try.ofCallable(timeLimiter.decorateFutureSupplier(futureSupplier));
+        try {
+            timeLimiter.decorateFutureSupplier(futureSupplier).call();
+        } catch (Exception ignored) {
+        }
 
         then(logger).should().info("TIMEOUT");
     }
 
     @Test
-    public void shouldConsumeOnErrorEvent() {
+    void shouldConsumeOnErrorEvent() {
         TimeLimiter timeLimiter = TimeLimiter.of(Duration.ofSeconds(1));
         timeLimiter.getEventPublisher()
             .onError(event -> logger
@@ -83,7 +84,10 @@ public class TimeLimiterEventPublisherTest {
         Supplier<CompletableFuture<String>> futureSupplier = () ->
             CompletableFuture.supplyAsync(this::fail);
 
-        Try.ofCallable(timeLimiter.decorateFutureSupplier(futureSupplier));
+        try {
+            timeLimiter.decorateFutureSupplier(futureSupplier).call();
+        } catch (Exception ignored) {
+        }
 
         then(logger).should().info("ERROR java.lang.RuntimeException");
     }

--- a/resilience4j-timelimiter/src/test/java/io/github/resilience4j/timelimiter/TimeLimiterRegistryTest.java
+++ b/resilience4j-timelimiter/src/test/java/io/github/resilience4j/timelimiter/TimeLimiterRegistryTest.java
@@ -3,29 +3,36 @@ package io.github.resilience4j.timelimiter;
 import io.github.resilience4j.core.ConfigurationNotFoundException;
 import io.github.resilience4j.core.EventProcessor;
 import io.github.resilience4j.core.Registry;
-import io.github.resilience4j.core.registry.*;
-import org.junit.Test;
+import io.github.resilience4j.core.registry.EntryAddedEvent;
+import io.github.resilience4j.core.registry.EntryRemovedEvent;
+import io.github.resilience4j.core.registry.EntryReplacedEvent;
+import io.github.resilience4j.core.registry.InMemoryRegistryStore;
+import io.github.resilience4j.core.registry.RegistryEventConsumer;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-
-public class TimeLimiterRegistryTest {
+class TimeLimiterRegistryTest {
 
     private static Optional<EventProcessor<?>> getEventProcessor(
         Registry.EventPublisher<TimeLimiter> eventPublisher) {
         if (eventPublisher instanceof EventProcessor<?>) {
             return Optional.of((EventProcessor<?>) eventPublisher);
         }
-
         return Optional.empty();
     }
 
     @Test
-    public void testCreateWithCustomConfig() {
+    void createWithCustomConfig() {
         TimeLimiterConfig config = TimeLimiterConfig.custom()
             .cancelRunningFuture(false)
             .timeoutDuration(Duration.ofMillis(500))
@@ -38,24 +45,24 @@ public class TimeLimiterRegistryTest {
     }
 
     @Test
-    public void shouldInitRegistryTags() {
+    void shouldInitRegistryTags() {
         TimeLimiterConfig timeLimiterConfig = TimeLimiterConfig.ofDefaults();
         Map<String, TimeLimiterConfig> timeLimiterConfigs = Collections
             .singletonMap("default", timeLimiterConfig);
-        TimeLimiterRegistry registry = TimeLimiterRegistry.of(timeLimiterConfigs, new NoOpTimeLimiterEventConsumer(), Map.of("Tag1Key","Tag1Value"));
+        TimeLimiterRegistry registry = TimeLimiterRegistry.of(timeLimiterConfigs, new NoOpTimeLimiterEventConsumer(), Map.of("Tag1Key", "Tag1Value"));
         assertThat(registry.getTags()).isNotEmpty();
-        assertThat(registry.getTags()).containsOnly(Map.entry("Tag1Key","Tag1Value"));
+        assertThat(registry.getTags()).containsOnly(Map.entry("Tag1Key", "Tag1Value"));
     }
 
     @Test
-    public void noTagsByDefault() {
+    void noTagsByDefault() {
         TimeLimiter timeLimiter = TimeLimiterRegistry.ofDefaults()
             .timeLimiter("testName");
         assertThat(timeLimiter.getTags()).isEmpty();
     }
 
     @Test
-    public void tagsOfRegistryAddedToInstance() {
+    void tagsOfRegistryAddedToInstance() {
         TimeLimiterConfig timeLimiterConfig = TimeLimiterConfig.ofDefaults();
         Map<String, TimeLimiterConfig> timeLimiterConfigs = Collections
             .singletonMap("default", timeLimiterConfig);
@@ -68,17 +75,16 @@ public class TimeLimiterRegistryTest {
     }
 
     @Test
-    public void tagsAddedToInstance() {
+    void tagsAddedToInstance() {
         TimeLimiterRegistry timeLimiterRegistry = TimeLimiterRegistry.ofDefaults();
         Map<String, String> timeLimiterTags = Map.of("key1", "value1", "key2", "value2");
-        TimeLimiter timeLimiter = timeLimiterRegistry
-            .timeLimiter("testName", timeLimiterTags);
+        TimeLimiter timeLimiter = timeLimiterRegistry.timeLimiter("testName", timeLimiterTags);
 
         assertThat(timeLimiter.getTags()).containsAllEntriesOf(timeLimiterTags);
     }
 
     @Test
-    public void tagsOfTimeLimitersShouldNotBeMixed() {
+    void tagsOfTimeLimitersShouldNotBeMixed() {
         TimeLimiterRegistry timeLimiterRegistry = TimeLimiterRegistry.ofDefaults();
         TimeLimiterConfig timeLimiterConfig = TimeLimiterConfig.ofDefaults();
         Map<String, String> timeLimiterTags = Map.of("key1", "value1", "key2", "value2");
@@ -93,7 +99,7 @@ public class TimeLimiterRegistryTest {
     }
 
     @Test
-    public void tagsOfInstanceTagsShouldOverrideRegistryTags() {
+    void tagsOfInstanceTagsShouldOverrideRegistryTags() {
         TimeLimiterConfig timeLimiterConfig = TimeLimiterConfig.ofDefaults();
         Map<String, TimeLimiterConfig> timeLimiterConfigs = Collections
             .singletonMap("default", timeLimiterConfig);
@@ -109,7 +115,7 @@ public class TimeLimiterRegistryTest {
     }
 
     @Test
-    public void testCreateWithConfigurationMap() {
+    void createWithConfigurationMap() {
         Map<String, TimeLimiterConfig> configs = new HashMap<>();
         configs.put("default", TimeLimiterConfig.ofDefaults());
         configs.put("custom", TimeLimiterConfig.ofDefaults());
@@ -121,7 +127,7 @@ public class TimeLimiterRegistryTest {
     }
 
     @Test
-    public void testCreateWithConfigurationMapWithoutDefaultConfig() {
+    void createWithConfigurationMapWithoutDefaultConfig() {
         Map<String, TimeLimiterConfig> configs = new HashMap<>();
         configs.put("custom", TimeLimiterConfig.ofDefaults());
 
@@ -132,7 +138,7 @@ public class TimeLimiterRegistryTest {
     }
 
     @Test
-    public void testCreateWithSingleRegistryEventConsumer() {
+    void createWithSingleRegistryEventConsumer() {
         TimeLimiterRegistry timeLimiterRegistry = TimeLimiterRegistry
             .of(TimeLimiterConfig.ofDefaults(), new NoOpTimeLimiterEventConsumer());
 
@@ -141,7 +147,7 @@ public class TimeLimiterRegistryTest {
     }
 
     @Test
-    public void testCreateWithMultipleRegistryEventConsumer() {
+    void createWithMultipleRegistryEventConsumer() {
         List<RegistryEventConsumer<TimeLimiter>> registryEventConsumers = new ArrayList<>();
         registryEventConsumers.add(new NoOpTimeLimiterEventConsumer());
         registryEventConsumers.add(new NoOpTimeLimiterEventConsumer());
@@ -154,7 +160,7 @@ public class TimeLimiterRegistryTest {
     }
 
     @Test
-    public void testCreateWithConfigurationMapWithSingleRegistryEventConsumer() {
+    void createWithConfigurationMapWithSingleRegistryEventConsumer() {
         Map<String, TimeLimiterConfig> configs = new HashMap<>();
         configs.put("custom", TimeLimiterConfig.ofDefaults());
 
@@ -166,7 +172,7 @@ public class TimeLimiterRegistryTest {
     }
 
     @Test
-    public void testCreateWithConfigurationMapWithMultiRegistryEventConsumer() {
+    void createWithConfigurationMapWithMultiRegistryEventConsumer() {
         Map<String, TimeLimiterConfig> configs = new HashMap<>();
         configs.put("custom", TimeLimiterConfig.ofDefaults());
 
@@ -182,7 +188,7 @@ public class TimeLimiterRegistryTest {
     }
 
     @Test
-    public void testAddConfiguration() {
+    void addConfiguration() {
         TimeLimiterRegistry timeLimiterRegistry = TimeLimiterRegistry.ofDefaults();
         timeLimiterRegistry.addConfiguration("custom", TimeLimiterConfig.custom().build());
 
@@ -191,15 +197,132 @@ public class TimeLimiterRegistryTest {
     }
 
     @Test
-    public void testWithNotExistingConfig() {
+    void withNotExistingConfig() {
         TimeLimiterRegistry timeLimiterRegistry = TimeLimiterRegistry.ofDefaults();
 
         assertThatThrownBy(() -> timeLimiterRegistry.timeLimiter("test", "doesNotExist"))
             .isInstanceOf(ConfigurationNotFoundException.class);
     }
 
-    private static class NoOpTimeLimiterEventConsumer implements
-        RegistryEventConsumer<TimeLimiter> {
+    @Test
+    void createUsingBuilderWithDefaultConfig() {
+        TimeLimiterRegistry timeLimiterRegistry =
+            TimeLimiterRegistry.custom().withTimeLimiterConfig(TimeLimiterConfig.ofDefaults()).build();
+        TimeLimiter timeLimiter = timeLimiterRegistry.timeLimiter("testName");
+        TimeLimiter timeLimiter2 = timeLimiterRegistry.timeLimiter("otherTestName");
+        assertThat(timeLimiter).isNotSameAs(timeLimiter2);
+
+        assertThat(timeLimiterRegistry.getAllTimeLimiters()).hasSize(2);
+    }
+
+    @Test
+    void createUsingBuilderWithCustomConfig() {
+        Duration durationForPeriod = Duration.ofSeconds(10);
+        TimeLimiterConfig timeLimiterConfig = TimeLimiterConfig.custom()
+            .timeoutDuration(durationForPeriod).build();
+
+        TimeLimiterRegistry timeLimiterRegistry =
+            TimeLimiterRegistry.custom().withTimeLimiterConfig(timeLimiterConfig).build();
+        TimeLimiter timeLimiter = timeLimiterRegistry.timeLimiter("testName");
+
+        assertThat(timeLimiter.getTimeLimiterConfig().getTimeoutDuration())
+            .isEqualTo(durationForPeriod);
+    }
+
+    @Test
+    void createUsingBuilderWithoutDefaultConfig() {
+        Duration durationForPeriod = Duration.ofSeconds(10);
+        TimeLimiterConfig timeLimiterConfig = TimeLimiterConfig.custom()
+            .timeoutDuration(durationForPeriod).build();
+
+        TimeLimiterRegistry timeLimiterRegistry =
+            TimeLimiterRegistry.custom().addTimeLimiterConfig("someSharedConfig", timeLimiterConfig).build();
+
+        assertThat(timeLimiterRegistry.getDefaultConfig()).isNotNull();
+        assertThat(timeLimiterRegistry.getDefaultConfig().getTimeoutDuration())
+            .isEqualTo(Duration.ofSeconds(1));
+        assertThat(timeLimiterRegistry.getConfiguration("someSharedConfig")).isPresent();
+
+        TimeLimiter timeLimiter = timeLimiterRegistry.timeLimiter("name", "someSharedConfig");
+
+        assertThat(timeLimiter.getTimeLimiterConfig()).isEqualTo(timeLimiterConfig);
+        assertThat(timeLimiter.getTimeLimiterConfig().getTimeoutDuration())
+            .isEqualTo(durationForPeriod);
+    }
+
+    @Test
+    void addMultipleDefaultConfigUsingBuilderShouldThrowException() {
+        TimeLimiterConfig timeLimiterConfig = TimeLimiterConfig.custom()
+            .timeoutDuration(Duration.ofSeconds(10)).build();
+        assertThatThrownBy(() -> TimeLimiterRegistry.custom()
+            .addTimeLimiterConfig("default", timeLimiterConfig).build())
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void createUsingBuilderWithDefaultAndCustomConfig() {
+        Duration defaultDuration = Duration.ofSeconds(10);
+        TimeLimiterConfig timeLimiterConfig = TimeLimiterConfig.custom()
+            .timeoutDuration(defaultDuration).build();
+        TimeLimiterConfig customTimeLimiterConfig = TimeLimiterConfig.custom()
+            .timeoutDuration(Duration.ofSeconds(20)).build();
+
+        TimeLimiterRegistry timeLimiterRegistry = TimeLimiterRegistry.custom()
+            .withTimeLimiterConfig(timeLimiterConfig)
+            .addTimeLimiterConfig("custom", customTimeLimiterConfig)
+            .build();
+
+        assertThat(timeLimiterRegistry.getDefaultConfig()).isNotNull();
+        assertThat(timeLimiterRegistry.getDefaultConfig().getTimeoutDuration())
+            .isEqualTo(defaultDuration);
+        assertThat(timeLimiterRegistry.getConfiguration("custom")).isPresent();
+    }
+
+    @Test
+    void createUsingBuilderWithNullConfig() {
+        assertThatThrownBy(
+            () -> TimeLimiterRegistry.custom().withTimeLimiterConfig(null).build())
+            .isInstanceOf(NullPointerException.class).hasMessage("Config must not be null");
+    }
+
+    @Test
+    void createUsingBuilderWithMultipleRegistryEventConsumer() {
+        TimeLimiterRegistry timeLimiterRegistry = TimeLimiterRegistry.custom()
+            .withTimeLimiterConfig(TimeLimiterConfig.ofDefaults())
+            .addRegistryEventConsumer(new NoOpTimeLimiterEventConsumer())
+            .addRegistryEventConsumer(new NoOpTimeLimiterEventConsumer())
+            .build();
+
+        getEventProcessor(timeLimiterRegistry.getEventPublisher())
+            .ifPresent(eventProcessor -> assertThat(eventProcessor.hasConsumers()).isTrue());
+    }
+
+    @Test
+    void createUsingBuilderWithRegistryTags() {
+        Map<String, String> timeLimiterTags = Map.of("key1", "value1", "key2", "value2");
+        TimeLimiterRegistry timeLimiterRegistry = TimeLimiterRegistry.custom()
+            .withTimeLimiterConfig(TimeLimiterConfig.ofDefaults())
+            .withTags(timeLimiterTags)
+            .build();
+        TimeLimiter timeLimiter = timeLimiterRegistry.timeLimiter("testName");
+
+        assertThat(timeLimiter.getTags()).containsAllEntriesOf(timeLimiterTags);
+    }
+
+    @Test
+    void createUsingBuilderWithRegistryStore() {
+        TimeLimiterRegistry timeLimiterRegistry = TimeLimiterRegistry.custom()
+            .withTimeLimiterConfig(TimeLimiterConfig.ofDefaults())
+            .withRegistryStore(new InMemoryRegistryStore<>())
+            .build();
+        TimeLimiter timeLimiter = timeLimiterRegistry.timeLimiter("testName");
+        TimeLimiter timeLimiter2 = timeLimiterRegistry.timeLimiter("otherTestName");
+
+        assertThat(timeLimiter).isNotSameAs(timeLimiter2);
+        assertThat(timeLimiterRegistry.getAllTimeLimiters()).hasSize(2);
+    }
+
+    private static class NoOpTimeLimiterEventConsumer implements RegistryEventConsumer<TimeLimiter> {
 
         @Override
         public void onEntryAddedEvent(EntryAddedEvent<TimeLimiter> entryAddedEvent) {
@@ -212,123 +335,5 @@ public class TimeLimiterRegistryTest {
         @Override
         public void onEntryReplacedEvent(EntryReplacedEvent<TimeLimiter> entryReplacedEvent) {
         }
-    }
-
-    @Test
-    public void testCreateUsingBuilderWithDefaultConfig() {
-        TimeLimiterRegistry timeLimiterRegistry =
-                TimeLimiterRegistry.custom().withTimeLimiterConfig(TimeLimiterConfig.ofDefaults()).build();
-        TimeLimiter timeLimiter = timeLimiterRegistry.timeLimiter("testName");
-        TimeLimiter timeLimiter2 = timeLimiterRegistry.timeLimiter("otherTestName");
-        assertThat(timeLimiter).isNotSameAs(timeLimiter2);
-
-        assertThat(timeLimiterRegistry.getAllTimeLimiters()).hasSize(2);
-    }
-
-    @Test
-    public void testCreateUsingBuilderWithCustomConfig() {
-        Duration durationForPeriod = Duration.ofSeconds(10);
-        TimeLimiterConfig timeLimiterConfig = TimeLimiterConfig.custom()
-                .timeoutDuration(durationForPeriod).build();
-
-        TimeLimiterRegistry timeLimiterRegistry =
-                TimeLimiterRegistry.custom().withTimeLimiterConfig(timeLimiterConfig).build();
-        TimeLimiter timeLimiter = timeLimiterRegistry.timeLimiter("testName");
-
-        assertThat(timeLimiter.getTimeLimiterConfig().getTimeoutDuration())
-                .isEqualTo(durationForPeriod);
-    }
-
-    @Test
-    public void testCreateUsingBuilderWithoutDefaultConfig() {
-        Duration durationForPeriod = Duration.ofSeconds(10);
-        TimeLimiterConfig timeLimiterConfig = TimeLimiterConfig.custom()
-                .timeoutDuration(durationForPeriod).build();
-
-        TimeLimiterRegistry timeLimiterRegistry =
-                TimeLimiterRegistry.custom().addTimeLimiterConfig("someSharedConfig", timeLimiterConfig).build();
-
-        assertThat(timeLimiterRegistry.getDefaultConfig()).isNotNull();
-        assertThat(timeLimiterRegistry.getDefaultConfig().getTimeoutDuration())
-                .isEqualTo(Duration.ofSeconds(1));
-        assertThat(timeLimiterRegistry.getConfiguration("someSharedConfig")).isNotEmpty();
-
-        TimeLimiter timeLimiter = timeLimiterRegistry
-                .timeLimiter("name", "someSharedConfig");
-
-        assertThat(timeLimiter.getTimeLimiterConfig()).isEqualTo(timeLimiterConfig);
-        assertThat(timeLimiter.getTimeLimiterConfig().getTimeoutDuration())
-                .isEqualTo(durationForPeriod);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testAddMultipleDefaultConfigUsingBuilderShouldThrowException() {
-        TimeLimiterConfig timeLimiterConfig = TimeLimiterConfig.custom()
-                .timeoutDuration(Duration.ofSeconds(10)).build();
-        TimeLimiterRegistry.custom().addTimeLimiterConfig("default", timeLimiterConfig).build();
-    }
-
-    @Test
-    public void testCreateUsingBuilderWithDefaultAndCustomConfig() {
-
-        Duration defaultDuration = Duration.ofSeconds(10);
-        TimeLimiterConfig timeLimiterConfig = TimeLimiterConfig.custom()
-                .timeoutDuration(defaultDuration).build();
-        TimeLimiterConfig customTimeLimiterConfig = TimeLimiterConfig.custom()
-                .timeoutDuration(Duration.ofSeconds(20)).build();
-
-        TimeLimiterRegistry timeLimiterRegistry = TimeLimiterRegistry.custom()
-                .withTimeLimiterConfig(timeLimiterConfig)
-                .addTimeLimiterConfig("custom", customTimeLimiterConfig)
-                .build();
-
-        assertThat(timeLimiterRegistry.getDefaultConfig()).isNotNull();
-        assertThat(timeLimiterRegistry.getDefaultConfig().getTimeoutDuration())
-                .isEqualTo(defaultDuration);
-        assertThat(timeLimiterRegistry.getConfiguration("custom")).isNotEmpty();
-    }
-
-    @Test
-    public void testCreateUsingBuilderWithNullConfig() {
-        assertThatThrownBy(
-                () -> TimeLimiterRegistry.custom().withTimeLimiterConfig(null).build())
-                .isInstanceOf(NullPointerException.class).hasMessage("Config must not be null");
-    }
-
-    @Test
-    public void testCreateUsingBuilderWithMultipleRegistryEventConsumer() {
-        TimeLimiterRegistry timeLimiterRegistry = TimeLimiterRegistry.custom()
-                .withTimeLimiterConfig(TimeLimiterConfig.ofDefaults())
-                .addRegistryEventConsumer(new NoOpTimeLimiterEventConsumer())
-                .addRegistryEventConsumer(new NoOpTimeLimiterEventConsumer())
-                .build();
-
-        getEventProcessor(timeLimiterRegistry.getEventPublisher())
-                .ifPresent(eventProcessor -> assertThat(eventProcessor.hasConsumers()).isTrue());
-    }
-
-    @Test
-    public void testCreateUsingBuilderWithRegistryTags() {
-        Map<String, String> timeLimiterTags = Map.of("key1", "value1", "key2", "value2");
-        TimeLimiterRegistry timeLimiterRegistry = TimeLimiterRegistry.custom()
-                .withTimeLimiterConfig(TimeLimiterConfig.ofDefaults())
-                .withTags(timeLimiterTags)
-                .build();
-        TimeLimiter timeLimiter = timeLimiterRegistry.timeLimiter("testName");
-
-        assertThat(timeLimiter.getTags()).containsAllEntriesOf(timeLimiterTags);
-    }
-
-    @Test
-    public void testCreateUsingBuilderWithRegistryStore() {
-        TimeLimiterRegistry timeLimiterRegistry = TimeLimiterRegistry.custom()
-                .withTimeLimiterConfig(TimeLimiterConfig.ofDefaults())
-                .withRegistryStore(new InMemoryRegistryStore<>())
-                .build();
-        TimeLimiter timeLimiter = timeLimiterRegistry.timeLimiter("testName");
-        TimeLimiter timeLimiter2 = timeLimiterRegistry.timeLimiter("otherTestName");
-
-        assertThat(timeLimiter).isNotSameAs(timeLimiter2);
-        assertThat(timeLimiterRegistry.getAllTimeLimiters()).hasSize(2);
     }
 }

--- a/resilience4j-timelimiter/src/test/java/io/github/resilience4j/timelimiter/internal/InMemoryTimeLimiterRegistryTest.java
+++ b/resilience4j-timelimiter/src/test/java/io/github/resilience4j/timelimiter/internal/InMemoryTimeLimiterRegistryTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2019 authors
+ *  Copyright 2026 authors
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -21,32 +21,31 @@ package io.github.resilience4j.timelimiter.internal;
 import io.github.resilience4j.timelimiter.TimeLimiter;
 import io.github.resilience4j.timelimiter.TimeLimiterConfig;
 import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Supplier;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
-public class InMemoryTimeLimiterRegistryTest {
+class InMemoryTimeLimiterRegistryTest {
 
     private static final String CONFIG_MUST_NOT_BE_NULL = "Config must not be null";
     private static final String NAME_MUST_NOT_BE_NULL = "Name must not be null";
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
     private TimeLimiterConfig config;
 
-    @Before
-    public void init() {
+    @BeforeEach
+    void init() {
         config = TimeLimiterConfig.ofDefaults();
     }
 
     @Test
-    public void timeLimiterPositive() {
+    void timeLimiterPositive() {
         TimeLimiterRegistry registry = TimeLimiterRegistry.of(config);
 
         TimeLimiter firstTimeLimiter = registry.timeLimiter("test");
@@ -59,15 +58,15 @@ public class InMemoryTimeLimiterRegistryTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void timeLimiterPositiveWithSupplier() {
+    void timeLimiterPositiveWithSupplier() {
         TimeLimiterRegistry registry = new InMemoryTimeLimiterRegistry(config);
         Supplier<TimeLimiterConfig> timeLimiterConfigSupplier = mock(Supplier.class);
         given(timeLimiterConfigSupplier.get()).willReturn(config);
 
         TimeLimiter firstTimeLimiter = registry.timeLimiter("test", timeLimiterConfigSupplier);
-        verify(timeLimiterConfigSupplier, times(1)).get();
+        verify(timeLimiterConfigSupplier).get();
         TimeLimiter sameAsFirst = registry.timeLimiter("test", timeLimiterConfigSupplier);
-        verify(timeLimiterConfigSupplier, times(1)).get();
+        verify(timeLimiterConfigSupplier).get();
         TimeLimiter anotherLimit = registry.timeLimiter("test1", timeLimiterConfigSupplier);
         verify(timeLimiterConfigSupplier, times(2)).get();
 
@@ -76,66 +75,59 @@ public class InMemoryTimeLimiterRegistryTest {
     }
 
     @Test
-    public void timeLimiterConfigIsNull() {
-        exception.expect(NullPointerException.class);
-        exception.expectMessage(CONFIG_MUST_NOT_BE_NULL);
-
-        new InMemoryTimeLimiterRegistry((TimeLimiterConfig) null);
+    void timeLimiterConfigIsNull() {
+        assertThatThrownBy(() -> new InMemoryTimeLimiterRegistry((TimeLimiterConfig) null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage(CONFIG_MUST_NOT_BE_NULL);
     }
 
     @Test
-    public void timeLimiterNewWithNullName() {
-        exception.expect(NullPointerException.class);
-        exception.expectMessage(NAME_MUST_NOT_BE_NULL);
+    void timeLimiterNewWithNullName() {
         TimeLimiterRegistry registry = new InMemoryTimeLimiterRegistry(config);
-
-        registry.timeLimiter(null);
+        assertThatThrownBy(() -> registry.timeLimiter(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage(NAME_MUST_NOT_BE_NULL);
     }
 
     @Test
-    public void timeLimiterNewWithNullNonDefaultConfig() {
-        exception.expect(NullPointerException.class);
-        exception.expectMessage(CONFIG_MUST_NOT_BE_NULL);
+    void timeLimiterNewWithNullNonDefaultConfig() {
         TimeLimiterRegistry registry = new InMemoryTimeLimiterRegistry(config);
-
-        registry.timeLimiter("name", (TimeLimiterConfig) null);
+        assertThatThrownBy(() -> registry.timeLimiter("name", (TimeLimiterConfig) null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage(CONFIG_MUST_NOT_BE_NULL);
     }
 
     @Test
-    public void timeLimiterNewWithNullNameAndNonDefaultConfig() {
-        exception.expect(NullPointerException.class);
-        exception.expectMessage(NAME_MUST_NOT_BE_NULL);
+    void timeLimiterNewWithNullNameAndNonDefaultConfig() {
         TimeLimiterRegistry registry = new InMemoryTimeLimiterRegistry(config);
-
-        registry.timeLimiter(null, config);
+        assertThatThrownBy(() -> registry.timeLimiter(null, config))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage(NAME_MUST_NOT_BE_NULL);
     }
 
     @Test
-    public void timeLimiterNewWithNullNameAndConfigSupplier() {
-        exception.expect(NullPointerException.class);
-        exception.expectMessage(NAME_MUST_NOT_BE_NULL);
+    void timeLimiterNewWithNullNameAndConfigSupplier() {
         TimeLimiterRegistry registry = new InMemoryTimeLimiterRegistry(config);
-
-        registry.timeLimiter(null, () -> config);
+        assertThatThrownBy(() -> registry.timeLimiter(null, () -> config))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage(NAME_MUST_NOT_BE_NULL);
     }
 
     @Test
-    public void timeLimiterNewWithNullConfigSupplier() {
-        exception.expect(NullPointerException.class);
-        exception.expectMessage("Supplier must not be null");
+    void timeLimiterNewWithNullConfigSupplier() {
         TimeLimiterRegistry registry = new InMemoryTimeLimiterRegistry(config);
-
-        registry.timeLimiter("name", (Supplier<TimeLimiterConfig>) null);
+        assertThatThrownBy(() -> registry.timeLimiter("name", (Supplier<TimeLimiterConfig>) null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("Supplier must not be null");
     }
 
     @Test
-    public void timeLimiterGetAllTimeLimiters() {
+    void timeLimiterGetAllTimeLimiters() {
         TimeLimiterRegistry registry = new InMemoryTimeLimiterRegistry(config);
 
         final TimeLimiter timeLimiter = registry.timeLimiter("foo");
 
-        then(registry.getAllTimeLimiters().size()).isEqualTo(1);
+        then(registry.getAllTimeLimiters()).hasSize(1);
         then(registry.getAllTimeLimiters()).contains(timeLimiter);
     }
-
 }

--- a/resilience4j-timelimiter/src/test/java/io/github/resilience4j/timelimiter/internal/TimeLimiterImplTest.java
+++ b/resilience4j-timelimiter/src/test/java/io/github/resilience4j/timelimiter/internal/TimeLimiterImplTest.java
@@ -2,25 +2,22 @@ package io.github.resilience4j.timelimiter.internal;
 
 import io.github.resilience4j.timelimiter.TimeLimiter;
 import io.github.resilience4j.timelimiter.TimeLimiterConfig;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.mockito.Mockito.spy;
 
-@RunWith(MockitoJUnitRunner.class)
-public class TimeLimiterImplTest {
+class TimeLimiterImplTest {
 
     private static final String NAME = "name";
     private TimeLimiterConfig timeLimiterConfig;
     private TimeLimiter timeLimiter;
 
-    @Before
-    public void init() {
+    @BeforeEach
+    void init() {
         timeLimiterConfig = TimeLimiterConfig.custom()
             .timeoutDuration(Duration.ZERO)
             .build();
@@ -29,12 +26,12 @@ public class TimeLimiterImplTest {
     }
 
     @Test
-    public void configPropagation() {
+    void configPropagation() {
         then(timeLimiter.getTimeLimiterConfig()).isEqualTo(timeLimiterConfig);
     }
 
     @Test
-    public void namePropagation() {
+    void namePropagation() {
         then(timeLimiter.getName()).isEqualTo(NAME);
     }
 }

--- a/resilience4j-timelimiter/src/test/java/io/github/resilience4j/timelimiter/internal/TimeLimiterTest.java
+++ b/resilience4j-timelimiter/src/test/java/io/github/resilience4j/timelimiter/internal/TimeLimiterTest.java
@@ -1,64 +1,69 @@
+/*
+ *
+ * Copyright 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *
+ */
 package io.github.resilience4j.timelimiter.internal;
 
 import io.github.resilience4j.core.ExecutorServiceFactory;
-import io.github.resilience4j.core.ThreadModeTestBase;
+import io.github.resilience4j.core.ThreadModeExtension;
 import io.github.resilience4j.core.ThreadType;
 import io.github.resilience4j.timelimiter.TimeLimiter;
 import io.github.resilience4j.timelimiter.TimeLimiterConfig;
-import io.vavr.control.Try;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.Duration;
-import java.util.Collection;
-import java.util.concurrent.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 
-@RunWith(Parameterized.class)
-public class TimeLimiterTest extends ThreadModeTestBase {
+class TimeLimiterTest {
 
     private static final String TIME_LIMITER_NAME = "TestTimeLimiter";
     private static final Duration TIMEOUT = Duration.ofMillis(1000);
+
     private ScheduledExecutorService scheduler;
 
-    public TimeLimiterTest(ThreadType threadType) {
-        super(threadType);
-    }
-
-    @Parameterized.Parameters(name = "{0} thread mode")
-    public static Collection<Object[]> threadModes() {
-        return ThreadModeTestBase.threadModes();
-    }
-
-    @Before
-    public void setUp() {
-        // Reset the scheduler for each test (ThreadModeTestBase handles thread mode setup)
-        if (scheduler != null) {
-            scheduler.shutdownNow();
-        }
-    }
-
-    @After
-    public void tearDown() {
-        // Clean up scheduler (ThreadModeTestBase handles thread mode cleanup)
+    @AfterEach
+    void tearDown() {
         if (scheduler != null) {
             scheduler.shutdownNow();
         }
     }
 
     @Test
-    public void shouldReturnCorrectTimeoutDuration() {
+    void shouldReturnCorrectTimeoutDuration() {
         Duration timeoutDuration = Duration.ofSeconds(1);
         TimeLimiter timeLimiter = TimeLimiter.of(timeoutDuration);
         assertThat(timeLimiter).isNotNull();
@@ -67,12 +72,12 @@ public class TimeLimiterTest extends ThreadModeTestBase {
     }
 
     @Test
-    public void shouldThrowTimeoutExceptionAndInvokeCancel() throws Exception {
+    void shouldThrowTimeoutExceptionAndInvokeCancel() throws Exception {
         Duration timeoutDuration = Duration.ofSeconds(1);
         TimeLimiterConfig timeLimiterConfig = TimeLimiterConfig.custom()
             .timeoutDuration(timeoutDuration)
             .build();
-        TimeLimiter timeLimiter = TimeLimiter.of(TIME_LIMITER_NAME,timeLimiterConfig);
+        TimeLimiter timeLimiter = TimeLimiter.of(TIME_LIMITER_NAME, timeLimiterConfig);
 
         @SuppressWarnings("unchecked")
         Future<Integer> mockFuture = (Future<Integer>) mock(Future.class);
@@ -82,24 +87,22 @@ public class TimeLimiterTest extends ThreadModeTestBase {
             .willThrow(new TimeoutException());
 
         Callable<Integer> decorated = TimeLimiter.decorateFutureSupplier(timeLimiter, supplier);
-        Try<Integer> decoratedResult = Try.ofCallable(decorated);
 
-        assertThat(decoratedResult.isFailure()).isTrue();
-        assertThat(decoratedResult.getCause()).isInstanceOf(TimeoutException.class);
-        assertThat(decoratedResult.getCause()).hasMessage(TimeLimiter.createdTimeoutExceptionWithName(TIME_LIMITER_NAME, null).getMessage());
+        assertThatThrownBy(decorated::call)
+            .isInstanceOf(TimeoutException.class)
+            .hasMessage(TimeLimiter.createdTimeoutExceptionWithName(TIME_LIMITER_NAME, null).getMessage());
 
         then(mockFuture).should().cancel(true);
     }
 
     @Test
-    public void shouldThrowTimeoutExceptionWithCompletionStage() throws Exception {
+    void shouldThrowTimeoutExceptionWithCompletionStage() throws Exception {
         Duration timeoutDuration = Duration.ofMillis(300);
         TimeLimiter timeLimiter = TimeLimiter.of(timeoutDuration);
-        scheduler = ExecutorServiceFactory.newSingleThreadScheduledExecutor("timeout-test-" + threadType);
+        scheduler = Executors.newScheduledThreadPool(1);
 
         Supplier<CompletionStage<Integer>> supplier = () -> CompletableFuture.supplyAsync(() -> {
             try {
-                // sleep for timeout.
                 Thread.sleep(500);
             } catch (InterruptedException e) {
                 // nothing
@@ -109,14 +112,14 @@ public class TimeLimiterTest extends ThreadModeTestBase {
 
         CompletionStage<Integer> decorated = TimeLimiter
             .decorateCompletionStage(timeLimiter, scheduler, supplier).get();
-        Try<Integer> decoratedResult = Try.ofCallable(() -> decorated.toCompletableFuture().get());
-        assertThat(decoratedResult.isFailure()).isTrue();
-        assertThat(decoratedResult.getCause()).isInstanceOf(ExecutionException.class)
+
+        assertThatThrownBy(() -> decorated.toCompletableFuture().get())
+            .isInstanceOf(ExecutionException.class)
             .hasCauseExactlyInstanceOf(TimeoutException.class);
     }
 
     @Test
-    public void shouldThrowTimeoutExceptionAndNotInvokeCancel() throws Exception {
+    void shouldThrowTimeoutExceptionAndNotInvokeCancel() throws Exception {
         Duration timeoutDuration = Duration.ofSeconds(1);
         TimeLimiter timeLimiter = TimeLimiter
             .of(TimeLimiterConfig.custom().timeoutDuration(timeoutDuration)
@@ -130,16 +133,15 @@ public class TimeLimiterTest extends ThreadModeTestBase {
             .willThrow(new TimeoutException());
 
         Callable<Integer> decorated = TimeLimiter.decorateFutureSupplier(timeLimiter, supplier);
-        Try<Integer> decoratedResult = Try.ofCallable(decorated);
 
-        assertThat(decoratedResult.isFailure()).isTrue();
-        assertThat(decoratedResult.getCause()).isInstanceOf(TimeoutException.class);
+        assertThatThrownBy(decorated::call)
+            .isInstanceOf(TimeoutException.class);
 
         then(mockFuture).should(never()).cancel(true);
     }
 
     @Test
-    public void shouldReturnResult() throws Exception {
+    void shouldReturnResult() throws Exception {
         Duration timeoutDuration = Duration.ofSeconds(1);
         TimeLimiter timeLimiter = TimeLimiter.of(timeoutDuration);
 
@@ -157,14 +159,13 @@ public class TimeLimiterTest extends ThreadModeTestBase {
     }
 
     @Test
-    public void shouldReturnResultWithCompletionStage() throws Exception {
+    void shouldReturnResultWithCompletionStage() throws Exception {
         Duration timeoutDuration = Duration.ofSeconds(1);
         TimeLimiter timeLimiter = TimeLimiter.of(timeoutDuration);
-        scheduler = ExecutorServiceFactory.newSingleThreadScheduledExecutor("result-test-" + threadType);
+        scheduler = Executors.newScheduledThreadPool(1);
 
         Supplier<CompletionStage<Integer>> supplier = () -> CompletableFuture.supplyAsync(() -> {
             try {
-                // sleep but not timeout.
                 Thread.sleep(500);
             } catch (InterruptedException e) {
                 // nothing
@@ -182,7 +183,7 @@ public class TimeLimiterTest extends ThreadModeTestBase {
     }
 
     @Test
-    public void unwrapExecutionException() {
+    void unwrapExecutionException() {
         TimeLimiter timeLimiter = TimeLimiter.ofDefaults();
         ExecutorService executorService = Executors.newSingleThreadExecutor();
 
@@ -191,41 +192,36 @@ public class TimeLimiterTest extends ThreadModeTestBase {
         });
         Callable<Integer> decorated = TimeLimiter.decorateFutureSupplier(timeLimiter, supplier);
 
-        Try<Integer> decoratedResult = Try.ofCallable(decorated);
-
-        assertThat(decoratedResult.getCause() instanceof RuntimeException).isTrue();
+        assertThatThrownBy(decorated::call)
+            .isInstanceOf(RuntimeException.class);
     }
 
     @Test
-    public void shouldSetGivenName() {
+    void shouldSetGivenName() {
         TimeLimiter timeLimiter = TimeLimiter.ofDefaults("TEST");
         assertThat(timeLimiter.getName()).isEqualTo("TEST");
     }
 
-    @Test
-    public void shouldUseCorrectThreadTypeForScheduler() throws Exception {
-        // Create scheduler via ExecutorServiceFactory which should respect thread mode
+    @TestTemplate
+    @ExtendWith(ThreadModeExtension.class)
+    void shouldUseCorrectThreadTypeForScheduler(ThreadType threadType) throws Exception {
+        boolean isVirtual = threadType == ThreadType.VIRTUAL;
         scheduler = ExecutorServiceFactory.newSingleThreadScheduledExecutor("timelimiter-test-" + threadType);
 
-        // Create TimeLimiter
         TimeLimiter timeLimiter = TimeLimiter.of(TimeLimiterConfig.custom()
             .timeoutDuration(TIMEOUT)
             .build());
 
-        // Setup a task to check if it's running on the expected thread type
         AtomicBoolean ranOnExpectedThreadType = new AtomicBoolean(false);
-
-        // Create executor that creates threads matching our expected mode
-        ExecutorService taskExecutor = isVirtualThreadMode() ?
+        ExecutorService taskExecutor = isVirtual ?
             Executors.newVirtualThreadPerTaskExecutor() :
             Executors.newSingleThreadExecutor();
 
         try {
             CompletableFuture<Boolean> future = CompletableFuture.supplyAsync(() -> {
                 try {
-                    // Simulate some work
                     Thread.sleep(50);
-                    boolean expectedThreadType = isVirtualThreadMode() ?
+                    boolean expectedThreadType = isVirtual ?
                         Thread.currentThread().isVirtual() :
                         !Thread.currentThread().isVirtual();
                     ranOnExpectedThreadType.set(expectedThreadType);
@@ -235,32 +231,24 @@ public class TimeLimiterTest extends ThreadModeTestBase {
                 }
             }, taskExecutor);
 
-            // Decorate with TimeLimiter
             Supplier<CompletionStage<Boolean>> decoratedSupplier = timeLimiter.decorateCompletionStage(
                 scheduler, () -> future);
 
-            // Execute and get result
             Boolean result = decoratedSupplier.get().toCompletableFuture().get(2, TimeUnit.SECONDS);
-
-            // Verify execution was successful
             assertThat(result).isTrue();
 
-            // Verify that the timeout handling uses the expected thread type
             CompletableFuture<Boolean> threadTypeFuture = new CompletableFuture<>();
             scheduler.execute(() -> {
-                boolean isExpectedType = isVirtualThreadMode() ?
+                boolean isExpectedType = isVirtual ?
                     Thread.currentThread().isVirtual() :
                     !Thread.currentThread().isVirtual();
                 threadTypeFuture.complete(isExpectedType);
             });
 
-            // Verify the scheduler used the expected thread type
             Boolean usedExpectedThreadType = threadTypeFuture.get(1, TimeUnit.SECONDS);
             assertThat(usedExpectedThreadType)
                 .as("TimeLimiter's scheduler should use " + threadType + " threads")
                 .isTrue();
-
-            // Also verify our test ran on the expected thread type
             assertThat(ranOnExpectedThreadType.get())
                 .as("CompletableFuture execution should run on " + threadType + " thread")
                 .isTrue();
@@ -269,60 +257,44 @@ public class TimeLimiterTest extends ThreadModeTestBase {
         }
     }
 
-    @Test
-    public void shouldTimeoutAndCancelOnCorrectThreadType() throws Exception {
-        // Create a CountDownLatch to track if our task was interrupted
+    @TestTemplate
+    @ExtendWith(ThreadModeExtension.class)
+    void shouldTimeoutAndCancelOnCorrectThreadType(ThreadType threadType) throws Exception {
+        boolean isVirtual = threadType == ThreadType.VIRTUAL;
         CountDownLatch interruptedLatch = new CountDownLatch(1);
 
-        // Create executor service for the test
-        ExecutorService executor = isVirtualThreadMode() ?
+        ExecutorService executor = isVirtual ?
             Executors.newVirtualThreadPerTaskExecutor() :
             Executors.newSingleThreadExecutor();
 
         try {
-            // Create TimeLimiter with short timeout
             TimeLimiter timeLimiter = TimeLimiter.of(TimeLimiterConfig.custom()
                 .timeoutDuration(Duration.ofMillis(50))
                 .cancelRunningFuture(true)
                 .build());
 
-            // Create a blocking callable that will run longer than our timeout
             Callable<String> longRunningTask = () -> {
                 try {
-                    Thread.sleep(10000); // Sleep for 10 seconds
+                    Thread.sleep(10000);
                     return "Task completed";
                 } catch (InterruptedException e) {
-                    interruptedLatch.countDown(); // Signal that we were interrupted
-                    throw e; // Rethrow to properly handle interruption
+                    interruptedLatch.countDown();
+                    throw e;
                 }
             };
 
-            // Submit the callable to get a cancellable future
             Future<String> future = executor.submit(longRunningTask);
 
-            // Now use the TimeLimiter directly on this Future
-            try {
-                // This should timeout and cancel the future
-                timeLimiter.decorateFutureSupplier(() -> future).call();
+            assertThatThrownBy(() -> timeLimiter.decorateFutureSupplier(() -> future).call())
+                .isInstanceOf(TimeoutException.class);
 
-                // Should not reach here
-                fail("Expected timeout exception");
-            } catch (TimeoutException e) {
-                // Expected - timeout occurred
-
-                // Wait for the interruption to propagate
-                boolean wasInterrupted = interruptedLatch.await(500, TimeUnit.MILLISECONDS);
-
-                // Verify the task was interrupted
-                assertThat(wasInterrupted)
-                    .as("Task should have been interrupted due to cancellation")
-                    .isTrue();
-
-                // Also verify the future was cancelled
-                assertThat(future.isCancelled())
-                    .as("Future should have been cancelled")
-                    .isTrue();
-            }
+            boolean wasInterrupted = interruptedLatch.await(500, TimeUnit.MILLISECONDS);
+            assertThat(wasInterrupted)
+                .as("Task should have been interrupted due to cancellation")
+                .isTrue();
+            assertThat(future.isCancelled())
+                .as("Future should have been cancelled")
+                .isTrue();
         } finally {
             executor.shutdownNow();
         }


### PR DESCRIPTION
## Changes

* Migrated JUnit 4.13 annotations to Junit Jupiter equivalents
* Migrated `ThreadModeTestBase` parameterized tests to `@TestTemplate` + `@ExtendWith(ThreadModeExtension.class)`
* Replaced `@Rule ExpectedException` with `assertThatThrownBy`
* Converted `@Test(expected=...)` to `assertThatThrownBy`
* Removed unnecessary vavr usages
* Applied OpenRewrite recipes
    * [JUnit 6 best practices](https://docs.openrewrite.org/recipes/java/testing/junit/junit6bestpractices)
    * [Mockito best practices](https://docs.openrewrite.org/recipes/java/testing/mockito/mockitobestpractices)
    * [Migrate JUnit asserts to AssertJ](https://docs.openrewrite.org/recipes/java/testing/assertj/junittoassertj)
    * [AssertJ best practices](https://docs.openrewrite.org/recipes/java/testing/assertj/assertj-best-practices)
* Removed `public` modifiers
* Updated Copyright to 2026

## Coverage

| Metric      | Before | After |
|-------------|--------|-------|
| Instruction | 92.1%  | 92.1% |
| Line        | 90.2%  | 90.2% |
| Branch      | 73.5%  | 73.5% |

## Test runtime

> [!NOTE]
> Test count decreased because vavr-based `Try.ofCallable` usages were replaced with direct assertions, removing some redundant test paths.

| Metric | Before | After |
|--------|--------|-------|
| Tests  | 64     | 56    |
| Time   | 4.1s   | 3.1s  |
