### PR TITLE
resilience4j-spring6: JUnit 4 → JUnit 6 migration

### DIFF
--- a/resilience4j-spring6/build.gradle
+++ b/resilience4j-spring6/build.gradle
@@ -14,9 +14,6 @@ dependencies {
     compileOnly(libs.spring6.context)
     compileOnly(libs.spring6.core)
 
-    testRuntimeOnly(libs.junit.vintage.engine)
-
-    testImplementation(libs.junit)
     testImplementation(project(":resilience4j-metrics"))
     testImplementation(project(":resilience4j-micrometer").sourceSets.test.output)
     testImplementation(project(":resilience4j-reactor"))

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/BulkheadDummyService.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/BulkheadDummyService.java
@@ -132,7 +132,6 @@ public class BulkheadDummyService implements TestDummyService {
         return backend;
     }
 
-
     @Bulkhead(name = "#root.args[0]", fallbackMethod = "#{'recovery'}", type = Bulkhead.Type.THREADPOOL)
     public CompletionStage<String> spelSyncThreadPoolNoCfg(String backend) {
         return CompletableFuture.completedFuture(backend);

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/TestApplication.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/TestApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 lespinsideg
+ * Copyright 2026 lespinsideg
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class TestApplication {
 
-    public static void main(String[] args) {
+    static void main(String[] args) {
         SpringApplication.run(TestApplication.class, args);
     }
 

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/TestThreadLocalContextPropagator.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/TestThreadLocalContextPropagator.java
@@ -6,7 +6,8 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import static io.github.resilience4j.spring6.TestThreadLocalContextPropagator.TestThreadLocalContextHolder.*;
+import static io.github.resilience4j.spring6.TestThreadLocalContextPropagator.TestThreadLocalContextHolder.get;
+import static io.github.resilience4j.spring6.TestThreadLocalContextPropagator.TestThreadLocalContextHolder.put;
 
 public class TestThreadLocalContextPropagator<T> implements ContextPropagator<T> {
 
@@ -28,7 +29,7 @@ public class TestThreadLocalContextPropagator<T> implements ContextPropagator<T>
         return (t) -> TestThreadLocalContextHolder.clear();
     }
 
-    public static class TestThreadLocalContextHolder {
+    static class TestThreadLocalContextHolder {
 
         private static final ThreadLocal threadLocal = new ThreadLocal();
 

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/bulkhead/configure/BulkHeadConfigurationSpringTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/bulkhead/configure/BulkHeadConfigurationSpringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Mahmoud Romeh
+ * Copyright 2026 Mahmoud Romeh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,56 +15,55 @@
  */
 package io.github.resilience4j.spring6.bulkhead.configure;
 
-import io.github.resilience4j.spring6.TestThreadLocalContextPropagator;
 import io.github.resilience4j.bulkhead.BulkheadRegistry;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkheadRegistry;
 import io.github.resilience4j.bulkhead.event.BulkheadEvent;
 import io.github.resilience4j.common.bulkhead.configuration.CommonThreadPoolBulkheadConfigurationProperties;
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
+import io.github.resilience4j.spring6.TestThreadLocalContextPropagator;
 import io.github.resilience4j.spring6.fallback.FallbackExecutor;
 import io.github.resilience4j.spring6.spelresolver.SpelResolver;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {
     BulkHeadConfigurationSpringTest.ConfigWithOverrides.class
 })
-public class BulkHeadConfigurationSpringTest {
+class BulkHeadConfigurationSpringTest {
 
     @Autowired
     private ConfigWithOverrides configWithOverrides;
 
     @Test
-    public void testAllCircuitBreakerConfigurationBeansOverridden() {
-        assertNotNull(configWithOverrides.bulkheadRegistry);
-        assertNotNull(configWithOverrides.bulkheadAspect);
-        assertNotNull(configWithOverrides.bulkheadConfigurationProperties);
-        assertNotNull(configWithOverrides.threadPoolBulkheadConfigurationProperties);
-        assertNotNull(configWithOverrides.bulkheadEventEventConsumerRegistry);
-        assertNotNull(configWithOverrides.threadPoolBulkheadRegistry);
-        assertTrue(configWithOverrides.threadPoolBulkheadConfigurationProperties.getConfigs().containsKey("sharedBackend"));
+    void testAllCircuitBreakerConfigurationBeansOverridden() {
+        assertThat(configWithOverrides.bulkheadRegistry).isNotNull();
+        assertThat(configWithOverrides.bulkheadAspect).isNotNull();
+        assertThat(configWithOverrides.bulkheadConfigurationProperties).isNotNull();
+        assertThat(configWithOverrides.threadPoolBulkheadConfigurationProperties).isNotNull();
+        assertThat(configWithOverrides.bulkheadEventEventConsumerRegistry).isNotNull();
+        assertThat(configWithOverrides.threadPoolBulkheadRegistry).isNotNull();
+        assertThat(configWithOverrides.threadPoolBulkheadConfigurationProperties.getConfigs().containsKey("sharedBackend"));
         assertThat(configWithOverrides.threadPoolBulkheadConfigurationProperties.getConfigs().get("sharedBackend").getContextPropagators()).isNotNull();
         assertThat(configWithOverrides.threadPoolBulkheadConfigurationProperties.getConfigs().get("sharedBackend").getContextPropagators().length).isEqualTo(1);
-        assertEquals(configWithOverrides.threadPoolBulkheadConfigurationProperties.getConfigs().get("sharedBackend").getContextPropagators()[0], TestThreadLocalContextPropagator.class);
-        assertTrue(configWithOverrides.bulkheadConfigurationProperties.getConfigs().size() == 1);
+        assertThat(configWithOverrides.threadPoolBulkheadConfigurationProperties.getConfigs().get("sharedBackend").getContextPropagators()[0]).isEqualTo(TestThreadLocalContextPropagator.class);
+        assertThat(configWithOverrides.bulkheadConfigurationProperties.getConfigs()).hasSize(1);
     }
 
     @Configuration
     @ComponentScan({"io.github.resilience4j.spring6.bulkhead", "io.github.resilience4j.spring6.fallback", "io.github.resilience4j.spring6.spelresolver"})
-    public static class ConfigWithOverrides {
+    static class ConfigWithOverrides {
 
         private BulkheadRegistry bulkheadRegistry;
 

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/bulkhead/configure/BulkHeadConfigurationTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/bulkhead/configure/BulkHeadConfigurationTest.java
@@ -1,8 +1,9 @@
 package io.github.resilience4j.spring6.bulkhead.configure;
 
-import io.github.resilience4j.spring6.TestThreadLocalContextPropagator;
-import io.github.resilience4j.bulkhead.*;
-import io.github.resilience4j.spring6.bulkhead.configure.threadpool.ThreadPoolBulkheadConfiguration;
+import io.github.resilience4j.bulkhead.Bulkhead;
+import io.github.resilience4j.bulkhead.BulkheadRegistry;
+import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
+import io.github.resilience4j.bulkhead.ThreadPoolBulkheadRegistry;
 import io.github.resilience4j.bulkhead.event.BulkheadEvent;
 import io.github.resilience4j.common.CompositeCustomizer;
 import io.github.resilience4j.common.bulkhead.configuration.CommonThreadPoolBulkheadConfigurationProperties;
@@ -10,7 +11,9 @@ import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.core.ConfigurationNotFoundException;
 import io.github.resilience4j.core.ContextPropagator;
 import io.github.resilience4j.core.registry.CompositeRegistryEventConsumer;
-import org.junit.Test;
+import io.github.resilience4j.spring6.TestThreadLocalContextPropagator;
+import io.github.resilience4j.spring6.bulkhead.configure.threadpool.ThreadPoolBulkheadConfiguration;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -24,10 +27,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * test custom init of bulkhead configuration
  */
-public class BulkHeadConfigurationTest {
+class BulkHeadConfigurationTest {
 
     @Test
-    public void tesFixedThreadPoolBulkHeadRegistry() {
+    void tesFixedThreadPoolBulkHeadRegistry() {
         //Given
         CommonThreadPoolBulkheadConfigurationProperties.InstanceProperties backendProperties1 = new CommonThreadPoolBulkheadConfigurationProperties.InstanceProperties();
         backendProperties1.setCoreThreadPoolSize(1);
@@ -69,7 +72,7 @@ public class BulkHeadConfigurationTest {
     }
 
     @Test
-    public void testCreateThreadPoolBulkHeadRegistryWithSharedConfigs() {
+    void testCreateThreadPoolBulkHeadRegistryWithSharedConfigs() {
         //Given
         CommonThreadPoolBulkheadConfigurationProperties.InstanceProperties defaultProperties = new CommonThreadPoolBulkheadConfigurationProperties.InstanceProperties();
         defaultProperties.setCoreThreadPoolSize(1);
@@ -133,7 +136,6 @@ public class BulkHeadConfigurationTest {
             assertThat(ctxPropagators).containsExactlyInAnyOrder(TestThreadLocalContextPropagator.class,
                 TestThreadLocalContextPropagator.class);
 
-
             // Unknown backend should get default config of Registry
             ThreadPoolBulkhead bulkhead3 = bulkheadRegistry.bulkhead("unknownBackend");
             assertThat(bulkhead3).isNotNull();
@@ -148,9 +150,8 @@ public class BulkHeadConfigurationTest {
         }
     }
 
-
     @Test
-    public void testBulkHeadRegistry() {
+    void testBulkHeadRegistry() {
         //Given
         io.github.resilience4j.common.bulkhead.configuration.CommonBulkheadConfigurationProperties.InstanceProperties instanceProperties1 = new io.github.resilience4j.common.bulkhead.configuration.CommonBulkheadConfigurationProperties.InstanceProperties();
         instanceProperties1.setMaxConcurrentCalls(3);
@@ -187,7 +188,7 @@ public class BulkHeadConfigurationTest {
     }
 
     @Test
-    public void testCreateBulkHeadRegistryWithSharedConfigs() {
+    void testCreateBulkHeadRegistryWithSharedConfigs() {
         //Given
         io.github.resilience4j.common.bulkhead.configuration.CommonBulkheadConfigurationProperties.InstanceProperties defaultProperties = new io.github.resilience4j.common.bulkhead.configuration.CommonBulkheadConfigurationProperties.InstanceProperties();
         defaultProperties.setMaxConcurrentCalls(3);
@@ -251,7 +252,7 @@ public class BulkHeadConfigurationTest {
     }
 
     @Test
-    public void testCreateBulkHeadRegistryWithUnknownConfig() {
+    void testCreateBulkHeadRegistryWithUnknownConfig() {
         BulkheadConfigurationProperties bulkheadConfigurationProperties = new BulkheadConfigurationProperties();
 
         io.github.resilience4j.common.bulkhead.configuration.CommonBulkheadConfigurationProperties.InstanceProperties instanceProperties = new io.github.resilience4j.common.bulkhead.configuration.CommonBulkheadConfigurationProperties.InstanceProperties();
@@ -269,5 +270,4 @@ public class BulkHeadConfigurationTest {
             .isInstanceOf(ConfigurationNotFoundException.class)
             .hasMessage("Configuration with name 'unknownConfig' does not exist");
     }
-
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/bulkhead/configure/BulkHeadInitializationInAspectTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/bulkhead/configure/BulkHeadInitializationInAspectTest.java
@@ -4,26 +4,23 @@ import io.github.resilience4j.bulkhead.Bulkhead;
 import io.github.resilience4j.bulkhead.BulkheadConfig;
 import io.github.resilience4j.bulkhead.BulkheadRegistry;
 import io.github.resilience4j.spring6.TestDummyService;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import static io.github.resilience4j.spring6.TestDummyService.BACKEND;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(properties = {
         "logging.level.io.github.resilience4j.bulkhead.configure=debug",
         "spring.main.allow-bean-definition-overriding=true"
 })
-public class BulkHeadInitializationInAspectTest {
+class BulkHeadInitializationInAspectTest {
 
     @TestConfiguration
     static class TestConfig {
@@ -49,26 +46,26 @@ public class BulkHeadInitializationInAspectTest {
     @Autowired
     BulkheadRegistry registry;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         // ensure no bulkheads are initialized
         assertThat(registry.getAllBulkheads()).isEmpty();
     }
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         // could have used DirtiesContext but spawns a springboot for each test
         registry.getAllBulkheads().stream().map(Bulkhead::getName).forEach(registry::remove);
     }
 
     @Test
-    public void testCorrectConfigIsUsedInAspect() {
+    void testCorrectConfigIsUsedInAspect() {
         // The bulkhead is configured to allow 0 concurrent calls, so the call should be rejected
         assertThat(testDummyService.syncSuccess()).isEqualTo("recovered");
     }
 
     @Test
-    public void testSpelWithoutMappingConfigurationInAspect() {
+    void testSpelWithoutMappingConfigurationInAspect() {
         // Default bulkhead is configured to allow several concurrent calls
         assertThat(testDummyService.spelSyncNoCfg("foo")).isEqualTo("foo");
         assertThat(registry.getAllBulkheads()).hasSize(1).first()
@@ -77,7 +74,7 @@ public class BulkHeadInitializationInAspectTest {
     }
 
     @Test
-    public void testSpelWithMappingConfigurationInAspect() {
+    void testSpelWithMappingConfigurationInAspect() {
         // The bulkhead is configured to allow 0 concurrent calls, so the call should be rejected
         assertThat(testDummyService.spelSyncWithCfg("foo")).isEqualTo("recovered");
         assertThat(registry.getAllBulkheads()).hasSize(1).first()
@@ -86,9 +83,8 @@ public class BulkHeadInitializationInAspectTest {
     }
 
     @Test
-    public void testConfigurationKeyIsUsedInAspect() {
+    void testConfigurationKeyIsUsedInAspect() {
         assertThat(testDummyService.spelSyncWithCfg(BACKEND)).isEqualTo("recovered");
         assertThat(testDummyService.spelSyncNoCfg(BACKEND)).isEqualTo("recovered");
     }
-
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/bulkhead/configure/BulkheadAspectSpelResolverTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/bulkhead/configure/BulkheadAspectSpelResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Kyuhyen Hwang
+ * Copyright 2026 Kyuhyen Hwang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,21 +15,18 @@
  */
 package io.github.resilience4j.spring6.bulkhead.configure;
 
+import io.github.resilience4j.bulkhead.BulkheadRegistry;
 import io.github.resilience4j.spring6.TestApplication;
 import io.github.resilience4j.spring6.TestDummyService;
-import io.github.resilience4j.bulkhead.BulkheadRegistry;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = TestApplication.class)
-public class BulkheadAspectSpelResolverTest {
+class BulkheadAspectSpelResolverTest {
     @Autowired
     @Qualifier("bulkheadDummyService")
     TestDummyService testDummyService;
@@ -38,7 +35,7 @@ public class BulkheadAspectSpelResolverTest {
     BulkheadRegistry registry;
 
     @Test
-    public void testSpel() {
+    void testSpel() {
         assertThat(registry.getAllBulkheads().stream().filter(it -> it.getName().equals("SPEL_BACKEND")).findAny().isPresent()).isFalse();
         assertThat(testDummyService.spelSync("SPEL_BACKEND")).isEqualTo("recovered");
         assertThat(registry.getAllBulkheads().stream().filter(it -> it.getName().equals("SPEL_BACKEND")).findAny().isPresent()).isTrue();

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/bulkhead/configure/BulkheadBuilderCustomizerTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/bulkhead/configure/BulkheadBuilderCustomizerTest.java
@@ -1,25 +1,28 @@
 package io.github.resilience4j.spring6.bulkhead.configure;
 
-import io.github.resilience4j.spring6.TestThreadLocalContextPropagator;
-import io.github.resilience4j.bulkhead.*;
-import io.github.resilience4j.spring6.bulkhead.configure.threadpool.ThreadPoolBulkheadConfiguration;
+import io.github.resilience4j.bulkhead.Bulkhead;
+import io.github.resilience4j.bulkhead.BulkheadRegistry;
+import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
+import io.github.resilience4j.bulkhead.ThreadPoolBulkheadRegistry;
 import io.github.resilience4j.bulkhead.event.BulkheadEvent;
 import io.github.resilience4j.common.CompositeCustomizer;
 import io.github.resilience4j.common.bulkhead.configuration.BulkheadConfigCustomizer;
-import io.github.resilience4j.common.bulkhead.configuration.ThreadPoolBulkheadConfigCustomizer;
 import io.github.resilience4j.common.bulkhead.configuration.CommonThreadPoolBulkheadConfigurationProperties;
+import io.github.resilience4j.common.bulkhead.configuration.ThreadPoolBulkheadConfigCustomizer;
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
 import io.github.resilience4j.core.ContextPropagator;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import io.github.resilience4j.spring6.TestThreadLocalContextPropagator;
+import io.github.resilience4j.spring6.bulkhead.configure.threadpool.ThreadPoolBulkheadConfiguration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.time.Duration;
 import java.util.List;
@@ -31,9 +34,9 @@ import java.util.function.Supplier;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.util.ReflectionTestUtils.getField;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {BulkheadBuilderCustomizerTest.Config.class})
-public class BulkheadBuilderCustomizerTest {
+class BulkheadBuilderCustomizerTest {
 
     @Autowired
     private ThreadPoolBulkheadRegistry threadPoolBulkheadRegistry;
@@ -49,9 +52,8 @@ public class BulkheadBuilderCustomizerTest {
     @Qualifier("compositeThreadPoolBulkheadCustomizer")
     private CompositeCustomizer<ThreadPoolBulkheadConfigCustomizer> compositeThreadPoolBulkheadCustomizer;
 
-
     @Test
-    public void testThreadPoolBulkheadCustomizer() {
+    void testThreadPoolBulkheadCustomizer() {
 
         assertThat(threadPoolBulkheadRegistry).isNotNull();
         assertThat(compositeThreadPoolBulkheadCustomizer).isNotNull();
@@ -102,7 +104,7 @@ public class BulkheadBuilderCustomizerTest {
     }
 
     @Test
-    public void testBulkheadCustomizer() {
+    void testBulkheadCustomizer() {
 
         assertThat(bulkheadRegistry).isNotNull();
         assertThat(compositeBulkheadCustomizer).isNotNull();
@@ -129,11 +131,9 @@ public class BulkheadBuilderCustomizerTest {
 
     }
 
-
     @Configuration
     @Import({ThreadPoolBulkheadConfiguration.class, BulkheadConfiguration.class})
     static class Config {
-
 
         @Bean
         public EventConsumerRegistry<BulkheadEvent> eventConsumerRegistry() {
@@ -223,7 +223,7 @@ public class BulkheadBuilderCustomizerTest {
         }
     }
 
-    public static class BeanContextPropagator implements ContextPropagator<String> {
+    static class BeanContextPropagator implements ContextPropagator<String> {
 
         @Override
         public Supplier<Optional<String>> retrieve() {

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/bulkhead/configure/BulkheadRecoveryTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/bulkhead/configure/BulkheadRecoveryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 lespinsideg
+ * Copyright 2026 lespinsideg
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,38 +17,35 @@ package io.github.resilience4j.spring6.bulkhead.configure;
 
 import io.github.resilience4j.spring6.TestApplication;
 import io.github.resilience4j.spring6.TestDummyService;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = TestApplication.class)
-public class BulkheadRecoveryTest {
+class BulkheadRecoveryTest {
 
     @Autowired
     @Qualifier("bulkheadDummyService")
     TestDummyService testDummyService;
 
     @Test
-    public void testRecovery() {
+    void testRecovery() {
         assertThat(testDummyService.sync()).isEqualTo("recovered");
     }
 
     @Test
-    public void testAsyncRecovery() throws Exception {
+    void testAsyncRecovery() throws Exception {
         assertThat(testDummyService.async().toCompletableFuture().get(5, TimeUnit.SECONDS))
             .isEqualTo("recovered");
     }
 
     @Test
-    public void testAsyncThreadPoolRecovery() throws Exception {
+    void testAsyncThreadPoolRecovery() throws Exception {
         assertThat(
             testDummyService.asyncThreadPool().toCompletableFuture().get(5, TimeUnit.SECONDS))
             .isEqualTo("recovered");
@@ -58,62 +55,62 @@ public class BulkheadRecoveryTest {
     }
 
     @Test
-    public void testMonoRecovery() {
+    void testMonoRecovery() {
         assertThat(testDummyService.mono("test").block()).isEqualTo("test");
     }
 
     @Test
-    public void testFluxRecovery() {
+    void testFluxRecovery() {
         assertThat(testDummyService.flux().blockFirst()).isEqualTo("recovered");
     }
 
     @Test
-    public void testObservableRecovery() {
+    void testObservableRecovery() {
         assertThat(testDummyService.observable().blockingFirst()).isEqualTo("recovered");
     }
 
     @Test
-    public void testSingleRecovery() {
+    void testSingleRecovery() {
         assertThat(testDummyService.single().blockingGet()).isEqualTo("recovered");
     }
 
     @Test
-    public void testCompletableRecovery() {
+    void testCompletableRecovery() {
         assertThat(testDummyService.completable().blockingGet()).isNull();
     }
 
     @Test
-    public void testMaybeRecovery() {
+    void testMaybeRecovery() {
         assertThat(testDummyService.maybe().blockingGet()).isEqualTo("recovered");
     }
 
     @Test
-    public void testFlowableRecovery() {
+    void testFlowableRecovery() {
         assertThat(testDummyService.flowable().blockingFirst()).isEqualTo("recovered");
     }
 
     @Test
-    public void testRx3ObservableRecovery() {
+    void testRx3ObservableRecovery() {
         assertThat(testDummyService.rx3Observable().blockingFirst()).isEqualTo("recovered");
     }
 
     @Test
-    public void testRx3SingleRecovery() {
+    void testRx3SingleRecovery() {
         assertThat(testDummyService.rx3Single().blockingGet()).isEqualTo("recovered");
     }
 
     @Test
-    public void testRx3CompletableRecovery() {
+    void testRx3CompletableRecovery() {
         testDummyService.rx3Completable().test().assertComplete();
     }
 
     @Test
-    public void testRx3MaybeRecovery() {
+    void testRx3MaybeRecovery() {
         assertThat(testDummyService.rx3Maybe().blockingGet()).isEqualTo("recovered");
     }
 
     @Test
-    public void testRx3FlowableRecovery() {
+    void testRx3FlowableRecovery() {
         assertThat(testDummyService.rx3Flowable().blockingFirst()).isEqualTo("recovered");
     }
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/bulkhead/configure/ReactorBulkheadAspectExtTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/bulkhead/configure/ReactorBulkheadAspectExtTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Mahmoud Romeh
+ * Copyright 2026 Mahmoud Romeh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,12 @@
 package io.github.resilience4j.spring6.bulkhead.configure;
 
 import io.github.resilience4j.bulkhead.Bulkhead;
-import io.github.resilience4j.spring6.bulkhead.configure.ReactorBulkheadAspectExt;
 import org.aspectj.lang.ProceedingJoinPoint;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -32,8 +31,8 @@ import static org.mockito.Mockito.when;
 /**
  * aspect unit test
  */
-@RunWith(MockitoJUnitRunner.class)
-public class ReactorBulkheadAspectExtTest {
+@ExtendWith(MockitoExtension.class)
+class ReactorBulkheadAspectExtTest {
 
     @Mock
     ProceedingJoinPoint proceedingJoinPoint;
@@ -41,15 +40,14 @@ public class ReactorBulkheadAspectExtTest {
     @InjectMocks
     ReactorBulkheadAspectExt reactorBulkheadAspectExt;
 
-
     @Test
-    public void testCheckTypes() {
+    void testCheckTypes() {
         assertThat(reactorBulkheadAspectExt.canHandleReturnType(Mono.class)).isTrue();
         assertThat(reactorBulkheadAspectExt.canHandleReturnType(Flux.class)).isTrue();
     }
 
     @Test
-    public void testReactorTypes() throws Throwable {
+    void testReactorTypes() throws Throwable {
         Bulkhead bulkhead = Bulkhead.ofDefaults("test");
 
         when(proceedingJoinPoint.proceed()).thenReturn(Mono.just("Test"));
@@ -60,6 +58,4 @@ public class ReactorBulkheadAspectExtTest {
         assertThat(reactorBulkheadAspectExt.handle(proceedingJoinPoint, bulkhead, "testMethod"))
             .isNotNull();
     }
-
-
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/bulkhead/configure/RxJava2BulkheadAspectExtTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/bulkhead/configure/RxJava2BulkheadAspectExtTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Mahmoud Romeh
+ * Copyright 2026 Mahmoud Romeh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,14 @@
 package io.github.resilience4j.spring6.bulkhead.configure;
 
 import io.github.resilience4j.bulkhead.Bulkhead;
-import io.github.resilience4j.spring6.bulkhead.configure.RxJava2BulkheadAspectExt;
 import io.reactivex.Flowable;
 import io.reactivex.Single;
 import org.aspectj.lang.ProceedingJoinPoint;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -32,8 +31,8 @@ import static org.mockito.Mockito.when;
 /**
  * aspect unit test
  */
-@RunWith(MockitoJUnitRunner.class)
-public class RxJava2BulkheadAspectExtTest {
+@ExtendWith(MockitoExtension.class)
+class RxJava2BulkheadAspectExtTest {
 
     @Mock
     ProceedingJoinPoint proceedingJoinPoint;
@@ -41,15 +40,14 @@ public class RxJava2BulkheadAspectExtTest {
     @InjectMocks
     RxJava2BulkheadAspectExt rxJava2BulkheadAspectExt;
 
-
     @Test
-    public void testCheckTypes() {
+    void testCheckTypes() {
         assertThat(rxJava2BulkheadAspectExt.canHandleReturnType(Flowable.class)).isTrue();
         assertThat(rxJava2BulkheadAspectExt.canHandleReturnType(Single.class)).isTrue();
     }
 
     @Test
-    public void testReactorTypes() throws Throwable {
+    void testReactorTypes() throws Throwable {
         Bulkhead bulkhead = Bulkhead.ofDefaults("test");
 
         when(proceedingJoinPoint.proceed()).thenReturn(Single.just("Test"));
@@ -60,6 +58,4 @@ public class RxJava2BulkheadAspectExtTest {
         assertThat(rxJava2BulkheadAspectExt.handle(proceedingJoinPoint, bulkhead, "testMethod"))
             .isNotNull();
     }
-
-
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/bulkhead/configure/RxJava3BulkheadAspectExtTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/bulkhead/configure/RxJava3BulkheadAspectExtTest.java
@@ -4,11 +4,11 @@ import io.github.resilience4j.bulkhead.Bulkhead;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
 import org.aspectj.lang.ProceedingJoinPoint;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -16,8 +16,8 @@ import static org.mockito.Mockito.when;
 /**
  * aspect unit test
  */
-@RunWith(MockitoJUnitRunner.class)
-public class RxJava3BulkheadAspectExtTest {
+@ExtendWith(MockitoExtension.class)
+class RxJava3BulkheadAspectExtTest {
 
     @Mock
     ProceedingJoinPoint proceedingJoinPoint;
@@ -25,15 +25,14 @@ public class RxJava3BulkheadAspectExtTest {
     @InjectMocks
     RxJava3BulkheadAspectExt rxJava3BulkheadAspectExt;
 
-
     @Test
-    public void testCheckTypes() {
+    void testCheckTypes() {
         assertThat(rxJava3BulkheadAspectExt.canHandleReturnType(Flowable.class)).isTrue();
         assertThat(rxJava3BulkheadAspectExt.canHandleReturnType(Single.class)).isTrue();
     }
 
     @Test
-    public void testRxTypes() throws Throwable {
+    void testRxTypes() throws Throwable {
         Bulkhead bulkhead = Bulkhead.ofDefaults("test");
 
         when(proceedingJoinPoint.proceed()).thenReturn(Single.just("Test"));
@@ -44,6 +43,4 @@ public class RxJava3BulkheadAspectExtTest {
         assertThat(rxJava3BulkheadAspectExt.handle(proceedingJoinPoint, bulkhead, "testMethod"))
             .isNotNull();
     }
-
-
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/bulkhead/configure/ThreadPoolBulkHeadInitializationInAspectTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/bulkhead/configure/ThreadPoolBulkHeadInitializationInAspectTest.java
@@ -1,35 +1,28 @@
 package io.github.resilience4j.spring6.bulkhead.configure;
 
-import io.github.resilience4j.bulkhead.Bulkhead;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkheadConfig;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkheadRegistry;
 import io.github.resilience4j.spring6.BulkheadDummyService;
-import io.github.resilience4j.spring6.TestDummyService;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static io.github.resilience4j.spring6.TestDummyService.BACKEND;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(properties = {
         "logging.level.io.github.resilience4j.bulkhead.configure=debug",
         "spring.main.allow-bean-definition-overriding=true"
 })
-public class ThreadPoolBulkHeadInitializationInAspectTest {
+class ThreadPoolBulkHeadInitializationInAspectTest {
 
     @TestConfiguration
     static class TestConfig {
@@ -56,19 +49,19 @@ public class ThreadPoolBulkHeadInitializationInAspectTest {
     @Qualifier("threadPoolBulkheadRegistry")
     ThreadPoolBulkheadRegistry registry;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         // ensure no bulkheads are initialized
         assertThat(registry.getAllBulkheads()).isEmpty();
     }
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         registry.getAllBulkheads().stream().map(ThreadPoolBulkhead::getName).forEach(registry::remove);
     }
 
     @Test
-    public void testSpelWithoutMappingConfigurationInAspect() throws Exception {
+    void testSpelWithoutMappingConfigurationInAspect() throws Exception {
         assertThat(testDummyService.spelSyncThreadPoolNoCfg("foo").toCompletableFuture().get(5, TimeUnit.SECONDS)).isEqualTo("foo");
         assertThat(registry.getAllBulkheads()).hasSize(1).first()
                 .matches(bulkhead -> bulkhead.getName().equals("foo"))
@@ -76,7 +69,7 @@ public class ThreadPoolBulkHeadInitializationInAspectTest {
     }
 
     @Test
-    public void testSpelWithMappingConfigurationInAspect() throws Exception {
+    void testSpelWithMappingConfigurationInAspect() throws Exception {
         // The bulkhead is configured to allow 0 concurrent calls, so the call should be rejected
         assertThat(testDummyService.spelSyncThreadPoolWithCfg("foo").toCompletableFuture().get(5, TimeUnit.SECONDS)).isEqualTo("foo");
         assertThat(registry.getAllBulkheads()).hasSize(1).first()

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/circuitbreaker/configure/CircuitBreakerAspectSpelResolverTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/circuitbreaker/configure/CircuitBreakerAspectSpelResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Kyuhyen Hwang
+ * Copyright 2026 Kyuhyen Hwang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,21 +15,21 @@
  */
 package io.github.resilience4j.spring6.circuitbreaker.configure;
 
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.spring6.TestApplication;
 import io.github.resilience4j.spring6.TestDummyService;
-import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = TestApplication.class)
-public class CircuitBreakerAspectSpelResolverTest {
+class CircuitBreakerAspectSpelResolverTest {
     @Autowired
     @Qualifier("circuitBreakerDummyService")
     TestDummyService testDummyService;
@@ -38,7 +38,7 @@ public class CircuitBreakerAspectSpelResolverTest {
     CircuitBreakerRegistry registry;
 
     @Test
-    public void testSpel() {
+    void testSpel() {
         assertThat(registry.getAllCircuitBreakers().stream().filter(it -> it.getName().equals("SPEL_BACKEND")).findAny().isPresent()).isFalse();
         assertThat(testDummyService.spelSync("SPEL_BACKEND")).isEqualTo("recovered");
         assertThat(registry.getAllCircuitBreakers().stream().filter(it -> it.getName().equals("SPEL_BACKEND")).findAny().isPresent()).isTrue();

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/circuitbreaker/configure/CircuitBreakerConfigurationTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/circuitbreaker/configure/CircuitBreakerConfigurationTest.java
@@ -9,11 +9,9 @@ import io.github.resilience4j.common.circuitbreaker.configuration.CommonCircuitB
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.core.ConfigurationNotFoundException;
 import io.github.resilience4j.core.registry.CompositeRegistryEventConsumer;
-import io.github.resilience4j.spring6.circuitbreaker.configure.CircuitBreakerConfiguration;
-import io.github.resilience4j.spring6.circuitbreaker.configure.CircuitBreakerConfigurationProperties;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 
@@ -24,11 +22,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * test custom init of circuit breaker registry
  */
-@RunWith(MockitoJUnitRunner.class)
-public class CircuitBreakerConfigurationTest {
+@ExtendWith(MockitoExtension.class)
+class CircuitBreakerConfigurationTest {
 
     @Test
-    public void testCreateCircuitBreakerRegistry() {
+    void testCreateCircuitBreakerRegistry() {
         InstanceProperties instanceProperties1 = new InstanceProperties();
         instanceProperties1.setSlidingWindowSize(1000);
         InstanceProperties instanceProperties2 = new InstanceProperties();
@@ -61,7 +59,7 @@ public class CircuitBreakerConfigurationTest {
     }
 
     @Test
-    public void testCreateCircuitBreakerRegistryWithSharedConfigs() {
+    void testCreateCircuitBreakerRegistryWithSharedConfigs() {
         InstanceProperties defaultProperties = new InstanceProperties();
         defaultProperties.setSlidingWindowSize(1000);
         defaultProperties.setPermittedNumberOfCallsInHalfOpenState(100);
@@ -118,7 +116,7 @@ public class CircuitBreakerConfigurationTest {
     }
 
     @Test
-    public void testCreateCircuitBreakerRegistryWithUnknownConfig() {
+    void testCreateCircuitBreakerRegistryWithUnknownConfig() {
         CircuitBreakerConfigurationProperties circuitBreakerConfigurationProperties = new CircuitBreakerConfigurationProperties();
         InstanceProperties instanceProperties = new InstanceProperties();
         instanceProperties.setBaseConfig("unknownConfig");
@@ -138,5 +136,4 @@ public class CircuitBreakerConfigurationTest {
     private CompositeCustomizer<CircuitBreakerConfigCustomizer> compositeCircuitBreakerCustomizerTestInstance() {
         return new CompositeCustomizer<>(Collections.emptyList());
     }
-
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/circuitbreaker/configure/CircuitBreakerInitializationInAspectTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/circuitbreaker/configure/CircuitBreakerInitializationInAspectTest.java
@@ -4,26 +4,26 @@ import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.spring6.TestDummyService;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static io.github.resilience4j.spring6.TestDummyService.BACKEND;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(properties = {
         "logging.level.io.github.resilience4j.circuitbreaker.configure=debug",
         "spring.main.allow-bean-definition-overriding=true"
 })
-public class CircuitBreakerInitializationInAspectTest {
+class CircuitBreakerInitializationInAspectTest {
 
     @TestConfiguration
     static class TestConfig {
@@ -49,26 +49,26 @@ public class CircuitBreakerInitializationInAspectTest {
     @Autowired
     CircuitBreakerRegistry registry;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         // ensure no circuit breakers are initialized
         assertThat(registry.getAllCircuitBreakers()).isEmpty();
     }
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         registry.getAllCircuitBreakers().stream().map(CircuitBreaker::getName).forEach(registry::remove);
     }
 
     @Test
-    public void testCorrectConfigIsUsedInAspect() {
+    void testCorrectConfigIsUsedInAspect() {
 
         // The circuit breaker is configured to start in the OPEN state, so the call should be rejected
         assertThat(testDummyService.syncSuccess()).isEqualTo("recovered");
     }
 
     @Test
-    public void testSpelWithoutConfigurationInAspect() {
+    void testSpelWithoutConfigurationInAspect() {
         // default circuit breaker is configured to start in CLOSE state
         assertThat(testDummyService.spelSyncNoCfg("foo")).isEqualTo("foo");
         assertThat(registry.getAllCircuitBreakers()).hasSize(1).first()
@@ -77,7 +77,7 @@ public class CircuitBreakerInitializationInAspectTest {
     }
 
     @Test
-    public void testSpelWithConfigurationInAspect() {
+    void testSpelWithConfigurationInAspect() {
         // backend circuit breaker is configured to start in the OPEN state, so the call should be rejected
         assertThat(testDummyService.spelSyncWithCfg("foo")).isEqualTo("recovered");
         assertThat(registry.getAllCircuitBreakers()).hasSize(1).first()

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/circuitbreaker/configure/CircuitBreakerRecoveryTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/circuitbreaker/configure/CircuitBreakerRecoveryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 lespinsideg
+ * Copyright 2026 lespinsideg
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,93 +17,93 @@ package io.github.resilience4j.spring6.circuitbreaker.configure;
 
 import io.github.resilience4j.spring6.TestApplication;
 import io.github.resilience4j.spring6.TestDummyService;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = TestApplication.class)
-public class CircuitBreakerRecoveryTest {
+class CircuitBreakerRecoveryTest {
 
     @Autowired
     @Qualifier("circuitBreakerDummyService")
     TestDummyService testDummyService;
 
     @Test
-    public void testRecovery() {
+    void testRecovery() {
         assertThat(testDummyService.sync()).isEqualTo("recovered");
     }
 
     @Test
-    public void testAsyncRecovery() throws Exception {
+    void testAsyncRecovery() throws Exception {
         assertThat(testDummyService.async().toCompletableFuture().get(5, TimeUnit.SECONDS))
             .isEqualTo("recovered");
     }
 
     @Test
-    public void testMonoRecovery() {
+    void testMonoRecovery() {
         assertThat(testDummyService.mono("test").block()).isEqualTo("test");
     }
 
     @Test
-    public void testFluxRecovery() {
+    void testFluxRecovery() {
         assertThat(testDummyService.flux().blockFirst()).isEqualTo("recovered");
     }
 
     @Test
-    public void testObservableRecovery() {
+    void testObservableRecovery() {
         assertThat(testDummyService.observable().blockingFirst()).isEqualTo("recovered");
     }
 
     @Test
-    public void testSingleRecovery() {
+    void testSingleRecovery() {
         assertThat(testDummyService.single().blockingGet()).isEqualTo("recovered");
     }
 
     @Test
-    public void testCompletableRecovery() {
+    void testCompletableRecovery() {
         assertThat(testDummyService.completable().blockingGet()).isNull();
     }
 
     @Test
-    public void testMaybeRecovery() {
+    void testMaybeRecovery() {
         assertThat(testDummyService.maybe().blockingGet()).isEqualTo("recovered");
     }
 
     @Test
-    public void testFlowableRecovery() {
+    void testFlowableRecovery() {
         assertThat(testDummyService.flowable().blockingFirst()).isEqualTo("recovered");
     }
 
     @Test
-    public void testRx3ObservableRecovery() {
+    void testRx3ObservableRecovery() {
         assertThat(testDummyService.rx3Observable().blockingFirst()).isEqualTo("recovered");
     }
 
     @Test
-    public void testRx3SingleRecovery() {
+    void testRx3SingleRecovery() {
         assertThat(testDummyService.rx3Single().blockingGet()).isEqualTo("recovered");
     }
 
     @Test
-    public void testRx3CompletableRecovery() {
+    void testRx3CompletableRecovery() {
         testDummyService.rx3Completable().test().assertComplete();
     }
 
     @Test
-    public void testRx3MaybeRecovery() {
+    void testRx3MaybeRecovery() {
         assertThat(testDummyService.rx3Maybe().blockingGet()).isEqualTo("recovered");
     }
 
     @Test
-    public void testRx3FlowableRecovery() {
+    void testRx3FlowableRecovery() {
         assertThat(testDummyService.rx3Flowable().blockingFirst()).isEqualTo("recovered");
     }
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/circuitbreaker/configure/FallbackConfigurationTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/circuitbreaker/configure/FallbackConfigurationTest.java
@@ -2,23 +2,23 @@ package io.github.resilience4j.spring6.circuitbreaker.configure;
 
 import io.github.resilience4j.spring6.fallback.FallbackDecorators;
 import io.github.resilience4j.spring6.fallback.configure.FallbackConfiguration;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = FallbackConfiguration.class)
-public class FallbackConfigurationTest {
+class FallbackConfigurationTest {
 
     @Autowired
     private FallbackDecorators fallbackDecorators;
 
     @Test
-    public void testSizeOfDecorators() {
+    void testSizeOfDecorators() {
         assertThat(fallbackDecorators.getFallbackDecorators().size()).isEqualTo(4);
     }
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/circuitbreaker/configure/ReactorCircuitBreakerAspectExtTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/circuitbreaker/configure/ReactorCircuitBreakerAspectExtTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Mahmoud Romeh
+ * Copyright 2026 Mahmoud Romeh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,12 @@
 package io.github.resilience4j.spring6.circuitbreaker.configure;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
-import io.github.resilience4j.spring6.circuitbreaker.configure.ReactorCircuitBreakerAspectExt;
 import org.aspectj.lang.ProceedingJoinPoint;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -32,8 +31,8 @@ import static org.mockito.Mockito.when;
 /**
  * aspect unit test
  */
-@RunWith(MockitoJUnitRunner.class)
-public class ReactorCircuitBreakerAspectExtTest {
+@ExtendWith(MockitoExtension.class)
+class ReactorCircuitBreakerAspectExtTest {
 
     @Mock
     ProceedingJoinPoint proceedingJoinPoint;
@@ -41,15 +40,14 @@ public class ReactorCircuitBreakerAspectExtTest {
     @InjectMocks
     ReactorCircuitBreakerAspectExt reactorCircuitBreakerAspectExt;
 
-
     @Test
-    public void testCheckTypes() {
+    void testCheckTypes() {
         assertThat(reactorCircuitBreakerAspectExt.canHandleReturnType(Mono.class)).isTrue();
         assertThat(reactorCircuitBreakerAspectExt.canHandleReturnType(Flux.class)).isTrue();
     }
 
     @Test
-    public void testReactorTypes() throws Throwable {
+    void testReactorTypes() throws Throwable {
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("test");
 
         when(proceedingJoinPoint.proceed()).thenReturn(Mono.just("Test"));
@@ -60,6 +58,4 @@ public class ReactorCircuitBreakerAspectExtTest {
         assertThat(reactorCircuitBreakerAspectExt
             .handle(proceedingJoinPoint, circuitBreaker, "testMethod")).isNotNull();
     }
-
-
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/circuitbreaker/configure/RxJava2CircuitBreakerAspectExtTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/circuitbreaker/configure/RxJava2CircuitBreakerAspectExtTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Mahmoud Romeh
+ * Copyright 2026 Mahmoud Romeh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,14 @@
 package io.github.resilience4j.spring6.circuitbreaker.configure;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
-import io.github.resilience4j.spring6.circuitbreaker.configure.RxJava2CircuitBreakerAspectExt;
 import io.reactivex.Flowable;
 import io.reactivex.Single;
 import org.aspectj.lang.ProceedingJoinPoint;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -32,8 +31,8 @@ import static org.mockito.Mockito.when;
 /**
  * aspect unit test
  */
-@RunWith(MockitoJUnitRunner.class)
-public class RxJava2CircuitBreakerAspectExtTest {
+@ExtendWith(MockitoExtension.class)
+class RxJava2CircuitBreakerAspectExtTest {
 
     @Mock
     ProceedingJoinPoint proceedingJoinPoint;
@@ -41,15 +40,14 @@ public class RxJava2CircuitBreakerAspectExtTest {
     @InjectMocks
     RxJava2CircuitBreakerAspectExt rxJava2CircuitBreakerAspectExt;
 
-
     @Test
-    public void testCheckTypes() {
+    void testCheckTypes() {
         assertThat(rxJava2CircuitBreakerAspectExt.canHandleReturnType(Flowable.class)).isTrue();
         assertThat(rxJava2CircuitBreakerAspectExt.canHandleReturnType(Single.class)).isTrue();
     }
 
     @Test
-    public void testReactorTypes() throws Throwable {
+    void testReactorTypes() throws Throwable {
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("test");
 
         when(proceedingJoinPoint.proceed()).thenReturn(Single.just("Test"));

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/circuitbreaker/configure/RxJava3CircuitBreakerAspectExtTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/circuitbreaker/configure/RxJava3CircuitBreakerAspectExtTest.java
@@ -4,11 +4,11 @@ import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
 import org.aspectj.lang.ProceedingJoinPoint;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -16,8 +16,8 @@ import static org.mockito.Mockito.when;
 /**
  * aspect unit test
  */
-@RunWith(MockitoJUnitRunner.class)
-public class RxJava3CircuitBreakerAspectExtTest {
+@ExtendWith(MockitoExtension.class)
+class RxJava3CircuitBreakerAspectExtTest {
 
     @Mock
     ProceedingJoinPoint proceedingJoinPoint;
@@ -25,15 +25,14 @@ public class RxJava3CircuitBreakerAspectExtTest {
     @InjectMocks
     RxJava3CircuitBreakerAspectExt rxJava3CircuitBreakerAspectExt;
 
-
     @Test
-    public void testCheckTypes() {
+    void testCheckTypes() {
         assertThat(rxJava3CircuitBreakerAspectExt.canHandleReturnType(Flowable.class)).isTrue();
         assertThat(rxJava3CircuitBreakerAspectExt.canHandleReturnType(Single.class)).isTrue();
     }
 
     @Test
-    public void testRxTypes() throws Throwable {
+    void testRxTypes() throws Throwable {
         CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaults("test");
 
         when(proceedingJoinPoint.proceed()).thenReturn(Single.just("Test"));

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/fallback/FallbackAspectTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/fallback/FallbackAspectTest.java
@@ -8,24 +8,23 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.assertj.core.api.AssertionsForClassTypes;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.stereotype.Component;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = {TestApplication.class, FallbackAspectTest.TestConfig.class})
-public class FallbackAspectTest {
+class FallbackAspectTest {
 
     @Autowired
     @Qualifier("fallbackTestDummyService")
@@ -36,12 +35,12 @@ public class FallbackAspectTest {
     TestDummyService testDependencyDummyService;
 
     @Test
-    public void testFallbackAspect() {
+    void testFallbackAspect() {
         AssertionsForClassTypes.assertThat(testDummyService.sync()).isEqualTo("aspect");
         AssertionsForClassTypes.assertThat(testDependencyDummyService.sync()).isEqualTo("dependency");
     }
 
-    public static class FallbackTestDummyService extends CircuitBreakerDummyService {
+    static class FallbackTestDummyService extends CircuitBreakerDummyService {
 
         @Override
         @CircuitBreaker(name = BACKEND, fallbackMethod = "fallback")
@@ -55,7 +54,7 @@ public class FallbackAspectTest {
         }
     }
 
-    public static class FallbackDependencyTestDummyService extends CircuitBreakerDummyService {
+    static class FallbackDependencyTestDummyService extends CircuitBreakerDummyService {
         private final DependencyTestDummyService dependencyTestDummyService;
 
         public FallbackDependencyTestDummyService(DependencyTestDummyService dependencyTestDummyService) {
@@ -74,7 +73,7 @@ public class FallbackAspectTest {
         }
     }
 
-    public static class DependencyTestDummyService {
+    static class DependencyTestDummyService {
         public String test() {
             return "dependency";
         }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/fallback/FallbackExecutorTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/fallback/FallbackExecutorTest.java
@@ -1,11 +1,9 @@
 package io.github.resilience4j.spring6.fallback;
 
 import io.github.resilience4j.core.functions.CheckedSupplier;
-import io.github.resilience4j.spring6.fallback.FallbackDecorators;
-import io.github.resilience4j.spring6.fallback.FallbackExecutor;
 import io.github.resilience4j.spring6.spelresolver.SpelResolver;
 import org.aspectj.lang.ProceedingJoinPoint;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.beans.factory.BeanFactory;
@@ -18,7 +16,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
-public class FallbackExecutorTest {
+class FallbackExecutorTest {
     private final SpelResolver spelResolver = mock(SpelResolver.class);
     private final FallbackDecorators fallbackDecorators = mock(FallbackDecorators.class);
     private final ProceedingJoinPoint proceedingJoinPoint = mock(ProceedingJoinPoint.class);
@@ -33,7 +31,7 @@ public class FallbackExecutorTest {
     }
 
     @Test
-    public void testPrimaryMethodExecutionWithFallback() throws Throwable {
+    void testPrimaryMethodExecutionWithFallback() throws Throwable {
         Method method = this.getClass().getMethod("getName", String.class);
         final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
         final String fallbackMethodValue = "getNameValidFallback";
@@ -52,7 +50,7 @@ public class FallbackExecutorTest {
     }
 
     @Test
-    public void testPrimaryMethodExecutionWithoutFallback() throws Throwable {
+    void testPrimaryMethodExecutionWithoutFallback() throws Throwable {
         Method method = this.getClass().getMethod("getName", String.class);
         final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
         final String fallbackMethodValue = "";
@@ -70,7 +68,7 @@ public class FallbackExecutorTest {
     }
 
     @Test
-    public void testPrimaryMethodExecutionWithFallbackNotFound() throws Throwable {
+    void testPrimaryMethodExecutionWithFallbackNotFound() throws Throwable {
         Method method = this.getClass().getMethod("getName", String.class);
         final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
         final String fallbackMethodValue = "incorrectFallbackMethodName";
@@ -88,7 +86,7 @@ public class FallbackExecutorTest {
     }
 
     @Test
-    public void testPrimaryMethodExecutionWithFallbackWithIncorrectSignature() throws Throwable {
+    void testPrimaryMethodExecutionWithFallbackWithIncorrectSignature() throws Throwable {
         Method method = this.getClass().getMethod("getName", String.class);
         final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
         final String fallbackMethodValue = "getNameInvalidFallback";
@@ -118,7 +116,7 @@ public class FallbackExecutorTest {
     }
 
     @Test
-    public void testPrimaryMethodExecutionWithFallbackBean() throws Throwable {
+    void testPrimaryMethodExecutionWithFallbackBean() throws Throwable {
         ExternalFallbackBean fallbackBean = new ExternalFallbackBean();
         Method method = this.getClass().getMethod("getName", String.class);
         final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
@@ -142,7 +140,7 @@ public class FallbackExecutorTest {
     }
 
     @Test
-    public void testPrimaryMethodExecutionWithFallbackMethodNotFound() throws Throwable {
+    void testPrimaryMethodExecutionWithFallbackMethodNotFound() throws Throwable {
         Method method = this.getClass().getMethod("getName", String.class);
         final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
         final String fallbackMethodValue = "myFallbackBean::nonExistentMethod";
@@ -160,7 +158,7 @@ public class FallbackExecutorTest {
     }
 
     @Test
-    public void testPrimaryMethodExecutionWithAopProxiedFallbackBean() throws Throwable {
+    void testPrimaryMethodExecutionWithAopProxiedFallbackBean() throws Throwable {
         // CGLIB-proxied bean must be unwrapped via AopProxyUtils.getSingletonTarget
         // so method discovery walks the real class instead of the synthetic subclass.
         ExternalFallbackBean target = new ExternalFallbackBean();
@@ -188,7 +186,7 @@ public class FallbackExecutorTest {
     }
 
     @Test
-    public void testPrimaryMethodExecutionWithEmptyFallbackBeanMethod() throws Throwable {
+    void testPrimaryMethodExecutionWithEmptyFallbackBeanMethod() throws Throwable {
         Method method = this.getClass().getMethod("getName", String.class);
         final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
         final String fallbackMethodValue = "myFallbackBean::";
@@ -205,7 +203,7 @@ public class FallbackExecutorTest {
     }
 
     @Test
-    public void testPrimaryMethodExecutionWithNonExistentFallbackBean() throws Throwable {
+    void testPrimaryMethodExecutionWithNonExistentFallbackBean() throws Throwable {
         Method method = this.getClass().getMethod("getName", String.class);
         final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
         final String fallbackMethodValue = "nonExistentBean::recover";
@@ -222,7 +220,7 @@ public class FallbackExecutorTest {
     }
 
     @Test
-    public void testPrimaryMethodExecutionWithEmptyBeanName() throws Throwable {
+    void testPrimaryMethodExecutionWithEmptyBeanName() throws Throwable {
         Method method = this.getClass().getMethod("getName", String.class);
         final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
         final String fallbackMethodValue = "::recover";
@@ -238,7 +236,7 @@ public class FallbackExecutorTest {
     }
 
     @Test
-    public void testPrimaryMethodExecutionWithSpelResolvedFallbackBean() throws Throwable {
+    void testPrimaryMethodExecutionWithSpelResolvedFallbackBean() throws Throwable {
         ExternalFallbackBean fallbackBean = new ExternalFallbackBean();
         Method method = this.getClass().getMethod("getName", String.class);
         final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
@@ -258,7 +256,7 @@ public class FallbackExecutorTest {
     }
 
     @Test
-    public void testPrimaryMethodExecutionWithMultipleSeparators() throws Throwable {
+    void testPrimaryMethodExecutionWithMultipleSeparators() throws Throwable {
         Method method = this.getClass().getMethod("getName", String.class);
         final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
         final String fallbackMethodValue = "bean::method::extra";
@@ -274,7 +272,7 @@ public class FallbackExecutorTest {
     }
 
     @Test
-    public void testCtorWithBeanFactoryArgResolvesExternalFallback() throws Throwable {
+    void testCtorWithBeanFactoryArgResolvesExternalFallback() throws Throwable {
         ExternalFallbackBean fallbackBean = new ExternalFallbackBean();
         FallbackExecutor executor = new FallbackExecutor(spelResolver, fallbackDecorators, beanFactory);
         Method method = this.getClass().getMethod("getName", String.class);
@@ -294,7 +292,7 @@ public class FallbackExecutorTest {
     }
 
     @Test
-    public void testPrimaryMethodExecutionWithBeanFactoryNullAndSeparator() throws Throwable {
+    void testPrimaryMethodExecutionWithBeanFactoryNullAndSeparator() throws Throwable {
         FallbackExecutor executorWithoutBeanFactory = new FallbackExecutor(spelResolver, fallbackDecorators);
         Method method = this.getClass().getMethod("getName", String.class);
         final CheckedSupplier<Object> primaryFunction = () -> getName("Name");
@@ -310,7 +308,7 @@ public class FallbackExecutorTest {
         verify(fallbackDecorators, never()).decorate(any(), any());
     }
 
-    public static class ExternalFallbackBean {
+    static class ExternalFallbackBean {
         public String getNameValidFallback(String parameter, Throwable throwable) {
             return "recovered-from-external-bean";
         }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/fallback/FallbackMethodParentTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/fallback/FallbackMethodParentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 authors
+ * Copyright 2026 authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package io.github.resilience4j.spring6.fallback;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * https://github.com/resilience4j/resilience4j/issues/653
  */
 @SuppressWarnings("unused")
-public class FallbackMethodParentTest {
+class FallbackMethodParentTest {
 
     public String testMethod(String parameter) {
         return "test";
@@ -42,7 +42,7 @@ public class FallbackMethodParentTest {
     }
 
     @Test
-    public void fallbackIgnoringParentMethod() throws Throwable {
+    void fallbackIgnoringParentMethod() throws Throwable {
         Proxy target = new Proxy();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
 
@@ -54,7 +54,7 @@ public class FallbackMethodParentTest {
     }
 
     @Test
-    public void fallbackIgnoringInterfaceMethod() throws Throwable {
+    void fallbackIgnoringInterfaceMethod() throws Throwable {
         Proxy target = new Proxy();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
 
@@ -66,7 +66,7 @@ public class FallbackMethodParentTest {
     }
 
     @Test
-    public void fallbackNotIgnoringInterfaceMethod() throws Throwable {
+    void fallbackNotIgnoringInterfaceMethod() throws Throwable {
         Proxy target = new Proxy();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
 
@@ -78,7 +78,7 @@ public class FallbackMethodParentTest {
     }
 
     @Test
-    public void dontFallbackAmbiguousMethod() throws Throwable {
+    void dontFallbackAmbiguousMethod() throws Throwable {
         Proxy target = new Proxy();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
 

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/fallback/FallbackMethodTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/fallback/FallbackMethodTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Kyuhyen Hwang , Mahmoud Romih
+ * Copyright 2026 Kyuhyen Hwang , Mahmoud Romih
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package io.github.resilience4j.spring6.fallback;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
 import java.util.concurrent.CompletableFuture;
@@ -24,10 +24,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SuppressWarnings("unused")
-public class FallbackMethodTest {
+class FallbackMethodTest {
 
     @Test
-    public void fallbackRuntimeExceptionTest() throws Throwable {
+    void fallbackRuntimeExceptionTest() throws Throwable {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
         FallbackMethod fallbackMethod = FallbackMethod
@@ -37,7 +37,7 @@ public class FallbackMethodTest {
     }
 
     @Test
-    public void fallbackFuture() throws Throwable {
+    void fallbackFuture() throws Throwable {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testFutureMethod", String.class);
         FallbackMethod fallbackMethod = FallbackMethod
@@ -47,7 +47,7 @@ public class FallbackMethodTest {
     }
 
     @Test
-    public void fallbackGlobalExceptionWithSameMethodReturnType() throws Throwable {
+    void fallbackGlobalExceptionWithSameMethodReturnType() throws Throwable {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
         FallbackMethod fallbackMethod = FallbackMethod
@@ -57,7 +57,7 @@ public class FallbackMethodTest {
     }
 
     @Test
-    public void fallbackGlobalExceptionWithSameMethodReturnTypeAndMultipleParameters() throws Throwable {
+    void fallbackGlobalExceptionWithSameMethodReturnTypeAndMultipleParameters() throws Throwable {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("multipleParameterTestMethod", String.class, String.class);
 
@@ -69,7 +69,7 @@ public class FallbackMethodTest {
     }
 
     @Test
-    public void fallbackClosestSuperclassExceptionTest() throws Throwable {
+    void fallbackClosestSuperclassExceptionTest() throws Throwable {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
         FallbackMethod fallbackMethod = FallbackMethod
@@ -79,7 +79,7 @@ public class FallbackMethodTest {
     }
 
     @Test
-    public void shouldThrowUnrecoverableThrowable() throws Throwable {
+    void shouldThrowUnrecoverableThrowable() throws Throwable {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
         FallbackMethod fallbackMethod = FallbackMethod
@@ -90,7 +90,7 @@ public class FallbackMethodTest {
     }
 
     @Test
-    public void shouldCallPrivateFallbackMethod() throws Throwable {
+    void shouldCallPrivateFallbackMethod() throws Throwable {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
         FallbackMethod fallbackMethod = FallbackMethod
@@ -100,7 +100,7 @@ public class FallbackMethodTest {
     }
 
     @Test
-    public void mismatchReturnType_shouldThrowNoSuchMethodException() throws Throwable {
+    void mismatchReturnType_shouldThrowNoSuchMethodException() throws Throwable {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
 
@@ -112,7 +112,7 @@ public class FallbackMethodTest {
     }
 
     @Test
-    public void shouldFailIf2FallBackMethodsHandleSameException() throws Throwable {
+    void shouldFailIf2FallBackMethodsHandleSameException() throws Throwable {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
         assertThatThrownBy(() -> FallbackMethod
@@ -123,7 +123,7 @@ public class FallbackMethodTest {
     }
 
     @Test
-    public void notFoundFallbackMethod_shouldThrowsNoSuchMethodException() throws Throwable {
+    void notFoundFallbackMethod_shouldThrowsNoSuchMethodException() throws Throwable {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
         assertThatThrownBy(
@@ -134,7 +134,7 @@ public class FallbackMethodTest {
     }
 
     @Test
-    public void rethrownFallbackMethodRuntimeExceptionShouldNotBeWrapped() throws Throwable {
+    void rethrownFallbackMethodRuntimeExceptionShouldNotBeWrapped() throws Throwable {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
         FallbackMethod fallbackMethod = FallbackMethod
@@ -144,7 +144,7 @@ public class FallbackMethodTest {
     }
 
     @Test
-    public void rethrownFallbackMethodCheckedExceptionShouldNotBeWrapped() throws Throwable {
+    void rethrownFallbackMethodCheckedExceptionShouldNotBeWrapped() throws Throwable {
         FallbackMethodTest target = new FallbackMethodTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
         FallbackMethod fallbackMethod = FallbackMethod

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/fallback/JdkProxyFallbackAspectTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/fallback/JdkProxyFallbackAspectTest.java
@@ -4,34 +4,34 @@ import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.spring6.CircuitBreakerDummyService;
 import io.github.resilience4j.spring6.TestApplication;
 import io.github.resilience4j.spring6.TestDummyService;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(
         classes = {TestApplication.class, JdkProxyFallbackAspectTest.TestConfig.class},
         properties = {"spring.aop.proxy-target-class=false"}
 )
-public class JdkProxyFallbackAspectTest {
+class JdkProxyFallbackAspectTest {
 
     @Autowired
     @Qualifier("fallbackTestDummyService")
     TestDummyService testDummyService;
 
     @Test
-    public void testFallbackAspect() {
+    void testFallbackAspect() {
         assertThat(testDummyService.sync()).isEqualTo("recovery");
     }
 
-    public static class FallbackTestDummyService extends CircuitBreakerDummyService {
+    static class FallbackTestDummyService extends CircuitBreakerDummyService {
 
         @Override
         @CircuitBreaker(name = BACKEND, fallbackMethod = "fallback")

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/fallback/RethrowCheckedException.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/fallback/RethrowCheckedException.java
@@ -1,5 +1,4 @@
 package io.github.resilience4j.spring6.fallback;
 
-class RethrowCheckedException extends Exception {
-
+public class RethrowCheckedException extends Exception {
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/fallback/RethrowException.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/fallback/RethrowException.java
@@ -1,5 +1,4 @@
 package io.github.resilience4j.spring6.fallback;
 
-class RethrowException extends RuntimeException {
-
+public class RethrowException extends RuntimeException {
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/micrometer/configure/DefaultTimerTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/micrometer/configure/DefaultTimerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Mahmoud Romeh
+ * Copyright 2026 Mahmoud Romeh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,11 +20,11 @@ import io.github.resilience4j.micrometer.TimerRegistry;
 import io.github.resilience4j.spring6.TestApplication;
 import io.github.resilience4j.spring6.micrometer.configure.utils.DefaultTimedService;
 import io.micrometer.core.instrument.MeterRegistry;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.concurrent.ExecutionException;
 
@@ -34,9 +34,9 @@ import static io.github.resilience4j.spring6.micrometer.configure.utils.DefaultT
 import static io.github.resilience4j.spring6.micrometer.configure.utils.DefaultTimedService.COMPLETABLE_STAGE_TIMER_NAME;
 import static org.assertj.core.api.BDDAssertions.then;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = TestApplication.class)
-public class DefaultTimerTest {
+class DefaultTimerTest {
 
     @Autowired
     private MeterRegistry meterRegistry;
@@ -46,7 +46,7 @@ public class DefaultTimerTest {
     private DefaultTimedService service;
 
     @Test
-    public void shouldTimeBasicOperation() {
+    void shouldTimeBasicOperation() {
         Timer timer = timerRegistry.timer(BASIC_OPERATION_TIMER_NAME);
 
         String result1 = service.succeed(123);
@@ -70,7 +70,7 @@ public class DefaultTimerTest {
     }
 
     @Test
-    public void shouldTimeCompletableStage() throws Throwable {
+    void shouldTimeCompletableStage() throws Throwable {
         Timer timer = timerRegistry.timer(COMPLETABLE_STAGE_TIMER_NAME);
 
         String result1 = service.succeedCompletionStage(123).toCompletableFuture().get();

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/micrometer/configure/ReactorTimerTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/micrometer/configure/ReactorTimerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Mahmoud Romeh
+ * Copyright 2026 Mahmoud Romeh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,11 +20,11 @@ import io.github.resilience4j.micrometer.TimerRegistry;
 import io.github.resilience4j.spring6.TestApplication;
 import io.github.resilience4j.spring6.micrometer.configure.utils.ReactorTimedService;
 import io.micrometer.core.instrument.MeterRegistry;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
 
@@ -36,9 +36,9 @@ import static java.time.Duration.ofSeconds;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.assertj.core.api.BDDAssertions.then;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = TestApplication.class)
-public class ReactorTimerTest {
+class ReactorTimerTest {
 
     @Autowired
     private MeterRegistry meterRegistry;
@@ -48,7 +48,7 @@ public class ReactorTimerTest {
     private ReactorTimedService service;
 
     @Test
-    public void shouldTimeMono() {
+    void shouldTimeMono() {
         Timer timer = timerRegistry.timer(MONO_TIMER_NAME);
 
         String result1 = service.succeedMono(123).block(ofSeconds(1));
@@ -73,7 +73,7 @@ public class ReactorTimerTest {
     }
 
     @Test
-    public void shouldTimeFlux() {
+    void shouldTimeFlux() {
         Timer timer = timerRegistry.timer(FLUX_TIMER_NAME);
 
         List<String> result1 = service.succeedFlux(123).collectList().block(ofSeconds(1));

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/micrometer/configure/RxJava2TimerTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/micrometer/configure/RxJava2TimerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Mahmoud Romeh
+ * Copyright 2026 Mahmoud Romeh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,11 +20,11 @@ import io.github.resilience4j.micrometer.TimerRegistry;
 import io.github.resilience4j.spring6.TestApplication;
 import io.github.resilience4j.spring6.micrometer.configure.utils.RxJava2TimedService;
 import io.micrometer.core.instrument.MeterRegistry;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
 
@@ -34,9 +34,9 @@ import static io.github.resilience4j.spring6.micrometer.configure.utils.RxJava2T
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.assertj.core.api.BDDAssertions.then;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = TestApplication.class)
-public class RxJava2TimerTest {
+class RxJava2TimerTest {
 
     @Autowired
     private MeterRegistry meterRegistry;
@@ -46,7 +46,7 @@ public class RxJava2TimerTest {
     private RxJava2TimedService service;
 
     @Test
-    public void shouldTimeCompletable() {
+    void shouldTimeCompletable() {
         Timer timer = timerRegistry.timer(COMPLETABLE_TIMER_NAME);
 
         Throwable result1 = service.succeedCompletable().blockingGet();
@@ -68,7 +68,7 @@ public class RxJava2TimerTest {
     }
 
     @Test
-    public void shouldTimeSingle() {
+    void shouldTimeSingle() {
         Timer timer = timerRegistry.timer(SINGLE_TIMER_NAME);
 
         String result1 = service.succeedSingle(123).blockingGet();
@@ -93,7 +93,7 @@ public class RxJava2TimerTest {
     }
 
     @Test
-    public void shouldTimeMaybe() {
+    void shouldTimeMaybe() {
         Timer timer = timerRegistry.timer(MAYBE_TIMER_NAME);
 
         String result1 = service.succeedMaybe(123).blockingGet();
@@ -118,7 +118,7 @@ public class RxJava2TimerTest {
     }
 
     @Test
-    public void shouldTimeObservable() {
+    void shouldTimeObservable() {
         Timer timer = timerRegistry.timer(OBSERVABLE_TIMER_NAME);
 
         List<String> result1 = service.succeedObservable(123).toList().blockingGet();
@@ -143,7 +143,7 @@ public class RxJava2TimerTest {
     }
 
     @Test
-    public void shouldTimeFlowable() {
+    void shouldTimeFlowable() {
         Timer timer = timerRegistry.timer(FLOWABLE_TIMER_NAME);
 
         List<String> result1 = service.succeedFlowable(123).toList().blockingGet();

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/micrometer/configure/RxJava3TimerTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/micrometer/configure/RxJava3TimerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Mahmoud Romeh
+ * Copyright 2026 Mahmoud Romeh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,11 +20,11 @@ import io.github.resilience4j.micrometer.TimerRegistry;
 import io.github.resilience4j.spring6.TestApplication;
 import io.github.resilience4j.spring6.micrometer.configure.utils.RxJava3TimedService;
 import io.micrometer.core.instrument.MeterRegistry;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
 
@@ -35,9 +35,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.assertj.core.api.BDDAssertions.then;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = TestApplication.class)
-public class RxJava3TimerTest {
+class RxJava3TimerTest {
 
     @Autowired
     private MeterRegistry meterRegistry;
@@ -47,7 +47,7 @@ public class RxJava3TimerTest {
     private RxJava3TimedService service;
 
     @Test
-    public void shouldTimeCompletable() {
+    void shouldTimeCompletable() {
         Timer timer = timerRegistry.timer(COMPLETABLE_TIMER_NAME);
 
         assertThat(service.succeedCompletable().toObservable().isEmpty().blockingGet()).isTrue();
@@ -71,7 +71,7 @@ public class RxJava3TimerTest {
     }
 
     @Test
-    public void shouldTimeSingle() {
+    void shouldTimeSingle() {
         Timer timer = timerRegistry.timer(SINGLE_TIMER_NAME);
 
         String result1 = service.succeedSingle(123).blockingGet();
@@ -96,7 +96,7 @@ public class RxJava3TimerTest {
     }
 
     @Test
-    public void shouldTimeMaybe() {
+    void shouldTimeMaybe() {
         Timer timer = timerRegistry.timer(MAYBE_TIMER_NAME);
 
         String result1 = service.succeedMaybe(123).blockingGet();
@@ -121,7 +121,7 @@ public class RxJava3TimerTest {
     }
 
     @Test
-    public void shouldTimeObservable() {
+    void shouldTimeObservable() {
         Timer timer = timerRegistry.timer(OBSERVABLE_TIMER_NAME);
 
         List<String> result1 = service.succeedObservable(123).toList().blockingGet();
@@ -146,7 +146,7 @@ public class RxJava3TimerTest {
     }
 
     @Test
-    public void shouldTimeFlowable() {
+    void shouldTimeFlowable() {
         Timer timer = timerRegistry.timer(FLOWABLE_TIMER_NAME);
 
         List<String> result1 = service.succeedFlowable(123).toList().blockingGet();

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/micrometer/configure/TimerConfigurationTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/micrometer/configure/TimerConfigurationTest.java
@@ -11,16 +11,16 @@ import io.github.resilience4j.micrometer.event.TimerEvent;
 import io.github.resilience4j.spring6.micrometer.configure.utils.FixedOnFailureTagResolver;
 import io.github.resilience4j.spring6.micrometer.configure.utils.QualifiedClassNameOnFailureTagResolver;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class TimerConfigurationTest {
+class TimerConfigurationTest {
 
     @Test
-    public void shouldConfigureInstancesUsingDedicatedConfigs() {
+    void shouldConfigureInstancesUsingDedicatedConfigs() {
         InstanceProperties instanceProperties1 = new InstanceProperties()
                 .setMetricNames("resilience4j.timer.operations1")
                 .setOnFailureTagResolver(QualifiedClassNameOnFailureTagResolver.class)
@@ -53,7 +53,7 @@ public class TimerConfigurationTest {
     }
 
     @Test
-    public void shouldConfigureInstancesUsingPredefinedDefaultConfig() {
+    void shouldConfigureInstancesUsingPredefinedDefaultConfig() {
         InstanceProperties instanceProperties1 = new InstanceProperties()
                 .setMetricNames("resilience4j.timer.operations1");
         InstanceProperties instanceProperties2 = new InstanceProperties()
@@ -82,7 +82,7 @@ public class TimerConfigurationTest {
     }
 
     @Test
-    public void shouldConfigureInstancesUsingCustomDefaultConfig() {
+    void shouldConfigureInstancesUsingCustomDefaultConfig() {
         InstanceProperties defaultProperties = new InstanceProperties()
                 .setMetricNames("resilience4j.timer.default")
                 .setOnFailureTagResolver(FixedOnFailureTagResolver.class);
@@ -115,7 +115,7 @@ public class TimerConfigurationTest {
     }
 
     @Test
-    public void shouldConfigureInstancesUsingCustomSharedConfig() {
+    void shouldConfigureInstancesUsingCustomSharedConfig() {
         InstanceProperties sharedProperties = new InstanceProperties()
                 .setMetricNames("resilience4j.timer.shared")
                 .setOnFailureTagResolver(FixedOnFailureTagResolver.class);
@@ -146,7 +146,7 @@ public class TimerConfigurationTest {
     }
 
     @Test
-    public void shouldNotConfigureInstanceUsingUnknownSharedConfig() {
+    void shouldNotConfigureInstanceUsingUnknownSharedConfig() {
         InstanceProperties instanceProperties = new InstanceProperties()
                 .setBaseConfig("unknown");
         TimerConfigurationProperties configurationProperties = new TimerConfigurationProperties();

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/micrometer/configure/utils/TestConfiguration.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/micrometer/configure/utils/TestConfiguration.java
@@ -6,7 +6,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-class TestConfiguration {
+public class TestConfiguration {
 
     @Bean
     public MeterRegistry meterRegistry() {

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/ratelimiter/configure/RateLimiterAspectSpelResolverTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/ratelimiter/configure/RateLimiterAspectSpelResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Kyuhyen Hwang
+ * Copyright 2026 Kyuhyen Hwang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,21 +15,21 @@
  */
 package io.github.resilience4j.spring6.ratelimiter.configure;
 
+import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
 import io.github.resilience4j.spring6.TestApplication;
 import io.github.resilience4j.spring6.TestDummyService;
-import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = TestApplication.class)
-public class RateLimiterAspectSpelResolverTest {
+class RateLimiterAspectSpelResolverTest {
     @Autowired
     @Qualifier("rateLimiterDummyService")
     TestDummyService testDummyService;
@@ -38,7 +38,7 @@ public class RateLimiterAspectSpelResolverTest {
     RateLimiterRegistry registry;
 
     @Test
-    public void testSpel() {
+    void testSpel() {
         assertThat(registry.getAllRateLimiters().stream().filter(it -> it.getName().equals("SPEL_BACKEND")).findAny().isPresent()).isFalse();
         assertThat(testDummyService.spelSync("SPEL_BACKEND")).isEqualTo("recovered");
         assertThat(registry.getAllRateLimiters().stream().filter(it -> it.getName().equals("SPEL_BACKEND")).findAny().isPresent()).isTrue();

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/ratelimiter/configure/RateLimiterConfigurationSpringTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/ratelimiter/configure/RateLimiterConfigurationSpringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Mahmoud Romeh
+ * Copyright 2026 Mahmoud Romeh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,46 +17,44 @@ package io.github.resilience4j.spring6.ratelimiter.configure;
 
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
-import io.github.resilience4j.spring6.fallback.FallbackExecutor;
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
 import io.github.resilience4j.ratelimiter.event.RateLimiterEvent;
+import io.github.resilience4j.spring6.fallback.FallbackExecutor;
 import io.github.resilience4j.spring6.spelresolver.SpelResolver;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {
     RateLimiterConfigurationSpringTest.ConfigWithOverrides.class
 })
-public class RateLimiterConfigurationSpringTest {
+class RateLimiterConfigurationSpringTest {
 
     @Autowired
     private ConfigWithOverrides configWithOverrides;
 
-
     @Test
-    public void testAllCircuitBreakerConfigurationBeansOverridden() {
-        assertNotNull(configWithOverrides.rateLimiterRegistry);
-        assertNotNull(configWithOverrides.rateLimiterAspect);
-        assertNotNull(configWithOverrides.rateLimiterEventEventConsumerRegistry);
-        assertNotNull(configWithOverrides.rateLimiterConfigurationProperties);
-        assertTrue(configWithOverrides.rateLimiterConfigurationProperties.getConfigs().size() == 1);
+    void testAllCircuitBreakerConfigurationBeansOverridden() {
+        assertThat(configWithOverrides.rateLimiterRegistry).isNotNull();
+        assertThat(configWithOverrides.rateLimiterAspect).isNotNull();
+        assertThat(configWithOverrides.rateLimiterEventEventConsumerRegistry).isNotNull();
+        assertThat(configWithOverrides.rateLimiterConfigurationProperties).isNotNull();
+        assertThat(configWithOverrides.rateLimiterConfigurationProperties.getConfigs()).hasSize(1);
     }
 
     @Configuration
     @ComponentScan({"io.github.resilience4j.spring6.ratelimiter", "io.github.resilience4j.spring6.fallback", "io.github.resilience4j.spring6.spelresolver"})
-    public static class ConfigWithOverrides {
+    static class ConfigWithOverrides {
 
         private RateLimiterRegistry rateLimiterRegistry;
 
@@ -108,5 +106,4 @@ public class RateLimiterConfigurationSpringTest {
 
         }
     }
-
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/ratelimiter/configure/RateLimiterConfigurationTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/ratelimiter/configure/RateLimiterConfigurationTest.java
@@ -8,11 +8,9 @@ import io.github.resilience4j.core.registry.CompositeRegistryEventConsumer;
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
 import io.github.resilience4j.ratelimiter.event.RateLimiterEvent;
-import io.github.resilience4j.spring6.ratelimiter.configure.RateLimiterConfiguration;
-import io.github.resilience4j.spring6.ratelimiter.configure.RateLimiterConfigurationProperties;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -24,11 +22,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * test custom init of rate limiter configuration
  */
-@RunWith(MockitoJUnitRunner.class)
-public class RateLimiterConfigurationTest {
+@ExtendWith(MockitoExtension.class)
+class RateLimiterConfigurationTest {
 
     @Test
-    public void testRateLimiterRegistry() {
+    void testRateLimiterRegistry() {
         io.github.resilience4j.common.ratelimiter.configuration.CommonRateLimiterConfigurationProperties.InstanceProperties instanceProperties1 = new io.github.resilience4j.common.ratelimiter.configuration.CommonRateLimiterConfigurationProperties.InstanceProperties();
         instanceProperties1.setLimitForPeriod(2);
         instanceProperties1.setSubscribeForEvents(true);
@@ -59,7 +57,7 @@ public class RateLimiterConfigurationTest {
     }
 
     @Test
-    public void testCreateRateLimiterRegistryWithSharedConfigs() {
+    void testCreateRateLimiterRegistryWithSharedConfigs() {
         //Given
         io.github.resilience4j.common.ratelimiter.configuration.CommonRateLimiterConfigurationProperties.InstanceProperties defaultProperties = new io.github.resilience4j.common.ratelimiter.configuration.CommonRateLimiterConfigurationProperties.InstanceProperties();
         defaultProperties.setLimitForPeriod(3);
@@ -125,7 +123,7 @@ public class RateLimiterConfigurationTest {
     }
 
     @Test
-    public void testCreateRateLimiterRegistryWithUnknownConfig() {
+    void testCreateRateLimiterRegistryWithUnknownConfig() {
         RateLimiterConfigurationProperties rateLimiterConfigurationProperties = new RateLimiterConfigurationProperties();
         io.github.resilience4j.common.ratelimiter.configuration.CommonRateLimiterConfigurationProperties.InstanceProperties instanceProperties = new io.github.resilience4j.common.ratelimiter.configuration.CommonRateLimiterConfigurationProperties.InstanceProperties();
         instanceProperties.setBaseConfig("unknownConfig");
@@ -144,5 +142,4 @@ public class RateLimiterConfigurationTest {
     public CompositeCustomizer<RateLimiterConfigCustomizer> compositeRateLimiterCustomizerTest() {
         return new CompositeCustomizer<>(Collections.emptyList());
     }
-
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/ratelimiter/configure/RateLimiterInitializationInAspectTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/ratelimiter/configure/RateLimiterInitializationInAspectTest.java
@@ -4,28 +4,28 @@ import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
 import io.github.resilience4j.spring6.TestDummyService;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.time.Duration;
 
 import static io.github.resilience4j.spring6.TestDummyService.BACKEND;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(properties = {
         "logging.level.io.github.resilience4j.ratelimiter.configure=debug",
         "spring.main.allow-bean-definition-overriding=true"
 })
-public class RateLimiterInitializationInAspectTest {
+class RateLimiterInitializationInAspectTest {
 
     @TestConfiguration
     static class TestConfig {
@@ -53,19 +53,19 @@ public class RateLimiterInitializationInAspectTest {
     @Autowired
     RateLimiterRegistry registry;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         // ensure no rate limiters are initialized
         assertThat(registry.getAllRateLimiters()).isEmpty();
     }
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         registry.getAllRateLimiters().stream().map(RateLimiter::getName).forEach(registry::remove);
     }
 
     @Test
-    public void testCorrectConfigIsUsedInAspect() {
+    void testCorrectConfigIsUsedInAspect() {
 
         // one successful call within 10s
         assertThat(testDummyService.syncSuccess()).isEqualTo("ok");
@@ -73,7 +73,7 @@ public class RateLimiterInitializationInAspectTest {
     }
 
     @Test
-    public void testDefaultConfigurationIsUsedIfNoConfigurationAspect() {
+    void testDefaultConfigurationIsUsedIfNoConfigurationAspect() {
         assertThat(testDummyService.spelSyncNoCfg("foo")).isEqualTo("foo");
         assertThat(testDummyService.spelSyncNoCfg("foo")).isEqualTo("foo");
         assertThat(registry.getAllRateLimiters()).hasSize(1)
@@ -82,7 +82,7 @@ public class RateLimiterInitializationInAspectTest {
     }
 
     @Test
-    public void testSpecifiedConfigurationIsUsedIfConfigurationAspect() {
+    void testSpecifiedConfigurationIsUsedIfConfigurationAspect() {
         assertThat(testDummyService.spelSyncWithCfg("foo")).isEqualTo("foo");
         assertThat(testDummyService.spelSyncWithCfg("foo")).isEqualTo("recovered");
         assertThat(registry.getAllRateLimiters()).hasSize(1)

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/ratelimiter/configure/RateLimiterRecoveryTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/ratelimiter/configure/RateLimiterRecoveryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 lespinsideg
+ * Copyright 2026 lespinsideg
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,93 +17,93 @@ package io.github.resilience4j.spring6.ratelimiter.configure;
 
 import io.github.resilience4j.spring6.TestApplication;
 import io.github.resilience4j.spring6.TestDummyService;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = TestApplication.class)
-public class RateLimiterRecoveryTest {
+class RateLimiterRecoveryTest {
 
     @Autowired
     @Qualifier("rateLimiterDummyService")
     TestDummyService testDummyService;
 
     @Test
-    public void testRecovery() {
+    void testRecovery() {
         assertThat(testDummyService.sync()).isEqualTo("recovered");
     }
 
     @Test
-    public void testAsyncRecovery() throws Exception {
+    void testAsyncRecovery() throws Exception {
         assertThat(testDummyService.async().toCompletableFuture().get(5, TimeUnit.SECONDS))
             .isEqualTo("recovered");
     }
 
     @Test
-    public void testMonoRecovery() {
+    void testMonoRecovery() {
         assertThat(testDummyService.mono("test").block()).isEqualTo("test");
     }
 
     @Test
-    public void testFluxRecovery() {
+    void testFluxRecovery() {
         assertThat(testDummyService.flux().blockFirst()).isEqualTo("recovered");
     }
 
     @Test
-    public void testObservableRecovery() {
+    void testObservableRecovery() {
         assertThat(testDummyService.observable().blockingFirst()).isEqualTo("recovered");
     }
 
     @Test
-    public void testSingleRecovery() {
+    void testSingleRecovery() {
         assertThat(testDummyService.single().blockingGet()).isEqualTo("recovered");
     }
 
     @Test
-    public void testCompletableRecovery() {
+    void testCompletableRecovery() {
         assertThat(testDummyService.completable().blockingGet()).isNull();
     }
 
     @Test
-    public void testMaybeRecovery() {
+    void testMaybeRecovery() {
         assertThat(testDummyService.maybe().blockingGet()).isEqualTo("recovered");
     }
 
     @Test
-    public void testFlowableRecovery() {
+    void testFlowableRecovery() {
         assertThat(testDummyService.flowable().blockingFirst()).isEqualTo("recovered");
     }
 
     @Test
-    public void testRx3ObservableRecovery() {
+    void testRx3ObservableRecovery() {
         assertThat(testDummyService.rx3Observable().blockingFirst()).isEqualTo("recovered");
     }
 
     @Test
-    public void testRx3SingleRecovery() {
+    void testRx3SingleRecovery() {
         assertThat(testDummyService.rx3Single().blockingGet()).isEqualTo("recovered");
     }
 
     @Test
-    public void testRx3CompletableRecovery() {
+    void testRx3CompletableRecovery() {
         testDummyService.rx3Completable().test().assertComplete();
     }
 
     @Test
-    public void testRx3MaybeRecovery() {
+    void testRx3MaybeRecovery() {
         assertThat(testDummyService.rx3Maybe().blockingGet()).isEqualTo("recovered");
     }
 
     @Test
-    public void testRx3FlowableRecovery() {
+    void testRx3FlowableRecovery() {
         assertThat(testDummyService.rx3Flowable().blockingFirst()).isEqualTo("recovered");
     }
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/ratelimiter/configure/ReactorRateLimiterAspectExtTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/ratelimiter/configure/ReactorRateLimiterAspectExtTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Mahmoud Romeh
+ * Copyright 2026 Mahmoud Romeh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,12 @@
 package io.github.resilience4j.spring6.ratelimiter.configure;
 
 import io.github.resilience4j.ratelimiter.RateLimiter;
-import io.github.resilience4j.spring6.ratelimiter.configure.ReactorRateLimiterAspectExt;
 import org.aspectj.lang.ProceedingJoinPoint;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -32,8 +31,8 @@ import static org.mockito.Mockito.when;
 /**
  * aspect unit test
  */
-@RunWith(MockitoJUnitRunner.class)
-public class ReactorRateLimiterAspectExtTest {
+@ExtendWith(MockitoExtension.class)
+class ReactorRateLimiterAspectExtTest {
 
     @Mock
     ProceedingJoinPoint proceedingJoinPoint;
@@ -41,15 +40,14 @@ public class ReactorRateLimiterAspectExtTest {
     @InjectMocks
     ReactorRateLimiterAspectExt reactorRateLimiterAspectExt;
 
-
     @Test
-    public void testCheckTypes() {
+    void testCheckTypes() {
         assertThat(reactorRateLimiterAspectExt.canHandleReturnType(Mono.class)).isTrue();
         assertThat(reactorRateLimiterAspectExt.canHandleReturnType(Flux.class)).isTrue();
     }
 
     @Test
-    public void testReactorTypes() throws Throwable {
+    void testReactorTypes() throws Throwable {
         RateLimiter rateLimiter = RateLimiter.ofDefaults("test");
 
         when(proceedingJoinPoint.proceed()).thenReturn(Mono.just("Test"));
@@ -62,6 +60,4 @@ public class ReactorRateLimiterAspectExtTest {
             reactorRateLimiterAspectExt.handle(proceedingJoinPoint, rateLimiter, "testMethod"))
             .isNotNull();
     }
-
-
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/ratelimiter/configure/RxJava2RateLimiterAspectExtTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/ratelimiter/configure/RxJava2RateLimiterAspectExtTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Mahmoud Romeh
+ * Copyright 2026 Mahmoud Romeh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,13 @@
 package io.github.resilience4j.spring6.ratelimiter.configure;
 
 import io.github.resilience4j.ratelimiter.RateLimiter;
-import io.github.resilience4j.spring6.ratelimiter.configure.RxJava2RateLimiterAspectExt;
 import io.reactivex.*;
 import org.aspectj.lang.ProceedingJoinPoint;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -31,8 +30,8 @@ import static org.mockito.Mockito.when;
 /**
  * aspect unit test
  */
-@RunWith(MockitoJUnitRunner.class)
-public class RxJava2RateLimiterAspectExtTest {
+@ExtendWith(MockitoExtension.class)
+class RxJava2RateLimiterAspectExtTest {
 
     @Mock
     ProceedingJoinPoint proceedingJoinPoint;
@@ -40,15 +39,14 @@ public class RxJava2RateLimiterAspectExtTest {
     @InjectMocks
     RxJava2RateLimiterAspectExt rxJava2RateLimiterAspectExt;
 
-
     @Test
-    public void testCheckTypes() {
+    void testCheckTypes() {
         assertThat(rxJava2RateLimiterAspectExt.canHandleReturnType(Flowable.class)).isTrue();
         assertThat(rxJava2RateLimiterAspectExt.canHandleReturnType(Single.class)).isTrue();
     }
 
     @Test
-    public void testReactorTypes() throws Throwable {
+    void testReactorTypes() throws Throwable {
         RateLimiter rateLimiter = RateLimiter.ofDefaults("test");
 
         when(proceedingJoinPoint.proceed()).thenReturn(Single.just("Test"));
@@ -75,7 +73,6 @@ public class RxJava2RateLimiterAspectExtTest {
         assertThat(
             rxJava2RateLimiterAspectExt.handle(proceedingJoinPoint, rateLimiter, "testMethod"))
             .isNotNull();
-
 
     }
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/ratelimiter/configure/RxJava3RateLimiterAspectExtTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/ratelimiter/configure/RxJava3RateLimiterAspectExtTest.java
@@ -3,11 +3,11 @@ package io.github.resilience4j.spring6.ratelimiter.configure;
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.reactivex.rxjava3.core.*;
 import org.aspectj.lang.ProceedingJoinPoint;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -15,8 +15,8 @@ import static org.mockito.Mockito.when;
 /**
  * aspect unit test
  */
-@RunWith(MockitoJUnitRunner.class)
-public class RxJava3RateLimiterAspectExtTest {
+@ExtendWith(MockitoExtension.class)
+class RxJava3RateLimiterAspectExtTest {
 
     @Mock
     ProceedingJoinPoint proceedingJoinPoint;
@@ -24,15 +24,14 @@ public class RxJava3RateLimiterAspectExtTest {
     @InjectMocks
     RxJava3RateLimiterAspectExt rxJava3RateLimiterAspectExt;
 
-
     @Test
-    public void testCheckTypes() {
+    void testCheckTypes() {
         assertThat(rxJava3RateLimiterAspectExt.canHandleReturnType(Flowable.class)).isTrue();
         assertThat(rxJava3RateLimiterAspectExt.canHandleReturnType(Single.class)).isTrue();
     }
 
     @Test
-    public void testRxTypes() throws Throwable {
+    void testRxTypes() throws Throwable {
         RateLimiter rateLimiter = RateLimiter.ofDefaults("test");
 
         when(proceedingJoinPoint.proceed()).thenReturn(Single.just("Test"));
@@ -59,7 +58,6 @@ public class RxJava3RateLimiterAspectExtTest {
         assertThat(
             rxJava3RateLimiterAspectExt.handle(proceedingJoinPoint, rateLimiter, "testMethod"))
             .isNotNull();
-
 
     }
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/retry/configure/ReactorRetryAspectExtTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/retry/configure/ReactorRetryAspectExtTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Mahmoud Romeh
+ * Copyright 2026 Mahmoud Romeh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,12 @@
 package io.github.resilience4j.spring6.retry.configure;
 
 import io.github.resilience4j.retry.Retry;
-import io.github.resilience4j.spring6.retry.configure.ReactorRetryAspectExt;
 import org.aspectj.lang.ProceedingJoinPoint;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -32,8 +31,8 @@ import static org.mockito.Mockito.when;
 /**
  * aspect unit test
  */
-@RunWith(MockitoJUnitRunner.class)
-public class ReactorRetryAspectExtTest {
+@ExtendWith(MockitoExtension.class)
+class ReactorRetryAspectExtTest {
 
     @Mock
     ProceedingJoinPoint proceedingJoinPoint;
@@ -41,15 +40,14 @@ public class ReactorRetryAspectExtTest {
     @InjectMocks
     ReactorRetryAspectExt reactorRetryAspectExt;
 
-
     @Test
-    public void testCheckTypes() {
+    void testCheckTypes() {
         assertThat(reactorRetryAspectExt.canHandleReturnType(Mono.class)).isTrue();
         assertThat(reactorRetryAspectExt.canHandleReturnType(Flux.class)).isTrue();
     }
 
     @Test
-    public void testReactorTypes() throws Throwable {
+    void testReactorTypes() throws Throwable {
         Retry retry = Retry.ofDefaults("test");
 
         when(proceedingJoinPoint.proceed()).thenReturn(Mono.just("Test"));
@@ -60,6 +58,4 @@ public class ReactorRetryAspectExtTest {
         assertThat(reactorRetryAspectExt.handle(proceedingJoinPoint, retry, "testMethod"))
             .isNotNull();
     }
-
-
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/retry/configure/RetryAspectSpelResolverTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/retry/configure/RetryAspectSpelResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Kyuhyen Hwang
+ * Copyright 2026 Kyuhyen Hwang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,21 +15,21 @@
  */
 package io.github.resilience4j.spring6.retry.configure;
 
+import io.github.resilience4j.retry.RetryRegistry;
 import io.github.resilience4j.spring6.TestApplication;
 import io.github.resilience4j.spring6.TestDummyService;
-import io.github.resilience4j.retry.RetryRegistry;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = TestApplication.class)
-public class RetryAspectSpelResolverTest {
+class RetryAspectSpelResolverTest {
     @Autowired
     @Qualifier("retryDummyService")
     TestDummyService testDummyService;
@@ -38,7 +38,7 @@ public class RetryAspectSpelResolverTest {
     RetryRegistry registry;
 
     @Test
-    public void testSpel() {
+    void testSpel() {
         assertThat(registry.getAllRetries().stream().filter(it -> it.getName().equals("SPEL_BACKEND")).findAny().isPresent()).isFalse();
         assertThat(testDummyService.spelSync("SPEL_BACKEND")).isEqualTo("recovered");
         assertThat(registry.getAllRetries().stream().filter(it -> it.getName().equals("SPEL_BACKEND")).findAny().isPresent()).isTrue();

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/retry/configure/RetryConfigurationSpringTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/retry/configure/RetryConfigurationSpringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Mahmoud Romeh
+ * Copyright 2026 Mahmoud Romeh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,48 +18,46 @@ package io.github.resilience4j.spring6.retry.configure;
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
 import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
-import io.github.resilience4j.spring6.fallback.FallbackExecutor;
-import io.github.resilience4j.spring6.fallback.configure.FallbackConfiguration;
 import io.github.resilience4j.retry.RetryRegistry;
 import io.github.resilience4j.retry.event.RetryEvent;
+import io.github.resilience4j.spring6.fallback.FallbackExecutor;
+import io.github.resilience4j.spring6.fallback.configure.FallbackConfiguration;
 import io.github.resilience4j.spring6.spelresolver.SpelResolver;
 import io.github.resilience4j.spring6.spelresolver.configure.SpelResolverConfiguration;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {
     RetryConfigurationSpringTest.ConfigWithOverrides.class
 })
-public class RetryConfigurationSpringTest {
+class RetryConfigurationSpringTest {
 
     @Autowired
     private ConfigWithOverrides configWithOverrides;
 
-
     @Test
-    public void testAllCircuitBreakerConfigurationBeansOverridden() {
-        assertNotNull(configWithOverrides.retryRegistry);
-        assertNotNull(configWithOverrides.retryAspect);
-        assertNotNull(configWithOverrides.retryEventEventConsumerRegistry);
-        assertNotNull(configWithOverrides.retryConfigurationProperties);
-        assertTrue(configWithOverrides.retryConfigurationProperties().getConfigs().size() == 1);
+    void testAllCircuitBreakerConfigurationBeansOverridden() {
+        assertThat(configWithOverrides.retryRegistry).isNotNull();
+        assertThat(configWithOverrides.retryAspect).isNotNull();
+        assertThat(configWithOverrides.retryEventEventConsumerRegistry).isNotNull();
+        assertThat(configWithOverrides.retryConfigurationProperties).isNotNull();
+        assertThat(configWithOverrides.retryConfigurationProperties().getConfigs()).hasSize(1);
     }
 
     @Configuration
     @Import({FallbackConfiguration.class, SpelResolverConfiguration.class})
-    public static class ConfigWithOverrides {
+    static class ConfigWithOverrides {
 
         private RetryRegistry retryRegistry;
 
@@ -112,5 +110,4 @@ public class RetryConfigurationSpringTest {
 
         }
     }
-
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/retry/configure/RetryConfigurationTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/retry/configure/RetryConfigurationTest.java
@@ -1,19 +1,17 @@
 package io.github.resilience4j.spring6.retry.configure;
 
 import io.github.resilience4j.common.CompositeCustomizer;
-import io.github.resilience4j.common.retry.configuration.RetryConfigCustomizer;
 import io.github.resilience4j.common.retry.configuration.CommonRetryConfigurationProperties.InstanceProperties;
+import io.github.resilience4j.common.retry.configuration.RetryConfigCustomizer;
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.core.ConfigurationNotFoundException;
 import io.github.resilience4j.core.registry.CompositeRegistryEventConsumer;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryRegistry;
 import io.github.resilience4j.retry.event.RetryEvent;
-import io.github.resilience4j.spring6.retry.configure.RetryConfiguration;
-import io.github.resilience4j.spring6.retry.configure.RetryConfigurationProperties;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -25,11 +23,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * test custom init of retry configuration
  */
-@RunWith(MockitoJUnitRunner.class)
-public class RetryConfigurationTest {
+@ExtendWith(MockitoExtension.class)
+class RetryConfigurationTest {
 
     @Test
-    public void testRetryRegistry() {
+    void testRetryRegistry() {
         InstanceProperties instanceProperties1 = new InstanceProperties();
         instanceProperties1.setMaxAttempts(3);
         InstanceProperties instanceProperties2 = new InstanceProperties();
@@ -57,7 +55,7 @@ public class RetryConfigurationTest {
     }
 
     @Test
-    public void testCreateRetryRegistryWithSharedConfigs() {
+    void testCreateRetryRegistryWithSharedConfigs() {
         InstanceProperties defaultProperties = new InstanceProperties();
         defaultProperties.setMaxAttempts(3);
         defaultProperties.setWaitDuration(Duration.ofMillis(100L));
@@ -103,7 +101,7 @@ public class RetryConfigurationTest {
     }
 
     @Test
-    public void testCreateRetryRegistryWithUnknownConfig() {
+    void testCreateRetryRegistryWithUnknownConfig() {
         RetryConfigurationProperties retryConfigurationProperties = new RetryConfigurationProperties();
         InstanceProperties instanceProperties = new InstanceProperties();
         instanceProperties.setBaseConfig("unknownConfig");
@@ -121,5 +119,4 @@ public class RetryConfigurationTest {
     private CompositeCustomizer<RetryConfigCustomizer> compositeRetryCustomizerTest() {
         return new CompositeCustomizer<>(Collections.emptyList());
     }
-
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/retry/configure/RetryInitializationInAspectTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/retry/configure/RetryInitializationInAspectTest.java
@@ -4,26 +4,26 @@ import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.retry.RetryRegistry;
 import io.github.resilience4j.spring6.TestDummyService;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static io.github.resilience4j.spring6.TestDummyService.BACKEND;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(properties = {
         "logging.level.io.github.resilience4j.retry.configure=debug",
         "spring.main.allow-bean-definition-overriding=true"
 })
-public class RetryInitializationInAspectTest {
+class RetryInitializationInAspectTest {
 
     @TestConfiguration
     static class TestConfig {
@@ -50,25 +50,25 @@ public class RetryInitializationInAspectTest {
     @Autowired
     RetryRegistry registry;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         // ensure no retries are initialized
         assertThat(registry.getAllRetries()).isEmpty();
     }
 
-    @After
-    public void tearDown() throws Exception {
+    @AfterEach
+    void tearDown() throws Exception {
         registry.getAllRetries().stream().map(Retry::getName).forEach(registry::remove);
     }
 
     @Test
-    public void testCorrectConfigIsUsedInAspect() {
+    void testCorrectConfigIsUsedInAspect() {
 
         assertThat(testDummyService.syncSuccess()).isEqualTo("ok");
     }
 
     @Test
-    public void testSpelWithoutConfiguration() {
+    void testSpelWithoutConfiguration() {
         assertThat(testDummyService.spelSyncNoCfg("foo")).isEqualTo("foo");
 
         assertThat(registry.getAllRetries()).hasSize(1).first()
@@ -77,7 +77,7 @@ public class RetryInitializationInAspectTest {
     }
 
     @Test
-    public void testSpelWithConfiguration() {
+    void testSpelWithConfiguration() {
         assertThat(testDummyService.spelSyncWithCfg("foo")).isEqualTo("foo");
 
         assertThat(registry.getAllRetries()).hasSize(1).first()

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/retry/configure/RetryRecoveryTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/retry/configure/RetryRecoveryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 lespinsideg
+ * Copyright 2026 lespinsideg
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,93 +17,93 @@ package io.github.resilience4j.spring6.retry.configure;
 
 import io.github.resilience4j.spring6.TestApplication;
 import io.github.resilience4j.spring6.TestDummyService;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = TestApplication.class)
-public class RetryRecoveryTest {
+class RetryRecoveryTest {
 
     @Autowired
     @Qualifier("retryDummyService")
     TestDummyService testDummyService;
 
     @Test
-    public void testRecovery() {
+    void testRecovery() {
         assertThat(testDummyService.sync()).isEqualTo("recovered");
     }
 
     @Test
-    public void testAsyncRecovery() throws Exception {
+    void testAsyncRecovery() throws Exception {
         assertThat(testDummyService.async().toCompletableFuture().get(5, TimeUnit.SECONDS))
             .isEqualTo("recovered");
     }
 
     @Test
-    public void testMonoRecovery() {
+    void testMonoRecovery() {
         assertThat(testDummyService.mono("test").block()).isEqualTo("test");
     }
 
     @Test
-    public void testFluxRecovery() {
+    void testFluxRecovery() {
         assertThat(testDummyService.flux().blockFirst()).isEqualTo("recovered");
     }
 
     @Test
-    public void testObservableRecovery() {
+    void testObservableRecovery() {
         assertThat(testDummyService.observable().blockingFirst()).isEqualTo("recovered");
     }
 
     @Test
-    public void testSingleRecovery() {
+    void testSingleRecovery() {
         assertThat(testDummyService.single().blockingGet()).isEqualTo("recovered");
     }
 
     @Test
-    public void testCompletableRecovery() {
+    void testCompletableRecovery() {
         assertThat(testDummyService.completable().blockingGet()).isNull();
     }
 
     @Test
-    public void testMaybeRecovery() {
+    void testMaybeRecovery() {
         assertThat(testDummyService.maybe().blockingGet()).isEqualTo("recovered");
     }
 
     @Test
-    public void testFlowableRecovery() {
+    void testFlowableRecovery() {
         assertThat(testDummyService.flowable().blockingFirst()).isEqualTo("recovered");
     }
 
     @Test
-    public void testRx3ObservableRecovery() {
+    void testRx3ObservableRecovery() {
         assertThat(testDummyService.rx3Observable().blockingFirst()).isEqualTo("recovered");
     }
 
     @Test
-    public void testRx3SingleRecovery() {
+    void testRx3SingleRecovery() {
         assertThat(testDummyService.rx3Single().blockingGet()).isEqualTo("recovered");
     }
 
     @Test
-    public void testRx3CompletableRecovery() {
+    void testRx3CompletableRecovery() {
         assertThat(testDummyService.rx3Completable().blockingAwait(2, TimeUnit.SECONDS)).isTrue();
     }
 
     @Test
-    public void testRx3MaybeRecovery() {
+    void testRx3MaybeRecovery() {
         assertThat(testDummyService.rx3Maybe().blockingGet()).isEqualTo("recovered");
     }
 
     @Test
-    public void testRx3FlowableRecovery() {
+    void testRx3FlowableRecovery() {
         assertThat(testDummyService.rx3Flowable().blockingFirst()).isEqualTo("recovered");
     }
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/retry/configure/RxJava2RetryAspectExtTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/retry/configure/RxJava2RetryAspectExtTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Mahmoud Romeh
+ * Copyright 2026 Mahmoud Romeh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,14 @@
 package io.github.resilience4j.spring6.retry.configure;
 
 import io.github.resilience4j.retry.Retry;
-import io.github.resilience4j.spring6.retry.configure.RxJava2RetryAspectExt;
 import io.reactivex.Flowable;
 import io.reactivex.Single;
 import org.aspectj.lang.ProceedingJoinPoint;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -32,8 +31,8 @@ import static org.mockito.Mockito.when;
 /**
  * aspect unit test
  */
-@RunWith(MockitoJUnitRunner.class)
-public class RxJava2RetryAspectExtTest {
+@ExtendWith(MockitoExtension.class)
+class RxJava2RetryAspectExtTest {
 
     @Mock
     ProceedingJoinPoint proceedingJoinPoint;
@@ -41,15 +40,14 @@ public class RxJava2RetryAspectExtTest {
     @InjectMocks
     RxJava2RetryAspectExt rxJava2RetryAspectExt;
 
-
     @Test
-    public void testCheckTypes() {
+    void testCheckTypes() {
         assertThat(rxJava2RetryAspectExt.canHandleReturnType(Flowable.class)).isTrue();
         assertThat(rxJava2RetryAspectExt.canHandleReturnType(Single.class)).isTrue();
     }
 
     @Test
-    public void testReactorTypes() throws Throwable {
+    void testReactorTypes() throws Throwable {
         Retry retry = Retry.ofDefaults("test");
 
         when(proceedingJoinPoint.proceed()).thenReturn(Single.just("Test"));

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/retry/configure/RxJava3RetryAspectExtTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/retry/configure/RxJava3RetryAspectExtTest.java
@@ -4,11 +4,11 @@ import io.github.resilience4j.retry.Retry;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
 import org.aspectj.lang.ProceedingJoinPoint;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -16,8 +16,8 @@ import static org.mockito.Mockito.when;
 /**
  * aspect unit test
  */
-@RunWith(MockitoJUnitRunner.class)
-public class RxJava3RetryAspectExtTest {
+@ExtendWith(MockitoExtension.class)
+class RxJava3RetryAspectExtTest {
 
     @Mock
     ProceedingJoinPoint proceedingJoinPoint;
@@ -25,15 +25,14 @@ public class RxJava3RetryAspectExtTest {
     @InjectMocks
     RxJava3RetryAspectExt rxJava3RetryAspectExt;
 
-
     @Test
-    public void testCheckTypes() {
+    void testCheckTypes() {
         assertThat(rxJava3RetryAspectExt.canHandleReturnType(Flowable.class)).isTrue();
         assertThat(rxJava3RetryAspectExt.canHandleReturnType(Single.class)).isTrue();
     }
 
     @Test
-    public void testRxTypes() throws Throwable {
+    void testRxTypes() throws Throwable {
         Retry retry = Retry.ofDefaults("test");
 
         when(proceedingJoinPoint.proceed()).thenReturn(Single.just("Test"));

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/spelresolver/DefaultSpelResolverTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/spelresolver/DefaultSpelResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Kyuhyen Hwang
+ * Copyright 2026 Kyuhyen Hwang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,11 @@
  */
 package io.github.resilience4j.spring6.spelresolver;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.times;
-
-import java.lang.reflect.Method;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import io.github.resilience4j.spring6.DummySpelBean;
+import io.github.resilience4j.spring6.TestApplication;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.beans.factory.config.EmbeddedValueResolver;
@@ -32,14 +27,18 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.StandardReflectionParameterNameDiscoverer;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import io.github.resilience4j.spring6.DummySpelBean;
-import io.github.resilience4j.spring6.TestApplication;
+import java.lang.reflect.Method;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = TestApplication.class, properties = "property=backend")
-public class DefaultSpelResolverTest {
+class DefaultSpelResolverTest {
     private DefaultSpelResolver sut;
 
     @Autowired
@@ -48,14 +47,14 @@ public class DefaultSpelResolverTest {
     @MockBean(name="dummySpelBean")
     DummySpelBean dummySpelBean;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         sut = new DefaultSpelResolver(new SpelExpressionParser(), new StandardReflectionParameterNameDiscoverer(), configurableBeanFactory);
         sut.setEmbeddedValueResolver(new EmbeddedValueResolver(configurableBeanFactory));
     }
 
     @Test
-    public void givenNonSpelExpression_whenParse_returnsItself() throws Exception {
+    void givenNonSpelExpression_whenParse_returnsItself() throws Exception {
         String testExpression = "backendA";
 
         DefaultSpelResolverTest target = new DefaultSpelResolverTest();
@@ -70,7 +69,7 @@ public class DefaultSpelResolverTest {
      * #root.args[0]
      */
     @Test
-    public void testRootArgs() throws Exception {
+    void testRootArgs() throws Exception {
         String testExpression = "#root.args[0]";
         String firstArgument = "test";
 
@@ -86,7 +85,7 @@ public class DefaultSpelResolverTest {
      * #root.methodName
      */
     @Test
-    public void testRootMethodName() throws Exception {
+    void testRootMethodName() throws Exception {
         String testExpression = "#root.methodName";
 
         DefaultSpelResolverTest target = new DefaultSpelResolverTest();
@@ -101,7 +100,7 @@ public class DefaultSpelResolverTest {
      * #root.className
      */
     @Test
-    public void testRootClassName() throws Exception {
+    void testRootClassName() throws Exception {
         String testExpression = "#root.className";
 
         DefaultSpelResolverTest target = new DefaultSpelResolverTest();
@@ -116,7 +115,7 @@ public class DefaultSpelResolverTest {
      * #p0
      */
     @Test
-    public void testP0() throws Exception {
+    void testP0() throws Exception {
         String testExpression = "#p0";
         String firstArgument = "test";
 
@@ -132,7 +131,7 @@ public class DefaultSpelResolverTest {
      * #a0
      */
     @Test
-    public void testA0() throws Exception {
+    void testA0() throws Exception {
         String testExpression = "#a0";
         String firstArgument = "test";
 
@@ -148,7 +147,7 @@ public class DefaultSpelResolverTest {
      * #{'recover'}
      */
     @Test
-    public void stringSpelTest() throws Exception {
+    void stringSpelTest() throws Exception {
         String testExpression = "#{'recover'}";
 
         DefaultSpelResolverTest target = new DefaultSpelResolverTest();
@@ -163,7 +162,7 @@ public class DefaultSpelResolverTest {
      * ${missingProperty:default}
      */
     @Test
-    public void placeholderSpelTest() throws Exception {
+    void placeholderSpelTest() throws Exception {
         String testExpression = "${missingProperty:default}";
 
         DefaultSpelResolverTest target = new DefaultSpelResolverTest();
@@ -178,7 +177,7 @@ public class DefaultSpelResolverTest {
      * ${property:default}
      */
     @Test
-    public void placeholderSpelTest2() throws Exception {
+    void placeholderSpelTest2() throws Exception {
         String testExpression = "${property:default}";
 
         DefaultSpelResolverTest target = new DefaultSpelResolverTest();
@@ -190,7 +189,7 @@ public class DefaultSpelResolverTest {
     }
 
     @Test
-    public void beanMethodSpelTest() throws Exception {
+    void beanMethodSpelTest() throws Exception {
         String testExpression = "@dummySpelBean.getBulkheadName(#parameter)";
         String testMethodArg = "argg";
         String bulkheadName = "sgt. bulko";
@@ -206,7 +205,7 @@ public class DefaultSpelResolverTest {
     }
 
     @Test
-    public void atTest() throws Exception {
+    void atTest() throws Exception {
         DefaultSpelResolverTest target = new DefaultSpelResolverTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
 
@@ -216,7 +215,7 @@ public class DefaultSpelResolverTest {
     }
 
     @Test
-    public void nullTest() throws Exception {
+    void nullTest() throws Exception {
         DefaultSpelResolverTest target = new DefaultSpelResolverTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
 
@@ -226,7 +225,7 @@ public class DefaultSpelResolverTest {
     }
 
     @Test
-    public void emptyStringTest() throws Exception {
+    void emptyStringTest() throws Exception {
         DefaultSpelResolverTest target = new DefaultSpelResolverTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
 
@@ -236,7 +235,7 @@ public class DefaultSpelResolverTest {
     }
 
     @Test
-    public void dollarTest() throws Exception {
+    void dollarTest() throws Exception {
         DefaultSpelResolverTest target = new DefaultSpelResolverTest();
         Method testMethod = target.getClass().getMethod("testMethod", String.class);
 
@@ -249,7 +248,7 @@ public class DefaultSpelResolverTest {
      * #{'one.' + #root.args[0]} - SpEL template with method args context
      */
     @Test
-    public void spelTemplateWithArgsTest() throws Exception {
+    void spelTemplateWithArgsTest() throws Exception {
         String testExpression = "#{'one.' + #root.args[0]}";
         String firstArgument = "two";
 
@@ -265,7 +264,7 @@ public class DefaultSpelResolverTest {
      * #{'prefix.' + @dummySpelBean.getBulkheadName(#parameter)} - SpEL template with bean reference
      */
     @Test
-    public void spelTemplateWithBeanReferenceTest() throws Exception {
+    void spelTemplateWithBeanReferenceTest() throws Exception {
         String testExpression = "#{'prefix.' + @dummySpelBean.getBulkheadName(#parameter)}";
         String testMethodArg = "argg";
         String bulkheadName = "sgt. bulko";
@@ -284,7 +283,7 @@ public class DefaultSpelResolverTest {
      * prefix-#{#root.args[0]}-suffix - SpEL template with literal text and embedded expression
      */
     @Test
-    public void spelTemplateWithMixedLiteralAndExpressionTest() throws Exception {
+    void spelTemplateWithMixedLiteralAndExpressionTest() throws Exception {
         String testExpression = "prefix-#{#root.args[0]}-suffix";
         String firstArgument = "value";
 
@@ -300,7 +299,7 @@ public class DefaultSpelResolverTest {
      * #{#root.args[0]}-#{#root.args[1]} - SpEL template with multiple embedded expressions
      */
     @Test
-    public void spelTemplateWithMultipleEmbeddedExpressionsTest() throws Exception {
+    void spelTemplateWithMultipleEmbeddedExpressionsTest() throws Exception {
         String testExpression = "#{#root.args[0]}-#{#root.args[1]}";
 
         DefaultSpelResolverTest target = new DefaultSpelResolverTest();

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/timelimiter/configure/ReactorTimeLimiterAspectExtTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/timelimiter/configure/ReactorTimeLimiterAspectExtTest.java
@@ -1,14 +1,12 @@
 package io.github.resilience4j.spring6.timelimiter.configure;
 
-import io.github.resilience4j.spring6.timelimiter.configure.IllegalReturnTypeException;
-import io.github.resilience4j.spring6.timelimiter.configure.ReactorTimeLimiterAspectExt;
 import io.github.resilience4j.timelimiter.TimeLimiter;
 import org.aspectj.lang.ProceedingJoinPoint;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -16,8 +14,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class ReactorTimeLimiterAspectExtTest {
+@ExtendWith(MockitoExtension.class)
+class ReactorTimeLimiterAspectExtTest {
 
     @Mock
     ProceedingJoinPoint proceedingJoinPoint;
@@ -25,15 +23,14 @@ public class ReactorTimeLimiterAspectExtTest {
     @InjectMocks
     ReactorTimeLimiterAspectExt reactorTimeLimiterAspectExt;
 
-
     @Test
-    public void testCheckTypes() {
+    void testCheckTypes() {
         assertThat(reactorTimeLimiterAspectExt.canHandleReturnType(Mono.class)).isTrue();
         assertThat(reactorTimeLimiterAspectExt.canHandleReturnType(Flux.class)).isTrue();
     }
 
     @Test
-    public void testReactorTypes() throws Throwable {
+    void testReactorTypes() throws Throwable {
         TimeLimiter timeLimiter = TimeLimiter.ofDefaults("test");
 
         when(proceedingJoinPoint.proceed()).thenReturn(Mono.just("Test"));
@@ -44,7 +41,7 @@ public class ReactorTimeLimiterAspectExtTest {
     }
 
     @Test
-    public void shouldThrowIllegalArgumentExceptionWithNotReactorType() throws Throwable{
+    void shouldThrowIllegalArgumentExceptionWithNotReactorType() throws Throwable{
         TimeLimiter timeLimiter = TimeLimiter.ofDefaults("test");
         when(proceedingJoinPoint.proceed()).thenReturn("NOT REACTOR TYPE");
 
@@ -57,5 +54,4 @@ public class ReactorTimeLimiterAspectExtTest {
                     "java.lang.String testMethod has unsupported by @TimeLimiter return type. Reactor expects Mono/Flux.");
         }
     }
-
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/timelimiter/configure/RxJava2TimeLimiterAspectExtTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/timelimiter/configure/RxJava2TimeLimiterAspectExtTest.java
@@ -1,22 +1,20 @@
 package io.github.resilience4j.spring6.timelimiter.configure;
 
-import io.github.resilience4j.spring6.timelimiter.configure.IllegalReturnTypeException;
-import io.github.resilience4j.spring6.timelimiter.configure.RxJava2TimeLimiterAspectExt;
 import io.github.resilience4j.timelimiter.TimeLimiter;
 import io.reactivex.*;
 import org.aspectj.lang.ProceedingJoinPoint;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class RxJava2TimeLimiterAspectExtTest {
+@ExtendWith(MockitoExtension.class)
+class RxJava2TimeLimiterAspectExtTest {
     @Mock
     ProceedingJoinPoint proceedingJoinPoint;
 
@@ -24,7 +22,7 @@ public class RxJava2TimeLimiterAspectExtTest {
     RxJava2TimeLimiterAspectExt rxJava2TimeLimiterAspectExt;
 
     @Test
-    public void testCheckTypes() {
+    void testCheckTypes() {
         assertThat(rxJava2TimeLimiterAspectExt.canHandleReturnType(Flowable.class)).isTrue();
         assertThat(rxJava2TimeLimiterAspectExt.canHandleReturnType(Single.class)).isTrue();
         assertThat(rxJava2TimeLimiterAspectExt.canHandleReturnType(Observable.class)).isTrue();
@@ -33,7 +31,7 @@ public class RxJava2TimeLimiterAspectExtTest {
     }
 
     @Test
-    public void testRxJava2Types() throws Throwable {
+    void testRxJava2Types() throws Throwable {
         TimeLimiter timeLimiter = TimeLimiter.ofDefaults("test");
 
         when(proceedingJoinPoint.proceed()).thenReturn(Single.just("Test"));
@@ -53,7 +51,7 @@ public class RxJava2TimeLimiterAspectExtTest {
     }
 
     @Test
-    public void shouldThrowIllegalArgumentExceptionWithNotRxJava2Type() throws Throwable{
+    void shouldThrowIllegalArgumentExceptionWithNotRxJava2Type() throws Throwable{
         TimeLimiter timeLimiter = TimeLimiter.ofDefaults("test");
         when(proceedingJoinPoint.proceed()).thenReturn("NOT RXJAVA2 TYPE");
 
@@ -66,5 +64,4 @@ public class RxJava2TimeLimiterAspectExtTest {
                     "java.lang.String testMethod has unsupported by @TimeLimiter return type. RxJava2 expects Flowable/Single/...");
         }
     }
-
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/timelimiter/configure/RxJava3TimeLimiterAspectExtTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/timelimiter/configure/RxJava3TimeLimiterAspectExtTest.java
@@ -3,18 +3,18 @@ package io.github.resilience4j.spring6.timelimiter.configure;
 import io.github.resilience4j.timelimiter.TimeLimiter;
 import io.reactivex.rxjava3.core.*;
 import org.aspectj.lang.ProceedingJoinPoint;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class RxJava3TimeLimiterAspectExtTest {
+@ExtendWith(MockitoExtension.class)
+class RxJava3TimeLimiterAspectExtTest {
     @Mock
     ProceedingJoinPoint proceedingJoinPoint;
 
@@ -22,7 +22,7 @@ public class RxJava3TimeLimiterAspectExtTest {
     RxJava3TimeLimiterAspectExt rxJava3TimeLimiterAspectExt;
 
     @Test
-    public void testCheckTypes() {
+    void testCheckTypes() {
         assertThat(rxJava3TimeLimiterAspectExt.canHandleReturnType(Flowable.class)).isTrue();
         assertThat(rxJava3TimeLimiterAspectExt.canHandleReturnType(Single.class)).isTrue();
         assertThat(rxJava3TimeLimiterAspectExt.canHandleReturnType(Observable.class)).isTrue();
@@ -31,7 +31,7 @@ public class RxJava3TimeLimiterAspectExtTest {
     }
 
     @Test
-    public void testRxJava3Types() throws Throwable {
+    void testRxJava3Types() throws Throwable {
         TimeLimiter timeLimiter = TimeLimiter.ofDefaults("test");
 
         when(proceedingJoinPoint.proceed()).thenReturn(Single.just("Test"));
@@ -51,7 +51,7 @@ public class RxJava3TimeLimiterAspectExtTest {
     }
 
     @Test
-    public void shouldThrowIllegalArgumentExceptionWithNotRxJava3Type() throws Throwable{
+    void shouldThrowIllegalArgumentExceptionWithNotRxJava3Type() throws Throwable{
         TimeLimiter timeLimiter = TimeLimiter.ofDefaults("test");
         when(proceedingJoinPoint.proceed()).thenReturn("NOT RXJAVA3 TYPE");
 
@@ -64,5 +64,4 @@ public class RxJava3TimeLimiterAspectExtTest {
                     "java.lang.String testMethod has unsupported by @TimeLimiter return type. RxJava3 expects Flowable/Single/...");
         }
     }
-
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterAspectSpelResolverTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterAspectSpelResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Kyuhyen Hwang
+ * Copyright 2026 Kyuhyen Hwang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,18 +18,18 @@ package io.github.resilience4j.spring6.timelimiter.configure;
 import io.github.resilience4j.spring6.TestApplication;
 import io.github.resilience4j.spring6.TestDummyService;
 import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = TestApplication.class)
-public class TimeLimiterAspectSpelResolverTest {
+class TimeLimiterAspectSpelResolverTest {
     @Autowired
     @Qualifier("timeLimiterDummyService")
     TestDummyService testDummyService;
@@ -38,7 +38,7 @@ public class TimeLimiterAspectSpelResolverTest {
     TimeLimiterRegistry registry;
 
     @Test
-    public void testSpel() {
+    void testSpel() {
         assertThat(registry.getAllTimeLimiters().stream().filter(it -> it.getName().equals("SPEL_BACKEND")).findAny().isPresent()).isFalse();
         assertThat(testDummyService.spelMono("SPEL_BACKEND").block()).isEqualTo("SPEL_BACKEND");
         assertThat(registry.getAllTimeLimiters().stream().filter(it -> it.getName().equals("SPEL_BACKEND")).findAny().isPresent()).isTrue();

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterConfigurationSpringTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterConfigurationSpringTest.java
@@ -7,45 +7,41 @@ import io.github.resilience4j.spring6.fallback.FallbackExecutor;
 import io.github.resilience4j.spring6.spelresolver.SpelResolver;
 import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
 import io.github.resilience4j.timelimiter.event.TimeLimiterEvent;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.time.Duration;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {
         TimeLimiterConfigurationSpringTest.ConfigWithOverrides.class
 })
-public class TimeLimiterConfigurationSpringTest {
+class TimeLimiterConfigurationSpringTest {
 
     @Autowired
     private ConfigWithOverrides configWithOverrides;
 
-
-
-
     @Test
-    public void testAllCircuitBreakerConfigurationBeansOverridden() {
-        assertNotNull(configWithOverrides.timeLimiterRegistry);
-        assertNotNull(configWithOverrides.timeLimiterAspect);
-        assertNotNull(configWithOverrides.timeLimiterEventEventConsumerRegistry);
-        assertNotNull(configWithOverrides.timeLimiterConfigurationProperties);
-        assertEquals(1, configWithOverrides.timeLimiterConfigurationProperties.getConfigs().size());
+    void testAllCircuitBreakerConfigurationBeansOverridden() {
+        assertThat(configWithOverrides.timeLimiterRegistry).isNotNull();
+        assertThat(configWithOverrides.timeLimiterAspect).isNotNull();
+        assertThat(configWithOverrides.timeLimiterEventEventConsumerRegistry).isNotNull();
+        assertThat(configWithOverrides.timeLimiterConfigurationProperties).isNotNull();
+        assertThat(configWithOverrides.timeLimiterConfigurationProperties.getConfigs()).hasSize(1);
     }
-
 
     @Configuration
     @ComponentScan({"io.github.resilience4j.spring6.timelimiter","io.github.resilience4j.spring6.fallback", "io.github.resilience4j.spring6.spelresolver"})
-    public static class ConfigWithOverrides {
+    static class ConfigWithOverrides {
 
         private TimeLimiterRegistry timeLimiterRegistry;
 
@@ -97,5 +93,4 @@ public class TimeLimiterConfigurationSpringTest {
 
         }
     }
-
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterConfigurationTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterConfigurationTest.java
@@ -1,18 +1,5 @@
 package io.github.resilience4j.spring6.timelimiter.configure;
 
-import static java.util.Collections.emptyList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import java.time.Duration;
-import java.util.Collections;
-
-import io.github.resilience4j.spring6.timelimiter.configure.TimeLimiterConfiguration;
-import io.github.resilience4j.spring6.timelimiter.configure.TimeLimiterConfigurationProperties;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
-
 import io.github.resilience4j.common.CompositeCustomizer;
 import io.github.resilience4j.common.timelimiter.configuration.TimeLimiterConfigCustomizer;
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
@@ -21,12 +8,22 @@ import io.github.resilience4j.core.registry.CompositeRegistryEventConsumer;
 import io.github.resilience4j.timelimiter.TimeLimiter;
 import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
 import io.github.resilience4j.timelimiter.event.TimeLimiterEvent;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
-public class TimeLimiterConfigurationTest {
+import java.time.Duration;
+import java.util.Collections;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ExtendWith(MockitoExtension.class)
+class TimeLimiterConfigurationTest {
 
     @Test
-    public void testTimeLimiterRegistry() {
+    void testTimeLimiterRegistry() {
 
         // Given
         io.github.resilience4j.common.timelimiter.configuration.CommonTimeLimiterConfigurationProperties.InstanceProperties instanceProperties1 = new io.github.resilience4j.common.timelimiter.configuration.CommonTimeLimiterConfigurationProperties.InstanceProperties();
@@ -61,7 +58,7 @@ public class TimeLimiterConfigurationTest {
     }
 
     @Test
-    public void testCreateTimeLimiterRegistryWithSharedConfigs() {
+    void testCreateTimeLimiterRegistryWithSharedConfigs() {
         // Given
         io.github.resilience4j.common.timelimiter.configuration.CommonTimeLimiterConfigurationProperties.InstanceProperties defaultProperties = new io.github.resilience4j.common.timelimiter.configuration.CommonTimeLimiterConfigurationProperties.InstanceProperties();
         defaultProperties.setTimeoutDuration(Duration.ofSeconds(3));
@@ -116,7 +113,7 @@ public class TimeLimiterConfigurationTest {
     }
 
     @Test
-    public void testCreateTimeLimiterRegistryWithUnknownConfig() {
+    void testCreateTimeLimiterRegistryWithUnknownConfig() {
         TimeLimiterConfigurationProperties timeLimiterConfigurationProperties = new TimeLimiterConfigurationProperties();
 
         io.github.resilience4j.common.timelimiter.configuration.CommonTimeLimiterConfigurationProperties.InstanceProperties instanceProperties = new io.github.resilience4j.common.timelimiter.configuration.CommonTimeLimiterConfigurationProperties.InstanceProperties();
@@ -135,5 +132,4 @@ public class TimeLimiterConfigurationTest {
     private CompositeCustomizer<TimeLimiterConfigCustomizer> compositeTimeLimiterCustomizerTestInstance() {
         return new CompositeCustomizer<>(Collections.emptyList());
     }
-
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterInitializationInAspectTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterInitializationInAspectTest.java
@@ -4,15 +4,15 @@ import io.github.resilience4j.spring6.TimeLimiterDummyService;
 import io.github.resilience4j.timelimiter.TimeLimiter;
 import io.github.resilience4j.timelimiter.TimeLimiterConfig;
 import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.time.Duration;
 import java.util.Map;
@@ -20,12 +20,12 @@ import java.util.Map;
 import static io.github.resilience4j.spring6.TestDummyService.BACKEND;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(properties = {
         "logging.level.io.github.resilience4j.timelimiter.configure=debug",
         "spring.main.allow-bean-definition-overriding=true"
 })
-public class TimeLimiterInitializationInAspectTest {
+class TimeLimiterInitializationInAspectTest {
 
     @TestConfiguration
     static class TestConfig {
@@ -49,19 +49,19 @@ public class TimeLimiterInitializationInAspectTest {
     @Autowired
     TimeLimiterRegistry registry;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         // ensure no time limiters are initialized
         assertThat(registry.getAllTimeLimiters()).isEmpty();
     }
 
-    @After
-    public void tearDown() throws Exception {
+    @AfterEach
+    void tearDown() throws Exception {
         registry.getAllTimeLimiters().stream().map(TimeLimiter::getName).forEach(registry::remove);
     }
 
     @Test
-    public void testCorrectConfigIsUsedInAspect() throws Exception {
+    void testCorrectConfigIsUsedInAspect() throws Exception {
 
         // Should not time out because the time limit is 3 seconds
         assertThat(testDummyService.success().toCompletableFuture().get())
@@ -69,7 +69,7 @@ public class TimeLimiterInitializationInAspectTest {
     }
 
     @Test
-    public void testTimeLimiterSpelWithoutConfiguration() {
+    void testTimeLimiterSpelWithoutConfiguration() {
         assertThat(testDummyService.spelMono("foo").block()).isEqualTo("foo");
 
         assertThat(registry.getAllTimeLimiters()).hasSize(1).first()
@@ -78,7 +78,7 @@ public class TimeLimiterInitializationInAspectTest {
     }
 
     @Test
-    public void testTimeLimiterSpelWithConfiguration() {
+    void testTimeLimiterSpelWithConfiguration() {
         assertThat(testDummyService.spelMonoWithCfg("foo").block()).isEqualTo("foo");
 
         assertThat(registry.getAllTimeLimiters()).hasSize(1).first()

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterRecoveryTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterRecoveryTest.java
@@ -2,87 +2,87 @@ package io.github.resilience4j.spring6.timelimiter.configure;
 
 import io.github.resilience4j.spring6.TestApplication;
 import io.github.resilience4j.spring6.TestDummyService;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = TestApplication.class)
-public class TimeLimiterRecoveryTest {
+class TimeLimiterRecoveryTest {
     @Autowired
     @Qualifier("timeLimiterDummyService")
     TestDummyService testDummyService;
 
     @Test
-    public void testAsyncRecovery() throws Exception {
+    void testAsyncRecovery() throws Exception {
         String result = testDummyService.async().toCompletableFuture().get(5, TimeUnit.SECONDS);
         assertThat(result).isEqualTo("recovered");
     }
 
     @Test
-    public void testMonoRecovery() {
+    void testMonoRecovery() {
         assertThat(testDummyService.mono("test").block()).isEqualTo("test");
     }
 
     @Test
-    public void testFluxRecovery() {
+    void testFluxRecovery() {
         assertThat(testDummyService.flux().blockFirst()).isEqualTo("recovered");
     }
 
     @Test
-    public void testObservableRecovery() {
+    void testObservableRecovery() {
         assertThat(testDummyService.observable().blockingFirst()).isEqualTo("recovered");
     }
 
     @Test
-    public void testSingleRecovery() {
+    void testSingleRecovery() {
         assertThat(testDummyService.single().blockingGet()).isEqualTo("recovered");
     }
 
     @Test
-    public void testCompletableRecovery() {
+    void testCompletableRecovery() {
         assertThat(testDummyService.completable().blockingGet()).isNull();
     }
 
     @Test
-    public void testMaybeRecovery() {
+    void testMaybeRecovery() {
         assertThat(testDummyService.maybe().blockingGet()).isEqualTo("recovered");
     }
 
     @Test
-    public void testFlowableRecovery() {
+    void testFlowableRecovery() {
         assertThat(testDummyService.flowable().blockingFirst()).isEqualTo("recovered");
     }
 
     @Test
-    public void testRx3ObservableRecovery() {
+    void testRx3ObservableRecovery() {
         assertThat(testDummyService.rx3Observable().blockingFirst()).isEqualTo("recovered");
     }
 
     @Test
-    public void testRx3SingleRecovery() {
+    void testRx3SingleRecovery() {
         assertThat(testDummyService.rx3Single().blockingGet()).isEqualTo("recovered");
     }
 
     @Test
-    public void testRx3CompletableRecovery() {
+    void testRx3CompletableRecovery() {
         testDummyService.rx3Completable().test().assertComplete();
     }
 
     @Test
-    public void testRx3MaybeRecovery() {
+    void testRx3MaybeRecovery() {
         assertThat(testDummyService.rx3Maybe().blockingGet()).isEqualTo("recovered");
     }
 
     @Test
-    public void testRx3FlowableRecovery() {
+    void testRx3FlowableRecovery() {
         assertThat(testDummyService.rx3Flowable().blockingFirst()).isEqualTo("recovered");
     }
 }

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/utils/AnnotationExtractorTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/utils/AnnotationExtractorTest.java
@@ -1,15 +1,14 @@
 package io.github.resilience4j.spring6.utils;
 
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
-import io.github.resilience4j.spring6.utils.AnnotationExtractor;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class AnnotationExtractorTest {
+class AnnotationExtractorTest {
 
     @Test
-    public void testExtract() {
+    void testExtract() {
         CircuitBreaker circuitBreaker = AnnotationExtractor
             .extract(AnnotatedClass.class, CircuitBreaker.class);
 
@@ -18,7 +17,7 @@ public class AnnotationExtractorTest {
     }
 
     @Test
-    public void testExtract2() {
+    void testExtract2() {
         CircuitBreaker circuitBreaker = AnnotationExtractor
             .extract(NotAnnotatedClass.class, CircuitBreaker.class);
 


### PR DESCRIPTION
## Changes

* Migrated JUnit 4.13 annotations to Junit Jupiter equivalents
* Replaced `@RunWith(SpringJUnit4ClassRunner.class)` with `@ExtendWith(SpringExtension.class)`
* Replaced `@RunWith(MockitoJUnitRunner.class)` with `@ExtendWith(MockitoExtension.class)`
* Applied OpenRewrite recipes
    * [JUnit 6 best practices](https://docs.openrewrite.org/recipes/java/testing/junit/junit6bestpractices)
    * [Mockito best practices](https://docs.openrewrite.org/recipes/java/testing/mockito/mockitobestpractices)
    * [Migrate JUnit asserts to AssertJ](https://docs.openrewrite.org/recipes/java/testing/assertj/junittoassertj)
    * [AssertJ best practices](https://docs.openrewrite.org/recipes/java/testing/assertj/assertj-best-practices)
* Removed `public` modifiers
* Updated Copyright to 2026

## Coverage

| Metric      | Before | After |
|-------------|--------|-------|
| Instruction | 83.3%  | 83.3% |
| Line        | 83.1%  | 83.1% |
| Branch      | 74.3%  | 74.3% |

## Test runtime

| Metric | Before | After |
|--------|--------|-------|
| Tests  | 221    | 221   |
| Time   | 26.1s  | 30.0s |
