### PR TITLE
Issue #2495: Change BulkheadConfig constructor visibility to protected

### DIFF
--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/BulkheadConfig.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/BulkheadConfig.java
@@ -40,7 +40,7 @@ public class BulkheadConfig implements Serializable {
     private final boolean writableStackTraceEnabled;
     private final boolean fairCallHandlingEnabled;
 
-    private BulkheadConfig(int maxConcurrentCalls, Duration maxWaitDuration,
+    protected BulkheadConfig(int maxConcurrentCalls, Duration maxWaitDuration,
         boolean writableStackTraceEnabled, boolean fairCallHandlingEnabled) {
         this.maxConcurrentCalls = maxConcurrentCalls;
         this.maxWaitDuration = maxWaitDuration;


### PR DESCRIPTION
Closes #2495

Changes BulkheadConfig's constructor visibility from `private` to `protected`,
so it can be subclassed to attach additional immutable metadata (e.g. for use
in custom EventConsumer logic or when auditing bulkheads via
BulkheadRegistry.getAllBulkheads()), as requested in the issue.

BulkheadConfig.Builder is already non-final, so no further changes are needed
there — subclasses can extend both the config and its builder if needed.

No existing usage constructs BulkheadConfig directly (all call sites go through
.custom()/.from()/.ofDefaults()), so this is a purely additive change with no
behavior impact on existing code.