### PR TITLE
Issue #2497: Bump kotlinx-coroutines-core from 1.6.4 to 1.11.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,7 +55,7 @@ feign-wiremock = { module = "org.wiremock:wiremock", version = "3.13.1" }
 
 # resilience4j-kotlin
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version = "1.9.25" }
-kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.6.4" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.11.0" }
 
 # resilience4j-metrics (Dropwizard)
 metrics-core = { module = "io.dropwizard.metrics:metrics-core", version = "4.1.16" }


### PR DESCRIPTION
## Description
Fixes #2497

Bumps `kotlinx-coroutines-core` from **1.6.4** (2022) to **1.11.0** (current stable) in the Gradle version catalog. This is the only place the dependency is declared; it is used by `resilience4j-kotlin`.

No source changes were required. The Kotlin wrappers continue to compile and pass their suite against coroutines 1.11.0 with the existing Kotlin JVM plugin (`2.1.21`).

## Motivation and Context
Issue #2497 notes that the project still pins a four-year-old coroutines version while newer stable releases (through 1.11.0) are available.

## How Has This Been Tested?
- JDK 21 (`openjdk 21.0.11`)
- `./gradlew :resilience4j-kotlin:test`
  - **76 tests**, 0 failures, 2 skipped
- Dependency resolution confirms:
  - `org.jetbrains.kotlinx:kotlinx-coroutines-core:1.11.0`
  - transitive `kotlin-stdlib` resolves to `2.2.20` (from coroutines)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Dependency update

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated tests that prove my fix is effective or that my feature works
- [x] Existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules