### PR TITLE
resilience4j-spring-boot4: JUnit 4 → JUnit 6 migration

### DIFF
--- a/resilience4j-spring-boot4/build.gradle
+++ b/resilience4j-spring-boot4/build.gradle
@@ -19,10 +19,6 @@ dependencies {
     compileOnly(libs.spring.cloud5.openfeign.core)
     compileOnly(libs.spring.cloud5.starter.openfeign)
 
-    testRuntimeOnly(libs.junit.vintage.engine)
-
-    testImplementation(libs.junit)
-    testImplementation(libs.awaitility.old)
     testImplementation(libs.vavr)
     testImplementation(project(":resilience4j-micrometer"))
     testImplementation(project(":resilience4j-micrometer").sourceSets.test.output)

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/ContextAwareScheduledThreadPoolAutoConfigurationTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/ContextAwareScheduledThreadPoolAutoConfigurationTest.java
@@ -1,28 +1,28 @@
 package io.github.resilience4j.springboot;
 
 import io.github.resilience4j.springboot.scheduled.threadpool.autoconfigure.ContextAwareScheduledThreadPoolAutoConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ContextAwareScheduledThreadPoolAutoConfigurationTest {
+class ContextAwareScheduledThreadPoolAutoConfigurationTest {
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner();
 
     @Test
-    public void registersBeanWhenConditionalPropertyIsInKebabCase() {
+    void registersBeanWhenConditionalPropertyIsInKebabCase() {
         assertBeanHasBeenCreated("resilience4j.scheduled.executor.core-pool-size=1");
     }
 
     @Test
-    public void registersBeanWhenConditionalPropertyIsInCamelCase() {
+    void registersBeanWhenConditionalPropertyIsInCamelCase() {
         assertBeanHasBeenCreated("resilience4j.scheduled.executor.corePoolSize=1");
     }
 
     @Test
-    public void doesNotRegisterBeanWhenConditionalPropertyNotSpecified() {
+    void doesNotRegisterBeanWhenConditionalPropertyNotSpecified() {
         assertBeanWasNotCreated("randomProperty");
     }
 
@@ -45,6 +45,4 @@ public class ContextAwareScheduledThreadPoolAutoConfigurationTest {
                 ContextAwareScheduledThreadPoolAutoConfiguration.class)
             );
     }
-
-
 }

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/LegacyMetricsAutoConfigurationTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/LegacyMetricsAutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ingyu Hwang, Artur Havliukovskyi
+ * Copyright 2026 Ingyu Hwang, Artur Havliukovskyi
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,18 +19,15 @@ package io.github.resilience4j.springboot;
 import io.github.resilience4j.core.metrics.MetricsPublisher;
 import io.github.resilience4j.micrometer.tagged.*;
 import io.github.resilience4j.springboot.service.test.TestApplication;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = TestApplication.class,
     properties = {
         "resilience4j.bulkhead.metrics.legacy.enabled=true",
@@ -40,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         "resilience4j.retry.metrics.legacy.enabled=true",
         "resilience4j.timelimiter.metrics.legacy.enabled=true"
     })
-public class LegacyMetricsAutoConfigurationTest {
+class LegacyMetricsAutoConfigurationTest {
 
     @Autowired(required = false)
     List<MetricsPublisher<?>> metricsPublishers = new ArrayList<>();
@@ -64,38 +61,37 @@ public class LegacyMetricsAutoConfigurationTest {
     TaggedTimeLimiterMetrics taggedTimeLimiterMetrics;
 
     @Test
-    public void newMetricsPublisherIsNotBound() {
+    void newMetricsPublisherIsNotBound() {
         assertThat(metricsPublishers).isEmpty();
     }
 
     @Test
-    public void legacyCircuitBreakerBinderIsBound() {
+    void legacyCircuitBreakerBinderIsBound() {
         assertThat(taggedCircuitBreakerMetrics).isNotNull();
     }
 
     @Test
-    public void legacyBulkheadBinderIsBound() {
+    void legacyBulkheadBinderIsBound() {
         assertThat(taggedBulkheadMetrics).isNotNull();
     }
 
     @Test
-    public void legacyThreadPoolBulkheadBinderIsBound() {
+    void legacyThreadPoolBulkheadBinderIsBound() {
         assertThat(taggedThreadPoolBulkheadMetrics).isNotNull();
     }
 
     @Test
-    public void legacyRateLimiterBinderIsBound() {
+    void legacyRateLimiterBinderIsBound() {
         assertThat(taggedRateLimiterMetrics).isNotNull();
     }
 
     @Test
-    public void legacyRetryBinderIsBound() {
+    void legacyRetryBinderIsBound() {
         assertThat(taggedRetryMetrics).isNotNull();
     }
 
     @Test
-    public void legacyTimeLimiterBinderIsBound() {
+    void legacyTimeLimiterBinderIsBound() {
         assertThat(taggedTimeLimiterMetrics).isNotNull();
     }
-
 }

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/MeterRegistryWithoutMetricsAutoConfigurationTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/MeterRegistryWithoutMetricsAutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Yevhenii Voievodin, Artur Havliukovskyi
+ * Copyright 2026 Yevhenii Voievodin, Artur Havliukovskyi
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,21 +17,18 @@ package io.github.resilience4j.springboot;
 
 import io.github.resilience4j.micrometer.tagged.*;
 import io.github.resilience4j.springboot.service.test.TestApplication;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.micrometer.metrics.autoconfigure.MetricsAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.autoconfigure.error.ErrorMvcAutoConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = TestApplication.class)
 @EnableAutoConfiguration(exclude = {MetricsAutoConfiguration.class, ErrorMvcAutoConfiguration.class})
-public class MeterRegistryWithoutMetricsAutoConfigurationTest {
+class MeterRegistryWithoutMetricsAutoConfigurationTest {
 
 	@Autowired(required = false)
 	TaggedCircuitBreakerMetricsPublisher taggedCircuitBreakerMetricsPublisher;
@@ -72,5 +69,4 @@ public class MeterRegistryWithoutMetricsAutoConfigurationTest {
 	public void newRetryPublisherIsBound() {
 		assertThat(taggedRetryMetricsPublisher).isNull();
 	}
-
 }

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/MetricsAutoConfigurationTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/MetricsAutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Yevhenii Voievodin, Artur Havliukovskyi
+ * Copyright 2026 Yevhenii Voievodin, Artur Havliukovskyi
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,24 +15,16 @@
  */
 package io.github.resilience4j.springboot;
 
-import io.github.resilience4j.micrometer.tagged.TaggedBulkheadMetricsPublisher;
-import io.github.resilience4j.micrometer.tagged.TaggedCircuitBreakerMetricsPublisher;
-import io.github.resilience4j.micrometer.tagged.TaggedRateLimiterMetricsPublisher;
-import io.github.resilience4j.micrometer.tagged.TaggedRetryMetricsPublisher;
-import io.github.resilience4j.micrometer.tagged.TaggedThreadPoolBulkheadMetricsPublisher;
-import io.github.resilience4j.micrometer.tagged.TaggedTimeLimiterMetricsPublisher;
+import io.github.resilience4j.micrometer.tagged.*;
 import io.github.resilience4j.springboot.service.test.TestApplication;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = TestApplication.class)
-public class MetricsAutoConfigurationTest {
+class MetricsAutoConfigurationTest {
 
     @Autowired(required = false)
     TaggedCircuitBreakerMetricsPublisher taggedCircuitBreakerMetricsPublisher;
@@ -53,27 +45,27 @@ public class MetricsAutoConfigurationTest {
     TaggedTimeLimiterMetricsPublisher taggedTimeLimiterMetricsPublisher;
 
     @Test
-    public void newCircuitBreakerPublisherIsBound() {
+    void newCircuitBreakerPublisherIsBound() {
         assertThat(taggedCircuitBreakerMetricsPublisher).isNotNull();
     }
 
     @Test
-    public void newBulkheadPublisherIsBound() {
+    void newBulkheadPublisherIsBound() {
         assertThat(taggedBulkheadMetricsPublisher).isNotNull();
     }
 
     @Test
-    public void newThreadPoolBulkheadPublisherIsBound() {
+    void newThreadPoolBulkheadPublisherIsBound() {
         assertThat(taggedThreadPoolBulkheadMetricsPublisher).isNotNull();
     }
 
     @Test
-    public void newRateLimiterPublisherIsBound() {
+    void newRateLimiterPublisherIsBound() {
         assertThat(taggedRateLimiterMetricsPublisher).isNotNull();
     }
 
     @Test
-    public void newRetryPublisherIsBound() {
+    void newRetryPublisherIsBound() {
         assertThat(taggedRetryMetricsPublisher).isNotNull();
     }
 

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/RefreshScopedAutoConfigurationTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/RefreshScopedAutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ingyu Hwang, Artur Havliukovskyi
+ * Copyright 2026 Ingyu Hwang, Artur Havliukovskyi
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,12 +21,12 @@ import io.github.resilience4j.springboot.circuitbreaker.autoconfigure.CircuitBre
 import io.github.resilience4j.springboot.circuitbreaker.autoconfigure.CircuitBreakerRefreshScopedRegistryAutoConfiguration;
 import io.github.resilience4j.springboot.ratelimiter.autoconfigure.RateLimiterAutoConfiguration;
 import io.github.resilience4j.springboot.ratelimiter.autoconfigure.RateLimiterRefreshScopedRegistryAutoConfiguration;
-import io.github.resilience4j.springboot.retry.autoconfigure.RetryRefreshScopedRegistryAutoConfiguration;
 import io.github.resilience4j.springboot.retry.autoconfigure.RetryAutoConfiguration;
-import io.github.resilience4j.springboot.timelimiter.autoconfigure.TimeLimiterRefreshScopedRegistryAutoConfiguration;
+import io.github.resilience4j.springboot.retry.autoconfigure.RetryRefreshScopedRegistryAutoConfiguration;
 import io.github.resilience4j.springboot.timelimiter.autoconfigure.TimeLimiterAutoConfiguration;
+import io.github.resilience4j.springboot.timelimiter.autoconfigure.TimeLimiterRefreshScopedRegistryAutoConfiguration;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
@@ -37,12 +37,12 @@ import org.springframework.core.type.MethodMetadata;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class RefreshScopedAutoConfigurationTest {
+class RefreshScopedAutoConfigurationTest {
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner();
 
     @Test
-    public void refreshScopedBulkheadRegistry() {
+    void refreshScopedBulkheadRegistry() {
         contextRunner
             .withConfiguration(AutoConfigurations.of(
                 BulkheadRefreshScopedRegistryAutoConfiguration.class,
@@ -55,7 +55,7 @@ public class RefreshScopedAutoConfigurationTest {
     }
 
     @Test
-    public void refreshScopedCircuitBreakerRegistry() {
+    void refreshScopedCircuitBreakerRegistry() {
         contextRunner
             .withConfiguration(AutoConfigurations.of(
                 CircuitBreakerRefreshScopedRegistryAutoConfiguration.class,
@@ -65,7 +65,7 @@ public class RefreshScopedAutoConfigurationTest {
     }
 
     @Test
-    public void refreshScopedRateLimiterRegistry() {
+    void refreshScopedRateLimiterRegistry() {
         contextRunner
             .withConfiguration(AutoConfigurations.of(
                 RateLimiterRefreshScopedRegistryAutoConfiguration.class,
@@ -75,7 +75,7 @@ public class RefreshScopedAutoConfigurationTest {
     }
 
     @Test
-    public void refreshScopedRetryRegistry() {
+    void refreshScopedRetryRegistry() {
         contextRunner
             .withConfiguration(AutoConfigurations.of(
                 RetryRefreshScopedRegistryAutoConfiguration.class,
@@ -85,7 +85,7 @@ public class RefreshScopedAutoConfigurationTest {
     }
 
     @Test
-    public void refreshScopedTimeLimiterRegistry() {
+    void refreshScopedTimeLimiterRegistry() {
         contextRunner
             .withConfiguration(AutoConfigurations.of(
                 TimeLimiterRefreshScopedRegistryAutoConfiguration.class,
@@ -95,7 +95,7 @@ public class RefreshScopedAutoConfigurationTest {
     }
 
     @Test
-    public void registriesNotRefreshableIfDisabled() {
+    void registriesNotRefreshableIfDisabled() {
         contextRunner
                 .withConfiguration(AutoConfigurations.of(
                     BulkheadRefreshScopedRegistryAutoConfiguration.class,

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/SpringBootCommonTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/SpringBootCommonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Mahmoud Romeh, Artur Havliukovskyi
+ * Copyright 2026 Mahmoud Romeh, Artur Havliukovskyi
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,33 +17,33 @@ package io.github.resilience4j.springboot;
 
 import io.github.resilience4j.bulkhead.BulkheadRegistry;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkheadRegistry;
-import io.github.resilience4j.spring6.bulkhead.configure.BulkheadConfigurationProperties;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
-import io.github.resilience4j.springboot.bulkhead.autoconfigure.BulkheadAutoConfiguration;
-import io.github.resilience4j.spring6.circuitbreaker.configure.CircuitBreakerConfigurationProperties;
 import io.github.resilience4j.common.CompositeCustomizer;
 import io.github.resilience4j.common.bulkhead.configuration.BulkheadConfigCustomizer;
-import io.github.resilience4j.common.bulkhead.configuration.ThreadPoolBulkheadConfigCustomizer;
 import io.github.resilience4j.common.bulkhead.configuration.CommonThreadPoolBulkheadConfigurationProperties;
+import io.github.resilience4j.common.bulkhead.configuration.ThreadPoolBulkheadConfigCustomizer;
 import io.github.resilience4j.common.circuitbreaker.configuration.CircuitBreakerConfigCustomizer;
 import io.github.resilience4j.common.timelimiter.configuration.TimeLimiterConfigCustomizer;
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.core.registry.CompositeRegistryEventConsumer;
+import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
+import io.github.resilience4j.retry.RetryRegistry;
+import io.github.resilience4j.spring6.bulkhead.configure.BulkheadConfigurationProperties;
+import io.github.resilience4j.spring6.circuitbreaker.configure.CircuitBreakerConfigurationProperties;
 import io.github.resilience4j.spring6.fallback.CompletionStageFallbackDecorator;
 import io.github.resilience4j.spring6.fallback.FallbackDecorators;
 import io.github.resilience4j.spring6.fallback.FallbackExecutor;
-import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
-import io.github.resilience4j.springboot.circuitbreaker.autoconfigure.CircuitBreakerAutoConfiguration;
 import io.github.resilience4j.spring6.ratelimiter.configure.RateLimiterConfigurationProperties;
-import io.github.resilience4j.retry.RetryRegistry;
-import io.github.resilience4j.springboot.ratelimiter.autoconfigure.RateLimiterAutoConfiguration;
 import io.github.resilience4j.spring6.retry.configure.RetryConfigurationProperties;
 import io.github.resilience4j.spring6.spelresolver.DefaultSpelResolver;
+import io.github.resilience4j.spring6.timelimiter.configure.TimeLimiterConfigurationProperties;
+import io.github.resilience4j.springboot.bulkhead.autoconfigure.BulkheadAutoConfiguration;
+import io.github.resilience4j.springboot.circuitbreaker.autoconfigure.CircuitBreakerAutoConfiguration;
+import io.github.resilience4j.springboot.ratelimiter.autoconfigure.RateLimiterAutoConfiguration;
 import io.github.resilience4j.springboot.retry.autoconfigure.RetryAutoConfiguration;
 import io.github.resilience4j.springboot.timelimiter.autoconfigure.TimeLimiterAutoConfiguration;
 import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
-import io.github.resilience4j.spring6.timelimiter.configure.TimeLimiterConfigurationProperties;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.core.StandardReflectionParameterNameDiscoverer;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
@@ -58,10 +58,10 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 /**
  * @author romeh
  */
-public class SpringBootCommonTest {
+class SpringBootCommonTest {
 
     @Test
-    public void testBulkHeadCommonConfig() {
+    void testBulkHeadCommonConfig() {
         BulkheadAutoConfiguration bulkheadAutoConfiguration = new BulkheadAutoConfiguration();
         assertThat(bulkheadAutoConfiguration
             .bulkheadRegistry(new BulkheadConfigurationProperties(),
@@ -90,7 +90,7 @@ public class SpringBootCommonTest {
     }
 
     @Test
-    public void testCircuitBreakerCommonConfig() {
+    void testCircuitBreakerCommonConfig() {
         CircuitBreakerAutoConfiguration circuitBreakerAutoConfiguration = new CircuitBreakerAutoConfiguration(
             new CircuitBreakerConfigurationProperties());
         assertThat(circuitBreakerAutoConfiguration.reactorCircuitBreakerAspect()).isNotNull();
@@ -109,7 +109,7 @@ public class SpringBootCommonTest {
     }
 
     @Test
-    public void testRetryCommonConfig() {
+    void testRetryCommonConfig() {
         RetryAutoConfiguration retryAutoConfiguration = new RetryAutoConfiguration();
         assertThat(retryAutoConfiguration.reactorRetryAspectExt()).isNotNull();
         assertThat(retryAutoConfiguration.rxJava2RetryAspectExt()).isNotNull();
@@ -129,7 +129,7 @@ public class SpringBootCommonTest {
     }
 
     @Test
-    public void testRateLimiterCommonConfig() {
+    void testRateLimiterCommonConfig() {
         RateLimiterAutoConfiguration rateLimiterAutoConfiguration = new RateLimiterAutoConfiguration();
         assertThat(rateLimiterAutoConfiguration.reactorRateLimiterAspectExt()).isNotNull();
         assertThat(rateLimiterAutoConfiguration.rxJava2RateLimiterAspectExt()).isNotNull();
@@ -151,7 +151,7 @@ public class SpringBootCommonTest {
     }
 
     @Test
-    public void testTimeLimiterCommonConfig() {
+    void testTimeLimiterCommonConfig() {
         TimeLimiterAutoConfiguration timeLimiterAutoConfiguration = new TimeLimiterAutoConfiguration();
         assertThat(timeLimiterAutoConfiguration.reactorTimeLimiterAspectExt()).isNotNull();
         assertThat(timeLimiterAutoConfiguration.rxJava2TimeLimiterAspectExt()).isNotNull();

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/TestThreadLocalContextPropagator.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/TestThreadLocalContextPropagator.java
@@ -6,7 +6,8 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import static io.github.resilience4j.springboot.TestThreadLocalContextPropagator.TestThreadLocalContextHolder.*;
+import static io.github.resilience4j.springboot.TestThreadLocalContextPropagator.TestThreadLocalContextHolder.get;
+import static io.github.resilience4j.springboot.TestThreadLocalContextPropagator.TestThreadLocalContextHolder.put;
 
 public class TestThreadLocalContextPropagator<T> implements ContextPropagator<T> {
 

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/TestUtils.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/TestUtils.java
@@ -7,7 +7,6 @@ import java.lang.reflect.Method;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-
 public class TestUtils {
 
     public static void assertAnnotations(Class<?> originalClass, Class<?> autoConfigurationClass)

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/bulkhead/BulkheadAutoConfigurationTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/bulkhead/BulkheadAutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 lespinsideg, Mahmoud Romeh, Artur Havliukovskyi
+ * Copyright 2026 lespinsideg, Mahmoud Romeh, Artur Havliukovskyi
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,32 @@
  */
 package io.github.resilience4j.springboot.bulkhead;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.util.ReflectionTestUtils.getField;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.github.resilience4j.bulkhead.Bulkhead;
+import io.github.resilience4j.bulkhead.BulkheadRegistry;
+import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
+import io.github.resilience4j.bulkhead.ThreadPoolBulkheadRegistry;
+import io.github.resilience4j.common.CompositeCustomizer;
+import io.github.resilience4j.common.bulkhead.configuration.BulkheadConfigCustomizer;
+import io.github.resilience4j.common.bulkhead.configuration.ThreadPoolBulkheadConfigCustomizer;
+import io.github.resilience4j.common.bulkhead.monitoring.endpoint.BulkheadEndpointResponse;
+import io.github.resilience4j.springboot.TestThreadLocalContextPropagator;
+import io.github.resilience4j.springboot.TestThreadLocalContextPropagator.TestThreadLocalContextHolder;
+import io.github.resilience4j.springboot.bulkhead.autoconfigure.BulkheadProperties;
+import io.github.resilience4j.springboot.bulkhead.autoconfigure.ThreadPoolBulkheadProperties;
+import io.github.resilience4j.springboot.service.test.BeanContextPropagator;
+import io.github.resilience4j.springboot.service.test.DummyFeignClient;
+import io.github.resilience4j.springboot.service.test.TestApplication;
+import io.github.resilience4j.springboot.service.test.bulkhead.BulkheadDummyService;
+import io.github.resilience4j.springboot.service.test.bulkhead.BulkheadReactiveDummyService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.ResponseEntity;
 
 import java.time.Duration;
 import java.util.Map;
@@ -26,45 +50,19 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
 
-import io.github.resilience4j.bulkhead.Bulkhead;
-import io.github.resilience4j.bulkhead.BulkheadRegistry;
-import io.github.resilience4j.bulkhead.ThreadPoolBulkhead;
-import io.github.resilience4j.bulkhead.ThreadPoolBulkheadRegistry;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.resttestclient.TestRestTemplate;
-import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
-import io.github.resilience4j.springboot.TestThreadLocalContextPropagator;
-import io.github.resilience4j.springboot.TestThreadLocalContextPropagator.TestThreadLocalContextHolder;
-import io.github.resilience4j.springboot.bulkhead.autoconfigure.BulkheadProperties;
-import io.github.resilience4j.springboot.bulkhead.autoconfigure.ThreadPoolBulkheadProperties;
-import io.github.resilience4j.common.CompositeCustomizer;
-import io.github.resilience4j.common.bulkhead.configuration.BulkheadConfigCustomizer;
-import io.github.resilience4j.common.bulkhead.configuration.ThreadPoolBulkheadConfigCustomizer;
-import io.github.resilience4j.common.bulkhead.monitoring.endpoint.BulkheadEndpointResponse;
-import io.github.resilience4j.springboot.service.test.BeanContextPropagator;
-import io.github.resilience4j.springboot.service.test.DummyFeignClient;
-import io.github.resilience4j.springboot.service.test.TestApplication;
-import io.github.resilience4j.springboot.service.test.bulkhead.BulkheadDummyService;
-import io.github.resilience4j.springboot.service.test.bulkhead.BulkheadReactiveDummyService;
-
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     classes = TestApplication.class)
 @AutoConfigureTestRestTemplate
-public class BulkheadAutoConfigurationTest {
+class BulkheadAutoConfigurationTest {
 
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(8090);
+    @RegisterExtension
+    static WireMockExtension wireMockServer = WireMockExtension.newInstance()
+            .options(wireMockConfig().port(8090))
+            .build();
     @Autowired
     private BulkheadRegistry bulkheadRegistry;
     @Autowired
@@ -87,7 +85,7 @@ public class BulkheadAutoConfigurationTest {
     private CompositeCustomizer<BulkheadConfigCustomizer> compositeBulkheadCustomizer;
 
     @Test
-    public void testThreadPoolBulkheadCustomizer() {
+    void testThreadPoolBulkheadCustomizer() {
         Map<String, ThreadPoolBulkheadConfigCustomizer> customizerMap = (Map<String, ThreadPoolBulkheadConfigCustomizer>) getField(
             compositeThreadPoolBulkheadCustomizer, "customizerMap");
         assertThat(customizerMap).isNotNull().hasSize(1).containsKeys("backendC");
@@ -116,7 +114,7 @@ public class BulkheadAutoConfigurationTest {
     }
 
     @Test
-    public void testBulkheadCustomizer() {
+    void testBulkheadCustomizer() {
         Map<String, BulkheadConfigCustomizer> customizerMap = (Map<String, BulkheadConfigCustomizer>) getField(
             compositeBulkheadCustomizer, "customizerMap");
         assertThat(customizerMap).isNotNull().hasSize(2).containsKeys("backendCustomizer", "backendD");
@@ -137,8 +135,8 @@ public class BulkheadAutoConfigurationTest {
      * same as @Bulkhead alone works with any normal service class
      */
     @Test
-    public void testFeignClient() throws InterruptedException {
-        WireMock.stubFor(WireMock
+    void testFeignClient() throws InterruptedException {
+        wireMockServer.stubFor(WireMock
             .get(WireMock.urlEqualTo("/sample/"))
             .willReturn(WireMock.aResponse().withStatus(200).withBody("This is successful call"))
         );
@@ -167,7 +165,7 @@ public class BulkheadAutoConfigurationTest {
      * BulkheadDummyService is invoked and that the Bulkhead records permitted and rejected calls.
      */
     @Test
-    public void testBulkheadAutoConfigurationThreadPool() throws InterruptedException, ExecutionException {
+    void testBulkheadAutoConfigurationThreadPool() throws InterruptedException, ExecutionException {
 
         assertThat(threadPoolBulkheadRegistry).isNotNull();
         assertThat(threadPoolBulkheadProperties).isNotNull();
@@ -200,7 +198,7 @@ public class BulkheadAutoConfigurationTest {
      * transfer context from ThreadLocal
      */
     @Test
-    public void testBulkheadAutoConfigurationThreadPoolContextPropagation()
+    void testBulkheadAutoConfigurationThreadPoolContextPropagation()
         throws InterruptedException, TimeoutException, ExecutionException {
         assertThat(threadPoolBulkheadRegistry).isNotNull();
         assertThat(threadPoolBulkheadProperties).isNotNull();
@@ -225,13 +223,12 @@ public class BulkheadAutoConfigurationTest {
         assertThat(value).isEqualTo("SurviveThreadBoundary");
     }
 
-
     /**
      * The test verifies that a Bulkhead instance is created and configured properly when the
      * BulkheadDummyService is invoked and that the Bulkhead records permitted and rejected calls.
      */
     @Test
-    public void testBulkheadAutoConfiguration() {
+    void testBulkheadAutoConfiguration() {
 
         assertThat(bulkheadRegistry).isNotNull();
         assertThat(bulkheadProperties).isNotNull();
@@ -264,7 +261,7 @@ public class BulkheadAutoConfigurationTest {
      * calls.
      */
     @Test
-    public void testBulkheadAutoConfigurationRxJava2() throws InterruptedException {
+    void testBulkheadAutoConfigurationRxJava2() throws InterruptedException {
         assertThat(bulkheadRegistry).isNotNull();
         assertThat(bulkheadProperties).isNotNull();
 
@@ -290,14 +287,13 @@ public class BulkheadAutoConfigurationTest {
         assertThat(rejected).hasValue(0);
     }
 
-
     /**
      * The test verifies that a Bulkhead instance is created and configured properly when the
      * BulkheadReactiveDummyService is invoked and that the Bulkhead records permitted and rejected
      * calls.
      */
     @Test
-    public void testBulkheadAutoConfigurationReactor() {
+    void testBulkheadAutoConfigurationReactor() {
         assertThat(bulkheadRegistry).isNotNull();
         assertThat(bulkheadProperties).isNotNull();
 

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/bulkhead/autoconfigure/BulkheadAutoConfigurationCustomizerTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/bulkhead/autoconfigure/BulkheadAutoConfigurationCustomizerTest.java
@@ -3,7 +3,7 @@ package io.github.resilience4j.springboot.bulkhead.autoconfigure;
 import io.github.resilience4j.bulkhead.BulkheadConfig;
 import io.github.resilience4j.bulkhead.BulkheadRegistry;
 import io.github.resilience4j.common.bulkhead.configuration.BulkheadConfigCustomizer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * </ul>
  * where N is index of the config. This way when asserting value {@code 200} it is guaranteed to be coming from instance properties.
  */
-public class BulkheadAutoConfigurationCustomizerTest {
+class BulkheadAutoConfigurationCustomizerTest {
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
         .withConfiguration(AutoConfigurations.of(BulkheadAutoConfiguration.class))
         .withPropertyValues(
@@ -38,7 +38,7 @@ public class BulkheadAutoConfigurationCustomizerTest {
         );
 
     @Test
-    public void testUserConfigShouldBeAbleToProvideCustomizers() {
+    void testUserConfigShouldBeAbleToProvideCustomizers() {
         // Given
         contextRunner.withUserConfiguration(CustomizerConfiguration.class)
             .withPropertyValues(
@@ -78,7 +78,7 @@ public class BulkheadAutoConfigurationCustomizerTest {
     }
 
     @Test
-    public void testCustomizersShouldOverrideProperties() {
+    void testCustomizersShouldOverrideProperties() {
         // Given
         contextRunner.withUserConfiguration(CustomizerConfiguration.class)
             .withPropertyValues(
@@ -100,7 +100,7 @@ public class BulkheadAutoConfigurationCustomizerTest {
     }
 
     @Test
-    public void testCustomizersAreAppliedOnConfigs() {
+    void testCustomizersAreAppliedOnConfigs() {
         // Given
         contextRunner.withUserConfiguration(ConfigCustomizerConfiguration.class)
             .withPropertyValues(
@@ -129,7 +129,6 @@ public class BulkheadAutoConfigurationCustomizerTest {
                 // from default config customizer
                 assertThat(backendWithoutSharedConfig.getMaxConcurrentCalls()).isEqualTo(1000);
 
-
                 BulkheadConfig backendWithSharedConfig = registry.bulkhead("backendWithSharedConfig").getBulkheadConfig();
                 // from shared config customizer
                 assertThat(backendWithSharedConfig.getMaxWaitDuration()).isEqualTo(Duration.ofMillis(2000));
@@ -149,7 +148,7 @@ public class BulkheadAutoConfigurationCustomizerTest {
     }
 
     @Configuration
-    public static class CustomizerConfiguration {
+    static class CustomizerConfiguration {
         @Bean
         public BulkheadConfigCustomizer backendWithoutSharedConfigCustomizer() {
             return BulkheadConfigCustomizer.of("backendWithoutSharedConfig",
@@ -173,7 +172,7 @@ public class BulkheadAutoConfigurationCustomizerTest {
     }
 
     @Configuration
-    public static class ConfigCustomizerConfiguration {
+    static class ConfigCustomizerConfiguration {
         @Bean
         public BulkheadConfigCustomizer defaultCustomizer() {
             return BulkheadConfigCustomizer.of("default",

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/bulkhead/autoconfigure/BulkheadConfigurationOnMissingBeanTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/bulkhead/autoconfigure/BulkheadConfigurationOnMissingBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Mahmoud Romeh, Artur Havliukovskyi
+ * Copyright 2026 Mahmoud Romeh, Artur Havliukovskyi
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,37 +15,37 @@
  */
 package io.github.resilience4j.springboot.bulkhead.autoconfigure;
 
-import io.github.resilience4j.springboot.TestUtils;
 import io.github.resilience4j.bulkhead.BulkheadRegistry;
 import io.github.resilience4j.bulkhead.ThreadPoolBulkheadRegistry;
-import io.github.resilience4j.spring6.bulkhead.configure.BulkheadAspect;
-import io.github.resilience4j.spring6.bulkhead.configure.BulkheadAspectExt;
-import io.github.resilience4j.spring6.bulkhead.configure.BulkheadConfiguration;
 import io.github.resilience4j.bulkhead.event.BulkheadEvent;
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
+import io.github.resilience4j.spring6.bulkhead.configure.BulkheadAspect;
+import io.github.resilience4j.spring6.bulkhead.configure.BulkheadAspectExt;
+import io.github.resilience4j.spring6.bulkhead.configure.BulkheadConfiguration;
 import io.github.resilience4j.spring6.fallback.FallbackExecutor;
 import io.github.resilience4j.spring6.spelresolver.SpelResolver;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import io.github.resilience4j.springboot.TestUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {
     BulkheadConfigurationOnMissingBeanTest.ConfigWithOverrides.class,
     BulkheadAutoConfiguration.class,
 })
 @EnableConfigurationProperties(BulkheadProperties.class)
-public class BulkheadConfigurationOnMissingBeanTest {
+class BulkheadConfigurationOnMissingBeanTest {
 
     @Autowired
     private ConfigWithOverrides configWithOverrides;
@@ -60,20 +60,19 @@ public class BulkheadConfigurationOnMissingBeanTest {
     private EventConsumerRegistry<BulkheadEvent> bulkheadEventEventConsumerRegistry;
 
     @Test
-    public void testAllBeansFromBulkHeadHasOnMissingBean() throws NoSuchMethodException {
+    void testAllBeansFromBulkHeadHasOnMissingBean() throws NoSuchMethodException {
         TestUtils.assertAnnotations(BulkheadConfiguration.class, BulkheadAutoConfiguration.class);
     }
 
     @Test
-    public void testAllBulkHeadConfigurationBeansOverridden() {
-        assertEquals(bulkheadRegistry, configWithOverrides.bulkheadRegistry);
-        assertEquals(bulkheadAspect, configWithOverrides.bulkheadAspect);
-        assertEquals(bulkheadEventEventConsumerRegistry,
-            configWithOverrides.bulkheadEventEventConsumerRegistry);
+    void testAllBulkHeadConfigurationBeansOverridden() {
+        assertThat(configWithOverrides.bulkheadRegistry).isEqualTo(bulkheadRegistry);
+        assertThat(configWithOverrides.bulkheadAspect).isEqualTo(bulkheadAspect);
+        assertThat(configWithOverrides.bulkheadEventEventConsumerRegistry).isEqualTo(bulkheadEventEventConsumerRegistry);
     }
 
     @Configuration
-    public static class ConfigWithOverrides {
+    static class ConfigWithOverrides {
 
         private BulkheadRegistry bulkheadRegistry;
 

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/CircuitBreakerActuatorTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/CircuitBreakerActuatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Robert Winkler, Artur Havliukovskyi
+ * Copyright 2026 Robert Winkler, Artur Havliukovskyi
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package io.github.resilience4j.springboot.circuitbreaker;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
@@ -23,26 +23,26 @@ import io.github.resilience4j.common.circuitbreaker.monitoring.endpoint.CircuitB
 import io.github.resilience4j.common.circuitbreaker.monitoring.endpoint.CircuitBreakerEndpointResponse;
 import io.github.resilience4j.common.circuitbreaker.monitoring.endpoint.CircuitBreakerUpdateStateResponse;
 import io.github.resilience4j.springboot.service.test.TestApplication;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.*;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     classes = TestApplication.class)
 @AutoConfigureTestRestTemplate
-public class CircuitBreakerActuatorTest {
+class CircuitBreakerActuatorTest {
 
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(8090);
+    @RegisterExtension
+    static WireMockExtension wireMockServer = WireMockExtension.newInstance()
+            .options(wireMockConfig().port(8090))
+            .build();
     @Autowired
     CircuitBreakerRegistry circuitBreakerRegistry;
 
@@ -50,7 +50,7 @@ public class CircuitBreakerActuatorTest {
     private TestRestTemplate restTemplate;
 
     @Test
-    public void testUpdateCircuitBreakerState() {
+    void testUpdateCircuitBreakerState() {
         // given
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
@@ -91,7 +91,7 @@ public class CircuitBreakerActuatorTest {
     }
 
     @Test
-    public void testCircuitBreakerDetails() {
+    void testCircuitBreakerDetails() {
         // given
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
@@ -126,5 +126,4 @@ public class CircuitBreakerActuatorTest {
         assertThat(cbDetailsA.getNotPermittedCalls()).isEqualTo(metrics.getNumberOfNotPermittedCalls());
         assertThat(cbDetailsA.getState()).isEqualTo(cbA.getState());
     }
-
 }

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/CircuitBreakerAutoConfigurationAsyncTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/CircuitBreakerAutoConfigurationAsyncTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Robert Winkler, Artur Havliukovskyi
+ * Copyright 2026 Robert Winkler, Artur Havliukovskyi
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,39 +15,39 @@
  */
 package io.github.resilience4j.springboot.circuitbreaker;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
-import io.github.resilience4j.springboot.circuitbreaker.autoconfigure.CircuitBreakerProperties;
 import io.github.resilience4j.common.circuitbreaker.monitoring.endpoint.CircuitBreakerEventDTO;
 import io.github.resilience4j.common.circuitbreaker.monitoring.endpoint.CircuitBreakerEventsEndpointResponse;
+import io.github.resilience4j.springboot.circuitbreaker.autoconfigure.CircuitBreakerProperties;
 import io.github.resilience4j.springboot.service.test.DummyService;
 import io.github.resilience4j.springboot.service.test.TestApplication;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     classes = TestApplication.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @AutoConfigureTestRestTemplate
-public class CircuitBreakerAutoConfigurationAsyncTest {
+class CircuitBreakerAutoConfigurationAsyncTest {
 
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(8090);
+    @RegisterExtension
+    static WireMockExtension wireMockServer = WireMockExtension.newInstance()
+            .options(wireMockConfig().port(8090))
+            .build();
     @Autowired
     CircuitBreakerRegistry circuitBreakerRegistry;
     @Autowired
@@ -63,7 +63,7 @@ public class CircuitBreakerAutoConfigurationAsyncTest {
      * DummyService is invoked and that the CircuitBreaker records successful and failed calls.
      */
     @Test
-    public void testCircuitBreakerAutoConfigurationAsync()
+    void testCircuitBreakerAutoConfigurationAsync()
         throws IOException, ExecutionException, InterruptedException {
         assertThat(circuitBreakerRegistry).isNotNull();
         assertThat(circuitBreakerProperties).isNotNull();

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/CircuitBreakerAutoConfigurationReactorTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/CircuitBreakerAutoConfigurationReactorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Robert Winkler, Artur Havliukovskyi
+ * Copyright 2026 Robert Winkler, Artur Havliukovskyi
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,39 +15,39 @@
  */
 package io.github.resilience4j.springboot.circuitbreaker;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
-import io.github.resilience4j.springboot.circuitbreaker.autoconfigure.CircuitBreakerProperties;
-import io.github.resilience4j.spring6.circuitbreaker.configure.CircuitBreakerAspect;
 import io.github.resilience4j.common.circuitbreaker.monitoring.endpoint.CircuitBreakerEventDTO;
 import io.github.resilience4j.common.circuitbreaker.monitoring.endpoint.CircuitBreakerEventsEndpointResponse;
+import io.github.resilience4j.spring6.circuitbreaker.configure.CircuitBreakerAspect;
+import io.github.resilience4j.springboot.circuitbreaker.autoconfigure.CircuitBreakerProperties;
 import io.github.resilience4j.springboot.service.test.DummyService;
 import io.github.resilience4j.springboot.service.test.ReactiveDummyService;
 import io.github.resilience4j.springboot.service.test.TestApplication;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.IOException;
 import java.util.List;
 
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     classes = TestApplication.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @AutoConfigureTestRestTemplate
-public class CircuitBreakerAutoConfigurationReactorTest {
+class CircuitBreakerAutoConfigurationReactorTest {
 
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(8090);
+    @RegisterExtension
+    static WireMockExtension wireMockServer = WireMockExtension.newInstance()
+            .options(wireMockConfig().port(8090))
+            .build();
     @Autowired
     CircuitBreakerRegistry circuitBreakerRegistry;
     @Autowired
@@ -66,7 +66,7 @@ public class CircuitBreakerAutoConfigurationReactorTest {
      * DummyService is invoked and that the CircuitBreaker records successful and failed calls.
      */
     @Test
-    public void testCircuitBreakerAutoConfigurationReactive() throws IOException {
+    void testCircuitBreakerAutoConfigurationReactive() throws IOException {
         assertThat(circuitBreakerRegistry).isNotNull();
         assertThat(circuitBreakerProperties).isNotNull();
 

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/CircuitBreakerAutoConfigurationRxJava2Test.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/CircuitBreakerAutoConfigurationRxJava2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Robert Winkler, Artur Havliukovskyi
+ * Copyright 2026 Robert Winkler, Artur Havliukovskyi
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,33 +16,30 @@
 package io.github.resilience4j.springboot.circuitbreaker;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
-import io.github.resilience4j.springboot.circuitbreaker.autoconfigure.CircuitBreakerProperties;
-import io.github.resilience4j.spring6.circuitbreaker.configure.CircuitBreakerAspect;
 import io.github.resilience4j.common.circuitbreaker.monitoring.endpoint.CircuitBreakerEventDTO;
 import io.github.resilience4j.common.circuitbreaker.monitoring.endpoint.CircuitBreakerEventsEndpointResponse;
+import io.github.resilience4j.spring6.circuitbreaker.configure.CircuitBreakerAspect;
+import io.github.resilience4j.springboot.circuitbreaker.autoconfigure.CircuitBreakerProperties;
 import io.github.resilience4j.springboot.service.test.DummyService;
 import io.github.resilience4j.springboot.service.test.ReactiveDummyService;
 import io.github.resilience4j.springboot.service.test.TestApplication;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.IOException;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     classes = TestApplication.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @AutoConfigureTestRestTemplate
-public class CircuitBreakerAutoConfigurationRxJava2Test {
+class CircuitBreakerAutoConfigurationRxJava2Test {
 
     @Autowired
     CircuitBreakerRegistry circuitBreakerRegistry;
@@ -62,13 +59,12 @@ public class CircuitBreakerAutoConfigurationRxJava2Test {
     @Autowired
     private ReactiveDummyService reactiveDummyService;
 
-
     /**
      * The test verifies that a CircuitBreaker instance is created and configured properly when the
      * DummyService is invoked and that the CircuitBreaker records successful and failed calls.
      */
     @Test
-    public void testCircuitBreakerAutoConfigurationReactiveRxJava2() throws IOException {
+    void testCircuitBreakerAutoConfigurationReactiveRxJava2() throws IOException {
         assertThat(circuitBreakerRegistry).isNotNull();
         assertThat(circuitBreakerProperties).isNotNull();
 

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/CircuitBreakerAutoConfigurationTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/CircuitBreakerAutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Robert Winkler, Artur Havliukovskyi
+ * Copyright 2026 Robert Winkler, Artur Havliukovskyi
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,47 +15,47 @@
  */
 package io.github.resilience4j.springboot.circuitbreaker;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
-import io.github.resilience4j.springboot.circuitbreaker.autoconfigure.CircuitBreakerProperties;
-import io.github.resilience4j.spring6.circuitbreaker.configure.CircuitBreakerAspect;
 import io.github.resilience4j.common.circuitbreaker.monitoring.endpoint.CircuitBreakerEventDTO;
 import io.github.resilience4j.common.circuitbreaker.monitoring.endpoint.CircuitBreakerEventsEndpointResponse;
+import io.github.resilience4j.spring6.circuitbreaker.configure.CircuitBreakerAspect;
+import io.github.resilience4j.springboot.circuitbreaker.autoconfigure.CircuitBreakerProperties;
 import io.github.resilience4j.springboot.service.test.DummyService;
 import io.github.resilience4j.springboot.service.test.TestApplication;
 import org.assertj.core.api.Assertions;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.equalTo;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     classes = TestApplication.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @AutoConfigureTestRestTemplate
-public class CircuitBreakerAutoConfigurationTest {
+class CircuitBreakerAutoConfigurationTest {
 
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(8090);
+    @RegisterExtension
+    static WireMockExtension wireMockServer = WireMockExtension.newInstance()
+            .options(wireMockConfig().port(8090))
+            .build();
     @Autowired
     CircuitBreakerRegistry circuitBreakerRegistry;
     @Autowired
@@ -67,13 +67,12 @@ public class CircuitBreakerAutoConfigurationTest {
     @Autowired
     private TestRestTemplate restTemplate;
 
-
     /**
      * The test verifies that a CircuitBreaker instance is created and configured properly when the
      * DummyService is invoked and that the CircuitBreaker records successful and failed calls.
      */
     @Test
-    public void testCircuitBreakerAutoConfiguration() throws IOException {
+    void testCircuitBreakerAutoConfiguration() throws IOException {
         assertThat(circuitBreakerRegistry).isNotNull();
         assertThat(circuitBreakerProperties).isNotNull();
         assertThat(circuitBreakerAspect.getOrder()).isEqualTo(400);

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/CircuitBreakerFeignTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/CircuitBreakerFeignTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Robert Winkler, Artur Havliukovskyi
+ * Copyright 2026 Robert Winkler, Artur Havliukovskyi
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,44 +16,43 @@
 package io.github.resilience4j.springboot.circuitbreaker;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.springboot.service.test.DummyFeignClient;
 import io.github.resilience4j.springboot.service.test.TestApplication;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     classes = TestApplication.class)
-public class CircuitBreakerFeignTest {
+class CircuitBreakerFeignTest {
 
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(8090);
+    @RegisterExtension
+    static WireMockExtension wireMockServer = WireMockExtension.newInstance()
+            .options(wireMockConfig().port(8090))
+            .build();
     @Autowired
     CircuitBreakerRegistry circuitBreakerRegistry;
 
     @Autowired
     private DummyFeignClient dummyFeignClient;
 
-
     /**
      * This test verifies that the combination of @FeignClient and @CircuitBreaker annotation works
      * as same as @CircuitBreaker alone works with any normal service class
      */
     @Test
-    public void testFeignClient() {
+    void testFeignClient() {
 
-        WireMock.stubFor(WireMock.get(WireMock.urlEqualTo("/sample/"))
+        wireMockServer.stubFor(WireMock.get(WireMock.urlEqualTo("/sample/"))
             .willReturn(WireMock.aResponse().withStatus(200).withBody("This is successful call")));
-        WireMock.stubFor(WireMock.get(WireMock.urlMatching("^.*\\/sample\\/error.*$"))
+        wireMockServer.stubFor(WireMock.get(WireMock.urlMatching("^.*\\/sample\\/error.*$"))
             .willReturn(WireMock.aResponse().withStatus(400).withBody("This is error")));
 
         try {

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/CompositeHealthResponse.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/CompositeHealthResponse.java
@@ -11,7 +11,7 @@ public final class CompositeHealthResponse {
         return details;
     }
 
-    public void setDetails(Map<String, HealthResponse> details) {
+    void setDetails(Map<String, HealthResponse> details) {
         this.details = details;
     }
 
@@ -19,7 +19,7 @@ public final class CompositeHealthResponse {
         return status;
     }
 
-    public void setStatus(String status) {
+    void setStatus(String status) {
         this.status = status;
     }
 }

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/HealthResponse.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/HealthResponse.java
@@ -12,7 +12,7 @@ public class HealthResponse {
         return details;
     }
 
-    public void setDetails(Map<String, Object> details) {
+    void setDetails(Map<String, Object> details) {
         this.details = details;
     }
 
@@ -20,7 +20,7 @@ public class HealthResponse {
         return status;
     }
 
-    public void setStatus(String status) {
+    void setStatus(String status) {
         this.status = status;
     }
 }

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/IgnoredException.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/IgnoredException.java
@@ -1,5 +1,4 @@
 package io.github.resilience4j.springboot.circuitbreaker;
 
 public class IgnoredException extends RuntimeException {
-
 }

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/RecordedException.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/RecordedException.java
@@ -1,5 +1,4 @@
 package io.github.resilience4j.springboot.circuitbreaker;
 
 public class RecordedException extends RuntimeException {
-
 }

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/autoconfigure/CircuitBreakerAutoConfigurationCustomizerTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/autoconfigure/CircuitBreakerAutoConfigurationCustomizerTest.java
@@ -3,7 +3,7 @@ package io.github.resilience4j.springboot.circuitbreaker.autoconfigure;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.common.circuitbreaker.configuration.CircuitBreakerConfigCustomizer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * </ul>
  * where N is index of the config. This way when asserting value {@code 200} it is guaranteed to be coming from instance properties.
  */
-public class CircuitBreakerAutoConfigurationCustomizerTest {
+class CircuitBreakerAutoConfigurationCustomizerTest {
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
         .withConfiguration(AutoConfigurations.of(CircuitBreakerAutoConfiguration.class))
         .withPropertyValues(
@@ -38,7 +38,7 @@ public class CircuitBreakerAutoConfigurationCustomizerTest {
         );
 
     @Test
-    public void testUserConfigShouldBeAbleToProvideCustomizers() {
+    void testUserConfigShouldBeAbleToProvideCustomizers() {
         // Given
         contextRunner.withUserConfiguration(CustomizerConfiguration.class)
             .withPropertyValues(
@@ -78,7 +78,7 @@ public class CircuitBreakerAutoConfigurationCustomizerTest {
     }
 
     @Test
-    public void testCustomizersShouldOverrideProperties() {
+    void testCustomizersShouldOverrideProperties() {
         // Given
         contextRunner.withUserConfiguration(CustomizerConfiguration.class)
             .withPropertyValues(
@@ -100,7 +100,7 @@ public class CircuitBreakerAutoConfigurationCustomizerTest {
     }
 
     @Test
-    public void testCustomizersAreAppliedOnConfigs() {
+    void testCustomizersAreAppliedOnConfigs() {
         // Given
         contextRunner.withUserConfiguration(ConfigCustomizerConfiguration.class)
             .withPropertyValues(
@@ -129,7 +129,6 @@ public class CircuitBreakerAutoConfigurationCustomizerTest {
                 // from default config customizer
                 assertThat(backendWithoutSharedConfig.getPermittedNumberOfCallsInHalfOpenState()).isEqualTo(1000);
 
-
                 CircuitBreakerConfig backendWithSharedConfig = registry.circuitBreaker("backendWithSharedConfig").getCircuitBreakerConfig();
                 // from shared config customizer
                 assertThat(backendWithSharedConfig.getSlowCallDurationThreshold()).isEqualTo(Duration.ofMillis(2000));
@@ -149,7 +148,7 @@ public class CircuitBreakerAutoConfigurationCustomizerTest {
     }
 
     @Configuration
-    public static class CustomizerConfiguration {
+    static class CustomizerConfiguration {
         @Bean
         public CircuitBreakerConfigCustomizer backendWithoutSharedConfigCustomizer() {
             return CircuitBreakerConfigCustomizer.of("backendWithoutSharedConfig",
@@ -173,7 +172,7 @@ public class CircuitBreakerAutoConfigurationCustomizerTest {
     }
 
     @Configuration
-    public static class ConfigCustomizerConfiguration {
+    static class ConfigCustomizerConfiguration {
         @Bean
         public CircuitBreakerConfigCustomizer defaultCustomizer() {
             return CircuitBreakerConfigCustomizer.of("default",

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/autoconfigure/CircuitBreakerConfigurationOnMissingBeanTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/autoconfigure/CircuitBreakerConfigurationOnMissingBeanTest.java
@@ -1,37 +1,37 @@
 package io.github.resilience4j.springboot.circuitbreaker.autoconfigure;
 
-import io.github.resilience4j.springboot.TestUtils;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
-import io.github.resilience4j.spring6.circuitbreaker.configure.CircuitBreakerAspect;
-import io.github.resilience4j.spring6.circuitbreaker.configure.CircuitBreakerAspectExt;
-import io.github.resilience4j.spring6.circuitbreaker.configure.CircuitBreakerConfiguration;
 import io.github.resilience4j.circuitbreaker.event.CircuitBreakerEvent;
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
+import io.github.resilience4j.spring6.circuitbreaker.configure.CircuitBreakerAspect;
+import io.github.resilience4j.spring6.circuitbreaker.configure.CircuitBreakerAspectExt;
+import io.github.resilience4j.spring6.circuitbreaker.configure.CircuitBreakerConfiguration;
 import io.github.resilience4j.spring6.fallback.FallbackExecutor;
 import io.github.resilience4j.spring6.spelresolver.SpelResolver;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import io.github.resilience4j.springboot.TestUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.health.autoconfigure.contributor.HealthContributorAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {
     HealthContributorAutoConfiguration.class,
     CircuitBreakerConfigurationOnMissingBeanTest.ConfigWithOverrides.class,
     CircuitBreakerAutoConfiguration.class,
 })
 @EnableConfigurationProperties(CircuitBreakerProperties.class)
-public class CircuitBreakerConfigurationOnMissingBeanTest {
+class CircuitBreakerConfigurationOnMissingBeanTest {
 
     @Autowired
     private ConfigWithOverrides configWithOverrides;
@@ -46,21 +46,20 @@ public class CircuitBreakerConfigurationOnMissingBeanTest {
     private EventConsumerRegistry<CircuitBreakerEvent> circuitEventConsumerBreakerRegistry;
 
     @Test
-    public void testAllBeansFromCircuitBreakerConfigurationHasOnMissingBean()
+    void testAllBeansFromCircuitBreakerConfigurationHasOnMissingBean()
         throws NoSuchMethodException {
         TestUtils.assertAnnotations(CircuitBreakerConfiguration.class, CircuitBreakerAutoConfiguration.class);
     }
 
     @Test
-    public void testAllCircuitBreakerConfigurationBeansOverridden() {
-        assertEquals(circuitBreakerRegistry, configWithOverrides.circuitBreakerRegistry);
-        assertEquals(circuitBreakerAspect, configWithOverrides.circuitBreakerAspect);
-        assertEquals(circuitEventConsumerBreakerRegistry,
-            configWithOverrides.circuitEventConsumerBreakerRegistry);
+    void testAllCircuitBreakerConfigurationBeansOverridden() {
+        assertThat(configWithOverrides.circuitBreakerRegistry).isEqualTo(circuitBreakerRegistry);
+        assertThat(configWithOverrides.circuitBreakerAspect).isEqualTo(circuitBreakerAspect);
+        assertThat(configWithOverrides.circuitEventConsumerBreakerRegistry).isEqualTo(circuitEventConsumerBreakerRegistry);
     }
 
     @Configuration
-    public static class ConfigWithOverrides {
+    static class ConfigWithOverrides {
 
         CircuitBreakerRegistry circuitBreakerRegistry;
 

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/monitoring/endpoint/CircuitBreakerEventsEndpointSnapshotReadTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/monitoring/endpoint/CircuitBreakerEventsEndpointSnapshotReadTest.java
@@ -21,22 +21,18 @@ import io.github.resilience4j.circuitbreaker.event.CircuitBreakerOnSuccessEvent;
 import io.github.resilience4j.common.circuitbreaker.monitoring.endpoint.CircuitBreakerEventsEndpointResponse;
 import io.github.resilience4j.consumer.CircularEventConsumer;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.ConcurrentModificationException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CircuitBreakerEventsEndpointSnapshotReadTest {
+class CircuitBreakerEventsEndpointSnapshotReadTest {
 
     @Test
-    public void shouldUseSnapshotListWhenGettingAllEvents() {
+    void shouldUseSnapshotListWhenGettingAllEvents() {
         InMemoryEventConsumerRegistry registry = new InMemoryEventConsumerRegistry();
         ThrowingStreamCircularEventConsumer eventConsumer = new ThrowingStreamCircularEventConsumer();
         eventConsumer.consumeEvent(new CircuitBreakerOnResetEvent("backendA"));
@@ -50,7 +46,7 @@ public class CircuitBreakerEventsEndpointSnapshotReadTest {
     }
 
     @Test
-    public void shouldUseSnapshotListWhenFilteringByName() {
+    void shouldUseSnapshotListWhenFilteringByName() {
         InMemoryEventConsumerRegistry registry = new InMemoryEventConsumerRegistry();
         ThrowingStreamCircularEventConsumer eventConsumer = new ThrowingStreamCircularEventConsumer();
         eventConsumer.consumeEvent(new CircuitBreakerOnSuccessEvent("backendA", Duration.ofMillis(5)));
@@ -68,7 +64,7 @@ public class CircuitBreakerEventsEndpointSnapshotReadTest {
     }
 
     @Test
-    public void shouldUseSnapshotListWhenFilteringByNameAndType() {
+    void shouldUseSnapshotListWhenFilteringByNameAndType() {
         InMemoryEventConsumerRegistry registry = new InMemoryEventConsumerRegistry();
         ThrowingStreamCircularEventConsumer eventConsumer = new ThrowingStreamCircularEventConsumer();
         eventConsumer.consumeEvent(new CircuitBreakerOnSuccessEvent("backendA", Duration.ofMillis(5)));

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/monitoring/events/CircuitBreakerHystrixStreamEventsTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/monitoring/events/CircuitBreakerHystrixStreamEventsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Vijay Ram, Artur Havliukovskyi
+ * Copyright 2026 Vijay Ram, Artur Havliukovskyi
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,12 @@
  */
 package io.github.resilience4j.springboot.circuitbreaker.monitoring.events;
 
-
 import io.github.resilience4j.common.circuitbreaker.monitoring.endpoint.CircuitBreakerEventsEndpointResponse;
 import io.github.resilience4j.springboot.service.test.DummyService;
 import io.github.resilience4j.springboot.service.test.TestApplication;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -30,7 +28,6 @@ import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTest
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.MediaType;
 import org.springframework.http.codec.ServerSentEvent;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
@@ -44,14 +41,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author vijayram
  */
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = TestApplication.class)
 @AutoConfigureWebTestClient(timeout="36000")
-@Ignore
-public class CircuitBreakerHystrixStreamEventsTest {
+@Disabled
+class CircuitBreakerHystrixStreamEventsTest {
 
-    public static final String ACTUATOR_STREAM_CIRCUITBREAKER_EVENTS = "/actuator/hystrixstreamcircuitbreakerevents";
-    public static final String ACTUATOR_CIRCUITBREAKEREVENTS = "/actuator/circuitbreakerevents";
+    static final String ACTUATOR_STREAM_CIRCUITBREAKER_EVENTS = "/actuator/hystrixstreamcircuitbreakerevents";
+    static final String ACTUATOR_CIRCUITBREAKEREVENTS = "/actuator/circuitbreakerevents";
 
     @LocalServerPort
     int randomServerPort;
@@ -62,8 +58,8 @@ public class CircuitBreakerHystrixStreamEventsTest {
 
     private WebClient webStreamClient;
 
-    @Before
-    public void setup(){
+    @BeforeEach
+    void setup(){
         webStreamClient = WebClient.create("http://localhost:" + randomServerPort);
     }
 
@@ -72,7 +68,7 @@ public class CircuitBreakerHystrixStreamEventsTest {
     };
 
     @Test
-    public void streamAllEvents() throws IOException, InterruptedException {
+    void streamAllEvents() throws IOException, InterruptedException {
         int noOfEvents =2;
         List<ServerSentEvent<String>> noOfEventsFromStream = getServerSentEvents(ACTUATOR_STREAM_CIRCUITBREAKER_EVENTS);
         CircuitBreakerEventsEndpointResponse circuitBreakerEventsBefore = circuitBreakerEvents(ACTUATOR_CIRCUITBREAKEREVENTS);
@@ -84,7 +80,7 @@ public class CircuitBreakerHystrixStreamEventsTest {
     }
 
     @Test
-    public void streamEventsbyName() throws IOException, InterruptedException {
+    void streamEventsbyName() throws IOException, InterruptedException {
         int noOfEvents =2;
         List<ServerSentEvent<String>> noOfEventsFromStream = getServerSentEvents(ACTUATOR_STREAM_CIRCUITBREAKER_EVENTS + "/backendA");
         CircuitBreakerEventsEndpointResponse circuitBreakerEventsBefore = circuitBreakerEvents(ACTUATOR_CIRCUITBREAKEREVENTS + "/backendA");
@@ -96,7 +92,7 @@ public class CircuitBreakerHystrixStreamEventsTest {
     }
 
     @Test
-    public void streamEventsbyNameAndType() throws IOException, InterruptedException {
+    void streamEventsbyNameAndType() throws IOException, InterruptedException {
         int noOfSuccessfulEvents =1;
         List<ServerSentEvent<String>> noOfEventsFromStream = getServerSentEvents(ACTUATOR_STREAM_CIRCUITBREAKER_EVENTS + "/backendA/SUCCESS");
         CircuitBreakerEventsEndpointResponse circuitBreakerEventsBefore = circuitBreakerEvents(ACTUATOR_CIRCUITBREAKEREVENTS + "/backendA");

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/monitoring/events/CircuitBreakerStreamEventsTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/monitoring/events/CircuitBreakerStreamEventsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Vijay Ram, Artur Havliukovskyi
+ * Copyright 2026 Vijay Ram, Artur Havliukovskyi
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,12 @@
  */
 package io.github.resilience4j.springboot.circuitbreaker.monitoring.events;
 
-
 import io.github.resilience4j.common.circuitbreaker.monitoring.endpoint.CircuitBreakerEventsEndpointResponse;
 import io.github.resilience4j.springboot.service.test.DummyService;
 import io.github.resilience4j.springboot.service.test.TestApplication;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -30,7 +28,6 @@ import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTest
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.MediaType;
 import org.springframework.http.codec.ServerSentEvent;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
@@ -41,18 +38,16 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-
 /**
  * @author vijayram
  */
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = TestApplication.class)
 @AutoConfigureWebTestClient(timeout="36000")
-@Ignore
-public class CircuitBreakerStreamEventsTest {
+@Disabled
+class CircuitBreakerStreamEventsTest {
 
-    public static final String ACTUATOR_STREAM_CIRCUITBREAKER_EVENTS = "/actuator/streamcircuitbreakerevents";
-    public static final String ACTUATOR_CIRCUITBREAKEREVENTS = "/actuator/circuitbreakerevents";
+    static final String ACTUATOR_STREAM_CIRCUITBREAKER_EVENTS = "/actuator/streamcircuitbreakerevents";
+    static final String ACTUATOR_CIRCUITBREAKEREVENTS = "/actuator/circuitbreakerevents";
     @LocalServerPort
     int randomServerPort;
     @Autowired
@@ -62,8 +57,8 @@ public class CircuitBreakerStreamEventsTest {
 
     private WebClient webStreamClient;
 
-    @Before
-    public void setup(){
+    @BeforeEach
+    void setup(){
         webStreamClient = WebClient.create("http://localhost:" + randomServerPort);
     }
 
@@ -72,7 +67,7 @@ public class CircuitBreakerStreamEventsTest {
     };
 
     @Test
-    public void streamAllEvents() throws IOException, InterruptedException {
+    void streamAllEvents() throws IOException, InterruptedException {
         int noOfEvents =2;
         List<ServerSentEvent<String>> noOfEventsFromStream = getServerSentEvents(ACTUATOR_STREAM_CIRCUITBREAKER_EVENTS);
         CircuitBreakerEventsEndpointResponse circuitBreakerEventsBefore = circuitBreakerEvents(ACTUATOR_CIRCUITBREAKEREVENTS);
@@ -84,7 +79,7 @@ public class CircuitBreakerStreamEventsTest {
     }
 
     @Test
-    public void streamEventsbyName() throws IOException, InterruptedException {
+    void streamEventsbyName() throws IOException, InterruptedException {
         int noOfEvents =2;
         List<ServerSentEvent<String>> noOfEventsFromStream = getServerSentEvents(ACTUATOR_STREAM_CIRCUITBREAKER_EVENTS + "/backendA");
         CircuitBreakerEventsEndpointResponse circuitBreakerEventsBefore = circuitBreakerEvents(ACTUATOR_CIRCUITBREAKEREVENTS + "/backendA");
@@ -96,7 +91,7 @@ public class CircuitBreakerStreamEventsTest {
     }
 
     @Test
-    public void streamEventsbyNameAndType() throws IOException, InterruptedException {
+    void streamEventsbyNameAndType() throws IOException, InterruptedException {
         int noOfSuccessfulEvents =1;
         List<ServerSentEvent<String>> noOfEventsFromStream = getServerSentEvents(ACTUATOR_STREAM_CIRCUITBREAKER_EVENTS + "/backendA/SUCCESS");
         CircuitBreakerEventsEndpointResponse circuitBreakerEventsBefore = circuitBreakerEvents(ACTUATOR_CIRCUITBREAKEREVENTS + "/backendA");

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/monitoring/health/CircuitBreakersHealthIndicatorTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/circuitbreaker/monitoring/health/CircuitBreakersHealthIndicatorTest.java
@@ -4,7 +4,7 @@ import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.spring6.circuitbreaker.configure.CircuitBreakerConfigurationProperties;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.health.actuate.endpoint.SimpleStatusAggregator;
 import org.springframework.boot.health.contributor.Health;
 import org.springframework.boot.health.contributor.Status;
@@ -20,10 +20,10 @@ import static org.mockito.Mockito.when;
 /**
  * @author bstorozhuk
  */
-public class CircuitBreakersHealthIndicatorTest {
+class CircuitBreakersHealthIndicatorTest {
 
     @Test
-    public void healthMetricsAndConfig() {
+    void healthMetricsAndConfig() {
         // given
         CircuitBreakerConfig config = mock(CircuitBreakerConfig.class);
         CircuitBreakerRegistry registry = mock(CircuitBreakerRegistry.class);
@@ -75,7 +75,7 @@ public class CircuitBreakersHealthIndicatorTest {
     }
 
     @Test
-    public void testHealthStatus() {
+    void testHealthStatus() {
         CircuitBreaker openCircuitBreaker = mock(CircuitBreaker.class);
         CircuitBreaker halfOpenCircuitBreaker = mock(CircuitBreaker.class);
         CircuitBreaker closeCircuitBreaker = mock(CircuitBreaker.class);
@@ -116,7 +116,7 @@ public class CircuitBreakersHealthIndicatorTest {
     }
 
     @Test
-    public void healthIndicatorMaxImpactCanBeOverridden() {
+    void healthIndicatorMaxImpactCanBeOverridden() {
         CircuitBreaker openCircuitBreaker = mock(CircuitBreaker.class);
         CircuitBreaker halfOpenCircuitBreaker = mock(CircuitBreaker.class);
         CircuitBreaker closeCircuitBreaker = mock(CircuitBreaker.class);
@@ -142,7 +142,6 @@ public class CircuitBreakersHealthIndicatorTest {
 
         CircuitBreakersHealthIndicator healthIndicator =
             new CircuitBreakersHealthIndicator(registry, circuitBreakerProperties, new SimpleStatusAggregator());
-
 
         // then
         Health health = healthIndicator.health();

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/fallback/FallbackConfigurationOnMissingBeanTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/fallback/FallbackConfigurationOnMissingBeanTest.java
@@ -1,24 +1,24 @@
 package io.github.resilience4j.springboot.fallback;
 
-import io.github.resilience4j.springboot.fallback.autoconfigure.FallbackConfigurationOnMissingBean;
 import io.github.resilience4j.spring6.fallback.FallbackDecorators;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import io.github.resilience4j.springboot.fallback.autoconfigure.FallbackConfigurationOnMissingBean;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = FallbackConfigurationOnMissingBean.class)
-public class FallbackConfigurationOnMissingBeanTest {
+class FallbackConfigurationOnMissingBeanTest {
 
     @Autowired
     private FallbackDecorators fallbackDecorators;
 
     @Test
-    public void testSizeOfDecorators() {
+    void testSizeOfDecorators() {
         assertThat(fallbackDecorators.getFallbackDecorators().size()).isEqualTo(4);
     }
 }

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/micrometer/TimerAutoConfigurationTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/micrometer/TimerAutoConfigurationTest.java
@@ -6,13 +6,11 @@ import io.github.resilience4j.micrometer.TimerRegistry;
 import io.github.resilience4j.springboot.service.test.TestApplication;
 import io.github.resilience4j.springboot.service.test.micrometer.FixedOnFailureTagResolver;
 import io.github.resilience4j.springboot.service.test.micrometer.QualifiedClassNameOnFailureTagResolver;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.resttestclient.TestRestTemplate;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.util.List;
 
@@ -20,10 +18,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(webEnvironment = RANDOM_PORT, classes = TestApplication.class)
 @AutoConfigureTestRestTemplate
-public class TimerAutoConfigurationTest {
+class TimerAutoConfigurationTest {
 
     @Autowired
     private TestRestTemplate httpClient;
@@ -31,7 +28,7 @@ public class TimerAutoConfigurationTest {
     private TimerRegistry registry;
 
     @Test
-    public void shouldConfigureTimersUsingConfigurationProperties() {
+    void shouldConfigureTimersUsingConfigurationProperties() {
         Timer timer = registry.timer("backend");
         assertThat(timer).isNotNull();
         assertThat(timer.getTimerConfig().getMetricNames()).isEqualTo("resilience4j.timer.calls");

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/micrometer/TimerTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/micrometer/TimerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Mahmoud Romeh, Artur Havliukovskyi
+ * Copyright 2026 Mahmoud Romeh, Artur Havliukovskyi
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,13 +22,11 @@ import io.github.resilience4j.micrometer.TimerRegistry;
 import io.github.resilience4j.springboot.service.test.TestApplication;
 import io.github.resilience4j.springboot.service.test.micrometer.TimedService;
 import io.micrometer.core.instrument.MeterRegistry;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.resttestclient.TestRestTemplate;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -43,10 +41,9 @@ import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(webEnvironment = RANDOM_PORT, classes = TestApplication.class)
 @AutoConfigureTestRestTemplate
-public class TimerTest {
+class TimerTest {
 
     @Autowired
     private TestRestTemplate httpClient;
@@ -58,7 +55,7 @@ public class TimerTest {
     private TimedService service;
 
     @Test
-    public void shouldTimeBasicOperation() {
+    void shouldTimeBasicOperation() {
         Timer timer = timerRegistry.timer(BASIC_TIMER_NAME);
         ZonedDateTime now = now();
 
@@ -76,7 +73,7 @@ public class TimerTest {
     }
 
     @Test
-    public void shouldTimeReactorOperation() {
+    void shouldTimeReactorOperation() {
         Timer timer = timerRegistry.timer(REACTOR_TIMER_NAME);
         ZonedDateTime now = now();
 
@@ -95,7 +92,7 @@ public class TimerTest {
     }
 
     @Test
-    public void shouldTimeRxJava2Operation() {
+    void shouldTimeRxJava2Operation() {
         Timer timer = timerRegistry.timer(RXJAVA2_TIMER_NAME);
         ZonedDateTime now = now();
 

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/ratelimiter/RateLimiterAutoConfigurationTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/ratelimiter/RateLimiterAutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Bohdan Storozhuk, Artur Havliukovskyi
+ * Copyright 2026 Bohdan Storozhuk, Artur Havliukovskyi
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,46 +16,46 @@
 package io.github.resilience4j.springboot.ratelimiter;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import io.github.resilience4j.common.ratelimiter.monitoring.endpoint.RateLimiterEndpointResponse;
 import io.github.resilience4j.common.ratelimiter.monitoring.endpoint.RateLimiterEventDTO;
 import io.github.resilience4j.common.ratelimiter.monitoring.endpoint.RateLimiterEventsEndpointResponse;
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
 import io.github.resilience4j.ratelimiter.RequestNotPermitted;
-import io.github.resilience4j.springboot.ratelimiter.autoconfigure.RateLimiterProperties;
-import io.github.resilience4j.spring6.ratelimiter.configure.RateLimiterAspect;
 import io.github.resilience4j.ratelimiter.event.RateLimiterEvent;
+import io.github.resilience4j.spring6.ratelimiter.configure.RateLimiterAspect;
+import io.github.resilience4j.springboot.ratelimiter.autoconfigure.RateLimiterProperties;
 import io.github.resilience4j.springboot.service.test.DummyService;
 import io.github.resilience4j.springboot.service.test.TestApplication;
 import io.github.resilience4j.springboot.service.test.ratelimiter.RateLimiterDummyFeignClient;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static io.github.resilience4j.springboot.service.test.ratelimiter.RateLimiterDummyFeignClient.RATE_LIMITER_FEIGN_CLIENT_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     classes = TestApplication.class)
 @AutoConfigureTestRestTemplate
-public class RateLimiterAutoConfigurationTest {
+class RateLimiterAutoConfigurationTest {
 
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(8090);
+    @RegisterExtension
+    static WireMockExtension wireMockServer = WireMockExtension.newInstance()
+            .options(wireMockConfig().port(8090))
+            .build();
     @Autowired
     private RateLimiterRegistry rateLimiterRegistry;
     @Autowired
@@ -75,12 +75,12 @@ public class RateLimiterAutoConfigurationTest {
      * same as @Bulkhead alone works with any normal service class
      */
     @Test
-    public void testFeignClient() {
-        WireMock.stubFor(WireMock
+    void testFeignClient() {
+        wireMockServer.stubFor(WireMock
             .get(WireMock.urlEqualTo("/limit/"))
             .willReturn(WireMock.aResponse().withStatus(200).withBody("This is successful call"))
         );
-        WireMock.stubFor(WireMock.get(WireMock.urlMatching("^.*\\/limit\\/error.*$"))
+        wireMockServer.stubFor(WireMock.get(WireMock.urlMatching("^.*\\/limit\\/error.*$"))
             .willReturn(WireMock.aResponse().withStatus(400).withBody("This is error")));
 
         assertThat(rateLimiterRegistry).isNotNull();
@@ -147,7 +147,7 @@ public class RateLimiterAutoConfigurationTest {
      * DummyService is invoked and that the RateLimiter records successful and failed calls.
      */
     @Test
-    public void testRateLimiterAutoConfiguration() throws IOException {
+    void testRateLimiterAutoConfiguration() throws IOException {
         assertThat(rateLimiterRegistry).isNotNull();
         assertThat(rateLimiterProperties).isNotNull();
 

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/ratelimiter/autoconfigure/RateLimiterAutoConfigurationCustomizerTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/ratelimiter/autoconfigure/RateLimiterAutoConfigurationCustomizerTest.java
@@ -1,9 +1,9 @@
 package io.github.resilience4j.springboot.ratelimiter.autoconfigure;
 
+import io.github.resilience4j.common.ratelimiter.configuration.RateLimiterConfigCustomizer;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
-import io.github.resilience4j.common.ratelimiter.configuration.RateLimiterConfigCustomizer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * </ul>
  * where N is index of the config. This way when asserting value {@code 200} it is guaranteed to be coming from instance properties.
  */
-public class RateLimiterAutoConfigurationCustomizerTest {
+class RateLimiterAutoConfigurationCustomizerTest {
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
         .withConfiguration(AutoConfigurations.of(RateLimiterAutoConfiguration.class))
         .withPropertyValues(
@@ -38,7 +38,7 @@ public class RateLimiterAutoConfigurationCustomizerTest {
         );
 
     @Test
-    public void testUserConfigShouldBeAbleToProvideCustomizers() {
+    void testUserConfigShouldBeAbleToProvideCustomizers() {
         // Given
         contextRunner.withUserConfiguration(CustomizerConfiguration.class)
             .withPropertyValues(
@@ -78,7 +78,7 @@ public class RateLimiterAutoConfigurationCustomizerTest {
     }
 
     @Test
-    public void testCustomizersShouldOverrideProperties() {
+    void testCustomizersShouldOverrideProperties() {
         // Given
         contextRunner.withUserConfiguration(CustomizerConfiguration.class)
             .withPropertyValues(
@@ -100,7 +100,7 @@ public class RateLimiterAutoConfigurationCustomizerTest {
     }
 
     @Test
-    public void testCustomizersAreAppliedOnConfigs() {
+    void testCustomizersAreAppliedOnConfigs() {
         // Given
         contextRunner.withUserConfiguration(ConfigCustomizerConfiguration.class)
             .withPropertyValues(
@@ -129,7 +129,6 @@ public class RateLimiterAutoConfigurationCustomizerTest {
                 // from default config customizer
                 assertThat(backendWithoutSharedConfig.getTimeoutDuration()).isEqualTo(Duration.ofMillis(1000));
 
-
                 RateLimiterConfig backendWithSharedConfig = registry.rateLimiter("backendWithSharedConfig").getRateLimiterConfig();
                 // from shared config customizer
                 assertThat(backendWithSharedConfig.getLimitRefreshPeriod()).isEqualTo(Duration.ofMillis(2000));
@@ -149,7 +148,7 @@ public class RateLimiterAutoConfigurationCustomizerTest {
     }
 
     @Configuration
-    public static class CustomizerConfiguration {
+    static class CustomizerConfiguration {
         @Bean
         public RateLimiterConfigCustomizer backendWithoutSharedConfigCustomizer() {
             return RateLimiterConfigCustomizer.of("backendWithoutSharedConfig",
@@ -173,7 +172,7 @@ public class RateLimiterAutoConfigurationCustomizerTest {
     }
 
     @Configuration
-    public static class ConfigCustomizerConfiguration {
+    static class ConfigCustomizerConfiguration {
         @Bean
         public RateLimiterConfigCustomizer defaultCustomizer() {
             return RateLimiterConfigCustomizer.of("default",

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/ratelimiter/autoconfigure/RateLimiterConfigurationOnMissingBeanTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/ratelimiter/autoconfigure/RateLimiterConfigurationOnMissingBeanTest.java
@@ -1,39 +1,39 @@
 package io.github.resilience4j.springboot.ratelimiter.autoconfigure;
 
-import io.github.resilience4j.springboot.TestUtils;
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
-import io.github.resilience4j.spring6.fallback.FallbackExecutor;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
+import io.github.resilience4j.ratelimiter.event.RateLimiterEvent;
+import io.github.resilience4j.spring6.fallback.FallbackExecutor;
 import io.github.resilience4j.spring6.ratelimiter.configure.RateLimiterAspect;
 import io.github.resilience4j.spring6.ratelimiter.configure.RateLimiterAspectExt;
 import io.github.resilience4j.spring6.ratelimiter.configure.RateLimiterConfiguration;
 import io.github.resilience4j.spring6.ratelimiter.configure.RateLimiterConfigurationProperties;
-import io.github.resilience4j.ratelimiter.event.RateLimiterEvent;
 import io.github.resilience4j.spring6.spelresolver.SpelResolver;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import io.github.resilience4j.springboot.TestUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.health.autoconfigure.contributor.HealthContributorAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {
     HealthContributorAutoConfiguration.class,
     RateLimiterConfigurationOnMissingBeanTest.ConfigWithOverrides.class,
     RateLimiterAutoConfiguration.class,
 })
 @EnableConfigurationProperties(RateLimiterProperties.class)
-public class RateLimiterConfigurationOnMissingBeanTest {
+class RateLimiterConfigurationOnMissingBeanTest {
 
     @Autowired
     public ConfigWithOverrides configWithOverrides;
@@ -48,21 +48,20 @@ public class RateLimiterConfigurationOnMissingBeanTest {
     private EventConsumerRegistry<RateLimiterEvent> rateLimiterEventsConsumerRegistry;
 
     @Test
-    public void testAllBeansFromCircuitBreakerConfigurationHasOnMissingBean()
+    void testAllBeansFromCircuitBreakerConfigurationHasOnMissingBean()
         throws NoSuchMethodException {
         TestUtils.assertAnnotations(RateLimiterConfiguration.class, RateLimiterAutoConfiguration.class);
     }
 
     @Test
-    public void testAllCircuitBreakerConfigurationBeansOverridden() {
-        assertEquals(rateLimiterRegistry, configWithOverrides.rateLimiterRegistry);
-        assertEquals(rateLimiterAspect, configWithOverrides.rateLimiterAspect);
-        assertEquals(rateLimiterEventsConsumerRegistry,
-            configWithOverrides.rateLimiterEventsConsumerRegistry);
+    void testAllCircuitBreakerConfigurationBeansOverridden() {
+        assertThat(configWithOverrides.rateLimiterRegistry).isEqualTo(rateLimiterRegistry);
+        assertThat(configWithOverrides.rateLimiterAspect).isEqualTo(rateLimiterAspect);
+        assertThat(configWithOverrides.rateLimiterEventsConsumerRegistry).isEqualTo(rateLimiterEventsConsumerRegistry);
     }
 
     @Configuration
-    public static class ConfigWithOverrides {
+    static class ConfigWithOverrides {
 
         public RateLimiterRegistry rateLimiterRegistry;
 

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/ratelimiter/monitoring/health/RateLimitersHealthIndicatorTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/ratelimiter/monitoring/health/RateLimitersHealthIndicatorTest.java
@@ -2,9 +2,9 @@ package io.github.resilience4j.springboot.ratelimiter.monitoring.health;
 
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
-import io.github.resilience4j.spring6.ratelimiter.configure.RateLimiterConfigurationProperties;
 import io.github.resilience4j.ratelimiter.internal.AtomicRateLimiter;
-import org.junit.Test;
+import io.github.resilience4j.spring6.ratelimiter.configure.RateLimiterConfigurationProperties;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.health.actuate.endpoint.SimpleStatusAggregator;
 import org.springframework.boot.health.contributor.Health;
 import org.springframework.boot.health.contributor.Status;
@@ -21,10 +21,10 @@ import static org.mockito.Mockito.when;
 /**
  * @author bstorozhuk
  */
-public class RateLimitersHealthIndicatorTest {
+class RateLimitersHealthIndicatorTest {
 
     @Test
-    public void health() throws Exception {
+    void health() throws Exception {
         // given
         RateLimiterConfig config = mock(RateLimiterConfig.class);
         AtomicRateLimiter.AtomicRateLimiterMetrics metrics = mock(
@@ -79,7 +79,7 @@ public class RateLimitersHealthIndicatorTest {
     }
 
     @Test
-    public void healthIndicatorMaxImpactCanBeOverridden() throws Exception {
+    void healthIndicatorMaxImpactCanBeOverridden() throws Exception {
         // given
         RateLimiterConfig config = mock(RateLimiterConfig.class);
         AtomicRateLimiter.AtomicRateLimiterMetrics metrics = mock(AtomicRateLimiter.AtomicRateLimiterMetrics.class);

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/retry/RetryAutoConfigurationAsyncTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/retry/RetryAutoConfigurationAsyncTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Mahmoud Romeh, Artur Havliukovskyi
+ * Copyright 2026 Mahmoud Romeh, Artur Havliukovskyi
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,27 +15,25 @@
  */
 package io.github.resilience4j.springboot.retry;
 
-import io.github.resilience4j.springboot.circuitbreaker.IgnoredException;
 import io.github.resilience4j.common.retry.monitoring.endpoint.RetryEndpointResponse;
 import io.github.resilience4j.common.retry.monitoring.endpoint.RetryEventsEndpointResponse;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryRegistry;
-import io.github.resilience4j.springboot.retry.autoconfigure.RetryProperties;
 import io.github.resilience4j.spring6.retry.configure.RetryAspect;
+import io.github.resilience4j.springboot.circuitbreaker.IgnoredException;
+import io.github.resilience4j.springboot.retry.autoconfigure.RetryProperties;
 import io.github.resilience4j.springboot.service.test.TestApplication;
-import io.github.resilience4j.springboot.service.test.retry.RetryDummyService;
 import io.github.resilience4j.springboot.service.test.retry.ReactiveRetryDummyService;
 import io.github.resilience4j.springboot.service.test.retry.RetryDummyFeignClient;
+import io.github.resilience4j.springboot.service.test.retry.RetryDummyService;
 import io.github.resilience4j.test.TestContextPropagators.TestThreadLocalContextPropagatorWithHolder.TestThreadLocalContextHolder;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -44,11 +42,10 @@ import java.util.concurrent.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     classes = TestApplication.class)
 @AutoConfigureTestRestTemplate
-public class RetryAutoConfigurationAsyncTest {
+class RetryAutoConfigurationAsyncTest {
 
     @Autowired
     RetryRegistry retryRegistry;
@@ -70,7 +67,7 @@ public class RetryAutoConfigurationAsyncTest {
      * RetryDummyService is invoked and that the Async Retry logic is properly handled
      */
     @Test
-    public void testRetryAutoConfigurationAsync() throws Throwable {
+    void testRetryAutoConfigurationAsync() throws Throwable {
         assertThat(retryRegistry).isNotNull();
 
         RetryEventsEndpointResponse retryEventListBefore = retryEvents("/actuator/retryevents");
@@ -121,7 +118,7 @@ public class RetryAutoConfigurationAsyncTest {
     }
 
     @Test
-    public void testRetryAutoConfigurationAsyncWithMDCContext() throws Throwable {
+    void testRetryAutoConfigurationAsyncWithMDCContext() throws Throwable {
         assertThat(retryRegistry).isNotNull();
 
         RetryEventsEndpointResponse retryEventListBefore = retryEvents("/actuator/retryevents");
@@ -178,7 +175,7 @@ public class RetryAutoConfigurationAsyncTest {
     }
 
     @Test
-    public void testRetryAutoConfigurationAsyncWithContextPropagator() throws Throwable {
+    void testRetryAutoConfigurationAsyncWithContextPropagator() throws Throwable {
         assertThat(retryRegistry).isNotNull();
 
         RetryEventsEndpointResponse retryEventListBefore = retryEvents("/actuator/retryevents");
@@ -235,7 +232,6 @@ public class RetryAutoConfigurationAsyncTest {
     private RetryEventsEndpointResponse retryEvents(String s) {
         return restTemplate.getForEntity(s, RetryEventsEndpointResponse.class).getBody();
     }
-
 
     private <T> T awaitResult(CompletionStage<T> completionStage, long timeoutSeconds)
         throws Throwable {

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/retry/RetryAutoConfigurationReactorTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/retry/RetryAutoConfigurationReactorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Mahmoud Romeh, Artur Havliukovskyi
+ * Copyright 2026 Mahmoud Romeh, Artur Havliukovskyi
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,31 +15,28 @@
  */
 package io.github.resilience4j.springboot.retry;
 
-import io.github.resilience4j.springboot.circuitbreaker.IgnoredException;
 import io.github.resilience4j.common.retry.monitoring.endpoint.RetryEventsEndpointResponse;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryRegistry;
-import io.github.resilience4j.springboot.retry.autoconfigure.RetryProperties;
 import io.github.resilience4j.spring6.retry.configure.RetryAspect;
+import io.github.resilience4j.springboot.circuitbreaker.IgnoredException;
+import io.github.resilience4j.springboot.retry.autoconfigure.RetryProperties;
 import io.github.resilience4j.springboot.service.test.TestApplication;
 import io.github.resilience4j.springboot.service.test.retry.ReactiveRetryDummyService;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.resttestclient.TestRestTemplate;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     classes = TestApplication.class)
 @AutoConfigureTestRestTemplate
-public class RetryAutoConfigurationReactorTest {
+class RetryAutoConfigurationReactorTest {
 
     @Autowired
     RetryRegistry retryRegistry;
@@ -61,7 +58,7 @@ public class RetryAutoConfigurationReactorTest {
      * RetryReactiveDummyService is invoked and that the Retry logic is properly handled
      */
     @Test
-    public void testRetryAutoConfigurationReactor() throws IOException {
+    void testRetryAutoConfigurationReactor() throws IOException {
         assertThat(retryRegistry).isNotNull();
         assertThat(retryProperties).isNotNull();
 
@@ -111,5 +108,4 @@ public class RetryAutoConfigurationReactorTest {
     private RetryEventsEndpointResponse retryEventListBody(String url) {
         return restTemplate.getForEntity(url, RetryEventsEndpointResponse.class).getBody();
     }
-
 }

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/retry/RetryAutoConfigurationRxJavaTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/retry/RetryAutoConfigurationRxJavaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Mahmoud Romeh, Artur Havliukovskyi
+ * Copyright 2026 Mahmoud Romeh, Artur Havliukovskyi
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,23 +24,20 @@ import io.github.resilience4j.springboot.circuitbreaker.IgnoredException;
 import io.github.resilience4j.springboot.retry.autoconfigure.RetryProperties;
 import io.github.resilience4j.springboot.service.test.TestApplication;
 import io.github.resilience4j.springboot.service.test.retry.ReactiveRetryDummyService;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.resttestclient.TestRestTemplate;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     classes = TestApplication.class)
 @AutoConfigureTestRestTemplate
-public class RetryAutoConfigurationRxJavaTest {
+class RetryAutoConfigurationRxJavaTest {
 
     @Autowired
     RetryRegistry retryRegistry;
@@ -62,7 +59,7 @@ public class RetryAutoConfigurationRxJavaTest {
      * RetryReactiveDummyService is invoked and that the Retry logic is properly handled
      */
     @Test
-    public void testRetryAutoConfigurationRxJava2() throws IOException {
+    void testRetryAutoConfigurationRxJava2() throws IOException {
         assertThat(retryRegistry).isNotNull();
         assertThat(retryProperties).isNotNull();
         RetryEventsEndpointResponse retryEventListBefore = getRetryEventsBody(
@@ -121,5 +118,4 @@ public class RetryAutoConfigurationRxJavaTest {
     private RetryEventsEndpointResponse getRetryEventsBody(String s) {
         return restTemplate.getForEntity(s, RetryEventsEndpointResponse.class).getBody();
     }
-
 }

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/retry/RetryAutoConfigurationTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/retry/RetryAutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Mahmoud Romeh, Artur Havliukovskyi
+ * Copyright 2026 Mahmoud Romeh, Artur Havliukovskyi
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,41 +16,41 @@
 package io.github.resilience4j.springboot.retry;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import io.github.resilience4j.springboot.circuitbreaker.IgnoredException;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import io.github.resilience4j.common.retry.monitoring.endpoint.RetryEndpointResponse;
 import io.github.resilience4j.common.retry.monitoring.endpoint.RetryEventsEndpointResponse;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryRegistry;
-import io.github.resilience4j.springboot.retry.autoconfigure.RetryProperties;
 import io.github.resilience4j.spring6.retry.configure.RetryAspect;
+import io.github.resilience4j.springboot.circuitbreaker.IgnoredException;
+import io.github.resilience4j.springboot.retry.autoconfigure.RetryProperties;
 import io.github.resilience4j.springboot.service.test.TestApplication;
+import io.github.resilience4j.springboot.service.test.retry.ReactiveRetryDummyService;
 import io.github.resilience4j.springboot.service.test.retry.RetryDummyFeignClient;
 import io.github.resilience4j.springboot.service.test.retry.RetryDummyService;
-import io.github.resilience4j.springboot.service.test.retry.ReactiveRetryDummyService;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.IOException;
 import java.util.HashSet;
 
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     classes = TestApplication.class)
 @AutoConfigureTestRestTemplate
-public class RetryAutoConfigurationTest {
+class RetryAutoConfigurationTest {
 
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(8090);
+    @RegisterExtension
+    static WireMockExtension wireMockServer = WireMockExtension.newInstance()
+            .options(wireMockConfig().port(8090))
+            .build();
     @Autowired
     RetryRegistry retryRegistry;
     @Autowired
@@ -69,13 +69,13 @@ public class RetryAutoConfigurationTest {
      * as @Retry alone works with any normal service class
      */
     @Test
-    public void testFeignClient() {
+    void testFeignClient() {
 
-        WireMock.stubFor(WireMock
+        wireMockServer.stubFor(WireMock
             .get(WireMock.urlEqualTo("/retry/"))
             .willReturn(WireMock.aResponse().withStatus(200).withBody("This is successful call"))
         );
-        WireMock.stubFor(WireMock.get(WireMock.urlMatching("^.*\\/retry\\/error.*$"))
+        wireMockServer.stubFor(WireMock.get(WireMock.urlMatching("^.*\\/retry\\/error.*$"))
             .willReturn(WireMock.aResponse().withStatus(400).withBody("This is error")));
 
         assertThat(retryRegistry).isNotNull();
@@ -133,7 +133,7 @@ public class RetryAutoConfigurationTest {
      * RetryDummyService is invoked and that the Retry logic is properly handled
      */
     @Test
-    public void testRetryAutoConfiguration() throws IOException {
+    void testRetryAutoConfiguration() throws IOException {
         assertThat(retryRegistry).isNotNull();
         assertThat(retryProperties).isNotNull();
 

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/retry/autoconfigure/RetryAutoConfigurationCustomizerTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/retry/autoconfigure/RetryAutoConfigurationCustomizerTest.java
@@ -1,9 +1,9 @@
 package io.github.resilience4j.springboot.retry.autoconfigure;
 
+import io.github.resilience4j.common.retry.configuration.RetryConfigCustomizer;
 import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.retry.RetryRegistry;
-import io.github.resilience4j.common.retry.configuration.RetryConfigCustomizer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * </ul>
  * where N is index of the config. This way when asserting value {@code 200} it is guaranteed to be coming from instance properties.
  */
-public class RetryAutoConfigurationCustomizerTest {
+class RetryAutoConfigurationCustomizerTest {
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
         .withConfiguration(AutoConfigurations.of(RetryAutoConfiguration.class))
         .withPropertyValues(
@@ -38,7 +38,7 @@ public class RetryAutoConfigurationCustomizerTest {
         );
 
     @Test
-    public void testUserConfigShouldBeAbleToProvideCustomizers() {
+    void testUserConfigShouldBeAbleToProvideCustomizers() {
         // Given
         contextRunner.withUserConfiguration(CustomizerConfiguration.class)
             .withPropertyValues(
@@ -78,7 +78,7 @@ public class RetryAutoConfigurationCustomizerTest {
     }
 
     @Test
-    public void testCustomizersShouldOverrideProperties() {
+    void testCustomizersShouldOverrideProperties() {
         // Given
         contextRunner.withUserConfiguration(CustomizerConfiguration.class)
             .withPropertyValues(
@@ -100,7 +100,7 @@ public class RetryAutoConfigurationCustomizerTest {
     }
 
     @Test
-    public void testCustomizersAreAppliedOnConfigs() {
+    void testCustomizersAreAppliedOnConfigs() {
         // Given
         contextRunner.withUserConfiguration(ConfigCustomizerConfiguration.class)
             .withPropertyValues(
@@ -129,7 +129,6 @@ public class RetryAutoConfigurationCustomizerTest {
                 // from default config customizer
                 assertThat(backendWithoutSharedConfig.isWritableStackTraceEnabled()).isEqualTo(true);
 
-
                 RetryConfig backendWithSharedConfig = registry.retry("backendWithSharedConfig").getRetryConfig();
                 // from shared config customizer
                 assertThat(backendWithSharedConfig.getIntervalBiFunction().apply(0, null)).isEqualTo(2000);
@@ -149,7 +148,7 @@ public class RetryAutoConfigurationCustomizerTest {
     }
 
     @Configuration
-    public static class CustomizerConfiguration {
+    static class CustomizerConfiguration {
         @Bean
         public RetryConfigCustomizer backendWithoutSharedConfigCustomizer() {
             return RetryConfigCustomizer.of("backendWithoutSharedConfig",
@@ -173,7 +172,7 @@ public class RetryAutoConfigurationCustomizerTest {
     }
 
     @Configuration
-    public static class ConfigCustomizerConfiguration {
+    static class ConfigCustomizerConfiguration {
         @Bean
         public RetryConfigCustomizer defaultCustomizer() {
             return RetryConfigCustomizer.of("default",

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/retry/autoconfigure/RetryConfigurationOnMissingBeanTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/retry/autoconfigure/RetryConfigurationOnMissingBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Mahmoud Romeh, Artur Havliukovskyi
+ * Copyright 2026 Mahmoud Romeh, Artur Havliukovskyi
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,37 +15,37 @@
  */
 package io.github.resilience4j.springboot.retry.autoconfigure;
 
-import io.github.resilience4j.springboot.TestUtils;
 import io.github.resilience4j.consumer.DefaultEventConsumerRegistry;
 import io.github.resilience4j.consumer.EventConsumerRegistry;
 import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
-import io.github.resilience4j.spring6.fallback.FallbackExecutor;
 import io.github.resilience4j.retry.RetryRegistry;
+import io.github.resilience4j.retry.event.RetryEvent;
+import io.github.resilience4j.spring6.fallback.FallbackExecutor;
 import io.github.resilience4j.spring6.retry.configure.RetryAspect;
 import io.github.resilience4j.spring6.retry.configure.RetryAspectExt;
 import io.github.resilience4j.spring6.retry.configure.RetryConfiguration;
-import io.github.resilience4j.retry.event.RetryEvent;
 import io.github.resilience4j.spring6.spelresolver.SpelResolver;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import io.github.resilience4j.springboot.TestUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {
     RetryConfigurationOnMissingBeanTest.ConfigWithOverrides.class,
     RetryAutoConfiguration.class,
 })
 @EnableConfigurationProperties(RetryProperties.class)
-public class RetryConfigurationOnMissingBeanTest {
+class RetryConfigurationOnMissingBeanTest {
 
     @Autowired
     private ConfigWithOverrides configWithOverrides;
@@ -60,19 +60,19 @@ public class RetryConfigurationOnMissingBeanTest {
     private EventConsumerRegistry<RetryEvent> retryEventConsumerRegistry;
 
     @Test
-    public void testAllBeansFromRetryHasOnMissingBean() throws NoSuchMethodException {
+    void testAllBeansFromRetryHasOnMissingBean() throws NoSuchMethodException {
         TestUtils.assertAnnotations(RetryConfiguration.class, RetryAutoConfiguration.class);
     }
 
     @Test
-    public void testAllRetryConfigurationBeansOverridden() {
-        assertEquals(retryAspect, configWithOverrides.retryAspect);
-        assertEquals(retryEventConsumerRegistry, configWithOverrides.retryEventConsumerRegistry);
-        assertEquals(retryRegistry, configWithOverrides.retryRegistry);
+    void testAllRetryConfigurationBeansOverridden() {
+        assertThat(configWithOverrides.retryAspect).isEqualTo(retryAspect);
+        assertThat(configWithOverrides.retryEventConsumerRegistry).isEqualTo(retryEventConsumerRegistry);
+        assertThat(configWithOverrides.retryRegistry).isEqualTo(retryRegistry);
     }
 
     @Configuration
-    public static class ConfigWithOverrides {
+    static class ConfigWithOverrides {
 
         private RetryRegistry retryRegistry;
 

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/service/test/DummyFeignClient.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/service/test/DummyFeignClient.java
@@ -1,6 +1,5 @@
 package io.github.resilience4j.springboot.service.test;
 
-
 import io.github.resilience4j.bulkhead.annotation.Bulkhead;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -13,5 +12,5 @@ import org.springframework.web.bind.annotation.PathVariable;
 public interface DummyFeignClient {
 
     @GetMapping(path = "/sample/{error}")
-    void doSomething(@PathVariable(name = "error") String error);
+    public void doSomething(@PathVariable(name = "error") String error);
 }

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/service/test/DummyService.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/service/test/DummyService.java
@@ -1,15 +1,14 @@
 package io.github.resilience4j.springboot.service.test;
 
-
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
 public interface DummyService {
 
-    String BACKEND = "backendA";
-    String BACKEND_B = "backendB";
+    public String BACKEND = "backendA";
+    public String BACKEND_B = "backendB";
 
-    void doSomething(boolean throwException) throws IOException;
+    public void doSomething(boolean throwException) throws IOException;
 
     CompletableFuture<String> longDoSomethingAsync() throws InterruptedException;
 

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/service/test/DummyServiceImpl.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/service/test/DummyServiceImpl.java
@@ -1,6 +1,5 @@
 package io.github.resilience4j.springboot.service.test;
 
-
 import io.github.resilience4j.bulkhead.annotation.Bulkhead;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.ratelimiter.annotation.RateLimiter;

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/service/test/ReactiveDummyService.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/service/test/ReactiveDummyService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Mahmoud Romeh, Artur Havliukovskyi
+ * Copyright 2026 Mahmoud Romeh, Artur Havliukovskyi
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 package io.github.resilience4j.springboot.service.test;
 
-
 import io.reactivex.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -27,7 +26,7 @@ import java.io.IOException;
  */
 public interface ReactiveDummyService {
 
-    String BACKEND = "backendB";
+    public String BACKEND = "backendB";
 
     Flux<String> doSomethingFlux(boolean throwException) throws IOException;
 
@@ -39,7 +38,7 @@ public interface ReactiveDummyService {
 
     Single<String> doSomethingSingle(boolean throwException) throws IOException;
 
-    Completable doSomethingCompletable(boolean throwException) throws IOException;
+    public Completable doSomethingCompletable(boolean throwException) throws IOException;
 
     Observable<String> doSomethingObservable(boolean throwException) throws IOException;
 }

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/service/test/ReactiveDummyServiceImpl.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/service/test/ReactiveDummyServiceImpl.java
@@ -92,5 +92,4 @@ public class ReactiveDummyServiceImpl implements ReactiveDummyService {
         }
         return Observable.just("testObservable");
     }
-
 }

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/service/test/TestApplication.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/service/test/TestApplication.java
@@ -19,7 +19,6 @@ import org.springframework.context.annotation.Import;
 import java.time.Duration;
 import java.util.List;
 
-
 /**
  * @author bstorozhuk
  */
@@ -28,7 +27,7 @@ import java.util.List;
 @Import(FeignAutoConfiguration.class)
 public class TestApplication {
 
-    public static void main(String[] args) {
+    static void main(String[] args) {
         SpringApplication.run(TestApplication.class, args);
     }
 
@@ -69,7 +68,6 @@ public class TestApplication {
         return RetryConfigCustomizer.of("retryBackendD",
                 builder -> builder.maxAttempts(4));
     }
-
 
     @Bean
     public TimeLimiterConfigCustomizer testTimeLimiterCustomizer() {

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/service/test/bulkhead/BulkheadDummyService.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/service/test/bulkhead/BulkheadDummyService.java
@@ -4,12 +4,12 @@ import java.util.concurrent.CompletableFuture;
 
 public interface BulkheadDummyService {
 
-    String BACKEND = "backendA";
-    String BACKEND_C = "backendC";
-    String BACKEND_D = "backendD";
-    String BACKEND_E = "backendE";
+    public String BACKEND = "backendA";
+    public String BACKEND_C = "backendC";
+    public String BACKEND_D = "backendD";
+    public String BACKEND_E = "backendE";
 
-    void doSomething();
+    public void doSomething();
 
     CompletableFuture<String> doSomethingAsync() throws InterruptedException;
 

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/service/test/bulkhead/BulkheadDummyServiceImpl.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/service/test/bulkhead/BulkheadDummyServiceImpl.java
@@ -1,12 +1,11 @@
 package io.github.resilience4j.springboot.service.test.bulkhead;
 
-import io.github.resilience4j.springboot.TestThreadLocalContextPropagator;
 import io.github.resilience4j.bulkhead.annotation.Bulkhead;
 import io.github.resilience4j.retry.annotation.Retry;
+import io.github.resilience4j.springboot.TestThreadLocalContextPropagator;
 import org.springframework.stereotype.Component;
 
 import java.util.concurrent.CompletableFuture;
-
 
 @Component
 public class BulkheadDummyServiceImpl implements BulkheadDummyService {

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/service/test/bulkhead/BulkheadReactiveDummyService.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/service/test/bulkhead/BulkheadReactiveDummyService.java
@@ -5,7 +5,7 @@ import reactor.core.publisher.Flux;
 
 public interface BulkheadReactiveDummyService {
 
-    String BACKEND = "backendB";
+    public String BACKEND = "backendB";
 
     Flux<String> doSomethingFlux();
 

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/service/test/ratelimiter/RateLimiterDummyFeignClient.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/service/test/ratelimiter/RateLimiterDummyFeignClient.java
@@ -1,6 +1,5 @@
 package io.github.resilience4j.springboot.service.test.ratelimiter;
 
-
 import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,8 +11,8 @@ import static io.github.resilience4j.springboot.service.test.ratelimiter.RateLim
 @RateLimiter(name = RATE_LIMITER_FEIGN_CLIENT_NAME)
 public interface RateLimiterDummyFeignClient {
 
-    String RATE_LIMITER_FEIGN_CLIENT_NAME = "rateLimiterDummyFeignClient";
+    public String RATE_LIMITER_FEIGN_CLIENT_NAME = "rateLimiterDummyFeignClient";
 
     @GetMapping(path = "/limit/{error}")
-    void doSomething(@PathVariable(name = "error") String error);
+    public void doSomething(@PathVariable(name = "error") String error);
 }

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/service/test/retry/ReactiveRetryDummyService.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/service/test/retry/ReactiveRetryDummyService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Mahmoud Romeh, Artur Havliukovskyi
+ * Copyright 2026 Mahmoud Romeh, Artur Havliukovskyi
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 package io.github.resilience4j.springboot.service.test.retry;
 
-
 import io.reactivex.Flowable;
 import reactor.core.publisher.Flux;
 
@@ -24,7 +23,7 @@ import reactor.core.publisher.Flux;
  */
 public interface ReactiveRetryDummyService {
 
-    String BACKEND_C = "retryBackendC";
+    public String BACKEND_C = "retryBackendC";
 
     Flux<String> doSomethingFlux(boolean throwException);
 

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/service/test/retry/RetryDummyFeignClient.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/service/test/retry/RetryDummyFeignClient.java
@@ -1,6 +1,5 @@
 package io.github.resilience4j.springboot.service.test.retry;
 
-
 import io.github.resilience4j.retry.annotation.Retry;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,8 +11,8 @@ import static io.github.resilience4j.springboot.service.test.retry.RetryDummyFei
 @Retry(name = RETRY_DUMMY_FEIGN_CLIENT_NAME)
 public interface RetryDummyFeignClient {
 
-    String RETRY_DUMMY_FEIGN_CLIENT_NAME = "retryDummyFeignClient";
+    public String RETRY_DUMMY_FEIGN_CLIENT_NAME = "retryDummyFeignClient";
 
     @GetMapping(path = "/retry/{error}")
-    void doSomething(@PathVariable(name = "error") String error);
+    public void doSomething(@PathVariable(name = "error") String error);
 }

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/service/test/retry/RetryDummyService.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/service/test/retry/RetryDummyService.java
@@ -1,15 +1,14 @@
 package io.github.resilience4j.springboot.service.test.retry;
 
-
 import java.io.IOException;
 import java.util.concurrent.CompletionStage;
 
 public interface RetryDummyService {
 
-    String RETRY_BACKEND_A = "retryBackendA";
-    String RETRY_BACKEND_B = "retryBackendB";
+    public String RETRY_BACKEND_A = "retryBackendA";
+    public String RETRY_BACKEND_B = "retryBackendB";
 
-    void doSomething(boolean throwException) throws IOException;
+    public void doSomething(boolean throwException) throws IOException;
 
     CompletionStage<String> doSomethingAsync(boolean throwException) throws IOException;
 }

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/service/test/retry/RetryDummyServiceImpl.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/service/test/retry/RetryDummyServiceImpl.java
@@ -1,13 +1,11 @@
 package io.github.resilience4j.springboot.service.test.retry;
 
-
 import io.github.resilience4j.retry.annotation.Retry;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-
 
 @Component
 public class RetryDummyServiceImpl implements RetryDummyService {

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/thread/autoconfigure/ThreadTypeAutoConfigurationTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/thread/autoconfigure/ThreadTypeAutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025
+ * Copyright 2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,25 +16,25 @@
 package io.github.resilience4j.springboot.thread.autoconfigure;
 
 import io.github.resilience4j.core.ThreadType;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ThreadTypeAutoConfigurationTest {
+class ThreadTypeAutoConfigurationTest {
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
         .withConfiguration(AutoConfigurations.of(Resilience4jThreadAutoConfiguration.class));
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         System.clearProperty("resilience4j.thread.type");
     }
 
     @Test
-    public void registersBeanWhenPropertyIsVirtual() {
+    void registersBeanWhenPropertyIsVirtual() {
         contextRunner
             .withPropertyValues("resilience4j.thread.type=virtual")
             .run(context ->
@@ -43,7 +43,7 @@ public class ThreadTypeAutoConfigurationTest {
     }
 
     @Test
-    public void doesNotRegisterBeanWhenPropertyNotSpecified() {
+    void doesNotRegisterBeanWhenPropertyNotSpecified() {
         contextRunner
             .withPropertyValues("randomProperty=value")
             .run(context ->
@@ -52,7 +52,7 @@ public class ThreadTypeAutoConfigurationTest {
     }
 
     @Test
-    public void systemPropertyIsPropagatedFromSpringProperty() {
+    void systemPropertyIsPropagatedFromSpringProperty() {
         System.clearProperty("resilience4j.thread.type");
 
         contextRunner
@@ -65,7 +65,7 @@ public class ThreadTypeAutoConfigurationTest {
     }
 
     @Test
-    public void existingSystemPropertyIsNotOverwritten() {
+    void existingSystemPropertyIsNotOverwritten() {
         System.setProperty("resilience4j.thread.type", ThreadType.PLATFORM.toString());
 
         contextRunner
@@ -79,7 +79,7 @@ public class ThreadTypeAutoConfigurationTest {
     }
 
     @Test
-    public void threadTypePropertiesBindingIsCorrect() {
+    void threadTypePropertiesBindingIsCorrect() {
         contextRunner
             .withPropertyValues("resilience4j.thread.type=virtual")
             .run(context -> {

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/timelimiter/TimeLimiterAutoConfigurationTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/timelimiter/TimeLimiterAutoConfigurationTest.java
@@ -1,40 +1,37 @@
 package io.github.resilience4j.springboot.timelimiter;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import io.github.resilience4j.common.CompositeCustomizer;
 import io.github.resilience4j.common.timelimiter.configuration.TimeLimiterConfigCustomizer;
 import io.github.resilience4j.common.timelimiter.monitoring.endpoint.TimeLimiterEventsEndpointResponse;
+import io.github.resilience4j.spring6.timelimiter.configure.TimeLimiterAspect;
 import io.github.resilience4j.springboot.service.test.DummyService;
 import io.github.resilience4j.springboot.service.test.TestApplication;
-import io.github.resilience4j.test.TestContextPropagators.TestThreadLocalContextPropagatorWithHolder.TestThreadLocalContextHolder;
 import io.github.resilience4j.springboot.timelimiter.autoconfigure.TimeLimiterProperties;
-import io.github.resilience4j.spring6.timelimiter.configure.TimeLimiterAspect;
+import io.github.resilience4j.test.TestContextPropagators.TestThreadLocalContextPropagatorWithHolder.TestThreadLocalContextHolder;
 import io.github.resilience4j.timelimiter.TimeLimiter;
 import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.resttestclient.TestRestTemplate;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import static com.jayway.awaitility.Awaitility.matches;
-import static com.jayway.awaitility.Awaitility.waitAtMost;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
         classes = TestApplication.class)
 @AutoConfigureTestRestTemplate
-public class TimeLimiterAutoConfigurationTest {
+class TimeLimiterAutoConfigurationTest {
 
     @Autowired
     TimeLimiterRegistry timeLimiterRegistry;
@@ -54,11 +51,13 @@ public class TimeLimiterAutoConfigurationTest {
     @Autowired
     private TestRestTemplate restTemplate;
 
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(8090);
+    @RegisterExtension
+    static WireMockExtension wireMockServer = WireMockExtension.newInstance()
+            .options(wireMockConfig().port(8090))
+            .build();
 
     @Test
-    public void testTimeLimiterAutoConfigurationTest() throws Exception {
+    void testTimeLimiterAutoConfigurationTest() throws Exception {
         assertThat(timeLimiterRegistry).isNotNull();
         assertThat(timeLimiterProperties).isNotNull();
         assertThat(compositeTimeLimiterConfigCustomizer).isNotNull();
@@ -96,7 +95,7 @@ public class TimeLimiterAutoConfigurationTest {
     }
 
     @Test
-    public void shouldThrowTimeOutExceptionAndPropagateContext() throws InterruptedException {
+    void shouldThrowTimeOutExceptionAndPropagateContext() throws InterruptedException {
         TimeLimiterEventsEndpointResponse timeLimiterEventsBefore =
             timeLimiterEvents("/actuator/timelimiterevents");
         TimeLimiterEventsEndpointResponse timeLimiterEventsForABefore =
@@ -117,8 +116,8 @@ public class TimeLimiterAutoConfigurationTest {
             return null;
         });
 
-        waitAtMost(3, TimeUnit.SECONDS).until(matches(() ->
-            assertThat(future).isCompletedWithValue("ValueShouldCrossThreadBoundary")));
+        await().atMost(3, TimeUnit.SECONDS).untilAsserted(() ->
+            assertThat(future).isCompletedWithValue("ValueShouldCrossThreadBoundary"));
 
         TimeLimiterEventsEndpointResponse timeLimiterEventList = timeLimiterEvents("/actuator/timelimiterevents");
         assertThat(timeLimiterEventList.getTimeLimiterEvents())
@@ -132,7 +131,7 @@ public class TimeLimiterAutoConfigurationTest {
     }
 
     @Test
-    public void shouldThrowTimeOutExceptionAndPropagateMDCContext() throws InterruptedException {
+    void shouldThrowTimeOutExceptionAndPropagateMDCContext() throws InterruptedException {
         TimeLimiterEventsEndpointResponse timeLimiterEventsBefore =
             timeLimiterEvents("/actuator/timelimiterevents");
         TimeLimiterEventsEndpointResponse timeLimiterEventsForABefore =
@@ -155,8 +154,8 @@ public class TimeLimiterAutoConfigurationTest {
             return null;
         });
 
-        waitAtMost(3, TimeUnit.SECONDS).until(matches(() ->
-            assertThat(future).isCompletedWithValue("ValueShouldCrossThreadBoundary")));
+        await().atMost(3, TimeUnit.SECONDS).untilAsserted(() ->
+            assertThat(future).isCompletedWithValue("ValueShouldCrossThreadBoundary"));
 
         TimeLimiterEventsEndpointResponse timeLimiterEventList = timeLimiterEvents("/actuator/timelimiterevents");
         assertThat(timeLimiterEventList.getTimeLimiterEvents())
@@ -172,5 +171,4 @@ public class TimeLimiterAutoConfigurationTest {
     private TimeLimiterEventsEndpointResponse timeLimiterEvents(String s) {
         return restTemplate.getForEntity(s, TimeLimiterEventsEndpointResponse.class).getBody();
     }
-
 }

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/timelimiter/autoconfigure/TimeLimiterAutoConfigurationCustomizerTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/timelimiter/autoconfigure/TimeLimiterAutoConfigurationCustomizerTest.java
@@ -1,9 +1,9 @@
 package io.github.resilience4j.springboot.timelimiter.autoconfigure;
 
+import io.github.resilience4j.common.timelimiter.configuration.TimeLimiterConfigCustomizer;
 import io.github.resilience4j.timelimiter.TimeLimiterConfig;
 import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
-import io.github.resilience4j.common.timelimiter.configuration.TimeLimiterConfigCustomizer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * </ul>
  * where N is index of the config. This way when asserting value {@code 200} it is guaranteed to be coming from instance properties.
  */
-public class TimeLimiterAutoConfigurationCustomizerTest {
+class TimeLimiterAutoConfigurationCustomizerTest {
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
         .withConfiguration(AutoConfigurations.of(TimeLimiterAutoConfiguration.class))
         .withPropertyValues(
@@ -36,7 +36,7 @@ public class TimeLimiterAutoConfigurationCustomizerTest {
         );
 
     @Test
-    public void testUserConfigShouldBeAbleToProvideCustomizers() {
+    void testUserConfigShouldBeAbleToProvideCustomizers() {
         // Given
         contextRunner.withUserConfiguration(CustomizerConfiguration.class)
             .withPropertyValues(
@@ -70,7 +70,7 @@ public class TimeLimiterAutoConfigurationCustomizerTest {
     }
 
     @Test
-    public void testCustomizersShouldOverrideProperties() {
+    void testCustomizersShouldOverrideProperties() {
         // Given
         contextRunner.withUserConfiguration(CustomizerConfiguration.class)
             .withPropertyValues(
@@ -90,7 +90,7 @@ public class TimeLimiterAutoConfigurationCustomizerTest {
     }
 
     @Test
-    public void testCustomizersAreAppliedOnConfigs() {
+    void testCustomizersAreAppliedOnConfigs() {
         // Given
         contextRunner.withUserConfiguration(ConfigCustomizerConfiguration.class)
             .withPropertyValues(
@@ -115,7 +115,6 @@ public class TimeLimiterAutoConfigurationCustomizerTest {
                 // from instance config
                 assertThat(backendWithoutSharedConfig.shouldCancelRunningFuture()).isEqualTo(false);
 
-
                 TimeLimiterConfig backendWithSharedConfig = registry.timeLimiter("backendWithSharedConfig").getTimeLimiterConfig();
                 // from shared config customizer
                 assertThat(backendWithSharedConfig.getTimeoutDuration()).isEqualTo(Duration.ofMillis(2000));
@@ -131,7 +130,7 @@ public class TimeLimiterAutoConfigurationCustomizerTest {
     }
 
     @Configuration
-    public static class CustomizerConfiguration {
+    static class CustomizerConfiguration {
         @Bean
         public TimeLimiterConfigCustomizer backendWithoutSharedConfigCustomizer() {
             return TimeLimiterConfigCustomizer.of("backendWithoutSharedConfig",
@@ -155,7 +154,7 @@ public class TimeLimiterAutoConfigurationCustomizerTest {
     }
 
     @Configuration
-    public static class ConfigCustomizerConfiguration {
+    static class ConfigCustomizerConfiguration {
         @Bean
         public TimeLimiterConfigCustomizer defaultCustomizer() {
             return TimeLimiterConfigCustomizer.of("default",

--- a/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/verifier/autoconfigure/SpringBoot4VerifierTest.java
+++ b/resilience4j-spring-boot4/src/test/java/io/github/resilience4j/springboot/verifier/autoconfigure/SpringBoot4VerifierTest.java
@@ -1,11 +1,11 @@
 package io.github.resilience4j.springboot.verifier.autoconfigure;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class SpringBoot4VerifierTest {
+class SpringBoot4VerifierTest {
 
     @Test
-    public void compatibleWithCurrentSpringBoot() {
+    void compatibleWithCurrentSpringBoot() {
         new SpringBoot4Verifier().verifyCompatibility();
     }
 }

--- a/resilience4j-spring-boot4/src/test/resources/application.yaml
+++ b/resilience4j-spring-boot4/src/test/resources/application.yaml
@@ -99,7 +99,6 @@ resilience4j.circuitbreaker:
       slidingWindowSize: 18
       permittedNumberOfCallsInHalfOpenState: 6
 
-
 resilience4j.ratelimiter:
   tags:
     tag1: tag1Value
@@ -227,7 +226,6 @@ resilience4j.micrometer.timer:
     backendI:
       baseConfig: shared
       metricNames: resilience4j.timer.callsI
-
 
 management.security.enabled: false
 management.endpoints.web.exposure.include: '*'


### PR DESCRIPTION
## Changes

* Migrated JUnit 4.13 annotations to Junit Jupiter equivalents
* Replaced `@RunWith(SpringJUnit4ClassRunner.class)` with `@ExtendWith(SpringExtension.class)`
* Replaced `@Rule WireMockRule` with `@RegisterExtension WireMockExtension`
* Migrated to awaitility 4.x
* Applied OpenRewrite recipes
    * [JUnit 6 best practices](https://docs.openrewrite.org/recipes/java/testing/junit/junit6bestpractices)
    * [Mockito best practices](https://docs.openrewrite.org/recipes/java/testing/mockito/mockitobestpractices)
    * [Migrate JUnit asserts to AssertJ](https://docs.openrewrite.org/recipes/java/testing/assertj/junittoassertj)
    * [AssertJ best practices](https://docs.openrewrite.org/recipes/java/testing/assertj/assertj-best-practices)
* Removed `public` modifiers
* Updated Copyright to 2026

## Coverage

| Metric      | Before | After |
|-------------|--------|-------|
| Instruction | 68.5%  | 68.5% |
| Line        | 72.8%  | 72.8% |
| Branch      | 44.2%  | 44.2% |

## Test runtime

| Metric | Before | After |
|--------|--------|-------|
| Tests  | 101    | 101   |
| Time   | 27.9s  | 26.2s |
