### PR TITLE
resilience4j-vavr: JUnit 4 → JUnit 6 migration

### DIFF
--- a/resilience4j-vavr/build.gradle
+++ b/resilience4j-vavr/build.gradle
@@ -8,9 +8,6 @@ dependencies {
     implementation(project(":resilience4j-ratelimiter"))
     implementation(project(":resilience4j-retry"))
 
-    testRuntimeOnly(libs.junit.vintage.engine)
-
-    testImplementation(libs.junit)
     testImplementation(project(":resilience4j-test"))
     testImplementation(libs.metrics.core)
 }

--- a/resilience4j-vavr/src/test/java/io/github/resilience4j/bulkhead/VavrBulkheadTest.java
+++ b/resilience4j-vavr/src/test/java/io/github/resilience4j/bulkhead/VavrBulkheadTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2020: KrnSaurabh
+ *  Copyright 2026: KrnSaurabh
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -26,20 +26,20 @@ import io.vavr.CheckedFunction1;
 import io.vavr.CheckedRunnable;
 import io.vavr.control.Either;
 import io.vavr.control.Try;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.*;
 
-public class VavrBulkheadTest {
+class VavrBulkheadTest {
     private HelloWorldService helloWorldService;
     private BulkheadConfig config;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         helloWorldService = mock(HelloWorldService.class);
         config = BulkheadConfig.custom()
             .maxConcurrentCalls(1)
@@ -47,7 +47,7 @@ public class VavrBulkheadTest {
     }
 
     @Test
-    public void shouldDecorateCheckedSupplierAndReturnWithSuccess() throws Throwable {
+    void shouldDecorateCheckedSupplierAndReturnWithSuccess() throws Throwable {
         Bulkhead bulkhead = Bulkhead.of("test", config);
         given(helloWorldService.returnHelloWorldWithException()).willReturn("Hello world");
         CheckedFunction0<String> checkedSupplier = VavrBulkhead
@@ -61,7 +61,7 @@ public class VavrBulkheadTest {
     }
 
     @Test
-    public void shouldDecorateCheckedSupplierAndReturnWithException() throws Throwable {
+    void shouldDecorateCheckedSupplierAndReturnWithException() throws Throwable {
         Bulkhead bulkhead = Bulkhead.of("test", config);
         given(helloWorldService.returnHelloWorldWithException())
             .willThrow(new RuntimeException("BAM!"));
@@ -77,7 +77,7 @@ public class VavrBulkheadTest {
     }
 
     @Test
-    public void shouldDecorateCheckedRunnableAndReturnWithSuccess() throws Throwable {
+    void shouldDecorateCheckedRunnableAndReturnWithSuccess() throws Throwable {
         Bulkhead bulkhead = Bulkhead.of("test", config);
 
         VavrBulkhead.decorateCheckedRunnable(bulkhead, helloWorldService::sayHelloWorldWithException)
@@ -88,7 +88,7 @@ public class VavrBulkheadTest {
     }
 
     @Test
-    public void shouldDecorateCheckedRunnableAndReturnWithException() {
+    void shouldDecorateCheckedRunnableAndReturnWithException() {
         Bulkhead bulkhead = Bulkhead.of("test", config);
         CheckedRunnable checkedRunnable = VavrBulkhead.decorateCheckedRunnable(bulkhead, () -> {
             throw new RuntimeException("BAM!");
@@ -102,7 +102,7 @@ public class VavrBulkheadTest {
     }
 
     @Test
-    public void shouldDecorateCheckedConsumerAndReturnWithSuccess() throws Throwable {
+    void shouldDecorateCheckedConsumerAndReturnWithSuccess() throws Throwable {
         Bulkhead bulkhead = Bulkhead.of("test", config);
 
         VavrBulkhead.decorateCheckedConsumer(bulkhead,
@@ -114,7 +114,7 @@ public class VavrBulkheadTest {
     }
 
     @Test
-    public void shouldDecorateCheckedConsumerAndReturnWithException() throws Throwable {
+    void shouldDecorateCheckedConsumerAndReturnWithException() throws Throwable {
         Bulkhead bulkhead = Bulkhead.of("test", config);
         CheckedConsumer<String> checkedConsumer = VavrBulkhead
             .decorateCheckedConsumer(bulkhead, (value) -> {
@@ -129,7 +129,7 @@ public class VavrBulkheadTest {
     }
 
     @Test
-    public void shouldDecorateCheckedFunctionAndReturnWithSuccess() throws Throwable {
+    void shouldDecorateCheckedFunctionAndReturnWithSuccess() throws Throwable {
         Bulkhead bulkhead = Bulkhead.of("test", config);
         given(helloWorldService.returnHelloWorldWithNameWithException("Tom"))
             .willReturn("Hello world Tom");
@@ -145,7 +145,7 @@ public class VavrBulkheadTest {
     }
 
     @Test
-    public void shouldDecorateCheckedFunctionAndReturnWithException() throws Throwable {
+    void shouldDecorateCheckedFunctionAndReturnWithException() throws Throwable {
         Bulkhead bulkhead = Bulkhead.of("test", config);
         given(helloWorldService.returnHelloWorldWithNameWithException("Tom"))
             .willThrow(new RuntimeException("BAM!"));
@@ -161,7 +161,7 @@ public class VavrBulkheadTest {
     }
 
     @Test
-    public void shouldReturnFailureWithBulkheadFullException() {
+    void shouldReturnFailureWithBulkheadFullException() {
         // tag::bulkheadFullException[]
         BulkheadConfig config = BulkheadConfig.custom().maxConcurrentCalls(2).build();
         Bulkhead bulkhead = Bulkhead.of("test", config);
@@ -179,7 +179,7 @@ public class VavrBulkheadTest {
     }
 
     @Test
-    public void shouldReturnFailureWithRuntimeException() {
+    void shouldReturnFailureWithRuntimeException() {
         BulkheadConfig config = BulkheadConfig.custom().maxConcurrentCalls(2).build();
         Bulkhead bulkhead = Bulkhead.of("test", config);
         bulkhead.tryAcquirePermission();
@@ -195,7 +195,7 @@ public class VavrBulkheadTest {
     }
 
     @Test
-    public void shouldChainDecoratedFunctions() {
+    void shouldChainDecoratedFunctions() {
         // tag::shouldChainDecoratedFunctions[]
         Bulkhead bulkhead = Bulkhead.of("test", config);
         Bulkhead anotherBulkhead = Bulkhead.of("testAnother", config);
@@ -217,7 +217,7 @@ public class VavrBulkheadTest {
     }
 
     @Test
-    public void shouldInvokeMap() {
+    void shouldInvokeMap() {
         // tag::shouldInvokeMap[]
         Bulkhead bulkhead = Bulkhead.of("testName", config);
         // When I decorate my function
@@ -236,7 +236,7 @@ public class VavrBulkheadTest {
     }
 
     @Test
-    public void shouldDecorateTrySupplierAndReturnWithSuccess() {
+    void shouldDecorateTrySupplierAndReturnWithSuccess() {
         Bulkhead bulkhead = Bulkhead.of("test", config);
         given(helloWorldService.returnTry()).willReturn(Try.success("Hello world"));
 
@@ -248,7 +248,7 @@ public class VavrBulkheadTest {
     }
 
     @Test
-    public void shouldDecorateTrySupplierAndReturnWithException() {
+    void shouldDecorateTrySupplierAndReturnWithException() {
         Bulkhead bulkhead = Bulkhead.of("test", config);
         given(helloWorldService.returnTry()).willReturn(Try.failure(new RuntimeException("BAM!")));
 
@@ -261,7 +261,7 @@ public class VavrBulkheadTest {
     }
 
     @Test
-    public void shouldDecorateEitherSupplierAndReturnWithSuccess() {
+    void shouldDecorateEitherSupplierAndReturnWithSuccess() {
         Bulkhead bulkhead = Bulkhead.of("test", config);
         given(helloWorldService.returnEither()).willReturn(Either.right("Hello world"));
 
@@ -274,7 +274,7 @@ public class VavrBulkheadTest {
     }
 
     @Test
-    public void shouldDecorateEitherSupplierAndReturnWithException() {
+    void shouldDecorateEitherSupplierAndReturnWithException() {
         Bulkhead bulkhead = Bulkhead.of("test", config);
         given(helloWorldService.returnEither()).willReturn(Either.left(new HelloWorldException()));
 
@@ -288,7 +288,7 @@ public class VavrBulkheadTest {
     }
 
     @Test
-    public void shouldDecorateTrySupplierAndReturnWithBulkheadFullException() {
+    void shouldDecorateTrySupplierAndReturnWithBulkheadFullException() {
         Bulkhead bulkhead = mock(Bulkhead.class, RETURNS_DEEP_STUBS);
         given(bulkhead.tryAcquirePermission()).willReturn(false);
 
@@ -301,7 +301,7 @@ public class VavrBulkheadTest {
     }
 
     @Test
-    public void shouldDecorateEitherSupplierAndReturnWithBulkheadFullException() {
+    void shouldDecorateEitherSupplierAndReturnWithBulkheadFullException() {
         Bulkhead bulkhead = mock(Bulkhead.class, RETURNS_DEEP_STUBS);
         given(bulkhead.tryAcquirePermission()).willReturn(false);
 

--- a/resilience4j-vavr/src/test/java/io/github/resilience4j/cache/VavrCacheTest.java
+++ b/resilience4j-vavr/src/test/java/io/github/resilience4j/cache/VavrCacheTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2020: KrnSaurabh
+ *  Copyright 2026: KrnSaurabh
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@
 package io.github.resilience4j.cache;
 
 import io.vavr.CheckedFunction1;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -31,17 +31,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.mock;
 
-public class VavrCacheTest {
+class VavrCacheTest {
     private javax.cache.Cache<String, String> cache;
 
     @SuppressWarnings("unchecked")
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         cache = mock(javax.cache.Cache.class);
     }
 
     @Test
-    public void shouldReturnValueFromDecoratedCheckedSupplier() throws Throwable {
+    void shouldReturnValueFromDecoratedCheckedSupplier() throws Throwable {
         given(cache.get("testKey")).willReturn(null);
         given(cache.invoke(eq("testKey"), any())).willAnswer(new CacheInvokeAnswer());
         Cache<String, String> cacheContext = Cache.of(cache);
@@ -56,7 +56,7 @@ public class VavrCacheTest {
     }
 
     @Test
-    public void shouldReturnValueFromDecoratedCallable() throws Throwable {
+    void shouldReturnValueFromDecoratedCallable() throws Throwable {
         given(cache.get("testKey")).willReturn(null);
         given(cache.invoke(eq("testKey"), any())).willAnswer(new CacheInvokeAnswer());
         Cache<String, String> cacheContext = Cache.of(cache);
@@ -71,7 +71,7 @@ public class VavrCacheTest {
     }
 
     @Test
-    public void shouldReturnValueOfSupplier() throws Throwable {
+    void shouldReturnValueOfSupplier() throws Throwable {
         given(cache.get("testKey")).willReturn(null);
         given(cache.invoke(eq("testKey"), any())).willThrow(new RuntimeException("Also not available"));
         Cache<String, String> cacheContext = Cache.of(cache);
@@ -86,7 +86,7 @@ public class VavrCacheTest {
     }
 
     @Test
-    public void shouldReturnCachedValue() throws Throwable {
+    void shouldReturnCachedValue() throws Throwable {
         given(cache.get("testKey")).willReturn("Hello from cache");
         Cache<String, String> cacheContext = Cache.of(cache);
         CheckedFunction1<String, String> cachedFunction = VavrCache
@@ -100,7 +100,7 @@ public class VavrCacheTest {
     }
 
     @Test
-    public void shouldReturnValueFromDecoratedCallableBecauseOfException() throws Throwable {
+    void shouldReturnValueFromDecoratedCallableBecauseOfException() throws Throwable {
         given(cache.get("testKey")).willThrow(new RuntimeException("Cache is not available"));
         given(cache.invoke(eq("testKey"), any())).willThrow(new RuntimeException("Also not available"));
         Cache<String, String> cacheContext = Cache.of(cache);

--- a/resilience4j-vavr/src/test/java/io/github/resilience4j/circuitbreaker/VavrCircuitBreakerTest.java
+++ b/resilience4j-vavr/src/test/java/io/github/resilience4j/circuitbreaker/VavrCircuitBreakerTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2020: KrnSaurabh
+ *  Copyright 2026: KrnSaurabh
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -26,8 +26,8 @@ import io.vavr.CheckedFunction1;
 import io.vavr.CheckedRunnable;
 import io.vavr.control.Either;
 import io.vavr.control.Try;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.SocketTimeoutException;
@@ -40,16 +40,16 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 
-public class VavrCircuitBreakerTest {
+class VavrCircuitBreakerTest {
     private HelloWorldService helloWorldService;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         helloWorldService = mock(HelloWorldService.class);
     }
 
     @Test
-    public void shouldDecorateCheckedSupplierAndReturnWithSuccess() throws Throwable {
+    void shouldDecorateCheckedSupplierAndReturnWithSuccess() throws Throwable {
         CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
         CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
@@ -68,7 +68,7 @@ public class VavrCircuitBreakerTest {
     }
 
     @Test
-    public void shouldDecorateCheckedSupplierAndReturnWithException() throws Throwable {
+    void shouldDecorateCheckedSupplierAndReturnWithException() throws Throwable {
         CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
         CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
@@ -89,7 +89,7 @@ public class VavrCircuitBreakerTest {
     }
 
     @Test
-    public void shouldDecorateCheckedRunnableAndReturnWithSuccess() throws Throwable {
+    void shouldDecorateCheckedRunnableAndReturnWithSuccess() throws Throwable {
         CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
         CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
@@ -106,7 +106,7 @@ public class VavrCircuitBreakerTest {
     }
 
     @Test
-    public void shouldDecorateCheckedRunnableAndReturnWithException() throws Throwable {
+    void shouldDecorateCheckedRunnableAndReturnWithException() throws Throwable {
         CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
         CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
@@ -125,7 +125,7 @@ public class VavrCircuitBreakerTest {
     }
 
     @Test
-    public void shouldDecorateCheckedConsumerAndReturnWithSuccess() throws Throwable {
+    void shouldDecorateCheckedConsumerAndReturnWithSuccess() throws Throwable {
         CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
         CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
@@ -142,7 +142,7 @@ public class VavrCircuitBreakerTest {
     }
 
     @Test
-    public void shouldDecorateCheckedConsumerAndReturnWithException() throws Throwable {
+    void shouldDecorateCheckedConsumerAndReturnWithException() throws Throwable {
         CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
         CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
@@ -163,7 +163,7 @@ public class VavrCircuitBreakerTest {
     }
 
     @Test
-    public void shouldDecorateCheckedFunctionAndReturnWithSuccess() throws Throwable {
+    void shouldDecorateCheckedFunctionAndReturnWithSuccess() throws Throwable {
         CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
         CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
@@ -183,9 +183,8 @@ public class VavrCircuitBreakerTest {
         then(helloWorldService).should().returnHelloWorldWithNameWithException("Tom");
     }
 
-
     @Test
-    public void shouldDecorateCheckedFunctionAndReturnWithException() throws Throwable {
+    void shouldDecorateCheckedFunctionAndReturnWithException() throws Throwable {
         CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
         CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("testName");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
@@ -206,7 +205,7 @@ public class VavrCircuitBreakerTest {
     }
 
     @Test
-    public void shouldReturnFailureWithCircuitBreakerOpenException() {
+    void shouldReturnFailureWithCircuitBreakerOpenException() {
         // Given
         CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
             .slidingWindowSize(2)
@@ -238,7 +237,7 @@ public class VavrCircuitBreakerTest {
     }
 
     @Test
-    public void shouldReturnFailureWithRuntimeException() {
+    void shouldReturnFailureWithRuntimeException() {
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
         assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
@@ -257,7 +256,7 @@ public class VavrCircuitBreakerTest {
     }
 
     @Test
-    public void shouldNotRecordIOExceptionAsAFailure() {
+    void shouldNotRecordIOExceptionAsAFailure() {
         // tag::shouldNotRecordIOExceptionAsAFailure[]
         CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
             .slidingWindowSize(2)
@@ -287,7 +286,7 @@ public class VavrCircuitBreakerTest {
     }
 
     @Test
-    public void shouldInvokeRecoverFunction() {
+    void shouldInvokeRecoverFunction() {
         // tag::shouldInvokeRecoverFunction[]
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
         // When I decorate my function and invoke the decorated function
@@ -306,7 +305,7 @@ public class VavrCircuitBreakerTest {
     }
 
     @Test
-    public void shouldInvokeMap() {
+    void shouldInvokeMap() {
         // tag::shouldInvokeMap[]
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
         // When I decorate my function
@@ -325,7 +324,7 @@ public class VavrCircuitBreakerTest {
     }
 
     @Test
-    public void shouldThrowCircuitBreakerOpenException() {
+    void shouldThrowCircuitBreakerOpenException() {
         // tag::shouldThrowCircuitBreakerOpenException[]
         CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
             .slidingWindowSize(2)
@@ -356,7 +355,7 @@ public class VavrCircuitBreakerTest {
     }
 
     @Test
-    public void shouldChainDecoratedFunctions() {
+    void shouldChainDecoratedFunctions() {
         // tag::shouldChainDecoratedFunctions[]
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
         CircuitBreaker anotherCircuitBreaker = CircuitBreaker.ofDefaults("anotherTestName");
@@ -382,7 +381,7 @@ public class VavrCircuitBreakerTest {
     }
 
     @Test
-    public void shouldExecuteTrySupplierAndReturnWithSuccess() {
+    void shouldExecuteTrySupplierAndReturnWithSuccess() {
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
         assertThat(metrics.getNumberOfBufferedCalls()).isZero();
@@ -398,7 +397,7 @@ public class VavrCircuitBreakerTest {
     }
 
     @Test
-    public void shouldExecuteEitherSupplierAndReturnWithSuccess() {
+    void shouldExecuteEitherSupplierAndReturnWithSuccess() {
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
         assertThat(metrics.getNumberOfBufferedCalls()).isZero();
@@ -415,7 +414,7 @@ public class VavrCircuitBreakerTest {
     }
 
     @Test
-    public void shouldExecuteTrySupplierAndReturnWithFailure() {
+    void shouldExecuteTrySupplierAndReturnWithFailure() {
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
         assertThat(metrics.getNumberOfBufferedCalls()).isZero();
@@ -432,7 +431,7 @@ public class VavrCircuitBreakerTest {
     }
 
     @Test
-    public void shouldExecuteTrySupplierAndReturnWithCallNotPermittedException() {
+    void shouldExecuteTrySupplierAndReturnWithCallNotPermittedException() {
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
         assertThat(metrics.getNumberOfBufferedCalls()).isZero();
@@ -447,9 +446,8 @@ public class VavrCircuitBreakerTest {
         then(helloWorldService).should(never()).returnTry();
     }
 
-
     @Test
-    public void shouldExecuteEitherSupplierAndReturnWithFailure() {
+    void shouldExecuteEitherSupplierAndReturnWithFailure() {
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
         assertThat(metrics.getNumberOfBufferedCalls()).isZero();
@@ -467,7 +465,7 @@ public class VavrCircuitBreakerTest {
     }
 
     @Test
-    public void shouldExecuteEitherSupplierAndReturnWithCallNotPermittedException() {
+    void shouldExecuteEitherSupplierAndReturnWithCallNotPermittedException() {
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("testName");
         CircuitBreaker.Metrics metrics = circuitBreaker.getMetrics();
         assertThat(metrics.getNumberOfBufferedCalls()).isZero();

--- a/resilience4j-vavr/src/test/java/io/github/resilience4j/core/VavrCheckedFunctionUtilsTest.java
+++ b/resilience4j-vavr/src/test/java/io/github/resilience4j/core/VavrCheckedFunctionUtilsTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2020: KrnSaurabh
+ *  Copyright 2026: KrnSaurabh
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -19,17 +19,18 @@
 package io.github.resilience4j.core;
 
 import io.vavr.CheckedFunction0;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class VavrCheckedFunctionUtilsTest {
+class VavrCheckedFunctionUtilsTest {
 
     @Test
-    public void shouldRecoverFromException() throws Throwable {
+    void shouldRecoverFromException() throws Throwable {
         CheckedFunction0<String> callable = () -> {
             throw new IOException("BAM!");
         };
@@ -41,7 +42,7 @@ public class VavrCheckedFunctionUtilsTest {
     }
 
     @Test
-    public void shouldRecoverFromSpecificExceptions() throws Throwable {
+    void shouldRecoverFromSpecificExceptions() throws Throwable {
         CheckedFunction0<String> callable = () -> {
             throw new IOException("BAM!");
         };
@@ -56,7 +57,7 @@ public class VavrCheckedFunctionUtilsTest {
     }
 
     @Test
-    public void shouldRecoverFromResult() throws Throwable {
+    void shouldRecoverFromResult() throws Throwable {
         CheckedFunction0<String> callable = () -> "Wrong Result";
 
         CheckedFunction0<String> callableWithRecovery = VavrCheckedFunctionUtils.andThen(callable, (result, ex) -> {
@@ -72,7 +73,7 @@ public class VavrCheckedFunctionUtilsTest {
     }
 
     @Test
-    public void shouldRecoverFromException2() throws Throwable {
+    void shouldRecoverFromException2() throws Throwable {
         CheckedFunction0<String> callable = () -> {
             throw new IllegalArgumentException("BAM!");
         };
@@ -89,7 +90,7 @@ public class VavrCheckedFunctionUtilsTest {
     }
 
     @Test
-    public void shouldRecoverFromSpecificResult() throws Throwable {
+    void shouldRecoverFromSpecificResult() throws Throwable {
         CheckedFunction0<String> supplier = () -> "Wrong Result";
 
         CheckedFunction0<String> callableWithRecovery = VavrCheckedFunctionUtils.recover(supplier, (result) -> result.equals("Wrong Result"), (r) -> "Bla");
@@ -98,9 +99,8 @@ public class VavrCheckedFunctionUtilsTest {
         assertThat(result).isEqualTo("Bla");
     }
 
-
-    @Test(expected = RuntimeException.class)
-    public void shouldRethrowException() throws Throwable {
+    @Test
+    void shouldRethrowException() {
         CheckedFunction0<String> callable = () -> {
             throw new IOException("BAM!");
         };
@@ -108,16 +108,16 @@ public class VavrCheckedFunctionUtilsTest {
             throw new RuntimeException();
         });
 
-        callableWithRecovery.apply();
+        assertThatThrownBy(callableWithRecovery::apply).isInstanceOf(RuntimeException.class);
     }
 
-    @Test(expected = RuntimeException.class)
-    public void shouldRethrowException2() throws Throwable {
+    @Test
+    void shouldRethrowException2() {
         CheckedFunction0<String> callable = () -> {
             throw new RuntimeException("BAM!");
         };
         CheckedFunction0<String> callableWithRecovery = VavrCheckedFunctionUtils.recover(callable, IllegalArgumentException.class, (ex) -> "Bla");
 
-        callableWithRecovery.apply();
+        assertThatThrownBy(callableWithRecovery::apply).isInstanceOf(RuntimeException.class);
     }
 }

--- a/resilience4j-vavr/src/test/java/io/github/resilience4j/decorators/VavrDecoratorsTest.java
+++ b/resilience4j-vavr/src/test/java/io/github/resilience4j/decorators/VavrDecoratorsTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2020: KrnSaurabh
+ *  Copyright 2026: KrnSaurabh
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -31,8 +31,8 @@ import io.vavr.CheckedFunction0;
 import io.vavr.CheckedFunction1;
 import io.vavr.CheckedRunnable;
 import io.vavr.control.Try;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -42,17 +42,17 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.*;
 
-public class VavrDecoratorsTest {
+class VavrDecoratorsTest {
     private boolean state = false;
     private HelloWorldService helloWorldService;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         helloWorldService = mock(HelloWorldService.class);
     }
 
     @Test
-    public void testDecorateCheckedSupplierWithFallbackFromResult() throws Throwable {
+    void testDecorateCheckedSupplierWithFallbackFromResult() throws Throwable {
         given(helloWorldService.returnHelloWorldWithException()).willReturn("Hello world");
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
         CheckedFunction0<String> decoratedSupplier = VavrDecorators
@@ -71,7 +71,7 @@ public class VavrDecoratorsTest {
     }
 
     @Test
-    public void testDecorateCheckedSupplier() throws IOException {
+    void testDecorateCheckedSupplier() throws IOException {
         given(helloWorldService.returnHelloWorldWithException()).willReturn("Hello world");
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
         CheckedFunction0<String> decoratedSupplier = VavrDecorators
@@ -92,7 +92,7 @@ public class VavrDecoratorsTest {
     }
 
     @Test
-    public void testDecorateCheckedSupplierWithFallback() throws Throwable {
+    void testDecorateCheckedSupplierWithFallback() throws Throwable {
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
         circuitBreaker.transitionToOpenState();
 
@@ -111,7 +111,7 @@ public class VavrDecoratorsTest {
     }
 
     @Test
-    public void testDecorateCheckedRunnable() throws IOException {
+    void testDecorateCheckedRunnable() throws IOException {
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
         CheckedRunnable decoratedRunnable = VavrDecorators
             .ofCheckedRunnable(() -> helloWorldService.sayHelloWorldWithException())
@@ -130,7 +130,7 @@ public class VavrDecoratorsTest {
     }
 
     @Test
-    public void testDecorateCheckedFunction() throws IOException {
+    void testDecorateCheckedFunction() throws IOException {
         given(helloWorldService.returnHelloWorldWithNameWithException("Name"))
             .willReturn("Hello world Name");
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("helloBackend");
@@ -151,7 +151,7 @@ public class VavrDecoratorsTest {
     }
 
     @Test
-    public void testDecoratorBuilderWithRateLimiter() {
+    void testDecoratorBuilderWithRateLimiter() {
         given(helloWorldService.returnHelloWorld()).willReturn("Hello world");
         RateLimiterConfig config = RateLimiterConfig.custom()
             .timeoutDuration(Duration.ofMillis(100))
@@ -188,7 +188,7 @@ public class VavrDecoratorsTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testDecorateCheckedSupplierWithCache() {
+    void testDecorateCheckedSupplierWithCache() {
         javax.cache.Cache<String, String> cache = mock(javax.cache.Cache.class);
         given(cache.containsKey("testKey")).willReturn(true);
         given(cache.get("testKey")).willReturn("Hello from cache");

--- a/resilience4j-vavr/src/test/java/io/github/resilience4j/metrics/VavrTimerTest.java
+++ b/resilience4j-vavr/src/test/java/io/github/resilience4j/metrics/VavrTimerTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2020: KrnSaurabh
+ *  Copyright 2026: KrnSaurabh
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -23,8 +23,8 @@ import io.github.resilience4j.test.HelloWorldService;
 import io.vavr.CheckedFunction0;
 import io.vavr.CheckedFunction1;
 import io.vavr.CheckedRunnable;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -32,21 +32,21 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 
-public class VavrTimerTest {
+class VavrTimerTest {
 
     private HelloWorldService helloWorldService;
     private Timer timer;
     private MetricRegistry metricRegistry;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         metricRegistry = new MetricRegistry();
         timer = Timer.ofMetricRegistry(VavrTimerTest.class.getName(), metricRegistry);
         helloWorldService = mock(HelloWorldService.class);
     }
 
     @Test
-    public void shouldDecorateCheckedSupplier() throws Throwable {
+    void shouldDecorateCheckedSupplier() throws Throwable {
         given(helloWorldService.returnHelloWorldWithException()).willReturn("Hello world");
         CheckedFunction0<String> timedSupplier = VavrTimer
             .decorateCheckedSupplier(timer, helloWorldService::returnHelloWorldWithException);
@@ -63,7 +63,7 @@ public class VavrTimerTest {
     }
 
     @Test
-    public void shouldDecorateCheckedRunnableAndReturnWithSuccess() throws Throwable {
+    void shouldDecorateCheckedRunnableAndReturnWithSuccess() throws Throwable {
         CheckedRunnable timedRunnable = VavrTimer
             .decorateCheckedRunnable(timer, helloWorldService::sayHelloWorldWithException);
 
@@ -76,7 +76,7 @@ public class VavrTimerTest {
     }
 
     @Test
-    public void shouldDecorateCheckedFunctionAndReturnWithSuccess() throws Throwable {
+    void shouldDecorateCheckedFunctionAndReturnWithSuccess() throws Throwable {
         given(helloWorldService.returnHelloWorldWithNameWithException("Tom"))
             .willReturn("Hello world Tom");
         CheckedFunction1<String, String> function = VavrTimer.decorateCheckedFunction(timer,

--- a/resilience4j-vavr/src/test/java/io/github/resilience4j/ratelimiter/VavrRateLimiterTest.java
+++ b/resilience4j-vavr/src/test/java/io/github/resilience4j/ratelimiter/VavrRateLimiterTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2020: KrnSaurabh
+ *  Copyright 2026: KrnSaurabh
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -23,8 +23,8 @@ import io.vavr.CheckedFunction1;
 import io.vavr.CheckedRunnable;
 import io.vavr.control.Either;
 import io.vavr.control.Try;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.function.Supplier;
@@ -36,7 +36,7 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 
-public class VavrRateLimiterTest {
+class VavrRateLimiterTest {
 
     private static final int LIMIT = 50;
     private static final Duration TIMEOUT = Duration.ofSeconds(5);
@@ -45,8 +45,8 @@ public class VavrRateLimiterTest {
     private RateLimiterConfig config;
     private RateLimiter limit;
 
-    @Before
-    public void init() {
+    @BeforeEach
+    void init() {
         config = RateLimiterConfig.custom()
             .timeoutDuration(TIMEOUT)
             .limitRefreshPeriod(REFRESH_PERIOD)
@@ -57,7 +57,7 @@ public class VavrRateLimiterTest {
     }
 
     @Test
-    public void decorateCheckedSupplier() throws Throwable {
+    void decorateCheckedSupplier() throws Throwable {
         CheckedFunction0 supplier = mock(CheckedFunction0.class);
         CheckedFunction0 decorated = VavrRateLimiter.decorateCheckedSupplier(limit, supplier);
         given(limit.acquirePermission(1)).willReturn(false);
@@ -74,7 +74,7 @@ public class VavrRateLimiterTest {
     }
 
     @Test
-    public void decorateCheckedRunnable() throws Throwable {
+    void decorateCheckedRunnable() throws Throwable {
         CheckedRunnable runnable = mock(CheckedRunnable.class);
         CheckedRunnable decorated = VavrRateLimiter.decorateCheckedRunnable(limit, runnable);
         given(limit.acquirePermission(1)).willReturn(false);
@@ -91,7 +91,7 @@ public class VavrRateLimiterTest {
     }
 
     @Test
-    public void decorateCheckedFunction() throws Throwable {
+    void decorateCheckedFunction() throws Throwable {
         CheckedFunction1<Integer, String> function = mock(CheckedFunction1.class);
         CheckedFunction1<Integer, String> decorated = VavrRateLimiter
             .decorateCheckedFunction(limit, function);
@@ -109,7 +109,7 @@ public class VavrRateLimiterTest {
     }
 
     @Test
-    public void decorateTrySupplier() {
+    void decorateTrySupplier() {
         Supplier<Try<String>> supplier = mock(Supplier.class);
         given(supplier.get()).willReturn(Try.success("Resource"));
         given(limit.acquirePermission(1)).willReturn(true);
@@ -121,7 +121,7 @@ public class VavrRateLimiterTest {
     }
 
     @Test
-    public void decorateEitherSupplier() {
+    void decorateEitherSupplier() {
         Supplier<Either<RuntimeException, String>> supplier = mock(Supplier.class);
         given(supplier.get()).willReturn(Either.right("Resource"));
         given(limit.acquirePermission(1)).willReturn(true);
@@ -134,7 +134,7 @@ public class VavrRateLimiterTest {
     }
 
     @Test
-    public void shouldExecuteTrySupplierAndReturnRequestNotPermitted() {
+    void shouldExecuteTrySupplierAndReturnRequestNotPermitted() {
         Supplier<Try<String>> supplier = mock(Supplier.class);
         given(limit.acquirePermission(1)).willReturn(false);
 
@@ -146,7 +146,7 @@ public class VavrRateLimiterTest {
     }
 
     @Test
-    public void shouldExecuteEitherSupplierAndReturnRequestNotPermitted() {
+    void shouldExecuteEitherSupplierAndReturnRequestNotPermitted() {
         
         Supplier<Either<RuntimeException, String>> supplier = mock(Supplier.class);
         given(limit.acquirePermission(1)).willReturn(false);

--- a/resilience4j-vavr/src/test/java/io/github/resilience4j/retry/SupplierVavrRetryTest.java
+++ b/resilience4j-vavr/src/test/java/io/github/resilience4j/retry/SupplierVavrRetryTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2020: KrnSaurabh
+ *  Copyright 2026: KrnSaurabh
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -26,8 +26,8 @@ import io.vavr.API;
 import io.vavr.CheckedFunction0;
 import io.vavr.Predicates;
 import io.vavr.control.Try;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static io.vavr.API.$;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,18 +36,18 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 
-public class SupplierVavrRetryTest {
+class SupplierVavrRetryTest {
     private HelloWorldService helloWorldService;
     private long sleptTime = 0L;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         helloWorldService = mock(HelloWorldService.class);
         RetryImpl.setSleepFunction(sleep -> sleptTime += sleep);
     }
 
     @Test
-    public void shouldNotRetryDecoratedTry() {
+    void shouldNotRetryDecoratedTry() {
         given(helloWorldService.returnTry()).willReturn(Try.success("Hello world"));
         final RetryConfig tryAgain = RetryConfig.<String>custom()
             .maxAttempts(2).build();
@@ -58,7 +58,7 @@ public class SupplierVavrRetryTest {
     }
 
     @Test
-    public void shouldReturnSuccessfullyAfterSecondAttempt() {
+    void shouldReturnSuccessfullyAfterSecondAttempt() {
         given(helloWorldService.returnHelloWorld())
             .willThrow(new HelloWorldException())
             .willReturn("Hello world");
@@ -74,7 +74,7 @@ public class SupplierVavrRetryTest {
     }
 
     @Test
-    public void shouldReturnAfterThreeAttempts() {
+    void shouldReturnAfterThreeAttempts() {
         given(helloWorldService.returnHelloWorld()).willThrow(new HelloWorldException());
         Retry retry = Retry.ofDefaults("id");
         CheckedFunction0<String> retryableSupplier = VavrRetry
@@ -89,7 +89,7 @@ public class SupplierVavrRetryTest {
     }
 
     @Test
-    public void shouldReturnAfterOneAttempt() {
+    void shouldReturnAfterOneAttempt() {
         given(helloWorldService.returnHelloWorld()).willThrow(new HelloWorldException());
         RetryConfig config = RetryConfig.custom().maxAttempts(1).build();
         Retry retry = Retry.of("id", config);
@@ -105,7 +105,7 @@ public class SupplierVavrRetryTest {
     }
 
     @Test
-    public void shouldReturnAfterOneAttemptAndIgnoreException() {
+    void shouldReturnAfterOneAttemptAndIgnoreException() {
         given(helloWorldService.returnHelloWorld()).willThrow(new HelloWorldException());
         RetryConfig config = RetryConfig.custom()
             .retryOnException(throwable -> API.Match(throwable).of(
@@ -126,7 +126,7 @@ public class SupplierVavrRetryTest {
     }
 
     @Test
-    public void shouldReturnAfterThreeAttemptsAndRecover() {
+    void shouldReturnAfterThreeAttemptsAndRecover() {
         given(helloWorldService.returnHelloWorld()).willThrow(new HelloWorldException());
         Retry retry = Retry.ofDefaults("id");
         CheckedFunction0<String> retryableSupplier = VavrRetry
@@ -142,7 +142,7 @@ public class SupplierVavrRetryTest {
     }
 
     @Test
-    public void shouldReturnAfterThreeAttemptsAndRecoverWithResult() {
+    void shouldReturnAfterThreeAttemptsAndRecoverWithResult() {
         given(helloWorldService.returnHelloWorld())
             .willThrow(new HelloWorldException())
             .willReturn("Hello world")
@@ -163,7 +163,7 @@ public class SupplierVavrRetryTest {
     }
 
     @Test
-    public void shouldTakeIntoAccountBackoffFunction() {
+    void shouldTakeIntoAccountBackoffFunction() {
         given(helloWorldService.returnHelloWorld()).willThrow(new HelloWorldException());
         RetryConfig config = RetryConfig.custom()
             .intervalFunction(IntervalFunction.ofExponentialBackoff(500, 2.0))

--- a/resilience4j-vavr/src/test/java/io/github/resilience4j/retry/VavrRetryTest.java
+++ b/resilience4j-vavr/src/test/java/io/github/resilience4j/retry/VavrRetryTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2020: KrnSaurabh
+ *  Copyright 2026: KrnSaurabh
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -26,8 +26,8 @@ import io.vavr.CheckedRunnable;
 import io.vavr.Predicates;
 import io.vavr.control.Either;
 import io.vavr.control.Try;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 
@@ -37,19 +37,19 @@ import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 
-public class VavrRetryTest {
+class VavrRetryTest {
 
     private HelloWorldService helloWorldService;
     private long sleptTime = 0L;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         helloWorldService = mock(HelloWorldService.class);
         RetryImpl.setSleepFunction(sleep -> sleptTime += sleep);
     }
 
     @Test
-    public void shouldReturnAfterThreeAttempts() {
+    void shouldReturnAfterThreeAttempts() {
         willThrow(new HelloWorldException()).given(helloWorldService).sayHelloWorld();
         Retry retry = Retry.ofDefaults("id");
         CheckedRunnable retryableRunnable = VavrRetry
@@ -64,7 +64,7 @@ public class VavrRetryTest {
     }
 
     @Test
-    public void shouldReturnAfterOneAttempt() {
+    void shouldReturnAfterOneAttempt() {
         willThrow(new HelloWorldException()).given(helloWorldService).sayHelloWorld();
         RetryConfig config = RetryConfig.custom().maxAttempts(1).build();
         Retry retry = Retry.of("id", config);
@@ -80,7 +80,7 @@ public class VavrRetryTest {
     }
 
     @Test
-    public void shouldReturnAfterOneAttemptAndIgnoreException() {
+    void shouldReturnAfterOneAttemptAndIgnoreException() {
         willThrow(new HelloWorldException()).given(helloWorldService).sayHelloWorld();
         RetryConfig config = RetryConfig.custom()
             .retryOnException(throwable -> Match(throwable).of(
@@ -101,7 +101,7 @@ public class VavrRetryTest {
     }
 
     @Test
-    public void shouldTakeIntoAccountBackoffFunction() {
+    void shouldTakeIntoAccountBackoffFunction() {
         willThrow(new HelloWorldException()).given(helloWorldService).sayHelloWorld();
         RetryConfig config = RetryConfig
             .custom()
@@ -120,7 +120,7 @@ public class VavrRetryTest {
     }
 
     @Test
-    public void shouldNotRetryDecoratedEither() {
+    void shouldNotRetryDecoratedEither() {
         given(helloWorldService.returnEither()).willReturn(Either.right("Hello world"));
         final RetryConfig tryAgain = RetryConfig.<String>custom()
             .maxAttempts(2).build();
@@ -134,7 +134,7 @@ public class VavrRetryTest {
     }
 
     @Test
-    public void shouldRetryDecoratedTry() {
+    void shouldRetryDecoratedTry() {
         given(helloWorldService.returnTry()).willReturn(Try.success("Hello world"));
         final RetryConfig tryAgain = RetryConfig.<String>custom()
             .retryOnResult(s -> s.contains("Hello world"))
@@ -148,7 +148,7 @@ public class VavrRetryTest {
     }
 
     @Test
-    public void shouldRetryDecoratedEither() {
+    void shouldRetryDecoratedEither() {
         given(helloWorldService.returnEither()).willReturn(Either.right("Hello world"));
         final RetryConfig tryAgain = RetryConfig.<String>custom()
             .retryOnResult(s -> s.contains("Hello world"))
@@ -163,7 +163,7 @@ public class VavrRetryTest {
     }
 
     @Test
-    public void shouldFailToRetryDecoratedTry() {
+    void shouldFailToRetryDecoratedTry() {
         given(helloWorldService.returnTry()).willReturn(Try.failure(new HelloWorldException()));
         final RetryConfig tryAgain = RetryConfig.<String>custom()
             .maxAttempts(2).build();
@@ -177,7 +177,7 @@ public class VavrRetryTest {
     }
 
     @Test
-    public void shouldFailToRetryDecoratedEither() {
+    void shouldFailToRetryDecoratedEither() {
         given(helloWorldService.returnEither()).willReturn(Either.left(new HelloWorldException()));
         final RetryConfig tryAgain = RetryConfig.<String>custom()
             .maxAttempts(2).build();
@@ -192,7 +192,7 @@ public class VavrRetryTest {
     }
 
     @Test
-    public void shouldIgnoreExceptionOfDecoratedTry() {
+    void shouldIgnoreExceptionOfDecoratedTry() {
         given(helloWorldService.returnTry()).willReturn(Try.failure(new HelloWorldException()));
         final RetryConfig tryAgain = RetryConfig.<String>custom()
             .ignoreExceptions(HelloWorldException.class)
@@ -207,7 +207,7 @@ public class VavrRetryTest {
     }
 
     @Test
-    public void shouldIgnoreExceptionOfDecoratedEither() {
+    void shouldIgnoreExceptionOfDecoratedEither() {
         given(helloWorldService.returnEither()).willReturn(Either.left(new HelloWorldException()));
         final RetryConfig tryAgain = RetryConfig.<String>custom()
             .ignoreExceptions(HelloWorldException.class)


### PR DESCRIPTION
## Changes

* Migrated JUnit 4.13 annotations to Junit Jupiter equivalents
* Converted `@Test(expected=...)` to `assertThatThrownBy`
* Applied OpenRewrite recipes
    * [JUnit 6 best practices](https://docs.openrewrite.org/recipes/java/testing/junit/junit6bestpractices)
    * [Mockito best practices](https://docs.openrewrite.org/recipes/java/testing/mockito/mockitobestpractices)
    * [Migrate JUnit asserts to AssertJ](https://docs.openrewrite.org/recipes/java/testing/assertj/junittoassertj)
    * [AssertJ best practices](https://docs.openrewrite.org/recipes/java/testing/assertj/assertj-best-practices)
* Removed `public` modifiers
* Updated Copyright to 2026

## Coverage

| Metric      | Before | After |
|-------------|--------|-------|
| Instruction | 83.0%  | 83.0% |
| Line        | 82.2%  | 82.2% |
| Branch      | 83.3%  | 83.3% |

## Test runtime

| Metric | Before | After |
|--------|--------|-------|
| Tests  | 87     | 87    |
| Time   | 2.6s   | 2.6s  |
