### PR TITLE
Issue #2492: Fixed ThreadPoolBulkheadConfig.from() mutating the base config

### DIFF
--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfig.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfig.java
@@ -133,7 +133,14 @@ public class ThreadPoolBulkheadConfig {
         private ThreadPoolBulkheadConfig config;
 
         public Builder(ThreadPoolBulkheadConfig bulkheadConfig) {
-            this.config = bulkheadConfig;
+            this.config = new ThreadPoolBulkheadConfig();
+            this.config.maxThreadPoolSize = bulkheadConfig.maxThreadPoolSize;
+            this.config.coreThreadPoolSize = bulkheadConfig.coreThreadPoolSize;
+            this.config.queueCapacity = bulkheadConfig.queueCapacity;
+            this.config.keepAliveDuration = bulkheadConfig.keepAliveDuration;
+            this.config.writableStackTraceEnabled = bulkheadConfig.writableStackTraceEnabled;
+            this.config.contextPropagators = new ArrayList<>(bulkheadConfig.contextPropagators);
+            this.config.rejectedExecutionHandler = bulkheadConfig.rejectedExecutionHandler;
         }
 
         public Builder() {

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfigTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfigTest.java
@@ -81,6 +81,33 @@ class ThreadPoolBulkheadConfigTest {
     }
 
     @Test
+    void fromShouldNotMutateBaseConfig() {
+        ThreadPoolBulkheadConfig baseConfig = ThreadPoolBulkheadConfig.custom()
+            .maxThreadPoolSize(4)
+            .coreThreadPoolSize(2)
+            .queueCapacity(10)
+            .contextPropagator(new TestCtxPropagator())
+            .build();
+
+        ThreadPoolBulkheadConfig derivedConfig = ThreadPoolBulkheadConfig.from(baseConfig)
+            .maxThreadPoolSize(20)
+            .coreThreadPoolSize(8)
+            .queueCapacity(50)
+            .contextPropagator(new TestCtxPropagator2())
+            .build();
+
+        assertThat(derivedConfig).isNotSameAs(baseConfig);
+        assertThat(baseConfig.getMaxThreadPoolSize()).isEqualTo(4);
+        assertThat(baseConfig.getCoreThreadPoolSize()).isEqualTo(2);
+        assertThat(baseConfig.getQueueCapacity()).isEqualTo(10);
+        assertThat(baseConfig.getContextPropagator()).hasSize(1);
+        assertThat(derivedConfig.getMaxThreadPoolSize()).isEqualTo(20);
+        assertThat(derivedConfig.getCoreThreadPoolSize()).isEqualTo(8);
+        assertThat(derivedConfig.getQueueCapacity()).isEqualTo(50);
+        assertThat(derivedConfig.getContextPropagator()).hasSize(2);
+    }
+
+    @Test
     void buildWithIllegalMaxThreadPoolSize() {
         assertThatThrownBy(() -> ThreadPoolBulkheadConfig.custom().maxThreadPoolSize(-1).build())
             .isInstanceOf(IllegalArgumentException.class);


### PR DESCRIPTION
Fixes #2492

`ThreadPoolBulkheadConfig.Builder(ThreadPoolBulkheadConfig)` aliased the passed-in config (`this.config = bulkheadConfig`) instead of copying its fields, so `from(base)...build()` mutated `base` and returned the same instance. This copies each field into a fresh config, matching `BulkheadConfig`, `RateLimiterConfig`, `TimeLimiterConfig` and `CircuitBreakerConfig`, all of which copy fields in their equivalent constructor. The context propagator list is copied into a new `ArrayList` so `build()`'s `addAll` no longer leaks into the base config's list.

**Impact:** when several thread-pool-bulkhead instances share a base config (e.g. the Spring Boot `default` config, via `CommonThreadPoolBulkheadConfigurationProperties` which calls `from(baseConfig)`), the first instance's overrides overwrite the shared base, and later instances start from the already-modified base.

Added a regression test (`fromShouldNotMutateBaseConfig`) that keeps a reference to the base config and asserts it stays unchanged after deriving a config from it — the existing `createFromBaseConfig` test passes the base config inline so it never keeps a reference and can't catch this.

Verification done:
1. No in-flight PR — the original reporter's PR (#2493) for this issue was closed 2026-08-06 by its author ("stepping back from open-source contributions"), not for correctness — another user (arjun2075) independently reproduced and confirmed the same fix resolves the issue. Issue #2492 is still open and unfixed on master.
2. No active competing claim — same as above, the prior PR author explicitly stepped back.
3. Code-focused change (single Java class + its test).
4. Confirmed the bug still exists on current `master` (`a8a33164`) by reverting the fix locally and re-running the new regression test — it fails without the fix, passes with it.
5. No parent epic.
6. N/A — not a `spring-projects/*` repo, no waiting-for-triage gate.

Ran `./gradlew :resilience4j-bulkhead:test` (JDK 21 toolchain) — all 176 tests in the module pass, including the new regression test.

This PR was written with AI assistance (Claude Code).