### PR TITLE
Issue #2492: ThreadPoolBulkheadConfig.from() should copy the base config

### DIFF
--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfig.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfig.java
@@ -133,7 +133,14 @@ public class ThreadPoolBulkheadConfig {
         private ThreadPoolBulkheadConfig config;
 
         public Builder(ThreadPoolBulkheadConfig bulkheadConfig) {
-            this.config = bulkheadConfig;
+            this.config = new ThreadPoolBulkheadConfig();
+            this.config.maxThreadPoolSize = bulkheadConfig.maxThreadPoolSize;
+            this.config.coreThreadPoolSize = bulkheadConfig.coreThreadPoolSize;
+            this.config.queueCapacity = bulkheadConfig.queueCapacity;
+            this.config.keepAliveDuration = bulkheadConfig.keepAliveDuration;
+            this.config.writableStackTraceEnabled = bulkheadConfig.writableStackTraceEnabled;
+            this.config.rejectedExecutionHandler = bulkheadConfig.rejectedExecutionHandler;
+            this.config.contextPropagators = new ArrayList<>(bulkheadConfig.contextPropagators);
         }
 
         public Builder() {

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfigTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfigTest.java
@@ -221,6 +221,54 @@ class ThreadPoolBulkheadConfigTest {
                 .endsWith("}");
     }
 
+    @Test
+    void fromShouldCopyConfigAndNotMutateTheBaseConfig() {
+        ThreadPoolBulkheadConfig baseConfig = ThreadPoolBulkheadConfig.custom()
+            .maxThreadPoolSize(20)
+            .coreThreadPoolSize(2)
+            .queueCapacity(50)
+            .keepAliveDuration(Duration.ofMillis(555))
+            .build();
+
+        ThreadPoolBulkheadConfig derivedConfig = ThreadPoolBulkheadConfig.from(baseConfig)
+            .maxThreadPoolSize(30)
+            .coreThreadPoolSize(4)
+            .queueCapacity(99)
+            .build();
+
+        // the derived config reflects the overrides
+        assertThat(derivedConfig.getMaxThreadPoolSize()).isEqualTo(30);
+        assertThat(derivedConfig.getCoreThreadPoolSize()).isEqualTo(4);
+        assertThat(derivedConfig.getQueueCapacity()).isEqualTo(99);
+
+        // the base config is left untouched (from(...) must copy, not alias)
+        assertThat(baseConfig.getMaxThreadPoolSize()).isEqualTo(20);
+        assertThat(baseConfig.getCoreThreadPoolSize()).isEqualTo(2);
+        assertThat(baseConfig.getQueueCapacity()).isEqualTo(50);
+
+        // build() must return a distinct instance, not the base config
+        assertThat(derivedConfig).isNotSameAs(baseConfig);
+    }
+
+    @Test
+    void fromShouldCopyTheContextPropagatorListSoTheBaseIsNotMutated() {
+        ThreadPoolBulkheadConfig baseConfig = ThreadPoolBulkheadConfig.custom()
+            .contextPropagator(new TestCtxPropagator())
+            .build();
+
+        int baseSizeBefore = baseConfig.getContextPropagator().size();
+
+        ThreadPoolBulkheadConfig derivedConfig = ThreadPoolBulkheadConfig.from(baseConfig)
+            .contextPropagator(new TestCtxPropagator2())
+            .build();
+
+        // adding a propagator to the derived config must not leak into the base config's list
+        assertThat(baseConfig.getContextPropagator()).hasSize(baseSizeBefore);
+        assertThat(derivedConfig.getContextPropagator()).hasSize(baseSizeBefore + 1);
+        assertThat(derivedConfig.getContextPropagator())
+            .isNotSameAs(baseConfig.getContextPropagator());
+    }
+
     public static class TestCtxPropagator implements ContextPropagator<Object> {
 
         @Override


### PR DESCRIPTION
Fixes #2492 

Problem
ThreadPoolBulkheadConfig.Builder(ThreadPoolBulkheadConfig) stored the passed-in config by reference:

public Builder(ThreadPoolBulkheadConfig bulkheadConfig) {
    this.config = bulkheadConfig;
}
Every subsequent builder call then wrote through to the base config, and build() returned that same instance. So ThreadPoolBulkheadConfig.from(baseConfig) mutates the base config instead of deriving an independent copy.

This is the only config class that behaves this way — BulkheadConfig, RateLimiterConfig, TimeLimiterConfig and CircuitBreakerConfig all copy the base config's fields into the builder.

Impact
When several thread-pool-bulkhead instances share a base config — e.g. the Spring Boot default config via CommonThreadPoolBulkheadConfigurationProperties.from(baseConfig) — the first instance's overrides overwrite the shared base, and later instances start from the already-mutated config.

Fix
Copy each field from the source into a fresh ThreadPoolBulkheadConfig, mirroring the sibling config classes. The contextPropagators list is copied defensively (new ArrayList<>(...)) so that adding a propagator to a derived config does not leak into a shared base config's list.

Tests
Added two regression tests to ThreadPoolBulkheadConfigTest:

fromShouldCopyConfigAndNotMutateTheBaseConfig — overriding scalar values on a config derived via from(...) leaves the base config unchanged, and build() returns a distinct instance.
fromShouldCopyTheContextPropagatorListSoTheBaseIsNotMutated — adding a context propagator to a derived config does not mutate the base config's propagator list.
Verified locally (JDK 21, :resilience4j-bulkhead:test): both tests fail against the previous behaviour and pass with this change.