### PR TITLE
Issue #878: Fixed concurrent private fallback invocation

### DIFF
--- a/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/fallback/FallbackMethod.java
+++ b/resilience4j-spring6/src/main/java/io/github/resilience4j/spring6/fallback/FallbackMethod.java
@@ -202,11 +202,8 @@ public class FallbackMethod {
      * @throws InvocationTargetException exception
      */
     private Object invoke(Method fallback, Throwable throwable) throws Throwable {
-        boolean accessible = fallback.isAccessible();
         try {
-            if (!accessible) {
-                ReflectionUtils.makeAccessible(fallback);
-            }
+            ReflectionUtils.makeAccessible(fallback);
             Object target = getTarget(fallback);
             if (args.length != 0) {
                 if (fallback.getParameterTypes().length == 1 && Throwable.class
@@ -224,10 +221,6 @@ public class FallbackMethod {
         } catch (InvocationTargetException e) {
             // We want the original fallback-method exception to propagate instead:
             throw e.getCause();
-        } finally {
-            if (!accessible) {
-                fallback.setAccessible(false);
-            }
         }
     }
 

--- a/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/fallback/FallbackMethodTest.java
+++ b/resilience4j-spring6/src/test/java/io/github/resilience4j/spring6/fallback/FallbackMethodTest.java
@@ -18,7 +18,14 @@ package io.github.resilience4j.spring6.fallback;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -97,6 +104,63 @@ class FallbackMethodTest {
             .create("privateFallback", testMethod, new Object[]{"test"}, target, target);
         assertThat(fallbackMethod.fallback(new RuntimeException("err")))
             .isEqualTo("recovered-privateMethod");
+    }
+
+    @Test
+    void shouldCallPrivateFallbackMethodConcurrently() throws Exception {
+        FallbackMethodTest target = new FallbackMethodTest();
+        Method testMethod = target.getClass().getMethod("testMethod", String.class);
+
+        FallbackMethod fallbackMethod = FallbackMethod
+                .create("privateFallback", testMethod, new Object[]{"test"}, target, target);
+
+        int threadCount = 16;
+        int callsPerThread = 10_000;
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch start = new CountDownLatch(1);
+        ConcurrentLinkedQueue<Throwable> failures = new ConcurrentLinkedQueue<>();
+        List<Future<?>> futures = new ArrayList<>();
+
+        try {
+            for (int i = 0; i < threadCount; i++) {
+                Future<?> future = executor.submit(() -> {
+                    start.await();
+
+                    for (int j = 0; j < callsPerThread; j++) {
+                        try {
+                            Object result = fallbackMethod.fallback(
+                                    new RuntimeException("err")
+                            );
+
+                            if (!"recovered-privateMethod".equals(result)) {
+                                failures.add(
+                                        new AssertionError(
+                                                "Unexpected fallback result: " + result
+                                        )
+                                );
+                            }
+                        } catch (Throwable throwable) {
+                            failures.add(throwable);
+                        }
+                    }
+
+                    return null;
+                });
+
+                futures.add(future);
+            }
+
+            start.countDown();
+
+            for (Future<?> future : futures) {
+                future.get();
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertThat(failures).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
## What changed?

Fixes a race condition when private fallback methods are invoked concurrently.

`FallbackMethod` previously changed the accessibility of a cached `Method`
before invocation and restored it afterwards. Since the cached `Method` can
be shared by concurrent invocations, one thread could restore the method to
inaccessible while another thread was invoking it, resulting in an
`IllegalAccessException`.

The fix avoids resetting the accessibility of the cached fallback method.

A concurrent regression test has been added for private fallback methods.

## Testing

The regression test reproduced the issue on current `master` with an
`IllegalAccessException`.

After the fix, the regression test and the Spring 6 fallback tests pass.

Fixes #878