### PR TITLE
Issue #2492: Fixed ThreadPoolBulkheadConfig.from() mutating the base config

### DIFF
--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfig.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfig.java
@@ -133,7 +133,14 @@ public class ThreadPoolBulkheadConfig {
         private ThreadPoolBulkheadConfig config;
 
         public Builder(ThreadPoolBulkheadConfig bulkheadConfig) {
-            this.config = bulkheadConfig;
+            this.config = new ThreadPoolBulkheadConfig();
+            this.config.maxThreadPoolSize = bulkheadConfig.maxThreadPoolSize;
+            this.config.coreThreadPoolSize = bulkheadConfig.coreThreadPoolSize;
+            this.config.queueCapacity = bulkheadConfig.queueCapacity;
+            this.config.keepAliveDuration = bulkheadConfig.keepAliveDuration;
+            this.config.writableStackTraceEnabled = bulkheadConfig.writableStackTraceEnabled;
+            this.config.contextPropagators = new ArrayList<>(bulkheadConfig.contextPropagators);
+            this.config.rejectedExecutionHandler = bulkheadConfig.rejectedExecutionHandler;
         }
 
         public Builder() {

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfigTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfigTest.java
@@ -221,6 +221,43 @@ class ThreadPoolBulkheadConfigTest {
                 .endsWith("}");
     }
 
+    @Test
+    void fromShouldNotMutateBaseConfig() {
+        ThreadPoolBulkheadConfig baseConfig = ThreadPoolBulkheadConfig.custom()
+            .maxThreadPoolSize(4)
+            .coreThreadPoolSize(2)
+            .queueCapacity(10)
+            .build();
+
+        ThreadPoolBulkheadConfig derivedConfig = ThreadPoolBulkheadConfig.from(baseConfig)
+            .maxThreadPoolSize(20)
+            .coreThreadPoolSize(8)
+            .queueCapacity(50)
+            .build();
+
+        assertThat(derivedConfig).isNotSameAs(baseConfig);
+        assertThat(baseConfig.getMaxThreadPoolSize()).isEqualTo(4);
+        assertThat(baseConfig.getCoreThreadPoolSize()).isEqualTo(2);
+        assertThat(baseConfig.getQueueCapacity()).isEqualTo(10);
+        assertThat(derivedConfig.getMaxThreadPoolSize()).isEqualTo(20);
+        assertThat(derivedConfig.getCoreThreadPoolSize()).isEqualTo(8);
+        assertThat(derivedConfig.getQueueCapacity()).isEqualTo(50);
+    }
+
+    @Test
+    void fromShouldNotLeakContextPropagatorsIntoBaseConfig() {
+        ThreadPoolBulkheadConfig baseConfig = ThreadPoolBulkheadConfig.custom()
+            .contextPropagator(new TestCtxPropagator())
+            .build();
+
+        ThreadPoolBulkheadConfig derivedConfig = ThreadPoolBulkheadConfig.from(baseConfig)
+            .contextPropagator(new TestCtxPropagator2())
+            .build();
+
+        assertThat(baseConfig.getContextPropagator()).hasSize(1);
+        assertThat(derivedConfig.getContextPropagator()).hasSize(2);
+    }
+
     public static class TestCtxPropagator implements ContextPropagator<Object> {
 
         @Override


### PR DESCRIPTION
`ThreadPoolBulkheadConfig.Builder(ThreadPoolBulkheadConfig)` aliased the passed-in config (`this.config = bulkheadConfig`) instead of copying its fields, so `from(base)...build()` mutated `base` and returned the same instance. This copies each field into a fresh config, matching `BulkheadConfig`, `RateLimiterConfig`, `TimeLimiterConfig` and `CircuitBreakerConfig`. The context propagator list is copied into a new `ArrayList` so `build()`'s `addAll` no longer leaks into the base config.

Added `ThreadPoolBulkheadConfigTest` cases that keep a reference to the base config and assert it stays unchanged (the existing `createFromBaseConfig` test passed the base inline, so it could not catch this).

Fixes #2492. This was written with AI assistance (see the `Co-Authored-By` trailer).
