### PR TITLE
Issue #2492: Copy the base config in ThreadPoolBulkheadConfig.from()

### DIFF
--- a/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfig.java
+++ b/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfig.java
@@ -70,7 +70,8 @@ public class ThreadPoolBulkheadConfig {
     }
 
     /**
-     * Returns a builder to create a custom ThreadPoolBulkheadConfig.
+     * Returns a builder to create a custom ThreadPoolBulkheadConfig based on another
+     * ThreadPoolBulkheadConfig. The given config is copied and left unchanged.
      *
      * @return a {@link Builder}
      */
@@ -132,7 +133,14 @@ public class ThreadPoolBulkheadConfig {
         private ThreadPoolBulkheadConfig config;
 
         public Builder(ThreadPoolBulkheadConfig bulkheadConfig) {
-            this.config = bulkheadConfig;
+            this.config = new ThreadPoolBulkheadConfig();
+            this.config.maxThreadPoolSize = bulkheadConfig.maxThreadPoolSize;
+            this.config.coreThreadPoolSize = bulkheadConfig.coreThreadPoolSize;
+            this.config.queueCapacity = bulkheadConfig.queueCapacity;
+            this.config.keepAliveDuration = bulkheadConfig.keepAliveDuration;
+            this.config.writableStackTraceEnabled = bulkheadConfig.writableStackTraceEnabled;
+            this.config.contextPropagators = new ArrayList<>(bulkheadConfig.contextPropagators);
+            this.config.rejectedExecutionHandler = bulkheadConfig.rejectedExecutionHandler;
         }
 
         public Builder() {

--- a/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfigTest.java
+++ b/resilience4j-bulkhead/src/test/java/io/github/resilience4j/bulkhead/ThreadPoolBulkheadConfigTest.java
@@ -81,6 +81,53 @@ class ThreadPoolBulkheadConfigTest {
     }
 
     @Test
+    void fromShouldNotMutateBaseConfig() {
+        ThreadPoolBulkheadConfig baseConfig = ThreadPoolBulkheadConfig.custom()
+            .maxThreadPoolSize(4)
+            .coreThreadPoolSize(2)
+            .queueCapacity(10)
+            .keepAliveDuration(Duration.ofMillis(100))
+            .writableStackTraceEnabled(false)
+            .build();
+
+        ThreadPoolBulkheadConfig derivedConfig = ThreadPoolBulkheadConfig.from(baseConfig)
+            .maxThreadPoolSize(20)
+            .coreThreadPoolSize(8)
+            .queueCapacity(50)
+            .keepAliveDuration(Duration.ofMillis(500))
+            .writableStackTraceEnabled(true)
+            .build();
+
+        assertThat(baseConfig.getMaxThreadPoolSize()).isEqualTo(4);
+        assertThat(baseConfig.getCoreThreadPoolSize()).isEqualTo(2);
+        assertThat(baseConfig.getQueueCapacity()).isEqualTo(10);
+        Assertions.assertThat(baseConfig.getKeepAliveDuration()).hasMillis(100);
+        assertThat(baseConfig.isWritableStackTraceEnabled()).isFalse();
+        assertThat(derivedConfig).isNotSameAs(baseConfig);
+        assertThat(derivedConfig.getMaxThreadPoolSize()).isEqualTo(20);
+        assertThat(derivedConfig.getCoreThreadPoolSize()).isEqualTo(8);
+        assertThat(derivedConfig.getQueueCapacity()).isEqualTo(50);
+    }
+
+    @Test
+    void fromShouldNotAccumulateContextPropagatorsOnBaseConfig() {
+        ThreadPoolBulkheadConfig baseConfig = ThreadPoolBulkheadConfig.custom()
+            .contextPropagator(TestCtxPropagator.class)
+            .build();
+
+        ThreadPoolBulkheadConfig first = ThreadPoolBulkheadConfig.from(baseConfig)
+            .contextPropagator(TestCtxPropagator.class)
+            .build();
+        ThreadPoolBulkheadConfig second = ThreadPoolBulkheadConfig.from(baseConfig)
+            .contextPropagator(TestCtxPropagator.class)
+            .build();
+
+        assertThat(baseConfig.getContextPropagator()).hasSize(1);
+        assertThat(first.getContextPropagator()).hasSize(2);
+        assertThat(second.getContextPropagator()).hasSize(2);
+    }
+
+    @Test
     void buildWithIllegalMaxThreadPoolSize() {
         assertThatThrownBy(() -> ThreadPoolBulkheadConfig.custom().maxThreadPoolSize(-1).build())
             .isInstanceOf(IllegalArgumentException.class);


### PR DESCRIPTION
Fixes #2492.

`ThreadPoolBulkheadConfig.Builder(ThreadPoolBulkheadConfig)` kept the passed-in config by reference, so every builder call wrote through to it and `build()` returned the same instance. `from(baseConfig)` therefore mutated the base config — when several thread-pool bulkheads share one (Spring Boot's `default` config via `CommonThreadPoolBulkheadConfigurationProperties`), the first instance's overrides leaked into the base and context propagators accumulated across instances.

The other config builders (`BulkheadConfig`, `RateLimiterConfig`, `TimeLimiterConfig`, `CircuitBreakerConfig`) copy the base config's fields into a fresh instance; this does the same here. `contextPropagators` is copied into a new list so `build()`'s `addAll` cannot reach the base either.

Tests: `fromShouldNotMutateBaseConfig` (the reproduction from the issue, extended to all copied fields) and `fromShouldNotAccumulateContextPropagatorsOnBaseConfig` (base keeps 1 propagator, each derived config gets its own 2). Both fail on `master` and pass with the fix; `resilience4j-bulkhead` tests are otherwise unchanged.
