### PR TITLE
bom: add resilience4j-micronaut and resilience4j-micronaut-annotation

### DIFF
--- a/resilience4j-bom/build.gradle
+++ b/resilience4j-bom/build.gradle
@@ -72,6 +72,8 @@ dependencies {
         api project(":resilience4j-rxjava3")
         api project(":resilience4j-reactor")
         api project(":resilience4j-micrometer")
+        api project(":resilience4j-micronaut")
+        api project(":resilience4j-micronaut-annotation")
         api project(":resilience4j-kotlin")
         api project(":resilience4j-vavr")
     }


### PR DESCRIPTION
Both `resilience4j-micronaut` and `resilience4j-micronaut-annotation` are declared in `settings.gradle` but were missing from the BOM constraints in `resilience4j-bom/build.gradle`.

Closes #2455.