### PR TITLE
Respect configured thread type when creating scheduled executors in Spring 6 aspects

### DIFF
--- a/resilience4j-spring6/build.gradle
+++ b/resilience4j-spring6/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     compileOnly(libs.spring6.core)
 
     testImplementation(project(":resilience4j-metrics"))
+    testImplementation(testFixtures(project(":resilience4j-core")))
     testImplementation(testFixtures(project(":resilience4j-micrometer")))
     testImplementation(project(":resilience4j-reactor"))
     testImplementation(project(":resilience4j-rxjava2"))

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/retry/configure/RetryAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/retry/configure/RetryAspect.java
@@ -16,6 +16,7 @@
 package io.github.resilience4j.spring6.retry.configure;
 
 import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
+import io.github.resilience4j.core.ExecutorServiceFactory;
 import io.github.resilience4j.core.functions.CheckedSupplier;
 import io.github.resilience4j.core.lang.Nullable;
 import io.github.resilience4j.spring6.fallback.FallbackExecutor;
@@ -93,7 +94,7 @@ public class RetryAspect implements Ordered, AutoCloseable {
         this.spelResolver = spelResolver;
         this.retryExecutorService = contextAwareScheduledThreadPoolExecutor != null ?
             contextAwareScheduledThreadPoolExecutor :
-            Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
+            ExecutorServiceFactory.newScheduledThreadPool(Runtime.getRuntime().availableProcessors(), "RetryAspect");
     }
 
     @Pointcut(value = "@within(retry) || @annotation(retry)", argNames = "retry")

--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterAspect.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/timelimiter/configure/TimeLimiterAspect.java
@@ -17,6 +17,7 @@
 package io.github.resilience4j.spring6.timelimiter.configure;
 
 import io.github.resilience4j.core.ContextAwareScheduledThreadPoolExecutor;
+import io.github.resilience4j.core.ExecutorServiceFactory;
 import io.github.resilience4j.core.functions.CheckedSupplier;
 import io.github.resilience4j.core.lang.Nullable;
 import io.github.resilience4j.spring6.fallback.FallbackExecutor;
@@ -64,7 +65,7 @@ public class TimeLimiterAspect implements Ordered, AutoCloseable {
         this.spelResolver = spelResolver;
         this.timeLimiterExecutorService = contextAwareScheduledThreadPoolExecutor != null ?
             contextAwareScheduledThreadPoolExecutor :
-            Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
+            ExecutorServiceFactory.newScheduledThreadPool(Runtime.getRuntime().availableProcessors(), "TimeLimiterAspect");
     }
 
     @Pointcut(value = "@within(timeLimiter) || @annotation(timeLimiter)", argNames = "timeLimiter")

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/retry/configure/AspectThreadModeTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/retry/configure/AspectThreadModeTest.java
@@ -1,0 +1,74 @@
+package io.github.resilience4j.spring6.retry.configure;
+
+import io.github.resilience4j.core.ExecutorServiceFactory;
+import io.github.resilience4j.core.ThreadModeExtension;
+import io.github.resilience4j.core.ThreadType;
+import io.github.resilience4j.retry.RetryRegistry;
+import io.github.resilience4j.spring6.timelimiter.configure.TimeLimiterAspect;
+import io.github.resilience4j.spring6.timelimiter.configure.TimeLimiterConfigurationProperties;
+import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(ThreadModeExtension.class)
+class AspectThreadModeTest {
+
+    @TestTemplate
+    void shouldCreateScheduledExecutorServiceWithConfiguredThreadType() throws Exception {
+        ThreadType configuredThreadType = ExecutorServiceFactory.getThreadType();
+
+        RetryAspect retryAspect = new RetryAspect(
+            new RetryConfigurationProperties(),
+            RetryRegistry.ofDefaults(),
+            null,
+            null,
+            null,
+            null
+        );
+
+        Field retryExecutorField = RetryAspect.class.getDeclaredField("retryExecutorService");
+        retryExecutorField.setAccessible(true);
+        ScheduledExecutorService retryExecutor = (ScheduledExecutorService) retryExecutorField.get(retryAspect);
+
+        verifyExecutorThreadType(retryExecutor, configuredThreadType);
+
+        TimeLimiterAspect timeLimiterAspect = new TimeLimiterAspect(
+            TimeLimiterRegistry.ofDefaults(),
+            new TimeLimiterConfigurationProperties(),
+            null,
+            null,
+            null,
+            null
+        );
+
+        Field timeLimiterExecutorField = TimeLimiterAspect.class.getDeclaredField("timeLimiterExecutorService");
+        timeLimiterExecutorField.setAccessible(true);
+        ScheduledExecutorService timeLimiterExecutor = (ScheduledExecutorService) timeLimiterExecutorField.get(timeLimiterAspect);
+
+        verifyExecutorThreadType(timeLimiterExecutor, configuredThreadType);
+
+        retryAspect.close();
+        timeLimiterAspect.close();
+    }
+
+    private void verifyExecutorThreadType(ScheduledExecutorService executor, ThreadType expectedType) throws Exception {
+        AtomicBoolean isVirtual = new AtomicBoolean(false);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        executor.submit(() -> {
+            isVirtual.set(Thread.currentThread().isVirtual());
+            latch.countDown();
+        });
+
+        assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(isVirtual.get()).isEqualTo(expectedType == ThreadType.VIRTUAL);
+    }
+}


### PR DESCRIPTION
## Summary

This PR updates the default scheduled executor creation in the Spring 6 `RetryAspect` and `TimeLimiterAspect` to respect the configured `resilience4j.thread.type`.

Previously, both aspects created scheduled executors directly using `Executors.newScheduledThreadPool(...)`, bypassing `ExecutorServiceFactory` and ignoring the configured thread type.

This change delegates executor creation to `ExecutorServiceFactory.newScheduledThreadPool(...)`, ensuring consistent behavior across the project.

## Changes

- Replace direct scheduled executor creation in:
  - `RetryAspect`
  - `TimeLimiterAspect`
- Add a regression test verifying virtual thread execution
- Add the required `resilience4j-core` test fixture dependency

## Verification

- Added regression test
- Ran:

```bash
./gradlew check
```

- All tests passed successfully.

Fixes #2450