### PR TITLE
fix(ratelimiter): prevent SemaphoreBasedRateLimiter refresh task from terminating after a downward limit change

### DIFF
--- a/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/internal/SemaphoreBasedRateLimiter.java
+++ b/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/internal/SemaphoreBasedRateLimiter.java
@@ -131,7 +131,11 @@ public class SemaphoreBasedRateLimiter implements RateLimiter {
     void refreshLimit() {
         int permissionsToRelease =
             this.rateLimiterConfig.get().getLimitForPeriod() - semaphore.availablePermits();
-        semaphore.release(permissionsToRelease);
+        if (permissionsToRelease > 0) {
+            semaphore.release(permissionsToRelease);
+        } else if (permissionsToRelease < 0) {
+            semaphore.tryAcquire(-permissionsToRelease);
+        }
     }
 
     /**

--- a/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/SemaphoreBasedRateLimiterRefreshLimitRegressionTest.java
+++ b/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/SemaphoreBasedRateLimiterRefreshLimitRegressionTest.java
@@ -1,0 +1,199 @@
+package io.github.resilience4j.ratelimiter.internal;
+
+import io.github.resilience4j.ratelimiter.RateLimiterConfig;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression test for a scheduler-death bug in {@link SemaphoreBasedRateLimiter#refreshLimit()}.
+ *
+ * <p>{@code refreshLimit()} computes {@code permissionsToRelease = limitForPeriod -
+ * semaphore.availablePermits()} and then calls {@code semaphore.release(permissionsToRelease)}.
+ * When {@link RateLimiterConfig#getLimitForPeriod()} is lowered at runtime via
+ * {@code changeLimitForPeriod(int)} below the number of permits currently available, the
+ * subtraction goes negative and {@link java.util.concurrent.Semaphore#release(int)} throws
+ * {@link IllegalArgumentException} (JDK contract: permits &lt; 0 is illegal).
+ *
+ * <p>Because {@code refreshLimit} is the task behind
+ * {@link java.util.concurrent.ScheduledExecutorService#scheduleAtFixedRate}, that uncaught
+ * exception permanently suppresses every subsequent execution (JDK contract for fixed-rate
+ * tasks), so the limiter stops replenishing permits forever — every later
+ * {@code acquirePermission} eventually returns {@code false} / throws {@code RequestNotPermitted}
+ * until the instance is discarded.
+ *
+ * <p>This test reproduces the failure deterministically with a <em>real</em>
+ * {@code ScheduledThreadPoolExecutor} (a thin subclass that only counts periodic firings; it
+ * delegates all scheduling to the real implementation — it is not a mock). It lowers the limit
+ * below the available permits and asserts:
+ * <ol>
+ *   <li>the periodic refresh task keeps running, and</li>
+ *   <li>excess permits are clamped down to the new limit rather than left in place
+ *       (analogous to {@code AtomicRateLimiter} clamping excess permits at each cycle boundary).</li>
+ * </ol>
+ *
+ * <p>Waits are condition-based with a nanoTime deadline (no {@code Thread.sleep}) and the test
+ * depends only on JUnit 5, so it needs no extra test libraries on the module classpath.
+ */
+class SemaphoreBasedRateLimiterRefreshLimitRegressionTest {
+
+    private static final int INITIAL_LIMIT_FOR_PERIOD = 5;
+    private static final int LOWERED_LIMIT_FOR_PERIOD = 1;
+    private static final Duration REFRESH_PERIOD = Duration.ofMillis(5);
+
+    @Test
+    void refreshSchedulerMustSurviveLimitDecreaseBelowAvailablePermits() {
+        RateLimiterConfig config = RateLimiterConfig.custom()
+            .limitForPeriod(INITIAL_LIMIT_FOR_PERIOD)
+            .limitRefreshPeriod(REFRESH_PERIOD)
+            .timeoutDuration(Duration.ofSeconds(1))
+            .build();
+
+        CountingScheduledExecutor scheduler = new CountingScheduledExecutor();
+        SemaphoreBasedRateLimiter limiter =
+            new SemaphoreBasedRateLimiter("refresh-limit-regression", config, scheduler);
+        try {
+            // 1. Warm up: prove the periodic refresh task is actually firing. While
+            //    limitForPeriod (5) == availablePermits (5), refreshLimit computes 0 and never throws.
+            assertTrue(waitForWithin(Duration.ofSeconds(2), () -> scheduler.refreshCount.get() >= 5),
+                "periodic refresh task should fire during warm-up");
+
+            // 2. Arm the bug: lower the limit below the currently available permits.
+            //    No permits have been acquired, so availablePermits == 5 > new limit (1). On the
+            //    unfixed code the next refreshLimit evaluates 1 - 5 = -4 and throws.
+            limiter.changeLimitForPeriod(LOWERED_LIMIT_FOR_PERIOD);
+
+            // Capture the liveness baseline AFTER the new limit is in effect. This is deliberately
+            // done after changeLimitForPeriod (not before) so the baseline is immune to main-thread
+            // scheduling jitter between reading the count and applying the change — without this, the
+            // scheduler could advance several "old-limit" ticks during the gap, making a pre-change
+            // baseline stale and the margin unreliable.
+            int baseline = scheduler.refreshCount.get();
+
+            // 3. Assert the scheduler is STILL firing well past the baseline. On the unfixed code the
+            //    first refreshLimit after the change throws IllegalArgumentException and
+            //    scheduleAtFixedRate suppresses all later executions, so the count freezes at
+            //    baseline (+ at most one in-flight tick) and this wait fails -> test fails.
+            //    Requiring +20 firings is a wide, deterministic margin: a healthy scheduler reaches
+            //    it in ~100ms; a dead one never does.
+            int requiredFirings = baseline + 20;
+            boolean keptRunning = waitForWithin(Duration.ofSeconds(2),
+                () -> scheduler.refreshCount.get() >= requiredFirings);
+            assertTrue(keptRunning,
+                "periodic refresh task stopped after lowering the limit "
+                    + "(refreshCount=" + scheduler.refreshCount.get() + ", baseline=" + baseline + ")");
+
+            // 4. Complementary signal: the fixed-rate future must still be RUNNING. For a fixed-rate
+            //    task, isDone() flips to true ONLY on an uncaught exception or cancellation — i.e.
+            //    precisely the scheduler death this regression guards against.
+            assertFalse(scheduler.periodicFuture.get().isDone(),
+                "periodic refresh task must not have terminated after lowering the limit");
+
+            // 5. Excess permits must be clamped down to the new limit, not just left in place.
+            //    After lowering the limit below available permits, refreshLimit should reduce
+            //    available permits to (or below) the new limit on the next refresh — matching
+            //    AtomicRateLimiter's behaviour of capping excess permits at each cycle boundary.
+            int availableAfter = limiter.getMetrics().getAvailablePermissions();
+            assertTrue(availableAfter <= LOWERED_LIMIT_FOR_PERIOD,
+                "excess permits must be clamped to the new limit; available="
+                    + availableAfter + ", newLimit=" + LOWERED_LIMIT_FOR_PERIOD);
+        } finally {
+            limiter.shutdown();
+            scheduler.shutdownNow();
+        }
+    }
+
+    /**
+     * Direct exercise of the clamp branch in {@link SemaphoreBasedRateLimiter#refreshLimit()}.
+     *
+     * <p>With {@code limitForPeriod=5} the semaphore starts with 5 permits and no acquire
+     * happens, so after {@code changeLimitForPeriod(1)} available permits are still 5
+     * (greater than the new limit 1). Calling {@code refreshLimit()} must remove the
+     * excess via {@code tryAcquire(-delta)} and must not throw.
+     *
+     * <p>This guarantees the documented contract of the clamp path: {@code
+     * Semaphore.tryAcquire(int)} is non-throwing and all-or-nothing — if permits are
+     * concurrently consumed between the {@code availablePermits} read and the {@code
+     * tryAcquire} call so that the full excess is no longer available, {@code tryAcquire}
+     * simply returns {@code false} (no exception is raised) and the surplus persists
+     * until the next refresh tick clamps it. The scheduled refresh task therefore
+     * survives any concurrent acquire traffic.
+     */
+    @Test
+    void refreshLimitClampsExcessPermitsWithoutThrowing() {
+        RateLimiterConfig config = RateLimiterConfig.custom()
+            .limitForPeriod(INITIAL_LIMIT_FOR_PERIOD)
+            .limitRefreshPeriod(Duration.ofHours(1)) // prevent scheduled refresh during this test
+            .timeoutDuration(Duration.ofSeconds(1))
+            .build();
+        SemaphoreBasedRateLimiter limiter = new SemaphoreBasedRateLimiter("clamp-direct", config);
+        try {
+            int before = limiter.getMetrics().getAvailablePermissions();
+            limiter.changeLimitForPeriod(LOWERED_LIMIT_FOR_PERIOD);
+            // No acquire happens, so availablePermits is still `before` (> new limit).
+            // Call refreshLimit() directly (package-private) to exercise the clamp branch.
+            limiter.refreshLimit();
+            int after = limiter.getMetrics().getAvailablePermissions();
+            assertTrue(before > LOWERED_LIMIT_FOR_PERIOD,
+                "precondition: excess must exist before the clamp; before=" + before);
+            assertTrue(after <= LOWERED_LIMIT_FOR_PERIOD,
+                "refreshLimit must clamp excess permits; before=" + before + " after=" + after);
+        } finally {
+            limiter.shutdown();
+        }
+    }
+
+    /**
+     * Waits for {@code condition} to become true within {@code timeout}, polling without
+     * {@code Thread.sleep}. Returns the last evaluated state of the condition. Bounded by a
+     * nanoTime deadline so it cannot hang.
+     */
+    private static boolean waitForWithin(Duration timeout, BooleanSupplier condition) {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        boolean last = condition.getAsBoolean();
+        while (!last && System.nanoTime() < deadline) {
+            Thread.yield();
+            last = condition.getAsBoolean();
+        }
+        return last;
+    }
+
+    /**
+     * A real, fully-functional {@link ScheduledThreadPoolExecutor} that additionally counts how many
+     * times the periodic refresh task has fired and retains a handle to its future. All scheduling
+     * behaviour is inherited from the JDK implementation unchanged; only the periodic-task hook is
+     * instrumented, so observed timing/semantics are those of a real executor.
+     */
+    static final class CountingScheduledExecutor extends ScheduledThreadPoolExecutor {
+
+        final AtomicInteger refreshCount = new AtomicInteger();
+        final AtomicReference<ScheduledFuture<?>> periodicFuture = new AtomicReference<>();
+
+        CountingScheduledExecutor() {
+            super(1);
+            setRemoveOnCancelPolicy(true);
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay,
+                                                      long period, TimeUnit unit) {
+            Runnable counting = () -> {
+                refreshCount.incrementAndGet(); // count every scheduled firing before it runs
+                command.run();
+            };
+            ScheduledFuture<?> future =
+                super.scheduleAtFixedRate(counting, initialDelay, period, unit);
+            periodicFuture.set(future);
+            return future;
+        }
+    }
+}

--- a/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/SemaphoreBasedRateLimiterRefreshLimitRegressionTest.java
+++ b/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/SemaphoreBasedRateLimiterRefreshLimitRegressionTest.java
@@ -1,3 +1,21 @@
+/*
+ *
+ *  Copyright 2026 Robert Winkler and Bohdan Storozhuk
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
 package io.github.resilience4j.ratelimiter.internal;
 
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
@@ -9,6 +27,7 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.LockSupport;
 import java.util.function.BooleanSupplier;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -161,7 +180,7 @@ class SemaphoreBasedRateLimiterRefreshLimitRegressionTest {
         long deadline = System.nanoTime() + timeout.toNanos();
         boolean last = condition.getAsBoolean();
         while (!last && System.nanoTime() < deadline) {
-            Thread.yield();
+            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(1));
             last = condition.getAsBoolean();
         }
         return last;


### PR DESCRIPTION
## Problem

`SemaphoreBasedRateLimiter.refreshLimit()` computes

```java
int permissionsToRelease =
    rateLimiterConfig.get().getLimitForPeriod()
        - semaphore.availablePermits();
semaphore.release(permissionsToRelease);
```

After `changeLimitForPeriod()` lowers the configured limit, the number of available permits may temporarily exceed the new limit until the next refresh period. In that situation, `permissionsToRelease` becomes negative.

Since `Semaphore.release(int)` throws `IllegalArgumentException` for negative values, the scheduled refresh task terminates unexpectedly. According to the JDK contract of `ScheduledExecutorService.scheduleAtFixedRate(...)`, an uncaught exception suppresses all subsequent executions of that periodic task.

As a result, the scheduled refresh task stops executing and the rate limiter no longer replenishes permits for the lifetime of that instance.

## Why this appears to be a bug

The JavaDoc of `RateLimiter#changeLimitForPeriod` states:

> "New limit won't affect current period permissions and will apply only from next one."

There is no documented restriction that the new limit must be greater than or equal to the current number of available permits, nor is lowering the limit documented as unsupported.

The existing implementation of `AtomicRateLimiter` supports decreasing the limit without terminating its internal state update mechanism. While the two implementations use different internal algorithms, they expose the same public API and currently behave differently when the configured limit is reduced.

## Proposed fix

Handle all three cases in `refreshLimit`:

```java
if (permissionsToRelease > 0) {
    semaphore.release(permissionsToRelease);           // deficit: top up to the limit
} else if (permissionsToRelease < 0) {
    semaphore.tryAcquire(-permissionsToRelease);      // excess: clamp down to the new limit
}
```

- **deficit** (`> 0`): release to top up
- **equal** (`0`): no-op
- **excess** (`< 0`): `tryAcquire` the excess so available permits reach the new limit

The clamp mirrors `AtomicRateLimiter`'s behaviour of capping excess permits at each cycle boundary (`min(nextPermissions + accumulated, permissionsPerCycle)`) and aligns with the `changeLimitForPeriod` JavaDoc that the new limit "will apply only from next one".

**Concurrency safety.** `Semaphore.tryAcquire(int)` is non-throwing and all-or-nothing: if permits are concurrently consumed between the `availablePermits` read and the `tryAcquire` call so that the full excess is no longer available, it returns `false` (never throws) and the surplus persists until the next refresh tick clamps it. The scheduled refresh task therefore survives any concurrent acquire traffic. The companion test `refreshLimitClampsExcessPermitsWithoutThrowing` exercises this contract directly.

The goal remains intentionally limited: clamp excess + keep the scheduler alive. If maintainers prefer a different semantic for downward limit changes (for example adjusting the semaphore state inside `changeLimitForPeriod()`), I'm happy to update this PR accordingly.

## Regression test

This PR adds two regression tests:

- `refreshSchedulerMustSurviveLimitDecreaseBelowAvailablePermits` uses a real `ScheduledThreadPoolExecutor` (a counting subclass, not a mock), lowers `limitForPeriod` below the currently available permits, and asserts that the periodic refresh keeps running and that excess permits are clamped down to the new limit.
- `refreshLimitClampsExcessPermitsWithoutThrowing` exercises the clamp branch directly by calling `refreshLimit()` after lowering the limit and verifies both that excess permits are removed and that no exception escapes (the `Semaphore.tryAcquire(int)` non-throwing contract).

Waits are condition-based with a nanoTime deadline (no `Thread.sleep`), and the tests depend only on JUnit 5, so no extra test libraries are needed on the module classpath.

Without this fix:

- the first test fails because `Semaphore.release(int)` throws `IllegalArgumentException` and the scheduled refresh task terminates (the periodic task stops firing and excess permits are never clamped)
- the second test fails directly with `IllegalArgumentException` from `refreshLimit()`

With this change:

- both tests pass

The existing `changeLimitForPeriod` tests only cover increasing the limit and use a mocked scheduler, so this execution path was previously untested.

The commits are intentionally split into a regression test followed by the fix, making it easy to verify that the tests fail before the fix and pass afterwards. The full `resilience4j-ratelimiter` test suite passes.

Relates to #2489.
