### PR TITLE
test: cover CircuitBreakerConfig.Builder null-arg and lock-free sliding-window branches

### DIFF
--- a/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfigTest.java
+++ b/resilience4j-circuitbreaker/src/test/java/io/github/resilience4j/circuitbreaker/CircuitBreakerConfigTest.java
@@ -101,6 +101,69 @@ class CircuitBreakerConfigTest {
     }
 
     @Test
+    void timeBasedLockFreeSlidingWindowSizeBelowTwoShouldFail() {
+        assertThatThrownBy(() -> custom().slidingWindow(
+            1, 1, SlidingWindowType.TIME_BASED, SlidingWindowSynchronizationStrategy.LOCK_FREE
+        ).build())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("TIME_BASED with LOCK_FREE");
+    }
+
+    @Test
+    void timeBasedLockFreeSlidingWindowSizeAtLeastTwoShouldSucceed() {
+        CircuitBreakerConfig circuitBreakerConfig = custom().slidingWindow(
+            2, 1, SlidingWindowType.TIME_BASED, SlidingWindowSynchronizationStrategy.LOCK_FREE
+        ).build();
+
+        then(circuitBreakerConfig.getSlidingWindowSize()).isEqualTo(2);
+        then(circuitBreakerConfig.getSlidingWindowSynchronizationStrategy())
+            .isEqualTo(SlidingWindowSynchronizationStrategy.LOCK_FREE);
+    }
+
+    @Test
+    void countBasedLockFreeSlidingWindowSizeBelowTwoShouldSucceed() {
+        // the TIME_BASED + LOCK_FREE + size<2 guard only applies to TIME_BASED windows
+        CircuitBreakerConfig circuitBreakerConfig = custom().slidingWindow(
+            1, 1, SlidingWindowType.COUNT_BASED, SlidingWindowSynchronizationStrategy.LOCK_FREE
+        ).build();
+
+        then(circuitBreakerConfig.getSlidingWindowSize()).isEqualTo(1);
+    }
+
+    @Test
+    void recordExceptionsWithNullVarargsShouldDefaultToEmpty() {
+        Class<? extends Throwable>[] nullVarargs = null;
+
+        CircuitBreakerConfig circuitBreakerConfig = custom()
+            .recordExceptions(nullVarargs)
+            .build();
+
+        assertThat(circuitBreakerConfig.toString())
+            .contains("recordExceptions=[]");
+    }
+
+    @Test
+    void ignoreExceptionsWithNullVarargsShouldDefaultToEmpty() {
+        Class<? extends Throwable>[] nullVarargs = null;
+
+        CircuitBreakerConfig circuitBreakerConfig = custom()
+            .ignoreExceptions(nullVarargs)
+            .build();
+
+        assertThat(circuitBreakerConfig.toString())
+            .contains("ignoreExceptions=[]");
+    }
+
+    @Test
+    void clockWithNullShouldFallBackToDefaultClock() {
+        CircuitBreakerConfig circuitBreakerConfig = custom()
+            .clock(null)
+            .build();
+
+        then(circuitBreakerConfig.getClock()).isNotNull();
+    }
+
+    @Test
     void zeroMinimumNumberOfCallsShouldFai2l() {
         assertThatThrownBy(() -> custom().minimumNumberOfCalls(0).build())
                 .isInstanceOf(IllegalArgumentException.class);


### PR DESCRIPTION
Four branches in `CircuitBreakerConfig.Builder` were unexercised by the existing test suite:

- `slidingWindow(...)` — the `TIME_BASED + LOCK_FREE + slidingWindowSize < 2` guard (line 681). No existing test uses `SlidingWindowSynchronizationStrategy.LOCK_FREE` at all — every test uses `SYNCHRONIZED`.
- `recordExceptions(...)` / `ignoreExceptions(...)` — the null-varargs branch that falls back to an empty array. Every existing test passes real exception classes.
- `clock(...)` — the null branch that falls back to `DEFAULT_CLOCK`. Every existing test passes a real `Clock`.

## Changes

Adds 6 tests to `CircuitBreakerConfigTest`, covering both outcomes of each branch:

- `timeBasedLockFreeSlidingWindowSizeBelowTwoShouldFail` / `...AtLeastTwoShouldSucceed` / `countBasedLockFreeSlidingWindowSizeBelowTwoShouldSucceed` — the three legs of the sliding-window guard (proves the guard is specific to `TIME_BASED`, not a blanket `size < 2` check)
- `recordExceptionsWithNullVarargsShouldDefaultToEmpty`
- `ignoreExceptionsWithNullVarargsShouldDefaultToEmpty`
- `clockWithNullShouldFallBackToDefaultClock`

## Coverage (measured locally, `:resilience4j-circuitbreaker:jacocoTestReport`)

`CircuitBreakerConfig.Builder` branch coverage: **48/52 → 51/52**.

The one remaining gap (`lambda$createRecordExceptionPredicate$0`) is an internal predicate lambda rather than a public `Builder` method — left out of scope here.

## Testing

Ran `:resilience4j-circuitbreaker:test` with `--rerun-tasks` multiple times locally (JDK 21) — passes consistently.
