### PR TITLE
Issue #1592: Non-blocking Bulkhead permission acquisition and non-blocking Reactor Bulkhead operator

### DIFF
--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/Bulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/Bulkhead.java
@@ -379,6 +379,46 @@ public interface Bulkhead {
     void acquirePermission();
 
     /**
+     * Acquires a permission to execute a call asynchronously, without blocking the calling
+     * thread.
+     * <p>
+     * The returned future completes successfully as soon as a permission has been acquired. If
+     * the Bulkhead is full and {@link BulkheadConfig#getMaxWaitDuration()} is greater than zero,
+     * the permission request is queued and granted in FIFO order as running calls complete. If
+     * no permission has been granted within the max wait duration, or the Bulkhead is full and
+     * the max wait duration is zero, the future completes exceptionally with a
+     * {@link BulkheadFullException}.
+     * <p>
+     * Once the future completes successfully, the caller must release the permission with
+     * {@link Bulkhead#onComplete()} or {@link Bulkhead#releasePermission()}, exactly like a
+     * permission acquired with {@link Bulkhead#tryAcquirePermission()}.
+     * <p>
+     * Cancelling the returned future while the permission request is queued removes it from the
+     * queue. If {@link CompletableFuture#cancel(boolean)} returns {@code false}, the permission
+     * was already granted and must still be released. The returned future must never be
+     * completed by the caller.
+     * <p>
+     * The default implementation is a blocking bridge which acquires the permission with
+     * {@link Bulkhead#acquirePermission()} and exists for backwards compatibility with custom
+     * implementations. The {@link SemaphoreBulkhead} overrides it with a non-blocking
+     * implementation which never parks the calling thread.
+     *
+     * @return a future which completes when a permission has been acquired and completes
+     * exceptionally with a {@link BulkheadFullException} when no permission could be acquired
+     * within the max wait duration.
+     */
+    default CompletableFuture<Void> acquirePermissionAsync() {
+        CompletableFuture<Void> permission = new CompletableFuture<>();
+        try {
+            acquirePermission();
+            permission.complete(null);
+        } catch (Throwable throwable) {
+            permission.completeExceptionally(throwable);
+        }
+        return permission;
+    }
+
+    /**
      * Releases a permission and increases the number of available permits by one.
      * <p>
      * Should only be used when a permission was acquired but not used. Otherwise use {@link

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/Bulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/Bulkhead.java
@@ -394,9 +394,10 @@ public interface Bulkhead {
      * permission acquired with {@link Bulkhead#tryAcquirePermission()}.
      * <p>
      * Cancelling the returned future while the permission request is queued removes it from the
-     * queue. If {@link CompletableFuture#cancel(boolean)} returns {@code false}, the permission
-     * was already granted and must still be released. The returned future must never be
-     * completed by the caller.
+     * queue without publishing an event, because the request was withdrawn by the caller and not
+     * rejected by the Bulkhead. If {@link CompletableFuture#cancel(boolean)} returns
+     * {@code false}, the permission was already granted and must still be released. The returned
+     * future must never be completed by the caller.
      * <p>
      * The default implementation is a blocking bridge which acquires the permission with
      * {@link Bulkhead#acquirePermission()} and exists for backwards compatibility with custom

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/BulkheadConfig.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/BulkheadConfig.java
@@ -145,8 +145,11 @@ public class BulkheadConfig implements Serializable {
          * can be set to 0.
          * <p>
          * Note: for threads running on an event-loop or equivalent (rx computation pool, etc),
-         * setting maxWaitDuration to 0 is highly recommended. Blocking an event-loop thread will
-         * most likely have a negative effect on application throughput.
+         * blocking the thread must be avoided. Callers which use the blocking
+         * {@link Bulkhead#acquirePermission()} or {@link Bulkhead#tryAcquirePermission()} on such
+         * threads should set maxWaitDuration to 0. {@link Bulkhead#acquirePermissionAsync()} and
+         * the reactive Bulkhead operators wait for a permission without blocking the calling
+         * thread, so they can be combined with a non-zero maxWaitDuration on an event-loop.
          *
          * @param maxWaitDuration maximum wait time for bulkhead entry
          * @return the BulkheadConfig.Builder

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/SchedulerFactory.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/SchedulerFactory.java
@@ -1,0 +1,116 @@
+/*
+ *
+ *  Copyright 2026 Oleksandr Shevchenko
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.resilience4j.bulkhead.internal;
+
+import io.github.resilience4j.core.ExecutorServiceFactory;
+import io.github.resilience4j.core.ThreadType;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Provides a lazily created, shared {@link ScheduledExecutorService} which is used by
+ * {@link SemaphoreBulkhead} to expire queued permission requests once their max wait duration
+ * has elapsed. It is modeled after the CircuitBreaker SchedulerFactory: the scheduler honors
+ * the configured Resilience4j thread type and is recreated when the configuration changes.
+ *
+ * <p>A {@link #reset()} method is provided mainly for tests to force recreation.
+ */
+final class SchedulerFactory {
+
+    private static final class Holder {
+        private static final SchedulerFactory INSTANCE = new SchedulerFactory();
+    }
+
+    /**
+     * Returns the singleton factory instance.
+     */
+    static SchedulerFactory getInstance() {
+        return Holder.INSTANCE;
+    }
+
+    /** cached scheduler (may be {@code null} until first access) */
+    private ScheduledExecutorService scheduler;
+    /** remembers whether the cached scheduler was created for virtual threads */
+    private boolean virtual;
+    /** ReentrantLock to protect the scheduler state - virtual thread compatible */
+    private final ReentrantLock lock = new ReentrantLock();
+
+    private SchedulerFactory() {
+    }
+
+    /**
+     * Returns a {@link ScheduledExecutorService} matching the current Resilience4j thread-type
+     * configuration. If the configuration changed since the last call, the previous scheduler
+     * is shut down and a new one is created.
+     */
+    ScheduledExecutorService getScheduler() {
+        ScheduledExecutorService old = null;
+        ScheduledExecutorService result;
+
+        lock.lock();
+        try {
+            boolean desiredVirtual = ExecutorServiceFactory.getThreadType() == ThreadType.VIRTUAL;
+
+            if (scheduler == null
+                || desiredVirtual != virtual
+                || scheduler.isShutdown()
+                || scheduler.isTerminated()) {
+
+                ThreadType desiredType = desiredVirtual ? ThreadType.VIRTUAL : ThreadType.PLATFORM;
+                ScheduledExecutorService fresh =
+                    ExecutorServiceFactory.newSingleThreadScheduledExecutor(
+                        "BulkheadPermissionTimeoutThread", desiredType);
+
+                old = scheduler;
+                scheduler = fresh;
+                virtual = desiredVirtual;
+            }
+            result = scheduler;
+        } finally {
+            lock.unlock();
+        }
+
+        if (old != null) {
+            old.shutdownNow();
+        }
+        return result;
+    }
+
+    /**
+     * For test-code: shut down and forget the current scheduler so that the next
+     * {@link #getScheduler()} call creates a fresh executor according to the then active
+     * configuration.
+     */
+    void reset() {
+        ScheduledExecutorService old;
+
+        lock.lock();
+        try {
+            old = scheduler;
+            scheduler = null;
+        } finally {
+            lock.unlock();
+        }
+
+        if (old != null) {
+            old.shutdownNow();
+        }
+    }
+}

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/SchedulerFactory.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/SchedulerFactory.java
@@ -58,7 +58,8 @@ final class SchedulerFactory {
     /**
      * Returns a {@link ScheduledExecutorService} matching the current Resilience4j thread-type
      * configuration. If the configuration changed since the last call, the previous scheduler
-     * is shut down and a new one is created.
+     * is shut down gracefully, so that already scheduled permission timeouts still fire, and a
+     * new one is created.
      */
     ScheduledExecutorService getScheduler() {
         ScheduledExecutorService old = null;
@@ -88,7 +89,7 @@ final class SchedulerFactory {
         }
 
         if (old != null) {
-            old.shutdownNow();
+            old.shutdown();
         }
         return result;
     }
@@ -96,7 +97,7 @@ final class SchedulerFactory {
     /**
      * For test-code: shut down and forget the current scheduler so that the next
      * {@link #getScheduler()} call creates a fresh executor according to the then active
-     * configuration.
+     * configuration. Already scheduled permission timeouts still fire on the old scheduler.
      */
     void reset() {
         ScheduledExecutorService old;
@@ -110,7 +111,7 @@ final class SchedulerFactory {
         }
 
         if (old != null) {
-            old.shutdownNow();
+            old.shutdown();
         }
     }
 }

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkhead.java
@@ -32,6 +32,7 @@ import io.github.resilience4j.core.exception.AcquirePermissionCancelledException
 import io.github.resilience4j.core.lang.Nullable;
 
 import java.util.Map;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ScheduledFuture;
@@ -202,7 +203,10 @@ public class SemaphoreBulkhead implements Bulkhead {
             timeoutTask.cancel(false);
             if (throwable != null) {
                 pendingPermissions.remove(permission);
-                publishBulkheadEvent(() -> new BulkheadOnCallRejectedEvent(name));
+                // A cancelled request was withdrawn by the caller, the Bulkhead did not reject it
+                if (!(throwable instanceof CancellationException)) {
+                    publishBulkheadEvent(() -> new BulkheadOnCallRejectedEvent(name));
+                }
             }
         });
         grantPendingPermissions();

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkhead.java
@@ -32,8 +32,12 @@ import io.github.resilience4j.core.exception.AcquirePermissionCancelledException
 import io.github.resilience4j.core.lang.Nullable;
 
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
@@ -52,6 +56,9 @@ public class SemaphoreBulkhead implements Bulkhead {
     private final Semaphore semaphore;
     private final BulkheadMetrics metrics;
     private final BulkheadEventProcessor eventProcessor;
+    private final ConcurrentLinkedQueue<CompletableFuture<Void>> pendingPermissions =
+        new ConcurrentLinkedQueue<>();
+    private final AtomicInteger grantsInProgress = new AtomicInteger();
 
     private final ReentrantLock lock = new ReentrantLock();
     private final Map<String, String> tags;
@@ -137,6 +144,7 @@ public class SemaphoreBulkhead implements Bulkhead {
         } finally {
             lock.unlock();
         }
+        grantPendingPermissions();
     }
 
     /**
@@ -173,8 +181,41 @@ public class SemaphoreBulkhead implements Bulkhead {
      * {@inheritDoc}
      */
     @Override
+    public CompletableFuture<Void> acquirePermissionAsync() {
+        if (pendingPermissions.isEmpty() && semaphore.tryAcquire()) {
+            publishBulkheadEvent(() -> new BulkheadOnCallPermittedEvent(name));
+            return CompletableFuture.completedFuture(null);
+        }
+        long maxWaitMillis = config.getMaxWaitDuration().toMillis();
+        if (maxWaitMillis == 0) {
+            publishBulkheadEvent(() -> new BulkheadOnCallRejectedEvent(name));
+            return CompletableFuture
+                .failedFuture(BulkheadFullException.createBulkheadFullException(this));
+        }
+        CompletableFuture<Void> permission = new CompletableFuture<>();
+        pendingPermissions.offer(permission);
+        ScheduledFuture<?> timeoutTask = SchedulerFactory.getInstance().getScheduler().schedule(
+            () -> permission
+                .completeExceptionally(BulkheadFullException.createBulkheadFullException(this)),
+            maxWaitMillis, TimeUnit.MILLISECONDS);
+        permission.whenComplete((result, throwable) -> {
+            timeoutTask.cancel(false);
+            if (throwable != null) {
+                pendingPermissions.remove(permission);
+                publishBulkheadEvent(() -> new BulkheadOnCallRejectedEvent(name));
+            }
+        });
+        grantPendingPermissions();
+        return permission;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void releasePermission() {
         semaphore.release();
+        grantPendingPermissions();
     }
 
     /**
@@ -184,6 +225,7 @@ public class SemaphoreBulkhead implements Bulkhead {
     public void onComplete() {
         semaphore.release();
         publishBulkheadEvent(() -> new BulkheadOnCallFinishedEvent(name));
+        grantPendingPermissions();
     }
 
     /**
@@ -243,6 +285,33 @@ public class SemaphoreBulkhead implements Bulkhead {
             Thread.currentThread().interrupt();
             return false;
         }
+    }
+
+    /**
+     * Grants queued permission requests in FIFO order as long as permits are available.
+     * Permission requests which are already completed, because they timed out or were
+     * cancelled, are skipped and their permit is returned.
+     * <p>
+     * Completing a permission request runs its dependent actions on the granting thread. Such
+     * an action may release its permission and trigger the next grant, so re-entrant and
+     * concurrent calls are folded into the already running grant loop instead of recursing.
+     */
+    private void grantPendingPermissions() {
+        if (grantsInProgress.getAndIncrement() != 0) {
+            return;
+        }
+        int missed = 1;
+        do {
+            while (!pendingPermissions.isEmpty() && semaphore.tryAcquire()) {
+                CompletableFuture<Void> permission = pendingPermissions.poll();
+                if (permission != null && permission.complete(null)) {
+                    publishBulkheadEvent(() -> new BulkheadOnCallPermittedEvent(name));
+                } else {
+                    semaphore.release();
+                }
+            }
+            missed = grantsInProgress.addAndGet(-missed);
+        } while (missed != 0);
     }
 
     private void publishBulkheadEvent(Supplier<BulkheadEvent> eventSupplier) {

--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkhead.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkhead.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -194,11 +195,18 @@ public class SemaphoreBulkhead implements Bulkhead {
                 .failedFuture(BulkheadFullException.createBulkheadFullException(this));
         }
         CompletableFuture<Void> permission = new CompletableFuture<>();
+        ScheduledFuture<?> timeoutTask;
+        try {
+            timeoutTask = SchedulerFactory.getInstance().getScheduler().schedule(
+                () -> permission
+                    .completeExceptionally(BulkheadFullException.createBulkheadFullException(this)),
+                maxWaitMillis, TimeUnit.MILLISECONDS);
+        } catch (RejectedExecutionException e) {
+            // The scheduler was shut down concurrently. Fail before queueing the request, otherwise
+            // a request nobody holds would be granted a permit later and leak it.
+            return CompletableFuture.failedFuture(e);
+        }
         pendingPermissions.offer(permission);
-        ScheduledFuture<?> timeoutTask = SchedulerFactory.getInstance().getScheduler().schedule(
-            () -> permission
-                .completeExceptionally(BulkheadFullException.createBulkheadFullException(this)),
-            maxWaitMillis, TimeUnit.MILLISECONDS);
         permission.whenComplete((result, throwable) -> {
             timeoutTask.cancel(false);
             if (throwable != null) {

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/BulkheadTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/BulkheadTest.java
@@ -39,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 
@@ -67,6 +68,33 @@ class BulkheadTest {
         assertThat(result).isEqualTo("Hello world");
         assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isOne();
         then(helloWorldService).should(times(1)).returnHelloWorld();
+    }
+
+    @Test
+    void acquirePermissionAsyncDefaultImplementationShouldBridgeAcquirePermission() {
+        Bulkhead bulkhead = mock(Bulkhead.class);
+        given(bulkhead.acquirePermissionAsync()).willCallRealMethod();
+
+        CompletableFuture<Void> granted = bulkhead.acquirePermissionAsync();
+
+        assertThat(granted).isCompleted();
+        then(bulkhead).should(times(1)).acquirePermission();
+    }
+
+    @Test
+    void acquirePermissionAsyncDefaultImplementationShouldCompleteExceptionallyWhenFull() {
+        Bulkhead bulkhead = mock(Bulkhead.class);
+        given(bulkhead.getBulkheadConfig()).willReturn(config);
+        given(bulkhead.getName()).willReturn("test");
+        given(bulkhead.acquirePermissionAsync()).willCallRealMethod();
+        BulkheadFullException exception = BulkheadFullException
+            .createBulkheadFullException(bulkhead);
+        willThrow(exception).given(bulkhead).acquirePermission();
+
+        CompletableFuture<Void> rejected = bulkhead.acquirePermissionAsync();
+
+        assertThat(rejected).isCompletedExceptionally();
+        assertThatThrownBy(rejected::join).hasCause(exception);
     }
 
     @Test

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkheadTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkheadTest.java
@@ -727,6 +727,7 @@ class SemaphoreBulkheadTest {
         Bulkhead bulkhead = createQueueingBulkhead("asyncCancel", threadType, 1,
             Duration.ofSeconds(10));
         assertThat(bulkhead.tryAcquirePermission()).isTrue();
+        TestSubscriber<BulkheadEvent.Type> testSubscriber = subscribe(bulkhead);
 
         CompletableFuture<Void> first = bulkhead.acquirePermissionAsync();
         CompletableFuture<Void> second = bulkhead.acquirePermissionAsync();
@@ -739,6 +740,25 @@ class SemaphoreBulkheadTest {
             .isCompleted();
         assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isZero();
 
+        bulkhead.onComplete();
+        assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(1);
+        // a cancelled request is withdrawn by the caller and must not be reported as rejected
+        testSubscriber.assertValues(CALL_FINISHED, CALL_PERMITTED, CALL_FINISHED);
+    }
+
+    @TestTemplate
+    void shouldStillExpireQueuedPermissionAsyncAfterSchedulerReset(ThreadType threadType) {
+        Bulkhead bulkhead = createQueueingBulkhead("asyncSchedulerReset", threadType, 1,
+            Duration.ofMillis(50));
+        assertThat(bulkhead.tryAcquirePermission()).isTrue();
+        CompletableFuture<Void> permission = bulkhead.acquirePermissionAsync();
+
+        SchedulerFactory.getInstance().reset();
+
+        assertThatThrownBy(() -> permission.get(5, SECONDS))
+            .as("timeout scheduled on the replaced scheduler must still fire in %s", threadType)
+            .isInstanceOf(ExecutionException.class)
+            .hasCauseInstanceOf(BulkheadFullException.class);
         bulkhead.onComplete();
         assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(1);
     }

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkheadTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/internal/SemaphoreBulkheadTest.java
@@ -20,6 +20,7 @@ package io.github.resilience4j.bulkhead.internal;
 
 import io.github.resilience4j.bulkhead.Bulkhead;
 import io.github.resilience4j.bulkhead.BulkheadConfig;
+import io.github.resilience4j.bulkhead.BulkheadFullException;
 import io.github.resilience4j.bulkhead.event.BulkheadEvent;
 import io.github.resilience4j.core.ThreadModeExtension;
 import io.github.resilience4j.core.ThreadType;
@@ -44,7 +45,14 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
@@ -623,6 +631,177 @@ class SemaphoreBulkheadTest {
         AssertionsForClassTypes.assertThat(inMemoryBulkheadRegistry.getConfiguration("testNotFound")).isEmpty();
         inMemoryBulkheadRegistry.addConfiguration("testConfig", defaultConfig);
         AssertionsForClassTypes.assertThat(inMemoryBulkheadRegistry.getConfiguration("testConfig")).isNotNull();
+    }
+
+    private Bulkhead createQueueingBulkhead(String name, ThreadType threadType, int maxConcurrentCalls,
+        Duration maxWaitDuration) {
+        BulkheadConfig config = BulkheadConfig.custom()
+            .maxConcurrentCalls(maxConcurrentCalls)
+            .maxWaitDuration(maxWaitDuration)
+            .build();
+        return Bulkhead.of(name + "-" + threadType, config);
+    }
+
+    @TestTemplate
+    void shouldCompletePermissionAsyncImmediatelyWhenPermitIsAvailable(ThreadType threadType) {
+        Bulkhead bulkhead = createQueueingBulkhead("asyncFastPath", threadType, 1,
+            Duration.ofSeconds(10));
+        TestSubscriber<BulkheadEvent.Type> testSubscriber = subscribe(bulkhead);
+
+        CompletableFuture<Void> permission = bulkhead.acquirePermissionAsync();
+
+        assertThat(permission).isCompleted();
+        assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isZero();
+        testSubscriber.assertValues(CALL_PERMITTED);
+
+        bulkhead.onComplete();
+        assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(1);
+    }
+
+    @TestTemplate
+    void shouldRejectPermissionAsyncImmediatelyWhenFullAndMaxWaitDurationIsZero(ThreadType threadType) {
+        Bulkhead bulkhead = createQueueingBulkhead("asyncFailFast", threadType, 1, Duration.ZERO);
+        assertThat(bulkhead.tryAcquirePermission()).isTrue();
+        TestSubscriber<BulkheadEvent.Type> testSubscriber = subscribe(bulkhead);
+
+        CompletableFuture<Void> permission = bulkhead.acquirePermissionAsync();
+
+        assertThat(permission).isCompletedExceptionally();
+        assertThatThrownBy(permission::join).hasCauseInstanceOf(BulkheadFullException.class);
+        testSubscriber.assertValues(CALL_REJECTED);
+        assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isZero();
+    }
+
+    @TestTemplate
+    void shouldQueuePermissionAsyncAndGrantInFifoOrderOnRelease(ThreadType threadType) {
+        Bulkhead bulkhead = createQueueingBulkhead("asyncQueue", threadType, 1,
+            Duration.ofSeconds(10));
+        assertThat(bulkhead.tryAcquirePermission()).isTrue();
+
+        CompletableFuture<Void> first = bulkhead.acquirePermissionAsync();
+        CompletableFuture<Void> second = bulkhead.acquirePermissionAsync();
+
+        assertThat(first).isNotDone();
+        assertThat(second).isNotDone();
+
+        bulkhead.onComplete();
+        assertThat(first)
+            .as("first queued permission should be granted in %s", threadType)
+            .isCompleted();
+        assertThat(second).isNotDone();
+        assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isZero();
+
+        bulkhead.onComplete();
+        assertThat(second)
+            .as("second queued permission should be granted in %s", threadType)
+            .isCompleted();
+
+        bulkhead.onComplete();
+        assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(1);
+    }
+
+    @TestTemplate
+    void shouldRejectQueuedPermissionAsyncAfterMaxWaitDuration(ThreadType threadType) {
+        Bulkhead bulkhead = createQueueingBulkhead("asyncTimeout", threadType, 1,
+            Duration.ofMillis(50));
+        assertThat(bulkhead.tryAcquirePermission()).isTrue();
+        TestSubscriber<BulkheadEvent.Type> testSubscriber = subscribe(bulkhead);
+
+        CompletableFuture<Void> permission = bulkhead.acquirePermissionAsync();
+
+        assertThatThrownBy(() -> permission.get(5, SECONDS))
+            .isInstanceOf(ExecutionException.class)
+            .hasCauseInstanceOf(BulkheadFullException.class);
+
+        bulkhead.onComplete();
+        assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls())
+            .as("expired permission request must not consume the released permit in %s", threadType)
+            .isEqualTo(1);
+        await().atMost(2, SECONDS).untilAsserted(
+            () -> testSubscriber.assertValueSet(Set.of(CALL_REJECTED, CALL_FINISHED))
+                .assertValueCount(2));
+    }
+
+    @TestTemplate
+    void shouldSkipCancelledPermissionAsyncWhenGranting(ThreadType threadType) {
+        Bulkhead bulkhead = createQueueingBulkhead("asyncCancel", threadType, 1,
+            Duration.ofSeconds(10));
+        assertThat(bulkhead.tryAcquirePermission()).isTrue();
+
+        CompletableFuture<Void> first = bulkhead.acquirePermissionAsync();
+        CompletableFuture<Void> second = bulkhead.acquirePermissionAsync();
+        assertThat(first.cancel(false)).isTrue();
+
+        bulkhead.onComplete();
+
+        assertThat(second)
+            .as("granting should skip the cancelled permission request in %s", threadType)
+            .isCompleted();
+        assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isZero();
+
+        bulkhead.onComplete();
+        assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(1);
+    }
+
+    @TestTemplate
+    void shouldGrantQueuedPermissionAsyncWhenIncreasingMaxConcurrentCalls(ThreadType threadType) {
+        Bulkhead bulkhead = createQueueingBulkhead("asyncChangeConfig", threadType, 1,
+            Duration.ofSeconds(10));
+        assertThat(bulkhead.tryAcquirePermission()).isTrue();
+        CompletableFuture<Void> queued = bulkhead.acquirePermissionAsync();
+        assertThat(queued).isNotDone();
+
+        bulkhead.changeConfig(BulkheadConfig.custom()
+            .maxConcurrentCalls(2)
+            .maxWaitDuration(Duration.ofSeconds(10))
+            .build());
+
+        assertThat(queued)
+            .as("queued permission should be granted by the additional permit in %s", threadType)
+            .isCompleted();
+
+        bulkhead.onComplete();
+        bulkhead.onComplete();
+        assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(2);
+    }
+
+    @TestTemplate
+    void shouldKeepStateConsistentUnderConcurrentPermissionAsyncLoad(ThreadType threadType)
+        throws InterruptedException {
+        int maxConcurrentCalls = 3;
+        int requests = 1500;
+        Bulkhead bulkhead = createQueueingBulkhead("asyncStress", threadType, maxConcurrentCalls,
+            Duration.ofSeconds(10));
+        AtomicInteger granted = new AtomicInteger();
+        AtomicInteger rejected = new AtomicInteger();
+        CountDownLatch settled = new CountDownLatch(requests);
+        ExecutorService executor = Executors.newFixedThreadPool(6);
+
+        try {
+            for (int i = 0; i < requests; i++) {
+                executor.execute(
+                    () -> bulkhead.acquirePermissionAsync().whenComplete((result, throwable) -> {
+                        if (throwable == null) {
+                            granted.incrementAndGet();
+                            bulkhead.onComplete();
+                        } else {
+                            rejected.incrementAndGet();
+                        }
+                        settled.countDown();
+                    }));
+            }
+
+            assertThat(settled.await(30, SECONDS))
+                .as("all permission requests should settle in %s", threadType)
+                .isTrue();
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertThat(granted.get() + rejected.get()).isEqualTo(requests);
+        assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls())
+            .as("all permits should be returned in %s", threadType)
+            .isEqualTo(maxConcurrentCalls);
     }
 
     private RegistryEventConsumer<Bulkhead> getNoOpsRegistryEventConsumer() {

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/BulkheadOperator.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/BulkheadOperator.java
@@ -28,6 +28,12 @@ import java.util.function.UnaryOperator;
  * A Bulkhead operator which checks if a subscriber/observer can acquire a permission to subscribe
  * to an upstream Publisher. Otherwise emits a {@link BulkheadFullException}, if the Bulkhead is
  * full.
+ * <p>
+ * The permission is acquired with {@link Bulkhead#acquirePermissionAsync()} and therefore never
+ * blocks the subscribing thread. When the Bulkhead is full and a max wait duration is
+ * configured, the subscription to the upstream Publisher is deferred until a permission has
+ * been granted, or a {@link BulkheadFullException} is emitted once the max wait duration has
+ * elapsed.
  *
  * @param <T> the value type
  */

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/FluxBulkhead.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/FluxBulkhead.java
@@ -16,11 +16,12 @@
 package io.github.resilience4j.reactor.bulkhead.operator;
 
 import io.github.resilience4j.bulkhead.Bulkhead;
-import io.github.resilience4j.bulkhead.BulkheadFullException;
 import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxOperator;
 import reactor.core.publisher.Operators;
+
+import java.util.concurrent.CompletableFuture;
 
 class FluxBulkhead<T> extends FluxOperator<T, T> {
 
@@ -33,11 +34,19 @@ class FluxBulkhead<T> extends FluxOperator<T, T> {
 
     @Override
     public void subscribe(CoreSubscriber<? super T> actual) {
-        if (bulkhead.tryAcquirePermission()) {
-            source.subscribe(new BulkheadSubscriber<>(bulkhead, actual, false));
+        CompletableFuture<Void> permission = bulkhead.acquirePermissionAsync();
+        if (permission.isDone()) {
+            if (permission.isCompletedExceptionally()) {
+                Operators.error(actual,
+                    PermissionAwaitingSubscription.permissionFailure(permission));
+            } else {
+                source.subscribe(new BulkheadSubscriber<>(bulkhead, actual, false));
+            }
         } else {
-            Operators.error(actual, BulkheadFullException.createBulkheadFullException(bulkhead));
+            PermissionAwaitingSubscription<T> subscription = new PermissionAwaitingSubscription<>(
+                source, bulkhead, actual, false, permission);
+            actual.onSubscribe(subscription);
+            subscription.await();
         }
     }
-
 }

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/MonoBulkhead.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/MonoBulkhead.java
@@ -16,11 +16,12 @@
 package io.github.resilience4j.reactor.bulkhead.operator;
 
 import io.github.resilience4j.bulkhead.Bulkhead;
-import io.github.resilience4j.bulkhead.BulkheadFullException;
 import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoOperator;
 import reactor.core.publisher.Operators;
+
+import java.util.concurrent.CompletableFuture;
 
 class MonoBulkhead<T> extends MonoOperator<T, T> {
 
@@ -33,10 +34,19 @@ class MonoBulkhead<T> extends MonoOperator<T, T> {
 
     @Override
     public void subscribe(CoreSubscriber<? super T> actual) {
-        if (bulkhead.tryAcquirePermission()) {
-            source.subscribe(new BulkheadSubscriber<>(bulkhead, actual, true));
+        CompletableFuture<Void> permission = bulkhead.acquirePermissionAsync();
+        if (permission.isDone()) {
+            if (permission.isCompletedExceptionally()) {
+                Operators.error(actual,
+                    PermissionAwaitingSubscription.permissionFailure(permission));
+            } else {
+                source.subscribe(new BulkheadSubscriber<>(bulkhead, actual, true));
+            }
         } else {
-            Operators.error(actual, BulkheadFullException.createBulkheadFullException(bulkhead));
+            PermissionAwaitingSubscription<T> subscription = new PermissionAwaitingSubscription<>(
+                source, bulkhead, actual, true, permission);
+            actual.onSubscribe(subscription);
+            subscription.await();
         }
     }
 }

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/PermissionAwaitingSubscription.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/PermissionAwaitingSubscription.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 Oleksandr Shevchenko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.reactor.bulkhead.operator;
+
+import io.github.resilience4j.bulkhead.Bulkhead;
+import org.reactivestreams.Subscription;
+import reactor.core.CorePublisher;
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Operators;
+import reactor.util.context.Context;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+/**
+ * A {@link Subscription} which is handed to the downstream subscriber while a bulkhead
+ * permission is being acquired asynchronously. Requests are accumulated and replayed once the
+ * permission has been granted and the upstream has been subscribed. Cancellation cancels the
+ * pending permission request, or releases the permission when it was granted concurrently.
+ *
+ * @param <T> the value type of the upstream and downstream
+ */
+final class PermissionAwaitingSubscription<T> extends Operators.DeferredSubscription
+    implements CoreSubscriber<T> {
+
+    private final CorePublisher<? extends T> source;
+    private final Bulkhead bulkhead;
+    private final CoreSubscriber<? super T> actual;
+    private final boolean singleProducer;
+    private final CompletableFuture<Void> permission;
+
+    PermissionAwaitingSubscription(CorePublisher<? extends T> source, Bulkhead bulkhead,
+        CoreSubscriber<? super T> actual, boolean singleProducer,
+        CompletableFuture<Void> permission) {
+        this.source = source;
+        this.bulkhead = bulkhead;
+        this.actual = actual;
+        this.singleProducer = singleProducer;
+        this.permission = permission;
+    }
+
+    /**
+     * Subscribes the upstream once the permission has been granted, or propagates the failure.
+     * Must be called after the downstream received this subscription via
+     * {@link CoreSubscriber#onSubscribe(Subscription)}.
+     */
+    void await() {
+        permission.whenComplete((granted, error) -> {
+            if (error != null) {
+                if (!(error instanceof CancellationException) && !isCancelled()) {
+                    actual.onError(error);
+                }
+            } else {
+                // The BulkheadSubscriber releases the permission on all terminal signals. When
+                // the downstream cancelled concurrently, set(...) cancels the incoming
+                // subscription, which also releases the permission.
+                source.subscribe(new BulkheadSubscriber<>(bulkhead, this, singleProducer));
+            }
+        });
+    }
+
+    @Override
+    public void cancel() {
+        super.cancel();
+        permission.cancel(false);
+    }
+
+    @Override
+    public void onSubscribe(Subscription s) {
+        set(s);
+    }
+
+    @Override
+    public void onNext(T t) {
+        actual.onNext(t);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        actual.onError(t);
+    }
+
+    @Override
+    public void onComplete() {
+        actual.onComplete();
+    }
+
+    @Override
+    public Context currentContext() {
+        return actual.currentContext();
+    }
+
+    /**
+     * Extracts the failure of an exceptionally completed permission future.
+     */
+    static Throwable permissionFailure(CompletableFuture<Void> permission) {
+        try {
+            permission.join();
+            throw new IllegalStateException("Permission future has not failed");
+        } catch (CancellationException e) {
+            return e;
+        } catch (CompletionException e) {
+            return e.getCause() != null ? e.getCause() : e;
+        }
+    }
+}

--- a/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/PermissionAwaitingSubscription.java
+++ b/resilience4j-reactor/src/main/java/io/github/resilience4j/reactor/bulkhead/operator/PermissionAwaitingSubscription.java
@@ -62,11 +62,16 @@ final class PermissionAwaitingSubscription<T> extends Operators.DeferredSubscrip
         permission.whenComplete((granted, error) -> {
             if (error != null) {
                 if (!(error instanceof CancellationException) && !isCancelled()) {
-                    actual.onError(error);
+                    actual.onError(unwrap(error));
                 }
+            } else if (isCancelled()) {
+                // The downstream cancelled while the permission was being granted. Nothing would
+                // consume the upstream, so release the permission instead of subscribing to a
+                // source which may have subscribe-time side effects.
+                bulkhead.releasePermission();
             } else {
                 // The BulkheadSubscriber releases the permission on all terminal signals. When
-                // the downstream cancelled concurrently, set(...) cancels the incoming
+                // the downstream cancels from here on, set(...) cancels the incoming
                 // subscription, which also releases the permission.
                 source.subscribe(new BulkheadSubscriber<>(bulkhead, this, singleProducer));
             }
@@ -114,7 +119,18 @@ final class PermissionAwaitingSubscription<T> extends Operators.DeferredSubscrip
         } catch (CancellationException e) {
             return e;
         } catch (CompletionException e) {
-            return e.getCause() != null ? e.getCause() : e;
+            return unwrap(e);
         }
+    }
+
+    /**
+     * Unwraps the cause of a {@link CompletionException}, which a Bulkhead implementation can
+     * surface when its permission future is a dependent stage.
+     */
+    private static Throwable unwrap(Throwable throwable) {
+        if (throwable instanceof CompletionException && throwable.getCause() != null) {
+            return throwable.getCause();
+        }
+        return throwable;
     }
 }

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/BulkheadOperatorQueueingTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/BulkheadOperatorQueueingTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2026 Oleksandr Shevchenko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.resilience4j.reactor.bulkhead.operator;
+
+import io.github.resilience4j.bulkhead.Bulkhead;
+import io.github.resilience4j.bulkhead.BulkheadConfig;
+import io.github.resilience4j.bulkhead.BulkheadFullException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import reactor.util.context.Context;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests the non-blocking queueing behavior of the {@link BulkheadOperator} with a real
+ * semaphore based Bulkhead: subscriptions to a full Bulkhead with a max wait duration are
+ * queued without blocking the subscribing thread and are granted in FIFO order as permissions
+ * are released.
+ */
+class BulkheadOperatorQueueingTest {
+
+    private Bulkhead bulkhead(int maxConcurrentCalls, Duration maxWaitDuration) {
+        return Bulkhead.of("test", BulkheadConfig.custom()
+            .maxConcurrentCalls(maxConcurrentCalls)
+            .maxWaitDuration(maxWaitDuration)
+            .build());
+    }
+
+    @Test
+    @Timeout(5)
+    void shouldNotBlockSubscribingThreadWhenBulkheadIsFull() {
+        Bulkhead bulkhead = bulkhead(1, Duration.ofMinutes(10));
+        assertThat(bulkhead.tryAcquirePermission()).isTrue();
+        AtomicReference<String> result = new AtomicReference<>();
+
+        Disposable subscription = Mono.just("Event")
+            .transformDeferred(BulkheadOperator.of(bulkhead))
+            .subscribe(result::set);
+
+        assertThat(result.get())
+            .as("subscription should be queued instead of being rejected or blocking")
+            .isNull();
+
+        bulkhead.onComplete();
+
+        assertThat(result.get()).isEqualTo("Event");
+        assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(1);
+        subscription.dispose();
+    }
+
+    @Test
+    @Timeout(5)
+    void shouldGrantQueuedSubscriptionsInFifoOrder() {
+        Bulkhead bulkhead = bulkhead(1, Duration.ofSeconds(10));
+        assertThat(bulkhead.tryAcquirePermission()).isTrue();
+        List<String> results = new CopyOnWriteArrayList<>();
+
+        Mono.just("first").transformDeferred(BulkheadOperator.of(bulkhead))
+            .subscribe(results::add);
+        Mono.just("second").transformDeferred(BulkheadOperator.of(bulkhead))
+            .subscribe(results::add);
+
+        assertThat(results).isEmpty();
+
+        bulkhead.onComplete();
+
+        assertThat(results)
+            .as("releasing one permission should cascade through the queued subscriptions")
+            .containsExactly("first", "second");
+        assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldEmitBulkheadFullExceptionAfterMaxWaitDuration() {
+        Bulkhead bulkhead = bulkhead(1, Duration.ofMillis(100));
+        assertThat(bulkhead.tryAcquirePermission()).isTrue();
+
+        StepVerifier.create(
+            Mono.just("Event")
+                .transformDeferred(BulkheadOperator.of(bulkhead)))
+            .expectSubscription()
+            .expectError(BulkheadFullException.class)
+            .verify(Duration.ofSeconds(5));
+
+        bulkhead.onComplete();
+        assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(1);
+    }
+
+    @Test
+    @Timeout(5)
+    void shouldNotConsumePermitWhenWaitingSubscriberIsCancelled() {
+        Bulkhead bulkhead = bulkhead(1, Duration.ofSeconds(10));
+        assertThat(bulkhead.tryAcquirePermission()).isTrue();
+
+        Disposable waiting = Mono.just("never")
+            .transformDeferred(BulkheadOperator.of(bulkhead))
+            .subscribe();
+        waiting.dispose();
+
+        bulkhead.onComplete();
+
+        assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls())
+            .as("cancelled waiting subscription must not consume the released permit")
+            .isEqualTo(1);
+
+        StepVerifier.create(
+            Mono.just("after")
+                .transformDeferred(BulkheadOperator.of(bulkhead)))
+            .expectNext("after")
+            .verifyComplete();
+    }
+
+    @Test
+    @Timeout(5)
+    void shouldReleasePermissionWhenSubscriptionIsCancelledAfterQueuedGrant() {
+        Bulkhead bulkhead = bulkhead(1, Duration.ofSeconds(10));
+        assertThat(bulkhead.tryAcquirePermission()).isTrue();
+
+        Disposable waiting = Mono.never()
+            .transformDeferred(BulkheadOperator.of(bulkhead))
+            .subscribe();
+
+        bulkhead.onComplete();
+        assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls())
+            .as("queued subscription should hold the released permit")
+            .isZero();
+
+        waiting.dispose();
+        assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(1);
+    }
+
+    @Test
+    @Timeout(5)
+    void shouldReleasePermissionWhenUpstreamErrorsAfterQueuedGrant() {
+        Bulkhead bulkhead = bulkhead(1, Duration.ofSeconds(10));
+        assertThat(bulkhead.tryAcquirePermission()).isTrue();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        Mono.error(new IOException("BAM!"))
+            .transformDeferred(BulkheadOperator.of(bulkhead))
+            .subscribe(value -> {
+            }, error::set);
+
+        bulkhead.onComplete();
+
+        assertThat(error.get()).isInstanceOf(IOException.class);
+        assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(1);
+    }
+
+    @Test
+    @Timeout(5)
+    void shouldDeliverAllElementsOfQueuedFlux() {
+        Bulkhead bulkhead = bulkhead(1, Duration.ofSeconds(10));
+        assertThat(bulkhead.tryAcquirePermission()).isTrue();
+        List<String> results = new CopyOnWriteArrayList<>();
+
+        Flux.just("Event 1", "Event 2")
+            .transformDeferred(BulkheadOperator.of(bulkhead))
+            .subscribe(results::add);
+
+        assertThat(results).isEmpty();
+
+        bulkhead.onComplete();
+
+        assertThat(results).containsExactly("Event 1", "Event 2");
+        assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldHonourRequestsMadeBeforeAndAfterQueuedGrant() {
+        Bulkhead bulkhead = bulkhead(1, Duration.ofSeconds(10));
+        assertThat(bulkhead.tryAcquirePermission()).isTrue();
+
+        StepVerifier.create(
+            Flux.just("Event 1", "Event 2", "Event 3")
+                .transformDeferred(BulkheadOperator.of(bulkhead)), 0)
+            .expectSubscription()
+            .thenRequest(1)
+            .then(bulkhead::onComplete)
+            .expectNext("Event 1")
+            .thenRequest(2)
+            .expectNext("Event 2", "Event 3")
+            .expectComplete()
+            .verify(Duration.ofSeconds(5));
+
+        assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(1);
+    }
+
+    @Test
+    @Timeout(5)
+    void shouldPropagateContextAcrossQueuedGrant() {
+        Bulkhead bulkhead = bulkhead(1, Duration.ofSeconds(10));
+        assertThat(bulkhead.tryAcquirePermission()).isTrue();
+        AtomicReference<String> result = new AtomicReference<>();
+
+        Mono.deferContextual(context -> Mono.just(context.get("key").toString()))
+            .transformDeferred(BulkheadOperator.of(bulkhead))
+            .contextWrite(Context.of("key", "value"))
+            .subscribe(result::set);
+
+        assertThat(result.get()).isNull();
+
+        bulkhead.onComplete();
+
+        assertThat(result.get()).isEqualTo("value");
+        assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(1);
+    }
+}

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/BulkheadOperatorQueueingTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/BulkheadOperatorQueueingTest.java
@@ -29,10 +29,17 @@ import reactor.util.context.Context;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 /**
  * Tests the non-blocking queueing behavior of the {@link BulkheadOperator} with a real
@@ -207,6 +214,52 @@ class BulkheadOperatorQueueingTest {
             .verify(Duration.ofSeconds(5));
 
         assertThat(bulkhead.getMetrics().getAvailableConcurrentCalls()).isEqualTo(1);
+    }
+
+    @Test
+    @Timeout(5)
+    void shouldReleasePermissionWithoutSubscribingWhenGrantRacesCancellation() {
+        Bulkhead bulkhead = mock(Bulkhead.class);
+        // Models a permission which is granted concurrently with the cancellation: cancelling
+        // the request loses the race and the granted permission has to be released.
+        CompletableFuture<Void> permission = new CompletableFuture<>() {
+            @Override
+            public boolean cancel(boolean mayInterruptIfRunning) {
+                return false;
+            }
+        };
+        given(bulkhead.acquirePermissionAsync()).willReturn(permission);
+        AtomicBoolean subscribed = new AtomicBoolean();
+
+        Disposable waiting = Mono.just("Event")
+            .doOnSubscribe(subscription -> subscribed.set(true))
+            .transformDeferred(BulkheadOperator.of(bulkhead))
+            .subscribe();
+        waiting.dispose();
+        permission.complete(null);
+
+        assertThat(subscribed)
+            .as("upstream must not be subscribed for a cancelled subscriber")
+            .isFalse();
+        verify(bulkhead).releasePermission();
+        verify(bulkhead, never()).onComplete();
+    }
+
+    @Test
+    @Timeout(5)
+    void shouldUnwrapCompletionExceptionOfQueuedPermission() {
+        Bulkhead bulkhead = mock(Bulkhead.class);
+        CompletableFuture<Void> permission = new CompletableFuture<>();
+        given(bulkhead.acquirePermissionAsync()).willReturn(permission);
+        IOException cause = new IOException("BAM!");
+
+        StepVerifier.create(
+            Mono.just("Event")
+                .transformDeferred(BulkheadOperator.of(bulkhead)))
+            .expectSubscription()
+            .then(() -> permission.completeExceptionally(new CompletionException(cause)))
+            .expectErrorSatisfies(error -> assertThat(error).isSameAs(cause))
+            .verify(Duration.ofSeconds(5));
     }
 
     @Test

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/FluxBulkheadTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/FluxBulkheadTest.java
@@ -24,6 +24,7 @@ import reactor.test.StepVerifier;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
@@ -39,7 +40,8 @@ class FluxBulkheadTest {
 
     @Test
     void shouldEmitEvent() {
-        given(bulkhead.tryAcquirePermission()).willReturn(true);
+        given(bulkhead.acquirePermissionAsync())
+            .willReturn(CompletableFuture.completedFuture(null));
 
         StepVerifier.create(
             Flux.just("Event 1", "Event 2")
@@ -53,7 +55,8 @@ class FluxBulkheadTest {
 
     @Test
     void shouldPropagateError() {
-        given(bulkhead.tryAcquirePermission()).willReturn(true);
+        given(bulkhead.acquirePermissionAsync())
+            .willReturn(CompletableFuture.completedFuture(null));
 
         StepVerifier.create(
             Flux.error(new IOException("BAM!"))
@@ -67,8 +70,9 @@ class FluxBulkheadTest {
 
     @Test
     void shouldEmitErrorWithBulkheadFullException() {
-        given(bulkhead.tryAcquirePermission()).willReturn(false);
-        bulkhead.tryAcquirePermission();
+        CompletableFuture<Void> rejectedPermission = CompletableFuture
+            .failedFuture(BulkheadFullException.createBulkheadFullException(bulkhead));
+        given(bulkhead.acquirePermissionAsync()).willReturn(rejectedPermission);
 
         StepVerifier.create(
             Flux.just("Event")
@@ -82,7 +86,9 @@ class FluxBulkheadTest {
 
     @Test
     void shouldEmitBulkheadFullExceptionEvenWhenErrorDuringSubscribe() {
-        given(bulkhead.tryAcquirePermission()).willReturn(false);
+        CompletableFuture<Void> rejectedPermission = CompletableFuture
+            .failedFuture(BulkheadFullException.createBulkheadFullException(bulkhead));
+        given(bulkhead.acquirePermissionAsync()).willReturn(rejectedPermission);
 
         StepVerifier.create(
             Flux.error(new IOException("BAM!"))
@@ -96,7 +102,9 @@ class FluxBulkheadTest {
 
     @Test
     void shouldEmitBulkheadFullExceptionEvenWhenErrorNotOnSubscribe() {
-        given(bulkhead.tryAcquirePermission()).willReturn(false);
+        CompletableFuture<Void> rejectedPermission = CompletableFuture
+            .failedFuture(BulkheadFullException.createBulkheadFullException(bulkhead));
+        given(bulkhead.acquirePermissionAsync()).willReturn(rejectedPermission);
 
         StepVerifier.create(
             Flux.error(new IOException("BAM!"), true)
@@ -110,7 +118,8 @@ class FluxBulkheadTest {
 
     @Test
     void shouldReleaseBulkheadSemaphoreOnCancel() {
-        given(bulkhead.tryAcquirePermission()).willReturn(true);
+        given(bulkhead.acquirePermissionAsync())
+            .willReturn(CompletableFuture.completedFuture(null));
 
         StepVerifier.create(
             Flux.just("Event")
@@ -125,7 +134,8 @@ class FluxBulkheadTest {
 
     @Test
     void shouldInvokeOnCompleteOnCancelWhenEventWasEmitted() {
-        given(bulkhead.tryAcquirePermission()).willReturn(true);
+        given(bulkhead.acquirePermissionAsync())
+            .willReturn(CompletableFuture.completedFuture(null));
 
         StepVerifier.create(
             Flux.just("Event1", "Event2", "Event3")
@@ -141,7 +151,8 @@ class FluxBulkheadTest {
 
     @Test
     void shouldOnceEmitCompleteWhenErrorInCompleteEvent() {
-        given(bulkhead.tryAcquirePermission()).willReturn(true);
+        given(bulkhead.acquirePermissionAsync())
+            .willReturn(CompletableFuture.completedFuture(null));
         doThrow(new RuntimeException("BAM!")).when(bulkhead).onComplete();
 
         StepVerifier.create(

--- a/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/MonoBulkheadTest.java
+++ b/resilience4j-reactor/src/test/java/io/github/resilience4j/reactor/bulkhead/operator/MonoBulkheadTest.java
@@ -24,6 +24,7 @@ import reactor.test.StepVerifier;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
@@ -39,7 +40,8 @@ class MonoBulkheadTest {
 
     @Test
     void shouldEmitEvent() {
-        given(bulkhead.tryAcquirePermission()).willReturn(true);
+        given(bulkhead.acquirePermissionAsync())
+            .willReturn(CompletableFuture.completedFuture(null));
 
         StepVerifier.create(
             Mono.just("Event")
@@ -52,7 +54,8 @@ class MonoBulkheadTest {
 
     @Test
     void shouldPropagateError() {
-        given(bulkhead.tryAcquirePermission()).willReturn(true);
+        given(bulkhead.acquirePermissionAsync())
+            .willReturn(CompletableFuture.completedFuture(null));
 
         StepVerifier.create(
             Mono.error(new IOException("BAM!"))
@@ -66,7 +69,9 @@ class MonoBulkheadTest {
 
     @Test
     void shouldEmitErrorWithBulkheadFullException() {
-        given(bulkhead.tryAcquirePermission()).willReturn(false);
+        CompletableFuture<Void> rejectedPermission = CompletableFuture
+            .failedFuture(BulkheadFullException.createBulkheadFullException(bulkhead));
+        given(bulkhead.acquirePermissionAsync()).willReturn(rejectedPermission);
 
         StepVerifier.create(
             Mono.just("Event")
@@ -80,7 +85,9 @@ class MonoBulkheadTest {
 
     @Test
     void shouldEmitBulkheadFullExceptionEvenWhenErrorDuringSubscribe() {
-        given(bulkhead.tryAcquirePermission()).willReturn(false);
+        CompletableFuture<Void> rejectedPermission = CompletableFuture
+            .failedFuture(BulkheadFullException.createBulkheadFullException(bulkhead));
+        given(bulkhead.acquirePermissionAsync()).willReturn(rejectedPermission);
 
         StepVerifier.create(
             Mono.error(new IOException("BAM!"))
@@ -92,7 +99,8 @@ class MonoBulkheadTest {
 
     @Test
     void shouldReleaseBulkheadSemaphoreOnCancel() {
-        given(bulkhead.tryAcquirePermission()).willReturn(true);
+        given(bulkhead.acquirePermissionAsync())
+            .willReturn(CompletableFuture.completedFuture(null));
 
         StepVerifier.create(
             Mono.just("Event")
@@ -107,7 +115,8 @@ class MonoBulkheadTest {
 
     @Test
     void shouldOnceEmitCompleteWhenErrorInCompleteEvent() {
-        given(bulkhead.tryAcquirePermission()).willReturn(true);
+        given(bulkhead.acquirePermissionAsync())
+            .willReturn(CompletableFuture.completedFuture(null));
         doThrow(new RuntimeException("BAM!")).when(bulkhead).onComplete();
 
         StepVerifier.create(


### PR DESCRIPTION
Fixes #1592

## Problem

`MonoBulkhead`/`FluxBulkhead` acquire the permission with `Bulkhead.tryAcquirePermission()` at subscription time, and `SemaphoreBulkhead` implements the wait with `java.util.concurrent.Semaphore.tryAcquire(timeout)`. Any `maxWaitDuration > 0` therefore parks the subscribing thread — in WebFlux that is a Netty event loop. The only non-blocking configuration today is fail-fast (`maxWaitDuration = 0`), which is not a substitute for queueing: [measurements in #1592](https://github.com/resilience4j/resilience4j/issues/1592#issuecomment-5437524586) show fail-fast losing ~45% of *successful* throughput at saturation, because the reject path competes for the same event loops that serve admitted requests.

## Design

This follows the design @RobWin outlined in https://github.com/resilience4j/resilience4j/issues/1592#issuecomment-1187240050: a `CompletableFuture`-based non-blocking acquisition living in the core Bulkhead module ("free of any Reactor classes"), backed by the semaphore plus a non-blocking, thread-safe FIFO queue of permission requests, where releasing a permission grants the first queued request.

**Core (`resilience4j-bulkhead`), no Reactor classes:**

* `Bulkhead#acquirePermissionAsync()` returns `CompletableFuture<Void>` which completes when a permission has been acquired:
  * permit available → completed future (fast path, no allocation beyond the shared completed future).
  * full and `maxWaitDuration = 0` → future completed exceptionally with `BulkheadFullException` (exact fail-fast parity with the sync API).
  * full and `maxWaitDuration > 0` → the request is queued in a `ConcurrentLinkedQueue` and granted in FIFO order as running calls complete. If not granted within `maxWaitDuration`, the future completes exceptionally with `BulkheadFullException`.
  * Cancelling the returned future removes the request from the queue; a permission granted concurrently with cancellation is returned to the semaphore, so permits can never leak.
* The default interface implementation is a blocking bridge over `acquirePermission()`, so custom `Bulkhead` implementations keep their exact current behavior; `SemaphoreBulkhead` overrides it with the non-blocking implementation.
* Release stays exactly as today: `onComplete()` / `releasePermission()`. Both now also grant queued requests.
* Events keep their semantics: `CallPermitted` when the permission is granted (immediately or from the queue), `CallRejected` when the request fails fast or times out, `CallFinished` on release. A cancelled request publishes no event: it was withdrawn by the caller, not rejected by the Bulkhead (mirroring the event-less `releasePermission()` the operator already uses on cancellation).

**Reactor (`resilience4j-reactor`):**

* `MonoBulkhead`/`FluxBulkhead` call `acquirePermissionAsync()` instead of `tryAcquirePermission()`. A completed future takes the same synchronous path as before. A pending future hands the downstream a `PermissionAwaitingSubscription` (based on `Operators.DeferredSubscription`, the same primitive `FluxDelaySubscription` uses): requests are accumulated and replayed once the permission is granted, cancellation cancels the pending permission request, and the untouched `BulkheadSubscriber` keeps handling release on all terminal signals. The public `BulkheadOperator` API is unchanged.
* The reactive-streams whitebox verification for `BulkheadSubscriber` is untouched and still passes.

### Deliberate deviations from the sketch in #1592, with reasoning

1. **Default method on `Bulkhead` instead of a separate `NonBlockingBulkhead` interface.** A parallel type would need its own registry, configuration, Spring/Micronaut wiring and operator overloads, and users would have to migrate to benefit. As a method on `Bulkhead`, the existing reactive operators are fixed transparently for every user who already configured `maxWaitDuration > 0`, and the core module still contains no Reactor classes.
2. **`CompletableFuture<Void>` + the existing release methods instead of `CompletableFuture<Permission>`.** Every existing call site releases through `onComplete()`/`releasePermission()`; introducing a second release protocol (a `Permission` handle) on the same class would be a new concept with no additional safety — the cancellation race is already handled by the atomicity of `CompletableFuture.complete`.
3. **Deadline-based expiry instead of an evicting circular queue.** Evicting the *oldest* waiter penalizes the request closest to being served and starves waiters under sustained load. Instead, queued requests keep FIFO order and expire after `maxWaitDuration` — the semantics users already configured. Expiry uses a lazily created, shared single-thread scheduler (same pattern and thread-type support as the CircuitBreaker `SchedulerFactory`; `SemaphoreBasedRateLimiter` also owns a scheduler), and the timeout task is cancelled as soon as the request settles. The queue is not explicitly bounded because every entry is time-bounded by `maxWaitDuration` — the same bound that applies to blocked threads today; an optional depth limit can be added later as a config property without breaking this API.

### Concurrency notes

* The permission handoff is the `CompletableFuture.complete` call itself: the granting side acquires a permit and only keeps it if `complete(null)` wins; a lost race (timeout/cancellation) returns the permit and grants the next request.
* Grant loops use a work-in-progress counter (the standard drain-loop pattern), because completing a future runs its continuations on the granting thread — a synchronous chain of grant→work→release would otherwise recurse once per queued waiter.
* A request is queued only after its expiry has been scheduled. If the shared scheduler was shut down concurrently (`reset()` / thread-type switch), the returned future fails with the `RejectedExecutionException` instead of leaving an unheld request in the queue, where a later grant would leak a permit.
* Fairness between async waiters and threads blocked in the sync API is not guaranteed (they contend on the semaphore); each style is FIFO among itself when `fairCallHandlingEnabled` is set. In practice a bulkhead instance is used through one style.

## Behavior matrix

| API | `maxWaitDuration = 0` | `maxWaitDuration > 0` |
|---|---|---|
| `acquirePermission()` / `tryAcquirePermission()` | unchanged | unchanged (blocking wait) |
| `acquirePermissionAsync()` (new) | grant or immediate `BulkheadFullException` | queue without blocking; grant FIFO or `BulkheadFullException` after the wait |
| Reactor operator | unchanged behavior | **before:** parks the subscribing thread; **after:** queues the subscription, no thread blocked |

## Tests

* `SemaphoreBulkheadTest` (each in platform and virtual thread mode): immediate grant, fail-fast, FIFO grant on release, expiry after `maxWaitDuration` without consuming a later permit, cancelled requests skipped, `changeConfig` granting waiters, and a 1500-request concurrent stress test asserting every request settles and all permits are returned.
* `BulkheadTest`: the default-method bridge (success and failure).
* `BulkheadOperatorQueueingTest` (real `SemaphoreBulkhead`): subscription does not block and is delivered on release; one release cascades through queued subscriptions in FIFO order; `BulkheadFullException` after the wait; cancelled waiters don't consume permits; cancellation after a queued grant releases the permission; upstream errors release; Flux delivery, backpressure across the deferred grant (requests before and after), and `Context` propagation.
* Existing `MonoBulkheadTest`/`FluxBulkheadTest` updated to stub the new acquisition call; assertions unchanged. `BulkheadSubscriberWhiteboxVerification` unchanged.

## Possible follow-ups (happy to contribute)

* RxJava 2/3 operators have the same blocking acquisition and can adopt `acquirePermissionAsync()` the same way.
* Kotlin `acquirePermissionSuspend()` currently offloads the blocking wait to `Dispatchers.IO`; it could `await()` the async future instead and stop consuming a thread per waiter.
* A queue-depth metric and an optional max pending-requests config.


