### PR TITLE
Fix ThreadPoolBulkheadConfig.from() mutating base config

### DIFF
--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfig.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfig.java
@@ -133,7 +133,14 @@ public class ThreadPoolBulkheadConfig {
         private ThreadPoolBulkheadConfig config;
 
         public Builder(ThreadPoolBulkheadConfig bulkheadConfig) {
-            this.config = bulkheadConfig;
+            config = new ThreadPoolBulkheadConfig();
+            config.maxThreadPoolSize = bulkheadConfig.maxThreadPoolSize;
+            config.coreThreadPoolSize = bulkheadConfig.coreThreadPoolSize;
+            config.queueCapacity = bulkheadConfig.queueCapacity;
+            config.keepAliveDuration = bulkheadConfig.keepAliveDuration;
+            config.writableStackTraceEnabled = bulkheadConfig.writableStackTraceEnabled;
+            config.contextPropagators = new ArrayList<>(bulkheadConfig.contextPropagators);
+            config.rejectedExecutionHandler = bulkheadConfig.rejectedExecutionHandler;
         }
 
         public Builder() {

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfigTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfigTest.java
@@ -221,6 +221,56 @@ class ThreadPoolBulkheadConfigTest {
                 .endsWith("}");
     }
 
+    @Test
+    void fromShouldNotMutateBaseConfig() {
+        ThreadPoolBulkheadConfig baseConfig = ThreadPoolBulkheadConfig.custom()
+            .maxThreadPoolSize(4)
+            .coreThreadPoolSize(2)
+            .queueCapacity(10)
+            .build();
+
+        ThreadPoolBulkheadConfig derivedConfig = ThreadPoolBulkheadConfig.from(baseConfig)
+            .maxThreadPoolSize(20)
+            .coreThreadPoolSize(8)
+            .queueCapacity(50)
+            .build();
+
+        // derivedConfig must be a different instance
+        assertThat(derivedConfig).isNotSameAs(baseConfig);
+
+        // base config must remain unchanged
+        assertThat(baseConfig.getMaxThreadPoolSize()).isEqualTo(4);
+        assertThat(baseConfig.getCoreThreadPoolSize()).isEqualTo(2);
+        assertThat(baseConfig.getQueueCapacity()).isEqualTo(10);
+
+        // derived config must have the new values
+        assertThat(derivedConfig.getMaxThreadPoolSize()).isEqualTo(20);
+        assertThat(derivedConfig.getCoreThreadPoolSize()).isEqualTo(8);
+        assertThat(derivedConfig.getQueueCapacity()).isEqualTo(50);
+    }
+
+    @Test
+    void fromShouldCopyAllFields() {
+        Duration keepAlive = Duration.ofSeconds(30);
+        ThreadPoolBulkheadConfig baseConfig = ThreadPoolBulkheadConfig.custom()
+            .maxThreadPoolSize(10)
+            .coreThreadPoolSize(5)
+            .queueCapacity(20)
+            .keepAliveDuration(keepAlive)
+            .writableStackTraceEnabled(false)
+            .build();
+
+        ThreadPoolBulkheadConfig derivedConfig = ThreadPoolBulkheadConfig.from(baseConfig)
+            .maxThreadPoolSize(50)
+            .build();
+
+        // All fields except maxThreadPoolSize should be copied from base
+        assertThat(derivedConfig.getCoreThreadPoolSize()).isEqualTo(5);
+        assertThat(derivedConfig.getQueueCapacity()).isEqualTo(20);
+        assertThat(derivedConfig.getKeepAliveDuration()).isEqualTo(keepAlive);
+        assertThat(derivedConfig.isWritableStackTraceEnabled()).isFalse();
+    }
+
     public static class TestCtxPropagator implements ContextPropagator<Object> {
 
         @Override


### PR DESCRIPTION
The Builder(ThreadPoolBulkheadConfig) constructor stored the base config by reference instead of copying its fields. This caused from(baseConfig) to return the same object, and any builder call would mutate the original.

Fix: copy all fields from the base config into a new instance, matching the pattern used by BulkheadConfig, RateLimiterConfig, and other config classes.

Added two regression tests:
- fromShouldNotMutateBaseConfig: verifies base config is unchanged
- fromShouldCopyAllFields: verifies all fields are copied correctly

Closes #2492