### PR TITLE
Issue #2489: Fixed SemaphoreBasedRateLimiter refresh after limit decr…

### DIFF
--- a/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/internal/SemaphoreBasedRateLimiter.java
+++ b/resilience4j-ratelimiter/src/main/java/io/github/resilience4j/ratelimiter/internal/SemaphoreBasedRateLimiter.java
@@ -129,9 +129,9 @@ public class SemaphoreBasedRateLimiter implements RateLimiter {
     }
 
     void refreshLimit() {
-        int permissionsToRelease =
-            this.rateLimiterConfig.get().getLimitForPeriod() - semaphore.availablePermits();
-        semaphore.release(permissionsToRelease);
+        int limitForPeriod = this.rateLimiterConfig.get().getLimitForPeriod();
+        semaphore.drainPermits();
+        semaphore.release(limitForPeriod);
     }
 
     /**

--- a/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/SemaphoreBasedRateLimiterImplTest.java
+++ b/resilience4j-ratelimiter/src/test/java/io/github/resilience4j/ratelimiter/internal/SemaphoreBasedRateLimiterImplTest.java
@@ -189,6 +189,28 @@ class SemaphoreBasedRateLimiterImplTest extends RateLimitersImplementationTest {
     }
 
     @Test
+    void shouldApplyDecreasedLimitForPeriodOnNextRefresh() {
+        ScheduledExecutorService scheduledExecutorService =
+                mock(ScheduledExecutorService.class);
+
+        SemaphoreBasedRateLimiter limit =
+                new SemaphoreBasedRateLimiter(
+                        "test",
+                        config,
+                        scheduledExecutorService
+                );
+
+        RateLimiter.Metrics metrics = limit.getMetrics();
+        then(metrics.getAvailablePermissions()).isEqualTo(LIMIT);
+        limit.changeLimitForPeriod(1);
+        then(metrics.getAvailablePermissions()).isEqualTo(LIMIT);
+        limit.refreshLimit();
+        then(metrics.getAvailablePermissions()).isEqualTo(1);
+        limit.refreshLimit();
+        then(metrics.getAvailablePermissions()).isEqualTo(1);
+    }
+
+    @Test
     void acquirePermissionInterruption() {
         ScheduledExecutorService scheduledExecutorService = mock(ScheduledExecutorService.class);
         RateLimiterConfig configSpy = spy(config);


### PR DESCRIPTION
## Summary

This is an alternative implementation for #2489.

There is already an open PR, #2490, addressing the same issue. I am opening this as a **draft** for discussion and comparison, particularly around the refresh semantics of `SemaphoreBasedRateLimiter`.

## Problem

When `limitForPeriod` is decreased below the currently available permits, the existing implementation calculates a negative value for `permissionsToRelease`.

Passing that value to `Semaphore.release(int)` throws `IllegalArgumentException`. Because `refreshLimit()` runs periodically, that exception can stop future scheduled refresh executions.

## Change

This implementation changes `refreshLimit()` to reset the available permits at the refresh boundary:

```java
int limitForPeriod = this.rateLimiterConfig.get().getLimitForPeriod();
semaphore.drainPermits();
semaphore.release(limitForPeriod);
```

This means:

* changing `limitForPeriod` does not alter the current period immediately;
* on the next refresh, available permits are reset to the newly configured limit;
* subsequent refreshes continue to reset permits to that configured limit;
* no negative value is passed to `Semaphore.release(int)`.

## Test coverage

Added `shouldApplyDecreasedLimitForPeriodOnNextRefresh()` covering:

1. the initial number of available permissions;
2. decreasing `limitForPeriod`;
3. confirming the current period remains unchanged;
4. confirming the new limit is applied on the next refresh;
5. confirming an additional refresh remains at the configured limit.

Local verification:

```text
./gradlew :resilience4j-ratelimiter:test
```

passes on Java 21.

I also ran:

```text
git diff --check upstream/master...HEAD
```

with no whitespace errors.

## Review feedback

I would particularly appreciate feedback on whether resetting the semaphore with `drainPermits()` followed by `release(limitForPeriod)` is the desired behavior at a refresh boundary, especially with concurrent permit acquisition.

If the maintainers prefer the more conservative approach used in #2490, I am happy to adjust or close this draft.

Relates to #2489.
