### PR TITLE
Preserve durationSupplierType when copying HedgeConfig (#2457)

### DIFF
--- a/resilience4j-hedge/src/main/java/io/github/resilience4j/hedge/HedgeConfig.java
+++ b/resilience4j-hedge/src/main/java/io/github/resilience4j/hedge/HedgeConfig.java
@@ -144,6 +144,7 @@ public class HedgeConfig implements Serializable {
         }
 
         public Builder(HedgeConfig baseConfig) {
+            this.hedgeDurationSupplierType = baseConfig.durationSupplierType;
             this.shouldUseFactorAsPercentage = baseConfig.shouldUseFactorAsPercentage;
             this.hedgeTimeFactor = baseConfig.hedgeTimeFactor;
             this.shouldMeasureErrors = baseConfig.shouldMeasureErrors;

--- a/resilience4j-hedge/src/test/java/io/github/resilience4j/hedge/HedgeConfigTest.java
+++ b/resilience4j-hedge/src/test/java/io/github/resilience4j/hedge/HedgeConfigTest.java
@@ -47,6 +47,17 @@ class HedgeConfigTest {
     }
 
     @Test
+    void shouldInitializeDurationSupplierTypeFromOtherConfig() {
+        HedgeConfig config = HedgeConfig.custom()
+            .averagePlusAmountDuration(200, false, 100).build();
+
+        HedgeConfig copiedConfig = HedgeConfig.from(config).build();
+
+        then(copiedConfig.getDurationSupplier())
+            .isEqualTo(HedgeConfig.HedgeDurationSupplierType.AVERAGE_PLUS);
+    }
+
+    @Test
     void configToString() {
         then(HedgeConfig.ofDefaults().toString()).isEqualTo(HEDGE_TO_STRING);
     }


### PR DESCRIPTION
## What

`HedgeConfig.Builder(HedgeConfig baseConfig)` (used by `HedgeConfig.from(...)`) copies most fields from the source config but **omits `durationSupplierType`**. Because the builder field defaults to `PRECONFIGURED`, an `AVERAGE_PLUS` config is silently downgraded to `PRECONFIGURED` whenever it is copied:

```java
HedgeConfig config = HedgeConfig.custom()
    .averagePlusAmountDuration(200, false, 100).build();   // AVERAGE_PLUS

HedgeConfig copied = HedgeConfig.from(config).build();
copied.getDurationSupplier();  // PRECONFIGURED  (expected AVERAGE_PLUS)
```

This addresses the copy-builder part of #2457.

## Change

- Copy `durationSupplierType` in the `Builder(HedgeConfig)` copy constructor.
- Add `shouldInitializeDurationSupplierTypeFromOtherConfig` to `HedgeConfigTest` (the reproducer from the issue). It fails before the change (gets `PRECONFIGURED`) and passes after.

## Test evidence

`./gradlew :resilience4j-hedge:test --tests 'io.github.resilience4j.hedge.HedgeConfigTest'` → all 6 tests pass, including the new one. The pre-existing `configToString` / `shouldInitializeFromOtherConfig` tests still pass, confirming default behavior is unchanged. (The other `resilience4j-hedge` tests fail in my environment only due to Mockito's inline mock-maker not yet supporting JDK 25 — unrelated to this change.)

## Scope note

The issue also reports that `HedgeConfig.ofDefaults()` produces an unusable default duration supplier (`PRECONFIGURED` with a `null` cutoff). As discussed in the issue thread, fixing that involves a design decision about the intended default (e.g. switching the default to `AVERAGE_PLUS` makes `ofDefaults()` non-null but causes hedges to fire on every call with a `ZERO` baseline). I've deliberately left that out of this PR so it can be decided separately; happy to follow up once the team confirms the desired default.

Verification done: confirmed the bug exists on current `master`, no in-flight PR addresses it, and the new test fails without the fix / passes with it.

Towards #2457