### PR TITLE
Issue #2173: Fixed rate exceeded events not being re-published in metrics only mode

### DIFF
--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachine.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachine.java
@@ -941,10 +941,6 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
         }
 
         private void checkIfThresholdsExceeded(Result result) {
-            if (!Result.hasExceededThresholds(result)) {
-                return;
-            }
-
             if (shouldPublishFailureRateExceededEvent(result)) {
                 publishCircuitFailureRateExceededEvent(getName(), circuitBreakerMetrics.getFailureRate());
             }
@@ -955,13 +951,26 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
         }
 
         private boolean shouldPublishFailureRateExceededEvent(Result result) {
-            return Result.hasFailureRateExceededThreshold(result) &&
-                isFailureRateExceeded.compareAndSet(false, true);
+            if (Result.hasFailureRateExceededThreshold(result)) {
+                return isFailureRateExceeded.compareAndSet(false, true);
+            }
+            // Once the rate drops back below the threshold we arm the flag again, so a later
+            // breach is published anew. BELOW_MINIMUM_CALLS_THRESHOLD means there is not enough
+            // data to tell, so we leave the flag untouched in that case.
+            if (result != Result.BELOW_MINIMUM_CALLS_THRESHOLD) {
+                isFailureRateExceeded.set(false);
+            }
+            return false;
         }
 
         private boolean shouldPublishSlowCallRateExceededEvent(Result result) {
-            return Result.hasSlowCallRateExceededThreshold(result) &&
-                isSlowCallRateExceeded.compareAndSet(false, true);
+            if (Result.hasSlowCallRateExceededThreshold(result)) {
+                return isSlowCallRateExceeded.compareAndSet(false, true);
+            }
+            if (result != Result.BELOW_MINIMUM_CALLS_THRESHOLD) {
+                isSlowCallRateExceeded.set(false);
+            }
+            return false;
         }
 
         @Override

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachineTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachineTest.java
@@ -860,6 +860,41 @@ class CircuitBreakerStateMachineTest {
     }
 
     @Test
+    void shouldPublishFailureRateExceededEventAgainAfterRateRecoversInMetricsOnlyState() {
+        CircuitBreaker circuitBreaker = new CircuitBreakerStateMachine("testName", custom()
+            .failureRateThreshold(50)
+            .slidingWindow(5, 5, SlidingWindowType.COUNT_BASED)
+            .build());
+        circuitBreaker.transitionToMetricsOnlyState();
+        circuitBreaker.getEventPublisher().onFailureRateExceeded(mockOnFailureRateExceededEventConsumer);
+
+        recordFailures(circuitBreaker, 5);
+        recordSuccesses(circuitBreaker, 5);
+        recordFailures(circuitBreaker, 5);
+
+        verify(mockOnFailureRateExceededEventConsumer, times(2))
+            .consumeEvent(any(CircuitBreakerOnFailureRateExceededEvent.class));
+    }
+
+    @Test
+    void shouldPublishSlowCallRateExceededEventAgainAfterRateRecoversInMetricsOnlyState() {
+        CircuitBreaker circuitBreaker = new CircuitBreakerStateMachine("testName", custom()
+            .slowCallRateThreshold(50)
+            .slowCallDurationThreshold(Duration.ofSeconds(1))
+            .slidingWindow(5, 5, SlidingWindowType.COUNT_BASED)
+            .build());
+        circuitBreaker.transitionToMetricsOnlyState();
+        circuitBreaker.getEventPublisher().onSlowCallRateExceeded(mockOnSlowCallRateExceededEventConsumer);
+
+        recordSlowCalls(circuitBreaker, 5);
+        recordSuccesses(circuitBreaker, 5);
+        recordSlowCalls(circuitBreaker, 5);
+
+        verify(mockOnSlowCallRateExceededEventConsumer, times(2))
+            .consumeEvent(any(CircuitBreakerOnSlowCallRateExceededEvent.class));
+    }
+
+    @Test
     void allCircuitBreakerStatesAllowTransitionToMetricsOnlyMode() {
         for (final CircuitBreaker.State state : CircuitBreaker.State.values()) {
             assertThatNoException().isThrownBy(() -> CircuitBreaker.StateTransition.transitionBetween(circuitBreaker.getName(), state, CircuitBreaker.State.METRICS_ONLY));
@@ -1012,6 +1047,24 @@ class CircuitBreakerStateMachineTest {
 
     private void assertThatMetricsAreReset() {
         assertCircuitBreakerMetricsEqualTo(-1f, 0, 0, 0, 0L);
+    }
+
+    private void recordFailures(CircuitBreaker circuitBreaker, int count) {
+        for (int i = 0; i < count; i++) {
+            circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new RuntimeException());
+        }
+    }
+
+    private void recordSuccesses(CircuitBreaker circuitBreaker, int count) {
+        for (int i = 0; i < count; i++) {
+            circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    private void recordSlowCalls(CircuitBreaker circuitBreaker, int count) {
+        for (int i = 0; i < count; i++) {
+            circuitBreaker.onSuccess(2, TimeUnit.SECONDS);
+        }
     }
 
 }


### PR DESCRIPTION
## Problem

In metrics only mode a `CircuitBreaker` only ever publishes a single `CircuitBreakerOnFailureRateExceededEvent` (and a single `CircuitBreakerOnSlowCallRateExceededEvent`) for the whole lifetime of the state. Once the rate drops back below the threshold and climbs above it again, no further event is fired even though the same thing is happening again. Today the only way to get another event is to restart the application or force a state transition. (#2173)

## Root cause

`MetricsOnlyState` guards each event with an `AtomicBoolean` (`isFailureRateExceeded` / `isSlowCallRateExceeded`) and flips it with `compareAndSet(false, true)`, so the event fires once and is then suppressed while the rate stays above the threshold. That debounce is intentional, but nothing ever sets the flag back to `false`. In CLOSED/HALF_OPEN this never bites, because crossing the threshold transitions to a new state object that starts with fresh flags. Metrics only mode never transitions, so the same instance — and the same latched flag — lives forever.

## Fix

Clear each flag once its rate falls back below the threshold, so a later breach is reported again while still publishing one event per breach. The two flags are handled independently since the failure rate and the slow call rate can move separately. When there aren't enough calls to evaluate the rate (`BELOW_MINIMUM_CALLS_THRESHOLD`) the flag is left as-is instead of being cleared — re-arming on "no data" felt wrong and could double-fire around the minimum-calls boundary. Happy to reset it there too if you'd prefer.

## Tests

Added two tests to `CircuitBreakerStateMachineTest` covering breach → recover → breach for both the failure rate and the slow call rate, asserting the event is published twice. The existing "publish each event once" test still passes, so the debounce while continuously above the threshold is unchanged.

Fixes #2173
