### PR TITLE
Issue #2324: Prevent permit leak when a CircuitBreaker record/ignore predicate throws

### DIFF
--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachine.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachine.java
@@ -41,6 +41,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
@@ -203,13 +204,13 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
     }
 
     private void handleThrowable(long duration, TimeUnit durationUnit, Throwable throwable) {
-        if (circuitBreakerConfig.getIgnoreExceptionPredicate().test(throwable)) {
+        if (evaluatePredicate(circuitBreakerConfig.getIgnoreExceptionPredicate(), throwable)) {
             LOG.debug("CircuitBreaker '{}' ignored an exception:", name, throwable);
             releasePermission();
             publishCircuitIgnoredErrorEvent(name, duration, durationUnit, throwable);
             return;
         }
-        if (circuitBreakerConfig.getRecordExceptionPredicate().test(throwable)) {
+        if (evaluatePredicate(circuitBreakerConfig.getRecordExceptionPredicate(), throwable)) {
             LOG.debug("CircuitBreaker '{}' recorded an exception as failure:", name, throwable);
             publishCircuitErrorEvent(name, duration, durationUnit, throwable);
             stateReference.get().onError(duration, durationUnit, throwable);
@@ -230,7 +231,7 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
 
     @Override
     public void onResult(long duration, TimeUnit durationUnit, @Nullable Object result) {
-        if (result != null && circuitBreakerConfig.getRecordResultPredicate().test(result)) {
+        if (result != null && evaluatePredicate(circuitBreakerConfig.getRecordResultPredicate(), result)) {
             LOG.debug("CircuitBreaker '{}' recorded a result type '{}' as failure:", name, result.getClass());
             ResultRecordedAsFailureException failure = new ResultRecordedAsFailureException(name, result);
             publishCircuitErrorEvent(name, duration, durationUnit, failure);
@@ -240,6 +241,22 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
             if (result != null) {
                 handlePossibleTransition(Either.left(result));
             }
+        }
+    }
+
+    /**
+     * Evaluates a user-supplied predicate, making sure a permission that was previously acquired is
+     * not leaked if the predicate throws. Without this, an exception escaping a record/ignore
+     * predicate would bypass {@link #releasePermission()} and the recording of the call, leaving the
+     * CircuitBreaker with a permanently lost permit (most visibly wedging the HALF_OPEN state). The
+     * original exception is rethrown so the caller still observes the failure.
+     */
+    private <T> boolean evaluatePredicate(Predicate<T> predicate, T value) {
+        try {
+            return predicate.test(value);
+        } catch (Exception predicateException) {
+            releasePermission();
+            throw predicateException;
         }
     }
 

--- a/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachine.java
+++ b/resilience4j-circuitbreaker/src/main/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerStateMachine.java
@@ -249,7 +249,7 @@ public final class CircuitBreakerStateMachine implements CircuitBreaker {
      * not leaked if the predicate throws. Without this, an exception escaping a record/ignore
      * predicate would bypass {@link #releasePermission()} and the recording of the call, leaving the
      * CircuitBreaker with a permanently lost permit (most visibly wedging the HALF_OPEN state). The
-     * original exception is rethrown so the caller still observes the failure.
+     * exception thrown by the predicate is rethrown so the caller still observes the failure.
      */
     private <T> boolean evaluatePredicate(Predicate<T> predicate, T value) {
         try {

--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerThrowingPredicateLeakTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/internal/CircuitBreakerThrowingPredicateLeakTest.java
@@ -1,0 +1,91 @@
+/*
+ *
+ *  Copyright 2026 Robert Winkler
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.circuitbreaker.internal;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Reproduction for issue #2324 (Java core variant): a user-supplied record/ignore exception
+ * predicate that throws inside {@code handleThrowable} leaks the acquired permission, because
+ * neither {@code releasePermission()} nor {@code stateReference.onError()} is reached.
+ */
+class CircuitBreakerThrowingPredicateLeakTest {
+
+    @Test
+    void shouldNotLeakPermitWhenRecordExceptionPredicateThrowsInHalfOpen() {
+        RuntimeException predicateFailure = new RuntimeException("predicate boom");
+        CircuitBreaker circuitBreaker = new CircuitBreakerStateMachine("test",
+            CircuitBreakerConfig.custom()
+                .permittedNumberOfCallsInHalfOpenState(1)
+                .recordException(throwable -> {
+                    throw predicateFailure;
+                })
+                .build());
+
+        circuitBreaker.transitionToOpenState();
+        circuitBreaker.transitionToHalfOpenState();
+
+        // Acquire the single half-open trial permit.
+        assertThat(circuitBreaker.tryAcquirePermission()).isTrue();
+        assertThat(circuitBreaker.tryAcquirePermission()).isFalse();
+
+        // The user-supplied predicate throws while the breaker handles the error.
+        assertThatThrownBy(
+            () -> circuitBreaker.onError(0, TimeUnit.NANOSECONDS, new IllegalStateException()))
+            .isSameAs(predicateFailure);
+
+        // The acquired permit must not be lost: a correct implementation releases it so the
+        // half-open breaker can keep permitting trial calls instead of being wedged forever.
+        assertThat(circuitBreaker.tryAcquirePermission())
+            .as("permit should be released after the predicate throws, but it leaks")
+            .isTrue();
+    }
+
+    @Test
+    void shouldNotLeakPermitWhenRecordResultPredicateThrowsInHalfOpen() {
+        RuntimeException predicateFailure = new RuntimeException("predicate boom");
+        CircuitBreaker circuitBreaker = new CircuitBreakerStateMachine("test",
+            CircuitBreakerConfig.custom()
+                .permittedNumberOfCallsInHalfOpenState(1)
+                .recordResult(result -> {
+                    throw predicateFailure;
+                })
+                .build());
+
+        circuitBreaker.transitionToOpenState();
+        circuitBreaker.transitionToHalfOpenState();
+
+        assertThat(circuitBreaker.tryAcquirePermission()).isTrue();
+        assertThat(circuitBreaker.tryAcquirePermission()).isFalse();
+
+        assertThatThrownBy(() -> circuitBreaker.onResult(0, TimeUnit.NANOSECONDS, "someResult"))
+            .isSameAs(predicateFailure);
+
+        assertThat(circuitBreaker.tryAcquirePermission())
+            .as("permit should be released after the result predicate throws, but it leaks")
+            .isTrue();
+    }
+}


### PR DESCRIPTION
Addresses the Java-core part of #2324 (complements the Kotlin wrapper fix in #2332, which does not touch `CircuitBreakerStateMachine`).

### Problem
In `CircuitBreakerStateMachine`, the user-supplied `ignoreException` / `recordException` predicates (in `handleThrowable`) and `recordResult` predicate (in `onResult`) are evaluated without a `try/catch`. A permission is acquired before the protected call; if one of these predicates throws while handling the outcome, neither `releasePermission()` nor `stateReference.onError()/onSuccess()` is reached, so the acquired permit is **neither released nor recorded**.

In the `HALF_OPEN` state, where the number of permitted calls is limited, this leaks a trial permit. With enough such failures the breaker can no longer permit calls and can never transition — it is wedged.

### Fix
Predicate evaluations now go through a small helper that releases the permission and rethrows the original exception if the predicate fails, leaving the breaker in a consistent state. `Exception` (not `Throwable`) is caught so `Error`s and interrupts are not affected; the original exception is rethrown so the caller still observes the failure. `releasePermission()` is already a no-op in `CLOSED` and restores the permit in `HALF_OPEN`, so this is safe in every state and consistent with the existing ignored-exception branch.

### Tests
Added `CircuitBreakerThrowingPredicateLeakTest` with a minimal reproduction for both the exception-predicate and result-predicate paths: a `HALF_OPEN` breaker with a throwing predicate, asserting the permit is released after the predicate throws. Both tests fail without the change and pass with it; the full `resilience4j-circuitbreaker` suite is green.

Open to adjusting the approach (e.g. `Exception` vs `Throwable`, or recording the failure instead of rethrowing) based on your preference.